### PR TITLE
Lint: Try dotcom's set of sniffs

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -64,7 +64,7 @@ function init() {
  */
 spl_autoload_register(
 	function ( $full_class ) {
-		$base_dir = \dirname( __FILE__ ) . '/includes/';
+		$base_dir = __DIR__ . '/includes/';
 		$base     = 'activitypub';
 
 		$class = strtolower( $full_class );
@@ -92,14 +92,14 @@ spl_autoload_register(
 	}
 );
 
-require_once \dirname( __FILE__ ) . '/includes/functions.php';
+require_once __DIR__ . '/includes/functions.php';
 
 // load NodeInfo endpoints only if blog is public
 if ( \get_option( 'blog_public', 1 ) ) {
 	Rest\NodeInfo::init();
 }
 
-$debug_file = \dirname( __FILE__ ) . '/includes/debug.php';
+$debug_file = __DIR__ . '/includes/debug.php';
 if ( \WP_DEBUG && file_exists( $debug_file ) && is_readable( $debug_file ) ) {
 	require_once $debug_file;
 	Debug::init();
@@ -150,7 +150,7 @@ function plugin_settings_link( $actions ) {
 add_action(
 	'bp_include',
 	function() {
-		require_once \dirname( __FILE__ ) . '/integration/class-buddypress.php';
+		require_once __DIR__ . '/integration/class-buddypress.php';
 		Integration\Buddypress::init();
 	},
 	0

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "phpcompatibility/php-compatibility": "*",
         "phpcompatibility/phpcompatibility-wp": "*",
         "squizlabs/php_codesniffer": "3.*",
-        "wp-coding-standards/wpcs": "*",
+        "wp-coding-standards/wpcs": "dev-develop",
         "yoast/phpunit-polyfills": "^2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
         "sirbrillig/phpcs-variable-analysis": "^2.11",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
         "squizlabs/php_codesniffer": "3.*",
         "wp-coding-standards/wpcs": "*",
         "yoast/phpunit-polyfills": "^2.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0"
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+        "sirbrillig/phpcs-variable-analysis": "^2.11",
+        "phpcsstandards/phpcsextra": "^1.1.0"
     },
     "config": {
         "allow-plugins": true
@@ -36,6 +38,9 @@
             "composer install",
             "bin/install-wp-tests.sh activitypub-test root activitypub-test test-db latest true",
             "vendor/bin/phpunit"
+        ],
+        "lint": [
+            "vendor/bin/phpcs"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
             "vendor/bin/phpunit"
         ],
         "lint": [
-            "vendor/bin/phpcs"
+            "vendor/bin/phpcs -n -q"
         ]
     }
 }

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -151,6 +151,5 @@ class Mention {
 			}
 		}
 		return $mentions;
-
 	}
 }

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -70,7 +70,6 @@ class Shortcodes {
 		}
 
 		return \wp_strip_all_tags( \get_the_title( $item->ID ), true );
-
 	}
 
 	/**

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -237,7 +237,7 @@ class Inbox {
 			//'type' => 'enum',
 			//'enum' => array( 'Create' ),
 			//'sanitize_callback' => function( $param, $request, $key ) {
-			//	return \strtolower( $param );
+			//  return \strtolower( $param );
 			//},
 		);
 
@@ -282,7 +282,7 @@ class Inbox {
 			//'type' => 'enum',
 			//'enum' => array( 'Create' ),
 			//'sanitize_callback' => function( $param, $request, $key ) {
-			//	return \strtolower( $param );
+			//  return \strtolower( $param );
 			//},
 		);
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -187,7 +187,7 @@ class Post {
 		// list post thumbnail first if this post has one
 		if ( \function_exists( 'has_post_thumbnail' ) && \has_post_thumbnail( $id ) ) {
 			$image_ids[] = \get_post_thumbnail_id( $id );
-			$max_images--;
+			--$max_images;
 		}
 
 		if ( $max_images > 0 ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,4 +23,50 @@
 	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress.WP.I18n"/>
 	<config name="text_domain" value="activitypub,default"/>
+	<arg value="ps"/>
+	<arg name="parallel" value="20"/>
+	<rule ref="VariableAnalysis"/>
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
+		<type>error</type>
+	</rule>
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+		<properties>
+			<property name="allowUnusedCaughtExceptions" value="true"/>
+		</properties>
+	</rule>
+	<rule ref="WordPress"/>
+	<rule ref="WordPress.WP.I18n.NoHtmlWrappedStrings">
+		<type>error</type>
+	</rule>
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
+	  <severity>0</severity>
+	</rule>
+	<rule ref="Universal.Arrays.DisallowShortArraySyntax">
+	  <severity>0</severity>
+	</rule>
+	<rule ref="Squiz.Commenting">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Generic.Commenting">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.Files.FileName">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.DB.PreparedSQL.NotPrepared">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.WP.CapitalPDangit">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.PHP.YodaConditions.NotYoda">
+		<type>warning</type>
+	</rule>
+	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing">
+		<exclude-pattern>**/*.asset.php</exclude-pattern>
+	</rule>
 </ruleset>


### PR DESCRIPTION
Probably worth investigating how Jetpack runs their phpcs setup as they're merging frequently into dotcom but this works reliably up and until latest PHP versions

```
composer install
composer run lint
```
