### PR TITLE
Profile settings: use string to fetch user description instead of constant

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -161,7 +161,7 @@ class Admin {
 	}
 
 	public static function add_profile( $user ) {
-		$description = get_user_meta( $user->ID, ACTIVITYPUB_USER_DESCRIPTION_KEY, true );
+		$description = get_user_meta( $user->ID, 'activitypub_user_description', true );
 
 		\load_template(
 			ACTIVITYPUB_PLUGIN_DIR . 'templates/user-settings.php',


### PR DESCRIPTION
Follow-up from #304

Since we do not use a constant anywhere else just yet, let's keep using a string in the settings page.
