### PR TITLE
Compat: avoid PHP notices when using PHP 8.2

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -29,13 +29,6 @@ class Post {
 	protected $wp_post;
 
 	/**
-	 * Attachment images, used in the content.
-	 *
-	 * @var array
-	 */
-	protected $attachments = array();
-
-	/**
 	 * The Allowed Tags, used in the content.
 	 *
 	 * @var array
@@ -252,8 +245,6 @@ class Post {
 				$images[] = $image;
 			}
 		}
-
-		$this->attachments = $images;
 
 		return $images;
 	}

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -29,6 +29,13 @@ class Post {
 	protected $wp_post;
 
 	/**
+	 * Attachment images, used in the content.
+	 *
+	 * @var array
+	 */
+	protected $attachments = array();
+
+	/**
 	 * The Allowed Tags, used in the content.
 	 *
 	 * @var array

--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 * Compatibility: add a new conditional, `\Activitypub\is_activitypub_request()`, to allow third-party plugins to detect ActivityPub requests.
 * Compatibility: add hooks to allow modifying images returned in ActivityPub requests.
 * Compatibility: indicate that the plugin is compatible and has been tested with the latest version of WordPress, 6.2.
+* Compatibility: avoid PHP notice on sites using PHP 8.2.
 
 = 0.17.0 =
 


### PR DESCRIPTION
## Proposed changes:

This PR should just avoid a PHP notice when using PHP 8.2:

```
PHP Deprecated:  Creation of dynamic property Activitypub\Transformer\Post::$attachments is deprecated in /var/www/html/wp-content/plugins/activitypub/includes/transformer/class-post.php on line 249
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

Not much to test here; if you have a local installation of WordPress using PHP 8.2, you should no longer see the deprecation notice when trying to access a post in an ActivityPub request.
