### PR TITLE
fix domain change issue on .com

### DIFF
--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -87,11 +87,6 @@ class Migration {
 				}
 			}
 		}
-
-		// set the default username for the Blog User
-		if ( ! \get_option( 'activitypub_blog_user_identifier' ) ) {
-			\update_option( 'activitypub_blog_user_identifier', Blog_User::get_default_username() );
-		}
 	}
 
 	/**


### PR DESCRIPTION
This should fix the issue on .com that saves the subdomain.wordpress.com domain to the options table before custom domain is set.

/cc @mattwiebe 