### PR TITLE
General: update tested WP version for upcoming WordPress 6.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ActivityPub #
-**Contributors:** [automattic](https://profiles.wordpress.org/automattic/), [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [mattwiebe](https://profiles.wordpress.org/mattwiebe/), [akirk](https://profiles.wordpress.org/akirk/), [jeherve](https://profiles.wordpress.org/jeherve/), [nuriapena](https://profiles.wordpress.org/nuriapena/)  
-**Tags:** OStatus, fediverse, activitypub, activitystream  
-**Requires at least:** 4.7  
-**Tested up to:** 6.2  
-**Stable tag:** 1.0.0  
-**Requires PHP:** 5.6  
-**License:** MIT  
-**License URI:** http://opensource.org/licenses/MIT  
+**Contributors:** [automattic](https://profiles.wordpress.org/automattic/), [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [mattwiebe](https://profiles.wordpress.org/mattwiebe/), [akirk](https://profiles.wordpress.org/akirk/), [jeherve](https://profiles.wordpress.org/jeherve/), [nuriapena](https://profiles.wordpress.org/nuriapena/)
+**Tags:** OStatus, fediverse, activitypub, activitystream
+**Requires at least:** 4.7
+**Tested up to:** 6.3
+**Stable tag:** 1.0.0
+**Requires PHP:** 5.6
+**License:** MIT
+**License URI:** http://opensource.org/licenses/MIT
 
 The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ActivityPub #
-**Contributors:** [automattic](https://profiles.wordpress.org/automattic/), [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [mattwiebe](https://profiles.wordpress.org/mattwiebe/), [akirk](https://profiles.wordpress.org/akirk/), [jeherve](https://profiles.wordpress.org/jeherve/), [nuriapena](https://profiles.wordpress.org/nuriapena/)
-**Tags:** OStatus, fediverse, activitypub, activitystream
-**Requires at least:** 4.7
-**Tested up to:** 6.3
-**Stable tag:** 1.0.0
-**Requires PHP:** 5.6
-**License:** MIT
-**License URI:** http://opensource.org/licenses/MIT
+**Contributors:** [automattic](https://profiles.wordpress.org/automattic/), [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [mattwiebe](https://profiles.wordpress.org/mattwiebe/), [akirk](https://profiles.wordpress.org/akirk/), [jeherve](https://profiles.wordpress.org/jeherve/), [nuriapena](https://profiles.wordpress.org/nuriapena/)  
+**Tags:** OStatus, fediverse, activitypub, activitystream  
+**Requires at least:** 4.7  
+**Tested up to:** 6.3  
+**Stable tag:** 1.0.0  
+**Requires PHP:** 5.6  
+**License:** MIT  
+**License URI:** http://opensource.org/licenses/MIT  
 
 The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
 
@@ -116,13 +116,15 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 
 ### 1.0.0 ###
 
-* Update: Improved linter (PHPCS)
-* Add: Simple caching
+* Add: blog-wide Account (catchall, like `mydomain.com@mydomain.com`)
 * Add: Signature Verification: https://docs.joinmastodon.org/spec/security/ .
-* Update: Complete rewrite of the Follower-System based on Taxonomies.
+* Update: Complete rewrite of the Follower-System based on Custom Post Types.
+* Add: Simple caching
+* Update: Improved linter (PHPCS)
 * Compatibility: add a new conditional, `\Activitypub\is_activitypub_request()`, to allow third-party plugins to detect ActivityPub requests.
 * Compatibility: add hooks to allow modifying images returned in ActivityPub requests.
-* Compatibility: indicate that the plugin is compatible and has been tested with the latest version of WordPress, 6.2.
+* Compatibility: indicate that the plugin is compatible and has been tested with the latest version of WordPress, 6.3.
+* Compatibility: avoid PHP notice on sites using PHP 8.2.
 
 ### 0.17.0 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, pfefferle, mediaformat, mattwiebe, akirk, jeherve, nuriapena
 Tags: OStatus, fediverse, activitypub, activitystream
 Requires at least: 4.7
-Tested up to: 6.2
+Tested up to: 6.3
 Stable tag: 1.0.0
 Requires PHP: 5.6
 License: MIT
@@ -123,7 +123,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 * Update: Improved linter (PHPCS)
 * Compatibility: add a new conditional, `\Activitypub\is_activitypub_request()`, to allow third-party plugins to detect ActivityPub requests.
 * Compatibility: add hooks to allow modifying images returned in ActivityPub requests.
-* Compatibility: indicate that the plugin is compatible and has been tested with the latest version of WordPress, 6.2.
+* Compatibility: indicate that the plugin is compatible and has been tested with the latest version of WordPress, 6.3.
 * Compatibility: avoid PHP notice on sites using PHP 8.2.
 
 = 0.17.0 =


### PR DESCRIPTION
## Proposed changes:

WordPress 6.3 will be released in the next few weeks. Let's indicate that the plugin is compatible with this new version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

Not much to test here. You can try running the plugin on a site running WordPress and [the WordPres Beta tester plugin](https://wordpress.org/plugins/wordpress-beta-tester/) set to Bleeding edge. Everything should still work.
