### PR TITLE
remote-follow endpoint

### DIFF
--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -150,7 +150,7 @@ class Webfinger {
 	public static function get_data( $identifier, $host ) {
 		$webfinger_url = 'https://' . $host . '/.well-known/webfinger?resource=' . rawurlencode( $identifier );
 
-		$response = wp_remote_get(
+		$response = wp_safe_remote_get(
 			$webfinger_url,
 			array(
 				'headers' => array( 'Accept' => 'application/jrd+json' ),

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -62,7 +62,7 @@ class Webfinger {
 		$response = \wp_remote_get(
 			$url,
 			array(
-				'headers' => array( 'Accept' => 'application/activity+json' ),
+				'headers' => array( 'Accept' => 'application/jrd+json' ),
 				'redirection' => 0,
 				'timeout' => 2,
 			)
@@ -93,5 +93,111 @@ class Webfinger {
 		$link = new WP_Error( 'webfinger_url_no_activitypub', null, $body );
 		\set_transient( $transient_key, $link, HOUR_IN_SECONDS ); // Cache the error for a shorter period.
 		return $link;
+	}
+
+	/**
+	 * Convert a URI string to an identifier and its host.
+	 * Automatically adds acct: if it's missing.
+	 *
+	 * @param string $url The URI (acct:, mailto:, http:, https:)
+	 *
+	 * @return WP_Error|array Error reaction or array with
+	 *                        identifier and host as values
+	 */
+	public static function get_identifier_and_host( $url ) {
+		// remove leading @
+		$url = ltrim( $url, '@' );
+
+		if ( ! preg_match( '/^([a-zA-Z+]+):/', $url, $match ) ) {
+			$identifier = 'acct:' . $url;
+			$scheme = 'acct';
+		} else {
+			$identifier = $url;
+			$scheme = $match[1];
+		}
+
+		$host = null;
+
+		switch ( $scheme ) {
+			case 'acct':
+			case 'mailto':
+			case 'xmpp':
+				if ( strpos( $identifier, '@' ) !== false ) {
+					$host = substr( $identifier, strpos( $identifier, '@' ) + 1 );
+				}
+				break;
+			default:
+				$host = wp_parse_url( $identifier, PHP_URL_HOST );
+				break;
+		}
+
+		if ( empty( $host ) ) {
+			return new WP_Error( 'invalid_identifier', __( 'Invalid Identifier', 'activitypub' ) );
+		}
+
+		return array( $identifier, $host );
+	}
+
+	/**
+	 * Get the WebFinger data for a given URI
+	 *
+	 * @param string $identifier The Identifier: <identifier>@<host>
+	 * @param string $host       The Host: <identifier>@<host>
+	 *
+	 * @return WP_Error|array Error reaction or array with
+	 *                        identifier and host as values
+	 */
+	public static function get_data( $identifier, $host ) {
+		$webfinger_url = 'https://' . $host . '/.well-known/webfinger?resource=' . rawurlencode( $identifier );
+
+		$response = wp_remote_get(
+			$webfinger_url,
+			array(
+				'headers' => array( 'Accept' => 'application/jrd+json' ),
+				'redirection' => 0,
+				'timeout' => 2,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'webfinger_url_not_accessible', null, $webfinger_url );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+
+		return json_decode( $body, true );
+	}
+
+	/**
+	 * Undocumented function
+	 *
+	 * @return void
+	 */
+	public static function get_remote_follow_endpoint( $uri ) {
+		$identifier_and_host = self::get_identifier_and_host( $uri );
+
+		if ( is_wp_error( $identifier_and_host ) ) {
+			return $identifier_and_host;
+		}
+
+		list( $identifier, $host ) = $identifier_and_host;
+
+		$data = self::get_data( $identifier, $host );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		if ( empty( $data['links'] ) ) {
+			return new WP_Error( 'webfinger_url_invalid_response', null, $data );
+		}
+
+		foreach ( $data['links'] as $link ) {
+			if ( 'http://ostatus.org/schema/1.0/subscribe' === $link['rel'] ) {
+				return $link['template'];
+			}
+		}
+
+		return new WP_Error( 'webfinger_remote_follow_endpoint_invalid', null, $data );
 	}
 }

--- a/includes/rest/class-users.php
+++ b/includes/rest/class-users.php
@@ -112,6 +112,11 @@ class Users {
 	public static function remote_follow_get( WP_REST_Request $request ) {
 		$resource = $request->get_param( 'resource' );
 		$user_id  = $request->get_param( 'user_id' );
+		$user     = User_Collection::get_by_various( $user_id );
+
+		if ( is_wp_error( $user ) ) {
+			return $user;
+		}
 
 		$template = Webfinger::get_remote_follow_endpoint( $resource );
 
@@ -119,7 +124,7 @@ class Users {
 			return $template;
 		}
 
-		$resource = Webfinger::get_user_resource( $user_id );
+		$resource = $user->get_resource();
 		$url      = str_replace( '{uri}', $resource, $template );
 
 		return new WP_REST_Response(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added in favour of #356 

The API works like: `https://example.org/wp-json/activitypub/1.0/users/1/remote-follow?resource=pfefferle@mastodon.social` and returns `{"url":"https:\/\/mastodon.social\/authorize_interaction?uri=test@localhost"}`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added functions to get Remote-Follow endpoint from Remote-Server
* Added API endpoint to query that endpoint

