### PR TITLE
fix migrate_from_0_17() error

### DIFF
--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -59,7 +59,7 @@ class Migration {
 			$followers = get_user_meta( $user_id, 'activitypub_followers', true );
 
 			if ( $followers ) {
-				foreach ( $followers as $follower ) {
+				foreach ( $followers as $actor ) {
 					$meta = get_remote_metadata_by_actor( $actor );
 
 					$follower = new Follower( $actor );


### PR DESCRIPTION
I think this should fix the problem of [$actor](https://github.com/Automattic/wordpress-activitypub/blob/master/includes/class-migration.php#L63) being undefined.

Untested.