### PR TITLE
Unmark comments as spam (maybe needs an option?)

### DIFF
--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -390,7 +390,12 @@ class Inbox {
 		// do not require email for AP entries
 		\add_filter( 'pre_option_require_name_email', '__return_false' );
 
-		$state = \wp_new_comment( $commentdata, true );
+		$commentid = \wp_new_comment( $commentdata, true );
+
+		if ('spam' === \wp_get_comment_status($commentid)) {
+			\wp_set_comment_status($commentid, 0);
+			\wp_notify_moderator( $commentid );
+		}
 
 		\remove_filter( 'pre_option_require_name_email', '__return_false' );
 
@@ -435,7 +440,13 @@ class Inbox {
 		// do not require email for AP entries
 		\add_filter( 'pre_option_require_name_email', '__return_false' );
 
-		$state = \wp_new_comment( $commentdata, true );
+		$commentid = \wp_new_comment( $commentdata, true );
+
+		if ('spam' === \wp_get_comment_status($commentid)) {
+			\wp_set_comment_status($commentid, 0);
+			\wp_notify_moderator( $commentid );
+		}
+
 
 		\remove_filter( 'pre_option_require_name_email', '__return_false' );
 


### PR DESCRIPTION
Hi,
I've noticed comments from the Fediverse have a tendancy to get flagged as spam by Akismet. 
I think that's unfortunate as there - for now ? - a lot less chance that this is the case.

This PR unflags spam on these comments and mark them for moderation instead.

Hope this helps, and thanks for the nice plugin!