### PR TITLE
Allow setting the REST namespace with `ACTIVITYPUB_REST_NAMESPACE`

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -32,8 +32,8 @@ function init() {
 	\define( 'ACTIVITYPUB_PLUGIN_FILE', plugin_dir_path( __FILE__ ) . '/' . basename( __FILE__ ) );
 
 	Migration::init();
-	Activity_Dispatcher::init();
 	Activitypub::init();
+	Activity_Dispatcher::init();
 	Collection\Followers::init();
 
 	// Configure the REST API route
@@ -41,13 +41,13 @@ function init() {
 	Rest\Inbox::init();
 	Rest\Followers::init();
 	Rest\Following::init();
+	Rest\Nodeinfo::init();
 	Rest\Webfinger::init();
 
 	Admin::init();
 	Hashtag::init();
 	Shortcodes::init();
 	Mention::init();
-	Debug::init();
 	Health_Check::init();
 	Scheduler::init();
 }
@@ -96,6 +96,7 @@ if ( \get_option( 'blog_public', 1 ) ) {
 $debug_file = \dirname( __FILE__ ) . '/includes/debug.php';
 if ( \WP_DEBUG && file_exists( $debug_file ) && is_readable( $debug_file ) ) {
 	require_once $debug_file;
+	Debug::init();
 }
 
 /**

--- a/activitypub.php
+++ b/activitypub.php
@@ -25,6 +25,7 @@ function init() {
 	\defined( 'ACTIVITYPUB_HASHTAGS_REGEXP' ) || \define( 'ACTIVITYPUB_HASHTAGS_REGEXP', '(?:(?<=\s)|(?<=<p>)|(?<=<br>)|^)#([A-Za-z0-9_]+)(?:(?=\s|[[:punct:]]|$))' );
 	\defined( 'ACTIVITYPUB_USERNAME_REGEXP' ) || \define( 'ACTIVITYPUB_USERNAME_REGEXP', '(?:([A-Za-z0-9_-]+)@((?:[A-Za-z0-9_-]+\.)+[A-Za-z]+))' );
 	\defined( 'ACTIVITYPUB_CUSTOM_POST_CONTENT' ) || \define( 'ACTIVITYPUB_CUSTOM_POST_CONTENT', "<strong>[ap_title]</strong>\n\n[ap_content]\n\n[ap_hashtags]\n\n[ap_shortlink]" );
+	defined( 'ACTIVITYPUB_REST_NAMESPACE' ) || define( 'ACTIVITYPUB_REST_NAMESPACE', 'activitypub/1.0' );
 
 	\define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 	\define( 'ACTIVITYPUB_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -120,12 +121,12 @@ function plugin_settings_link( $actions ) {
  */
 function add_rewrite_rules() {
 	if ( ! \class_exists( 'Webfinger' ) ) {
-		\add_rewrite_rule( '^.well-known/webfinger', 'index.php?rest_route=/activitypub/1.0/webfinger', 'top' );
+		\add_rewrite_rule( '^.well-known/webfinger', 'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/webfinger', 'top' );
 	}
 
 	if ( ! \class_exists( 'Nodeinfo' ) || ! (bool) \get_option( 'blog_public', 1 ) ) {
-		\add_rewrite_rule( '^.well-known/nodeinfo', 'index.php?rest_route=/activitypub/1.0/nodeinfo/discovery', 'top' );
-		\add_rewrite_rule( '^.well-known/x-nodeinfo2', 'index.php?rest_route=/activitypub/1.0/nodeinfo2', 'top' );
+		\add_rewrite_rule( '^.well-known/nodeinfo', 'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/nodeinfo/discovery', 'top' );
+		\add_rewrite_rule( '^.well-known/x-nodeinfo2', 'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/nodeinfo2', 'top' );
 	}
 
 	\add_rewrite_endpoint( 'activitypub', EP_AUTHORS | EP_PERMALINK | EP_PAGES );

--- a/activitypub.php
+++ b/activitypub.php
@@ -25,7 +25,7 @@ function init() {
 	\defined( 'ACTIVITYPUB_HASHTAGS_REGEXP' ) || \define( 'ACTIVITYPUB_HASHTAGS_REGEXP', '(?:(?<=\s)|(?<=<p>)|(?<=<br>)|^)#([A-Za-z0-9_]+)(?:(?=\s|[[:punct:]]|$))' );
 	\defined( 'ACTIVITYPUB_USERNAME_REGEXP' ) || \define( 'ACTIVITYPUB_USERNAME_REGEXP', '(?:([A-Za-z0-9_-]+)@((?:[A-Za-z0-9_-]+\.)+[A-Za-z]+))' );
 	\defined( 'ACTIVITYPUB_CUSTOM_POST_CONTENT' ) || \define( 'ACTIVITYPUB_CUSTOM_POST_CONTENT', "<strong>[ap_title]</strong>\n\n[ap_content]\n\n[ap_hashtags]\n\n[ap_shortlink]" );
-	defined( 'ACTIVITYPUB_REST_NAMESPACE' ) || define( 'ACTIVITYPUB_REST_NAMESPACE', 'activitypub/1.0' );
+	\defined( 'ACTIVITYPUB_REST_NAMESPACE' ) || \define( 'ACTIVITYPUB_REST_NAMESPACE', 'activitypub/1.0' );
 
 	\define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 	\define( 'ACTIVITYPUB_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -225,7 +225,7 @@ class Activitypub {
 		if ( ! \class_exists( 'Webfinger' ) ) {
 			\add_rewrite_rule(
 				'^.well-known/webfinger',
-				'index.php?rest_route=/activitypub/1.0/webfinger',
+				'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/webfinger',
 				'top'
 			);
 		}
@@ -233,12 +233,12 @@ class Activitypub {
 		if ( ! \class_exists( 'Nodeinfo' ) && true === (bool) \get_option( 'blog_public', 1 ) ) {
 			\add_rewrite_rule(
 				'^.well-known/nodeinfo',
-				'index.php?rest_route=/activitypub/1.0/nodeinfo/discovery',
+				'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/nodeinfo/discovery',
 				'top'
 			);
 			\add_rewrite_rule(
 				'^.well-known/x-nodeinfo2',
-				'index.php?rest_route=/activitypub/1.0/nodeinfo2',
+				'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/nodeinfo2',
 				'top'
 			);
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -233,6 +233,7 @@ function is_tombstone( $wp_error ) {
  * Get the REST URL relative to this plugin's namespace.
  *
  * @param string $path Optional. REST route path. Otherwise this plugin's namespaced root.
+ *
  * @return string REST URL relative to this plugin's namespace.
  */
 function get_rest_url_by_path( $path = '' ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -228,3 +228,16 @@ function is_tombstone( $wp_error ) {
 
 	return false;
 }
+
+/**
+ * Get the REST URL relative to this plugin's namespace.
+ *
+ * @param string $path Optional. REST route path. Otherwise this plugin's namespaced root.
+ * @return string REST URL relative to this plugin's namespace.
+ */
+function get_rest_url_by_path( $path = '' ) {
+	// we'll handle the leading slash.
+	$path = ltrim( $path, '/' );
+	$url = sprintf( '/%s/%s', ACTIVITYPUB_REST_NAMESPACE, $path );
+	return \get_rest_url( null, $url );
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -239,10 +239,7 @@ function get_rest_url_by_path( $path = '' ) {
 	// we'll handle the leading slash.
 	$path = ltrim( $path, '/' );
 	$namespaced_path = sprintf( '/%s/%s', ACTIVITYPUB_REST_NAMESPACE, $path );
-	$rest_url = \get_rest_url( null, $namespaced_path );
-	// Just in case there are non-default ways of handling REST URLs.
-	$rest_url = \apply_filters( 'activitypub_rest_url', $rest_url, $path, ACTIVITYPUB_REST_NAMESPACE );
-	return $rest_url;
+	return \get_rest_url( null, $namespaced_path );
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -238,8 +238,11 @@ function is_tombstone( $wp_error ) {
 function get_rest_url_by_path( $path = '' ) {
 	// we'll handle the leading slash.
 	$path = ltrim( $path, '/' );
-	$url = sprintf( '/%s/%s', ACTIVITYPUB_REST_NAMESPACE, $path );
-	return \get_rest_url( null, $url );
+	$namespaced_path = sprintf( '/%s/%s', ACTIVITYPUB_REST_NAMESPACE, $path );
+	$rest_url = \get_rest_url( null, $namespaced_path );
+	// Just in case there are non-default ways of handling REST URLs.
+	$rest_url = \apply_filters( 'activitypub_rest_url', $rest_url, $path, ACTIVITYPUB_REST_NAMESPACE );
+	return $rest_url;
 }
 
 /**

--- a/includes/model/class-activity.php
+++ b/includes/model/class-activity.php
@@ -148,7 +148,8 @@ class Activity {
 			$this->published = $object['published'];
 		}
 
-		$this->add_to( \get_rest_url( null, '/activitypub/1.0/users/' . intval( $post->get_post_author() ) . '/followers' ) );
+		$url = sprintf( '/%/users/%d/followers', ACTIVITYPUB_REST_NAMESPACE, intval( $post->get_post_author() ) );
+		$this->add_to( \get_rest_url( null, $url ) );
 
 		if ( isset( $this->object['attributedTo'] ) ) {
 			$this->actor = $this->object['attributedTo'];

--- a/includes/model/class-activity.php
+++ b/includes/model/class-activity.php
@@ -148,8 +148,8 @@ class Activity {
 			$this->published = $object['published'];
 		}
 
-		$url = sprintf( '/%/users/%d/followers', ACTIVITYPUB_REST_NAMESPACE, intval( $post->get_post_author() ) );
-		$this->add_to( \get_rest_url( null, $url ) );
+		$path = sprintf( 'users/%d/followers', intval( $post->get_post_author() ) );
+		$this->add_to( get_rest_url_by_path( $path ) );
 
 		if ( isset( $this->object['attributedTo'] ) ) {
 			$this->actor = $this->object['attributedTo'];

--- a/includes/model/class-activity.php
+++ b/includes/model/class-activity.php
@@ -1,6 +1,8 @@
 <?php
 namespace Activitypub\Model;
 
+use function Activitypub\get_rest_url_by_path;
+
 /**
  * ActivityPub Post Class
  *

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -142,8 +142,8 @@ class Post {
 	 */
 	public function __construct( $post ) {
 		$this->post = \get_post( $post );
-		$url = sprintf( '/%/users/%d/followers', ACTIVITYPUB_REST_NAMESPACE, intval( $post->get_post_author() ) );
-		$this->add_to( \get_rest_url( null, $url ) );
+		$path = sprintf( 'users/%d/followers', intval( $this->get_post_author() ) );
+		$this->add_to( get_rest_url_by_path( $path ) );
 	}
 
 	/**

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -142,7 +142,8 @@ class Post {
 	 */
 	public function __construct( $post ) {
 		$this->post = \get_post( $post );
-		$this->add_to( \get_rest_url( null, '/activitypub/1.0/users/' . intval( $this->get_post_author() ) . '/followers' ) );
+		$url = sprintf( '/%/users/%d/followers', ACTIVITYPUB_REST_NAMESPACE, intval( $post->get_post_author() ) );
+		$this->add_to( \get_rest_url( null, $url ) );
 	}
 
 	/**

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -1,6 +1,8 @@
 <?php
 namespace Activitypub\Model;
 
+use function Activitypub\get_rest_url_by_path;
+
 /**
  * ActivityPub Post Class
  *

--- a/includes/rest/class-followers.php
+++ b/includes/rest/class-followers.php
@@ -78,7 +78,7 @@ class Followers {
 		$json->actor = \get_author_posts_url( $user_id );
 		$json->type = 'OrderedCollectionPage';
 
-		$json->partOf = \get_rest_url( null, sprintf( '/%s/users/%d/followers', ACTIVITYPUB_REST_NAMESPACE, $user_id ) ); // phpcs:ignore
+		$json->partOf = get_rest_url_by_path( sprintf( 'users/%d/followers', $user_id ) ); // phpcs:ignore
 		$json->first = $json->partOf; // phpcs:ignore
 		$json->totalItems = FollowerCollection::count_followers( $user_id ); // phpcs:ignore
 		$json->orderedItems = FollowerCollection::get_followers( $user_id, ARRAY_N ); // phpcs:ignore

--- a/includes/rest/class-followers.php
+++ b/includes/rest/class-followers.php
@@ -27,7 +27,7 @@ class Followers {
 	 */
 	public static function register_routes() {
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/users/(?P<user_id>\d+)/followers',
 			array(
 				array(
@@ -78,7 +78,7 @@ class Followers {
 		$json->actor = \get_author_posts_url( $user_id );
 		$json->type = 'OrderedCollectionPage';
 
-		$json->partOf = \get_rest_url( null, "/activitypub/1.0/users/$user_id/followers" ); // phpcs:ignore
+		$json->partOf = \get_rest_url( null, sprintf( '/%s/users/%d/followers', ACTIVITYPUB_REST_NAMESPACE, $user_id ) ); // phpcs:ignore
 		$json->first = $json->partOf; // phpcs:ignore
 		$json->totalItems = FollowerCollection::count_followers( $user_id ); // phpcs:ignore
 		$json->orderedItems = FollowerCollection::get_followers( $user_id, ARRAY_N ); // phpcs:ignore

--- a/includes/rest/class-followers.php
+++ b/includes/rest/class-followers.php
@@ -6,6 +6,7 @@ use stdClass;
 use WP_REST_Server;
 use WP_REST_Response;
 use Activitypub\Collection\Followers as FollowerCollection;
+
 use function Activitypub\get_rest_url_by_path;
 
 /**

--- a/includes/rest/class-followers.php
+++ b/includes/rest/class-followers.php
@@ -6,6 +6,7 @@ use stdClass;
 use WP_REST_Server;
 use WP_REST_Response;
 use Activitypub\Collection\Followers as FollowerCollection;
+use function Activitypub\get_rest_url_by_path;
 
 /**
  * ActivityPub Followers REST-Class

--- a/includes/rest/class-following.php
+++ b/includes/rest/class-following.php
@@ -21,7 +21,7 @@ class Following {
 	 */
 	public static function register_routes() {
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/users/(?P<user_id>\d+)/following',
 			array(
 				array(
@@ -72,7 +72,7 @@ class Following {
 		$json->actor = \get_author_posts_url( $user_id );
 		$json->type = 'OrderedCollectionPage';
 
-		$json->partOf = \get_rest_url( null, "/activitypub/1.0/users/$user_id/following" ); // phpcs:ignore
+		$json->partOf = \get_rest_url( null, sprintf( '/%s/users/%d/following', ACTIVITYPUB_REST_NAMESPACE, $user_id ) ); // phpcs:ignore
 		$json->totalItems = 0; // phpcs:ignore
 		$json->orderedItems = apply_filters( 'activitypub_following', array(), $user ); // phpcs:ignore
 

--- a/includes/rest/class-following.php
+++ b/includes/rest/class-following.php
@@ -1,6 +1,8 @@
 <?php
 namespace Activitypub\Rest;
 
+use function Activitypub\get_rest_url_by_path;
+
 /**
  * ActivityPub Following REST-Class
  *

--- a/includes/rest/class-following.php
+++ b/includes/rest/class-following.php
@@ -72,7 +72,7 @@ class Following {
 		$json->actor = \get_author_posts_url( $user_id );
 		$json->type = 'OrderedCollectionPage';
 
-		$json->partOf = \get_rest_url( null, sprintf( '/%s/users/%d/following', ACTIVITYPUB_REST_NAMESPACE, $user_id ) ); // phpcs:ignore
+		$json->partOf = get_rest_url_by_path( sprintf( 'users/%d/following', $user_id ) ); // phpcs:ignore
 		$json->totalItems = 0; // phpcs:ignore
 		$json->orderedItems = apply_filters( 'activitypub_following', array(), $user ); // phpcs:ignore
 

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -2,6 +2,7 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Model\Activity;
+use function Activitypub\get_rest_url_by_path;
 
 /**
  * ActivityPub Inbox REST-Class

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -108,7 +108,7 @@ class Inbox {
 		$json->id = \home_url( \add_query_arg( null, null ) );
 		$json->generator = 'http://wordpress.org/?v=' . \get_bloginfo_rss( 'version' );
 		$json->type = 'OrderedCollectionPage';
-		$json->partOf = \get_rest_url( null, sprintf( '/%s/users/%d/inbox', ACTIVITYPUB_REST_NAMESPACE, $user_id ) ); // phpcs:ignore
+		$json->partOf = get_rest_url_by_path( sprintf( 'users/%d/inbox', $user_id ) ); // phpcs:ignore
 
 		$json->totalItems = 0; // phpcs:ignore
 

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -2,6 +2,7 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Model\Activity;
+
 use function Activitypub\get_rest_url_by_path;
 
 /**

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -26,7 +26,7 @@ class Inbox {
 	 */
 	public static function register_routes() {
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/inbox',
 			array(
 				array(
@@ -39,7 +39,7 @@ class Inbox {
 		);
 
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/users/(?P<user_id>\d+)/inbox',
 			array(
 				array(
@@ -108,7 +108,7 @@ class Inbox {
 		$json->id = \home_url( \add_query_arg( null, null ) );
 		$json->generator = 'http://wordpress.org/?v=' . \get_bloginfo_rss( 'version' );
 		$json->type = 'OrderedCollectionPage';
-		$json->partOf = \get_rest_url( null, "/activitypub/1.0/users/$user_id/inbox" ); // phpcs:ignore
+		$json->partOf = \get_rest_url( null, sprintf( '/%s/users/%d/inbox', ACTIVITYPUB_REST_NAMESPACE, $user_id ) ); // phpcs:ignore
 
 		$json->totalItems = 0; // phpcs:ignore
 

--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -1,6 +1,8 @@
 <?php
 namespace Activitypub\Rest;
 
+use function Activitypub\get_rest_url_by_path;
+
 /**
  * ActivityPub NodeInfo REST-Class
  *

--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -173,7 +173,7 @@ class Nodeinfo {
 		$discovery['links'] = array(
 			array(
 				'rel' => 'http://nodeinfo.diaspora.software/ns/schema/2.0',
-				'href' => \get_rest_url( null, ACTIVITYPUB_REST_NAMESPACE . '/nodeinfo' ),
+				'href' => get_rest_url_by_path( 'nodeinfo' ),
 			),
 		);
 

--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -23,7 +23,7 @@ class Nodeinfo {
 	 */
 	public static function register_routes() {
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/nodeinfo/discovery',
 			array(
 				array(
@@ -35,7 +35,7 @@ class Nodeinfo {
 		);
 
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/nodeinfo',
 			array(
 				array(
@@ -47,7 +47,7 @@ class Nodeinfo {
 		);
 
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/nodeinfo2',
 			array(
 				array(
@@ -173,7 +173,7 @@ class Nodeinfo {
 		$discovery['links'] = array(
 			array(
 				'rel' => 'http://nodeinfo.diaspora.software/ns/schema/2.0',
-				'href' => \get_rest_url( null, 'activitypub/1.0/nodeinfo' ),
+				'href' => \get_rest_url( null, ACTIVITYPUB_REST_NAMESPACE . '/nodeinfo' ),
 			),
 		);
 

--- a/includes/rest/class-ostatus.php
+++ b/includes/rest/class-ostatus.php
@@ -14,7 +14,7 @@ class Ostatus {
 	 */
 	public static function register_routes() {
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/ostatus/remote-follow',
 			array(
 				array(

--- a/includes/rest/class-outbox.php
+++ b/includes/rest/class-outbox.php
@@ -72,7 +72,7 @@ class Outbox {
 		$json->generator = 'http://wordpress.org/?v=' . \get_bloginfo_rss( 'version' );
 		$json->actor = \get_author_posts_url( $user_id );
 		$json->type = 'OrderedCollectionPage';
-		$json->partOf = \get_rest_url( null, sprintf( '/%s/users/%d/outbox', ACTIVITYPUB_REST_NAMESPACE, $user_id ) ); // phpcs:ignore
+		$json->partOf = get_rest_url_by_path( sprintf( 'users/%d/outbox', $user_id ) ); // phpcs:ignore
 		$json->totalItems = 0; // phpcs:ignore
 
 		// phpcs:ignore

--- a/includes/rest/class-outbox.php
+++ b/includes/rest/class-outbox.php
@@ -1,6 +1,8 @@
 <?php
 namespace Activitypub\Rest;
 
+use function Activitypub\get_rest_url_by_path;
+
 /**
  * ActivityPub Outbox REST-Class
  *

--- a/includes/rest/class-outbox.php
+++ b/includes/rest/class-outbox.php
@@ -21,7 +21,7 @@ class Outbox {
 	 */
 	public static function register_routes() {
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/users/(?P<user_id>\d+)/outbox',
 			array(
 				array(
@@ -72,7 +72,7 @@ class Outbox {
 		$json->generator = 'http://wordpress.org/?v=' . \get_bloginfo_rss( 'version' );
 		$json->actor = \get_author_posts_url( $user_id );
 		$json->type = 'OrderedCollectionPage';
-		$json->partOf = \get_rest_url( null, "/activitypub/1.0/users/$user_id/outbox" ); // phpcs:ignore
+		$json->partOf = \get_rest_url( null, sprintf( '/%s/users/%d/outbox', ACTIVITYPUB_REST_NAMESPACE, $user_id ) ); // phpcs:ignore
 		$json->totalItems = 0; // phpcs:ignore
 
 		// phpcs:ignore

--- a/includes/rest/class-webfinger.php
+++ b/includes/rest/class-webfinger.php
@@ -24,7 +24,6 @@ class Webfinger {
 	 * Register routes
 	 */
 	public static function register_routes() {
-		\l( 'register webfinger' );
 		\register_rest_route(
 			ACTIVITYPUB_REST_NAMESPACE,
 			'/webfinger',

--- a/includes/rest/class-webfinger.php
+++ b/includes/rest/class-webfinger.php
@@ -25,7 +25,7 @@ class Webfinger {
 	 */
 	public static function register_routes() {
 		\register_rest_route(
-			'activitypub/1.0',
+			ACTIVITYPUB_REST_NAMESPACE,
 			'/webfinger',
 			array(
 				array(

--- a/includes/rest/class-webfinger.php
+++ b/includes/rest/class-webfinger.php
@@ -24,6 +24,7 @@ class Webfinger {
 	 * Register routes
 	 */
 	public static function register_routes() {
+		\l( 'register webfinger' );
 		\register_rest_route(
 			ACTIVITYPUB_REST_NAMESPACE,
 			'/webfinger',

--- a/templates/author-json.php
+++ b/templates/author-json.php
@@ -1,6 +1,4 @@
 <?php
-use function Activitypub\get_rest_url_by_path;
-
 $author_id = \get_the_author_meta( 'ID' );
 
 $json = new \stdClass();
@@ -30,10 +28,10 @@ if ( \has_header_image() ) {
 	);
 }
 
-$json->inbox = get_rest_url_by_path( sprintf( 'users/%d/inbox', $author_id ) );
-$json->outbox = get_rest_url_by_path( sprintf( 'users/%d/outbox', $author_id ) );
-$json->followers = get_rest_url_by_path( sprintf( 'users/%d/followers', $author_id ) );
-$json->following = get_rest_url_by_path( sprintf( 'users/%d/following', $author_id ) );
+$json->inbox = \Activitypub\get_rest_url_by_path( sprintf( 'users/%d/inbox', $author_id ) );
+$json->outbox = \Activitypub\get_rest_url_by_path( sprintf( 'users/%d/outbox', $author_id ) );
+$json->followers = \Activitypub\get_rest_url_by_path( sprintf( 'users/%d/followers', $author_id ) );
+$json->following = \Activitypub\get_rest_url_by_path( sprintf( 'users/%d/following', $author_id ) );
 
 $json->manuallyApprovesFollowers = \apply_filters( 'activitypub_json_manually_approves_followers', \__return_false() ); // phpcs:ignore
 

--- a/templates/author-json.php
+++ b/templates/author-json.php
@@ -28,10 +28,10 @@ if ( \has_header_image() ) {
 	);
 }
 
-$json->inbox = \get_rest_url( null, "/activitypub/1.0/users/$author_id/inbox" );
-$json->outbox = \get_rest_url( null, "/activitypub/1.0/users/$author_id/outbox" );
-$json->followers = \get_rest_url( null, "/activitypub/1.0/users/$author_id/followers" );
-$json->following = \get_rest_url( null, "/activitypub/1.0/users/$author_id/following" );
+$json->inbox = \get_rest_url( null, sprintf( '/%s/users/%d/inbox', ACTIVITYPUB_REST_NAMESPACE, $author_id ) );
+$json->outbox = \get_rest_url( null, sprintf( '/%s/users/%d/outbox', ACTIVITYPUB_REST_NAMESPACE, $author_id ) );
+$json->followers = \get_rest_url( null, sprintf( '/%s/users/%d/followers', ACTIVITYPUB_REST_NAMESPACE, $author_id ) );
+$json->following = \get_rest_url( null, sprintf( '/%s/users/%d/following', ACTIVITYPUB_REST_NAMESPACE, $author_id ) );
 
 $json->manuallyApprovesFollowers = \apply_filters( 'activitypub_json_manually_approves_followers', \__return_false() ); // phpcs:ignore
 

--- a/templates/author-json.php
+++ b/templates/author-json.php
@@ -1,4 +1,6 @@
 <?php
+use function Activitypub\get_rest_url_by_path;
+
 $author_id = \get_the_author_meta( 'ID' );
 
 $json = new \stdClass();

--- a/templates/author-json.php
+++ b/templates/author-json.php
@@ -28,10 +28,10 @@ if ( \has_header_image() ) {
 	);
 }
 
-$json->inbox = \get_rest_url( null, sprintf( '/%s/users/%d/inbox', ACTIVITYPUB_REST_NAMESPACE, $author_id ) );
-$json->outbox = \get_rest_url( null, sprintf( '/%s/users/%d/outbox', ACTIVITYPUB_REST_NAMESPACE, $author_id ) );
-$json->followers = \get_rest_url( null, sprintf( '/%s/users/%d/followers', ACTIVITYPUB_REST_NAMESPACE, $author_id ) );
-$json->following = \get_rest_url( null, sprintf( '/%s/users/%d/following', ACTIVITYPUB_REST_NAMESPACE, $author_id ) );
+$json->inbox = get_rest_url_by_path( sprintf( 'users/%d/inbox', $author_id ) );
+$json->outbox = get_rest_url_by_path( sprintf( 'users/%d/outbox', $author_id ) );
+$json->followers = get_rest_url_by_path( sprintf( 'users/%d/followers', $author_id ) );
+$json->following = get_rest_url_by_path( sprintf( 'users/%d/following', $author_id ) );
 
 $json->manuallyApprovesFollowers = \apply_filters( 'activitypub_json_manually_approves_followers', \__return_false() ); // phpcs:ignore
 

--- a/templates/blog-json.php
+++ b/templates/blog-json.php
@@ -1,4 +1,6 @@
 <?php
+use function Activitypub\get_rest_url_by_path;
+
 $json = new \stdClass();
 
 $json->{'@context'} = \Activitypub\get_context();

--- a/templates/blog-json.php
+++ b/templates/blog-json.php
@@ -27,12 +27,10 @@ if ( \has_header_image() ) {
 	);
 }
 
-$blog_base = sprintf( '/%s/blog/', ACTIVITYPUB_REST_NAMESPACE );
-
-$json->inbox = \get_rest_url( null, $blog_base . 'inbox' );
-$json->outbox = \get_rest_url( null, $blog_base . 'outbox' );
-$json->followers = \get_rest_url( null, $blog_base . 'followers' );
-$json->following = \get_rest_url( null, $blog_base . 'following' );
+$json->inbox = get_rest_url_by_path( 'blog/inbox' );
+$json->outbox = get_rest_url_by_path( 'blog/outbox' );
+$json->followers = get_rest_url_by_path( 'blog/followers' );
+$json->following = get_rest_url_by_path( 'blog/following' );
 
 $json->manuallyApprovesFollowers = \apply_filters( 'activitypub_json_manually_approves_followers', \__return_false() ); // phpcs:ignore
 

--- a/templates/blog-json.php
+++ b/templates/blog-json.php
@@ -1,6 +1,4 @@
 <?php
-use function Activitypub\get_rest_url_by_path;
-
 $json = new \stdClass();
 
 $json->{'@context'} = \Activitypub\get_context();
@@ -29,10 +27,10 @@ if ( \has_header_image() ) {
 	);
 }
 
-$json->inbox = get_rest_url_by_path( 'blog/inbox' );
-$json->outbox = get_rest_url_by_path( 'blog/outbox' );
-$json->followers = get_rest_url_by_path( 'blog/followers' );
-$json->following = get_rest_url_by_path( 'blog/following' );
+$json->inbox = \Activitypub\get_rest_url_by_path( 'blog/inbox' );
+$json->outbox = \Activitypub\get_rest_url_by_path( 'blog/outbox' );
+$json->followers = \Activitypub\get_rest_url_by_path( 'blog/followers' );
+$json->following = \Activitypub\get_rest_url_by_path( 'blog/following' );
 
 $json->manuallyApprovesFollowers = \apply_filters( 'activitypub_json_manually_approves_followers', \__return_false() ); // phpcs:ignore
 

--- a/templates/blog-json.php
+++ b/templates/blog-json.php
@@ -27,10 +27,12 @@ if ( \has_header_image() ) {
 	);
 }
 
-$json->inbox = \get_rest_url( null, '/activitypub/1.0/blog/inbox' );
-$json->outbox = \get_rest_url( null, '/activitypub/1.0/blog/outbox' );
-$json->followers = \get_rest_url( null, '/activitypub/1.0/blog/followers' );
-$json->following = \get_rest_url( null, '/activitypub/1.0/blog/following' );
+$blog_base = sprintf( '/%s/blog/', ACTIVITYPUB_REST_NAMESPACE );
+
+$json->inbox = \get_rest_url( null, $blog_base . 'inbox' );
+$json->outbox = \get_rest_url( null, $blog_base . 'outbox' );
+$json->followers = \get_rest_url( null, $blog_base . 'followers' );
+$json->following = \get_rest_url( null, $blog_base . 'following' );
 
 $json->manuallyApprovesFollowers = \apply_filters( 'activitypub_json_manually_approves_followers', \__return_false() ); // phpcs:ignore
 

--- a/tests/test-class-activitypub-activity.php
+++ b/tests/test-class-activitypub-activity.php
@@ -22,7 +22,7 @@ class Test_Activitypub_Activity extends WP_UnitTestCase {
 		$activitypub_activity = new \Activitypub\Model\Activity( 'Create' );
 		$activitypub_activity->from_post( $activitypub_post );
 
-		$this->assertContains( \get_rest_url( null, '/' . ACTIVITYPUB_REST_NAMESPACE . '/users/1/followers' ), $activitypub_activity->get_to() );
+		$this->assertContains(  get_rest_url_by_path( 'users/1/followers' ), $activitypub_activity->get_to() );
 		$this->assertContains( 'https://example.com/alex', $activitypub_activity->get_cc() );
 
 		remove_all_filters( 'activitypub_extract_mentions' );

--- a/tests/test-class-activitypub-activity.php
+++ b/tests/test-class-activitypub-activity.php
@@ -22,7 +22,7 @@ class Test_Activitypub_Activity extends WP_UnitTestCase {
 		$activitypub_activity = new \Activitypub\Model\Activity( 'Create' );
 		$activitypub_activity->from_post( $activitypub_post );
 
-		$this->assertContains(  get_rest_url_by_path( 'users/1/followers' ), $activitypub_activity->get_to() );
+		$this->assertContains(  \Activitypub\get_rest_url_by_path( 'users/1/followers' ), $activitypub_activity->get_to() );
 		$this->assertContains( 'https://example.com/alex', $activitypub_activity->get_cc() );
 
 		remove_all_filters( 'activitypub_extract_mentions' );

--- a/tests/test-class-activitypub-activity.php
+++ b/tests/test-class-activitypub-activity.php
@@ -22,7 +22,7 @@ class Test_Activitypub_Activity extends WP_UnitTestCase {
 		$activitypub_activity = new \Activitypub\Model\Activity( 'Create' );
 		$activitypub_activity->from_post( $activitypub_post );
 
-		$this->assertContains( \get_rest_url( null, '/activitypub/1.0/users/1/followers' ), $activitypub_activity->get_to() );
+		$this->assertContains( \get_rest_url( null, '/' . ACTIVITYPUB_REST_NAMESPACE . '/users/1/followers' ), $activitypub_activity->get_to() );
 		$this->assertContains( 'https://example.com/alex', $activitypub_activity->get_cc() );
 
 		remove_all_filters( 'activitypub_extract_mentions' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As discussed elsewhere, the REST API will need to land within a `wpcom/*` namespace to work with our very particular requirements on wordpress.com. This change should allow it to be configurable by us or anyone who would want to use a different namespace in their own environment.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduce a `ACTIVITYPUB_REST_NAMESPACE` constant that can be overridden from the default `activitypub/1.0` namespace.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
I don't know how, yet. :)