### PR TITLE
Ensure everything is loaded properly after #376

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -67,7 +67,12 @@ spl_autoload_register(
 		$base     = 'Activitypub\\';
 
 		if ( strncmp( $full_class, $base, strlen( $base ) ) === 0 ) {
-			$class = strtolower( str_replace( $base, '', $full_class ) );
+			$maybe_uppercase = str_replace( $base, '', $full_class );
+			$class = strtolower( $maybe_uppercase );
+			// All classes should be capitalized. If this is instead looking for a lowercase method, we ignore that.
+			if ( $maybe_uppercase === $class ) {
+				return;
+			}
 
 			if ( false !== strpos( $class, '\\' ) ) {
 				$parts    = explode( '\\', $class );

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -28,7 +28,7 @@ class Activitypub {
 		\add_action( 'wp_trash_post', array( self::class, 'trash_post' ), 1 );
 		\add_action( 'untrash_post', array( self::class, 'untrash_post' ), 1 );
 
-		\add_action( 'init', array( self::class, 'add_rewrite_rules' ) );
+		\add_action( 'init', array( self::class, 'add_rewrite_rules' ), 11 );
 
 		\add_action( 'after_setup_theme', array( self::class, 'theme_compat' ), 99 );
 	}

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -5,7 +5,8 @@ use Activitypub\Collection\Followers;
 
 class Blocks {
 	public static function init() {
-		\add_action( 'init', array( self::class, 'register_blocks' ) );
+		// this is already being called on the init hook, so just add it.
+		self::register_blocks();
 		\add_action( 'wp_enqueue_scripts', array( self::class, 'add_data' ) );
 		\add_action( 'enqueue_block_editor_assets', array( self::class, 'add_data' ) );
 	}


### PR DESCRIPTION
Some things weren't firing because they were trying to add actions to init @ 10 priority while that priority was firing.

Also some more code on wpcom was trying to see if `method_exists( 'Activitypub', 'init' )` and that was causing a `wp_die`. This fixes that to only use the autoloader for capitalized class names.