### PR TITLE
Settings page cleanups

### DIFF
--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -55,6 +55,26 @@ summary {
 	color: #2271b1;
 }
 
+.activitypub_post_content_details {
+	margin-left: 40px;
+	padding: 10px;
+	background-color: lightgrey;
+}
+
+.activitypub_post_content_details pre {
+	margin-top: 0px;
+}
+
+.activitypub_post_content_details hr {
+	margin-bottom: 14px;
+}
+
+.activitypub_post_content_type_details {
+	cursor: pointer;
+	text-decoration: underline;
+	color: #2271b1;
+}
+
 .activitypub-settings-accordion {
 	border: 1px solid #c3c4c7;
 }

--- a/assets/js/activitypub-admin.js
+++ b/assets/js/activitypub-admin.js
@@ -11,10 +11,43 @@ jQuery( function( $ ) {
 			$( '#' + $( this ).attr( 'aria-controls' ) ).attr( 'hidden', false );
 		}
 	} );
-	
+
+	$(document).on( 'click', '#activitypub_post_content_type_title_link_details', function() {
+		var content = $( '#activitypub_post_content_type_title_link_details_content');
+		var isExpanded = ( 'block' === content.css( 'display' ) );
+
+		if ( isExpanded ) {
+			content.css( 'display', 'none' );
+		} else {
+			content.css( 'display', 'block' );
+		}
+	} );
+
+	$(document).on( 'click', '#activitypub_post_content_type_excerpt_link_details', function() {
+		var content = $( '#activitypub_post_content_type_excerpt_link_details_content');
+		var isExpanded = ( 'block' === content.css( 'display' ) );
+
+		if ( isExpanded ) {
+			content.css( 'display', 'none' );
+		} else {
+			content.css( 'display', 'block' );
+		}
+	} );
+
+	$(document).on( 'click', '#activitypub_post_content_type_content_link_details', function() {
+		var content = $( '#activitypub_post_content_type_content_link_details_content');
+		var isExpanded = ( 'block' === content.css( 'display' ) );
+
+		if ( isExpanded ) {
+			content.css( 'display', 'none' );
+		} else {
+			content.css( 'display', 'block' );
+		}
+	} );
+
 	$(document).on( 'wp-plugin-install-success', function( event, response ) {
 		setTimeout( function() {
 			$( '.activate-now' ).removeClass( 'thickbox open-plugin-details-modal' );
 		}, 1200 );
-	} );	
+	} );
 } );

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -38,7 +38,7 @@
 			<tbody>
 				<tr>
 					<th scope="row">
-						<?php \esc_html_e( 'Post-Content', 'activitypub' ); ?>
+						<?php \esc_html_e( 'Post Content', 'activitypub' ); ?>
 					</th>
 					<td>
 						<p>
@@ -76,7 +76,7 @@
 				</tr>
 				<tr>
 					<th scope="row">
-						<?php \esc_html_e( 'Activity-Object-Type', 'activitypub' ); ?>
+						<?php \esc_html_e( 'Activity Object Type', 'activitypub' ); ?>
 					</th>
 					<td>
 						<p>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -42,13 +42,32 @@
 					</th>
 					<td>
 						<p>
-							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_title_link" value="title" <?php echo \checked( 'title', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Title and link', 'activitypub' ); ?></label> - <span class="description"><?php \esc_html_e( 'Only the title and a link.', 'activitypub' ); ?></span>
+							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_title_link" value="title" <?php echo \checked( 'title', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Title and link', 'activitypub' ); ?></label> - <span class="description"><?php echo \wp_kses( sprintf( __( 'Only the title and a link (%sdetails%s).', 'activitypub' ), '<span class="activitypub_post_content_type_details" id="activitypub_post_content_type_title_link_details">', '</span>' ), 'post' ); ?></span>
+							<div class="activitypub_post_content_details" style="display: none" id="activitypub_post_content_type_title_link_details_content">
+								<pre><?php echo esc_html("<p><strong>%title%</strong></p>\n\n<p>%permalink%</p>"); ?></pre>
+								<hr>
+								<p><strong>Title</strong></p>
+								<p><?php echo esc_html( 'http://localhost' . get_option( 'permalink_structure' ) ); ?></p>
+							</div>
 						</p>
 						<p>
-							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_excerpt" value="excerpt" <?php echo \checked( 'excerpt', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Excerpt', 'activitypub' ); ?></label> - <span class="description"><?php \esc_html_e( 'A content summary, shortened to 400 characters and without markup.', 'activitypub' ); ?></span>
+							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_excerpt" value="excerpt" <?php echo \checked( 'excerpt', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Excerpt', 'activitypub' ); ?></label> - <span class="description"><?php echo \wp_kses( sprintf( __( 'A content summary, shortened to 400 characters and without markup (%sdetails%s).', 'activitypub' ), '<span class="activitypub_post_content_type_details" id="activitypub_post_content_type_excerpt_link_details">', '</span>' ), 'post' ); ?></span>
+							<div class="activitypub_post_content_details" style="display: none" id="activitypub_post_content_type_excerpt_link_details_content">
+								<pre><?php echo esc_html("%excerpt%\n\n<p>%permalink%</p>"); ?></pre>
+								<hr>
+								A short excerpt of your post.
+								<p><?php echo esc_html( 'http://localhost' . get_option( 'permalink_structure' ) ); ?></p>
+							</div>
 						</p>
 						<p>
