### PR TITLE
Update comment type

### DIFF
--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -3,6 +3,7 @@ namespace Activitypub;
 
 use Activitypub\Signature;
 use Activitypub\Collection\Users;
+use function Activitypub\get_reply_comment_type;
 
 /**
  * ActivityPub Class
@@ -128,24 +129,11 @@ class Activitypub {
 	public static function pre_get_avatar_data( $args, $id_or_email ) {
 		if (
 			! $id_or_email instanceof \WP_Comment ||
-			! isset( $id_or_email->comment_type ) ||
+			empty( $id_or_email->comment_type ) ||
+			! get_reply_comment_type( $id_or_email->comment_type ) ||
 			$id_or_email->user_id
 		) {
 			return $args;
-		}
-
-		$allowed_comment_types = \apply_filters( 'get_avatar_comment_types', array( 'comment' ) );
-		if (
-			! empty( $id_or_email->comment_type ) &&
-			! \in_array(
-				$id_or_email->comment_type,
-				(array) $allowed_comment_types,
-				true
-			)
-		) {
-			$args['url'] = false;
-			/** This filter is documented in wp-includes/link-template.php */
-			return \apply_filters( 'get_avatar_data', $args, $id_or_email );
 		}
 
 		// Check if comment has an avatar.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -422,10 +422,10 @@ if ( ! function_exists( 'get_self_link' ) ) {
 
 /**
  * Returns the comment type for ActivityPub.
- * Filterable with `activitypub_comment_type`.
+ * Filterable with `activitypub_reply_comment_type`.
  *
- * @return string The comment type. Defaults to `activitypub_in_reply_to`.
+ * @return string The comment type. Defaults to `activitypub_reply`.
  */
-function get_comment_type() {
-	return apply_filters( 'activitypub_comment_type', 'activitypub_in_reply_to' );
+function get_reply_comment_type() {
+	return apply_filters( 'activitypub_reply_comment_type', 'activitypub_reply' );
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -419,3 +419,13 @@ if ( ! function_exists( 'get_self_link' ) ) {
 		return esc_url( apply_filters( 'self_link', set_url_scheme( 'http://' . $host['host'] . $path ) ) );
 	}
 }
+
+/**
+ * Returns the comment type for ActivityPub.
+ * Filterable with `activitypub_comment_type`.
+ *
+ * @return string The comment type. Defaults to `activitypub_in_reply_to`.
+ */
+function get_comment_type() {
+	return apply_filters( 'activitypub_comment_type', 'activitypub_in_reply_to' );
+}

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -11,7 +11,7 @@ use function Activitypub\get_context;
 use function Activitypub\url_to_authorid;
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_remote_metadata_by_actor;
-use function Activitypub\get_comment_type;
+use function Activitypub\get_reply_comment_type;
 
 /**
  * ActivityPub Inbox REST-Class
@@ -404,7 +404,7 @@ class Inbox {
 			'comment_author' => \esc_attr( $meta['name'] ),
 			'comment_author_url' => \esc_url_raw( $object['actor'] ),
 			'comment_content' => \wp_filter_kses( $object['object']['content'] ),
-			'comment_type' => get_comment_type(),
+			'comment_type' => get_reply_comment_type(),
 			'comment_author_email' => '',
 			'comment_parent' => 0,
 			'comment_meta' => array(

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -11,6 +11,7 @@ use function Activitypub\get_context;
 use function Activitypub\url_to_authorid;
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_remote_metadata_by_actor;
+use function Activitypub\get_comment_type;
 
 /**
  * ActivityPub Inbox REST-Class
@@ -403,7 +404,7 @@ class Inbox {
 			'comment_author' => \esc_attr( $meta['name'] ),
 			'comment_author_url' => \esc_url_raw( $object['actor'] ),
 			'comment_content' => \wp_filter_kses( $object['object']['content'] ),
-			'comment_type' => 'comment',
+			'comment_type' => get_comment_type(),
 			'comment_author_email' => '',
 			'comment_parent' => 0,
 			'comment_meta' => array(


### PR DESCRIPTION
It's useful to have more than just metadata to identify our comments, and a useful cue for spam systems to validate replies.

This introduces a new helper function, `get_reply_comment_type` that can also be filtered. A bonus was that it simplified our logic in the avatar filtering.

Will we need to introduce some form of upgrade functionality so that old comments get the new comment_type ?