### PR TITLE
Compat: introduce a conditional to detect ActivityPub requests

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -228,3 +228,47 @@ function is_tombstone( $wp_error ) {
 
 	return false;
 }
+
+/**
+ * Check if a request is for an ActivityPub request.
+ *
+ * @return bool False by default.
+ */
+function is_activitypub_request() {
+	global $wp_query;
+
+	/*
+	 * ActivityPub requests are currently only made for
+	 * author archives, singular posts, and the homepage.
+	 */
+	if ( ! \is_author() && ! \is_singular() && ! \is_home() ) {
+		return false;
+	}
+
+	// One can trigger an ActivityPub request by adding ?activitypub to the URL.
+	global $wp_query;
+	if ( isset( $wp_query->query_vars['activitypub'] ) ) {
+		return true;
+	}
+
+	/*
+	 * The other (more common) option to make an ActivityPub request
+	 * is to send an Accept header.
+	 */
+	if ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
+		$accept = $_SERVER['HTTP_ACCEPT'];
+
+		/*
+		 * $accept can be a single value, or a comma separated list of values.
+		 * We want to support both scenarios,
+		 * and return true when the header includes at least one of the following:
+		 * - application/activity+json
+		 * - application/ld+json
+		 */
+		if ( preg_match( '/(application\/(ld\+json|activity\+json))/', $accept ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 
 = Next =
 
+* Compatibility: add a new conditional, `\Activitypub\is_activitypub_request()`, to allow third-party plugins to detect ActivityPub requests.
 * Compatibility: add hooks to allow modifying images returned in ActivityPub requests.
 * Compatibility: indicate that the plugin is compatible and has been tested with the latest version of WordPress, 6.2.
 


### PR DESCRIPTION
## Proposed changes:

This conditional could be used within the plugin, but also by third-party plugins, to detect whether a request is an ActivityPub request, without having to manually check for query vars and headers every time.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This is better tested with a code snippet, just like a third-party plugin would use on their end. Something like this:

```php
add_action(
	'wp',
	function () {
		if ( function_exists( '\Activitypub\is_activitypub_request' ) ) {
			error_log( 'the function exists' );
			if ( \Activitypub\is_activitypub_request() ) {
				error_log( 'This is an ActivityPub request' );
			}
		}
	}
);
```

Then make requests and see the output of the function:

* Single posts
* Single posts with a custom `Accept: application/activity+json` header.
* Archive pages.

