### PR TITLE
Disable the akismet nonce when processing our comments

### DIFF
--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -362,6 +362,14 @@ class Inbox {
 		// do not require email for AP entries
 		\add_filter( 'pre_option_require_name_email', '__return_false' );
 
+		// No nonce possible for this submission route
+		\add_filter(
+			'akismet_comment_nonce',
+			function() {
+				return 'inactive';
+			}
+		);
+
 		$state = \wp_new_comment( $commentdata, true );
 
 		\remove_filter( 'pre_option_require_name_email', '__return_false' );
@@ -418,6 +426,14 @@ class Inbox {
 
 		// do not require email for AP entries
 		\add_filter( 'pre_option_require_name_email', '__return_false' );
+
+		// No nonce possible for this submission route
+		\add_filter(
+			'akismet_comment_nonce',
+			function() {
+				return 'inactive';
+			}
+		);
 
 		$state = \wp_new_comment( $commentdata, true );
 


### PR DESCRIPTION
Akismet tries to add a nonce to harden spam submissions. Since these comments aren't submitted through the comment box, we should disable that.