-							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_content" value="content" <?php echo \checked( 'content', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Content (default)', 'activitypub' ); ?></label> - <span class="description"><?php \esc_html_e( 'The full content.', 'activitypub' ); ?></span>
+							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_content" value="content" <?php echo \checked( 'content', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Content (default)', 'activitypub' ); ?></label> - <span class="description"><?php echo \wp_kses( sprintf( __( 'The full content (%sdetails%s).', 'activitypub' ), '<span class="activitypub_post_content_type_details" id="activitypub_post_content_type_content_link_details">', '</span>' ), 'post' ); ?></span>
+							<div class="activitypub_post_content_details" style="display: none" id="activitypub_post_content_type_content_link_details_content">
+								<pre><?php echo esc_html("%content%\n\n<p>%hashtags%</p>\n\n<p>%permalink%</p>"); ?></pre>
+								<hr>
+								The full content of your post.
+								<p>#HashTagOne #HashTagTwo</p>
+								<p><?php echo esc_html( 'http://localhost' . get_option( 'permalink_structure' ) ); ?></p>
+							</div>
 						</p>
 						<p>
 							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_custom" value="custom" <?php echo \checked( 'custom', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Custom', 'activitypub' ); ?></label> - <span class="description"><?php \esc_html_e( 'Use the text-area below, to customize your activities.', 'activitypub' ); ?></span>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -110,7 +110,7 @@
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><?php \esc_html_e( 'Supported post types', 'activitypub' ); ?></th>
+					<th scope="row"><?php \esc_html_e( 'Supported Post Types', 'activitypub' ); ?></th>
 					<td>
 						<fieldset>
 							<?php \esc_html_e( 'Enable ActivityPub support for the following post types:', 'activitypub' ); ?>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -44,7 +44,7 @@
 						<p>
 							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_title_link" value="title" <?php echo \checked( 'title', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Title and link', 'activitypub' ); ?></label> - <span class="description"><?php echo \wp_kses( sprintf( __( 'Only the title and a link (%sdetails%s).', 'activitypub' ), '<span class="activitypub_post_content_type_details" id="activitypub_post_content_type_title_link_details">', '</span>' ), 'post' ); ?></span>
 							<div class="activitypub_post_content_details" style="display: none" id="activitypub_post_content_type_title_link_details_content">
-								<pre><?php echo esc_html("<p><strong>%title%</strong></p>\n\n<p>%permalink%</p>"); ?></pre>
+								<pre><?php echo esc_html("<p>[ap_title]</p>\n\n<p>[ap_permalink]</p>"); ?></pre>
 								<hr>
 								<p><strong>Title</strong></p>
 								<p><?php echo esc_html( 'http://localhost' . get_option( 'permalink_structure' ) ); ?></p>
@@ -53,7 +53,7 @@
 						<p>
 							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_excerpt" value="excerpt" <?php echo \checked( 'excerpt', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Excerpt', 'activitypub' ); ?></label> - <span class="description"><?php echo \wp_kses( sprintf( __( 'A content summary, shortened to 400 characters and without markup (%sdetails%s).', 'activitypub' ), '<span class="activitypub_post_content_type_details" id="activitypub_post_content_type_excerpt_link_details">', '</span>' ), 'post' ); ?></span>
 							<div class="activitypub_post_content_details" style="display: none" id="activitypub_post_content_type_excerpt_link_details_content">
-								<pre><?php echo esc_html("%excerpt%\n\n<p>%permalink%</p>"); ?></pre>
+								<pre><?php echo esc_html("[ap_excerpt]\n\n<p>[ap_permalink]</p>"); ?></pre>
 								<hr>
 								A short excerpt of your post.
 								<p><?php echo esc_html( 'http://localhost' . get_option( 'permalink_structure' ) ); ?></p>
@@ -62,7 +62,7 @@
 						<p>
 							<label><input type="radio" name="activitypub_post_content_type" id="activitypub_post_content_type_content" value="content" <?php echo \checked( 'content', \get_option( 'activitypub_post_content_type', 'content' ) ); ?> /> <?php \esc_html_e( 'Content (default)', 'activitypub' ); ?></label> - <span class="description"><?php echo \wp_kses( sprintf( __( 'The full content (%sdetails%s).', 'activitypub' ), '<span class="activitypub_post_content_type_details" id="activitypub_post_content_type_content_link_details">', '</span>' ), 'post' ); ?></span>
 							<div class="activitypub_post_content_details" style="display: none" id="activitypub_post_content_type_content_link_details_content">
-								<pre><?php echo esc_html("%content%\n\n<p>%hashtags%</p>\n\n<p>%permalink%</p>"); ?></pre>
+								<pre><?php echo esc_html("[ap_content]\n\n<p>[ap_hashtags]</p>\n\n<p>[ap_permalink]</p>"); ?></pre>
 								<hr>
 								The full content of your post.
 								<p>#HashTagOne #HashTagTwo</p>


### PR DESCRIPTION
- Add in some details to what each of the predefined post content actaully are in a hidden area, including a preview/sample of them.
- Remove the dashes in the "Post Content" and "Activity Object Type" to make them consistent with the other titles.
- Standardize the case of the "Supported Post Types" title to make it consistent with the other titles.