### PR TITLE
Autoloader: more precise matching

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -64,12 +64,10 @@ function init() {
 spl_autoload_register(
 	function ( $full_class ) {
 		$base_dir = __DIR__ . '/includes/';
-		$base     = 'activitypub';
+		$base     = 'Activitypub\\';
 
-		$class = strtolower( $full_class );
-
-		if ( strncmp( $class, $base, strlen( $base ) ) === 0 ) {
-			$class = str_replace( 'activitypub\\', '', $class );
+		if ( strncmp( $full_class, $base, strlen( $base ) ) === 0 ) {
+			$class = strtolower( str_replace( $base, '', $full_class ) );
 
 			if ( false !== strpos( $class, '\\' ) ) {
 				$parts    = explode( '\\', $class );


### PR DESCRIPTION
Our notifications code on dotcom effectively called `class_exists( 'activitypub_followed_note' )` and caused a fatal error because it was trying to load `includes/class-activitypub-followed-note.php`

This is because the pre-existing code converts the checked class to lowercase before checking, whereas it should first ensure 1) we're using the capitalized version, and 2) we have a backslash to indicate actual namespaced code.