### PR TITLE
Words: copy and language consistency/improvements everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ The ActivityPub protocol is a decentralized social networking protocol based upo
 
 ## Description ##
 
-This is BETA software, see the FAQ to see the current feature set or rather what is still planned.
+Enter the fediverse with **ActivityPub**, broadcasting your blog to a wider audience! Attract followers, deliver updates, and receive comments from a diverse user base of **ActivityPub**\-compliant platforms.
 
-The plugin implements the ActivityPub protocol for your blog, which means that your readers will be able to follow your blog posts on Mastodon and other federated platforms that support ActivityPub. In addition, replies to your posts on Mastodon and related platforms will automatically become comments on your blog post.
+With the ActivityPub plugin installed, your WordPress blog itself function as a federated profile, along with profiles for each author. For instance, if your website is `example.com``, then the blog-wide profile can be found at `@example.com@example.com`, and authors like Jane and Bob would have their individual profiles at `@jane@example.com` and `@bobz@example.com`, respectively.
+
+An example: I give you my Mastodon profile name: `@pfefferle@mastodon.social`. You search, see my profile, and hit follow. Now, any post I make appears in your Home feed. Similarly, with the ActivityPub plugin, you can find and follow Jane's profile at `@jane@example.com`.
+
+Once you follow Jane's `@jane@example.com` profile, any blog post she crafts on `example.com` will land in your Home feed. Simultaneously, by following the blog-wide profile `@example.com@example.com`, you'll receive updates from all authors.
+
+**Note**: if no one follows your author or blog instance, your posts remain unseen. The simplest method to verify the plugin's operation is by following your profile. If you possess a Mastodon profile, initiate by following your new one.
 
 The plugin works with the following tested federated platforms, but there may be more that it works with as well:
 
@@ -27,24 +33,18 @@ The plugin works with the following tested federated platforms, but there may be
 * [Misskey](https://join.misskey.page/)
 * [Calckey](https://calckey.org/)
 
-Here’s what that means and what you can expect.
-
-Once the ActivityPub plugin is installed, each author’s page on your WordPress blog will become its own federated instance. In other words, if you have two authors, Jane and Bob, on your website, `example.com`, then your authors would have their own author pages at `example.com/author/jane` and `example.com/author/bob`. Each of those author pages would now be available to Mastodon users (and all other federated platform users) as a profile that can be followed. Let’s break that down further. Let’s say you have a friend on Mastodon who tells you to follow them and they give you their profile name `@janelivesheresomeofthetime@mastodon.social`. You search for her name, see her profile, and click the follow button, right? From then on, everything Jane posts on her profile shows up in your Home feed. Okay, similarly, now that Jane has installed the ActivityPub plugin on her `example.com` site, her friends can also follow her on Mastodon by searching for `@jane@example.com` and clicking the Follow button on that profile.
-
-From now on, every blog post Jane publishes on example.com will show up on your Home feed because you follow her `@jane@example.com` profile.
-Of course, if no one follows your author instance, then no one will ever see the posts - including you! So the easiest way to even know if the plugin is working is to follow your new profile yourself. If you already have a Mastodon profile, just follow your new one from there.
-
 Some things to note:
 
-1. Many single-author blogs have chosen to turn off or redirect their author profile pages, usually via an SEO plugin like Yoast or Rank Math. This is usually done to avoid duplicate content with your blog’s home page. If your author page has been deactivated in this way, then ActivityPub won’t work for you. Instead, you can turn your author profile page back on, and then use the option in your SEO plugin to noindex the author page. This will enable the page to be live and ActivityPub will now work, but the live page won’t cause any duplicate content issues with search engines.
-1. Once ActivityPub is installed, only new posts going forward will be available in the fediverse. Likewise, even if you’ve been using ActivityPub for a while, anyone who follows your site, will only see new posts you publish from that moment on. They will never see previously-published posts in their Home feed. This process is very similar to subscribing to a newsletter. If you subscribe to a newsletter, you will only receive future emails, but not the old archived ones. With ActivityPub, if someone follows your site, they will only receive new blog posts you publish from then on.
+1. The blog-wide profile is only compatible with sites with rewrite rules enabled. If your site does not have rewrite rules enabled, the author-specific profiles may still work.
+1. Many single-author blogs have chosen to turn off or redirect their author profile pages, usually via an SEO plugin like Yoast or Rank Math. This is usually done to avoid duplicate content with your blog’s home page. If your author page has been deactivated in this way, then ActivityPub author profiles won’t work for you. Instead, you can turn your author profile page back on, and then use the option in your SEO plugin to noindex the author page. This will duplicate content issues with search engines and will enable ActivityPub author profiles to work.
+1. Once ActivityPub is installed, *only new posts going forward* will be available in the fediverse. Likewise, even if you’ve been using ActivityPub for a while, anyone who follows your site, will only see new posts you publish from that moment on. They will never see previously-published posts in their Home feed. This process is very similar to subscribing to a newsletter. If you subscribe to a newsletter, you will only receive future emails, but not the old archived ones. With ActivityPub, if someone follows your site, they will only receive new blog posts you publish from then on.
 
 So what’s the process?
 
 1. Install the ActivityPub plugin.
 1. Go to the plugin’s settings page and adjust the settings to your liking. Click the Save button when ready.
-1. Make sure your blog’s author profile page is active.
-1. Go to Mastodon or any other federated platform, search for your author’s new federated profile, and follow it. Your new profile will be in the form of @yourauthorname@yourwebsite.com, so that is what you’ll search for.
+1. Make sure your blog’s author profile page is active if you are using author profiles.
+1. Go to Mastodon or any other federated platform, and search for your profile, and follow it. Your new profile will be in the form of either `@your_username@example.com` or `@example.com@example.com, so that is what you’ll search for.
 1. On your blog, publish a new post.
 1. From Mastodon, check to see if the new post appears in your Home feed.
 
@@ -54,22 +54,14 @@ Please note that it may take up to 15 minutes or so for the new post to show up 
 
 ### tl;dr ###
 
-This plugin connects your WordPress blog to popular social platforms like Mastodon, making your posts more accessible to a wider audience. Once installed, your blog's author pages can be followed by users on these platforms, allowing them to receive your new posts in their feeds.
-
-Here's how it works:
-
-1. Install the plugin and adjust settings as needed.
-1. Ensure your blog's author profile page is active.
-1. On Mastodon or other supported platforms, search for and follow your author's new profile (e.g., `@yourauthorname@yourwebsite.com`).
-1. Publish a new post on your blog and check if it appears in your Mastodon feed.
-
-Please note that it may take up to 15 minutes for a new post to appear in your feed, as messages are sent on a delay to avoid overwhelming your followers. Be patient and give it some time.
+This plugin connects your WordPress blog to popular social platforms like Mastodon, making your posts more accessible to a wider audience. Once installed, your blog can be followed by users on these platforms, allowing them to receive your new posts in their feeds.
 
 ### What is the status of this plugin? ###
 
 Implemented:
 
-* profile pages (JSON representation)
+* blog profile pages (JSON representation)
+* author profile pages (JSON representation)
 * custom links
 * functional inbox/outbox
 * follow (accept follows)
@@ -79,8 +71,8 @@ Implemented:
 
 To implement:
 
-* better configuration possibilities
 * threaded comments support
+* replace shortcodes with blocks for layout
 
 ### What is "ActivityPub for WordPress" ###
 
@@ -115,7 +107,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 
 ### 1.0.0 ###
 
-* Add: blog-wide Account (catchall, like `mydomain.com@mydomain.com`)
+* Add: blog-wide Account (catchall, like `example.com@example.com`)
 * Add: Signature Verification: https://docs.joinmastodon.org/spec/security/ .
 * Add: a Followers Block.
 * Add: Simple caching

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "dev": "wp-scripts start",
-    "build": "wp-scripts build"
+    "build": "wp-scripts build",
+    "readme": "grunt wp_readme_to_markdown"
   },
   "license": "MIT",
   "bugs": {

--- a/readme.txt
+++ b/readme.txt
@@ -12,9 +12,15 @@ The ActivityPub protocol is a decentralized social networking protocol based upo
 
 == Description ==
 
-This is BETA software, see the FAQ to see the current feature set or rather what is still planned.
+Enter the fediverse with **ActivityPub**, broadcasting your blog to a wider audience! Attract followers, deliver updates, and receive comments from a diverse user base of **ActivityPub**\-compliant platforms.
 
-The plugin implements the ActivityPub protocol for your blog, which means that your readers will be able to follow your blog posts on Mastodon and other federated platforms that support ActivityPub. In addition, replies to your posts on Mastodon and related platforms will automatically become comments on your blog post.
+With the ActivityPub plugin installed, your WordPress blog itself function as a federated profile, along with profiles for each author. For instance, if your website is `example.com``, then the blog-wide profile can be found at `@example.com@example.com`, and authors like Jane and Bob would have their individual profiles at `@jane@example.com` and `@bobz@example.com`, respectively.
+
+An example: I give you my Mastodon profile name: `@pfefferle@mastodon.social`. You search, see my profile, and hit follow. Now, any post I make appears in your Home feed. Similarly, with the ActivityPub plugin, you can find and follow Jane's profile at `@jane@example.com`.
+
+Once you follow Jane's `@jane@example.com` profile, any blog post she crafts on `example.com` will land in your Home feed. Simultaneously, by following the blog-wide profile `@example.com@example.com`, you'll receive updates from all authors.
+
+**Note**: if no one follows your author or blog instance, your posts remain unseen. The simplest method to verify the plugin's operation is by following your profile. If you possess a Mastodon profile, initiate by following your new one.
 
 The plugin works with the following tested federated platforms, but there may be more that it works with as well:
 
@@ -27,24 +33,18 @@ The plugin works with the following tested federated platforms, but there may be
 * [Misskey](https://join.misskey.page/)
 * [Calckey](https://calckey.org/)
 
-Here’s what that means and what you can expect.
-
-Once the ActivityPub plugin is installed, each author’s page on your WordPress blog will become its own federated instance. In other words, if you have two authors, Jane and Bob, on your website, `example.com`, then your authors would have their own author pages at `example.com/author/jane` and `example.com/author/bob`. Each of those author pages would now be available to Mastodon users (and all other federated platform users) as a profile that can be followed. Let’s break that down further. Let’s say you have a friend on Mastodon who tells you to follow them and they give you their profile name `@janelivesheresomeofthetime@mastodon.social`. You search for her name, see her profile, and click the follow button, right? From then on, everything Jane posts on her profile shows up in your Home feed. Okay, similarly, now that Jane has installed the ActivityPub plugin on her `example.com` site, her friends can also follow her on Mastodon by searching for `@jane@example.com` and clicking the Follow button on that profile.
-
-From now on, every blog post Jane publishes on example.com will show up on your Home feed because you follow her `@jane@example.com` profile.
-Of course, if no one follows your author instance, then no one will ever see the posts - including you! So the easiest way to even know if the plugin is working is to follow your new profile yourself. If you already have a Mastodon profile, just follow your new one from there.
-
 Some things to note:
 
-1. Many single-author blogs have chosen to turn off or redirect their author profile pages, usually via an SEO plugin like Yoast or Rank Math. This is usually done to avoid duplicate content with your blog’s home page. If your author page has been deactivated in this way, then ActivityPub won’t work for you. Instead, you can turn your author profile page back on, and then use the option in your SEO plugin to noindex the author page. This will enable the page to be live and ActivityPub will now work, but the live page won’t cause any duplicate content issues with search engines.
-1. Once ActivityPub is installed, only new posts going forward will be available in the fediverse. Likewise, even if you’ve been using ActivityPub for a while, anyone who follows your site, will only see new posts you publish from that moment on. They will never see previously-published posts in their Home feed. This process is very similar to subscribing to a newsletter. If you subscribe to a newsletter, you will only receive future emails, but not the old archived ones. With ActivityPub, if someone follows your site, they will only receive new blog posts you publish from then on.
+1. The blog-wide profile is only compatible with sites with rewrite rules enabled. If your site does not have rewrite rules enabled, the author-specific profiles may still work.
+1. Many single-author blogs have chosen to turn off or redirect their author profile pages, usually via an SEO plugin like Yoast or Rank Math. This is usually done to avoid duplicate content with your blog’s home page. If your author page has been deactivated in this way, then ActivityPub author profiles won’t work for you. Instead, you can turn your author profile page back on, and then use the option in your SEO plugin to noindex the author page. This will duplicate content issues with search engines and will enable ActivityPub author profiles to work.
+1. Once ActivityPub is installed, *only new posts going forward* will be available in the fediverse. Likewise, even if you’ve been using ActivityPub for a while, anyone who follows your site, will only see new posts you publish from that moment on. They will never see previously-published posts in their Home feed. This process is very similar to subscribing to a newsletter. If you subscribe to a newsletter, you will only receive future emails, but not the old archived ones. With ActivityPub, if someone follows your site, they will only receive new blog posts you publish from then on.
 
 So what’s the process?
 
 1. Install the ActivityPub plugin.
 1. Go to the plugin’s settings page and adjust the settings to your liking. Click the Save button when ready.
-1. Make sure your blog’s author profile page is active.
-1. Go to Mastodon or any other federated platform, search for your author’s new federated profile, and follow it. Your new profile will be in the form of @yourauthorname@yourwebsite.com, so that is what you’ll search for.
+1. Make sure your blog’s author profile page is active if you are using author profiles.
+1. Go to Mastodon or any other federated platform, and search for your profile, and follow it. Your new profile will be in the form of either `@your_username@example.com` or `@example.com@example.com, so that is what you’ll search for.
 1. On your blog, publish a new post.
 1. From Mastodon, check to see if the new post appears in your Home feed.
 
@@ -54,22 +54,14 @@ Please note that it may take up to 15 minutes or so for the new post to show up 
 
 = tl;dr =
 
-This plugin connects your WordPress blog to popular social platforms like Mastodon, making your posts more accessible to a wider audience. Once installed, your blog's author pages can be followed by users on these platforms, allowing them to receive your new posts in their feeds.
-
-Here's how it works:
-
-1. Install the plugin and adjust settings as needed.
-1. Ensure your blog's author profile page is active.
-1. On Mastodon or other supported platforms, search for and follow your author's new profile (e.g., `@yourauthorname@yourwebsite.com`).
-1. Publish a new post on your blog and check if it appears in your Mastodon feed.
-
-Please note that it may take up to 15 minutes for a new post to appear in your feed, as messages are sent on a delay to avoid overwhelming your followers. Be patient and give it some time.
+This plugin connects your WordPress blog to popular social platforms like Mastodon, making your posts more accessible to a wider audience. Once installed, your blog can be followed by users on these platforms, allowing them to receive your new posts in their feeds.
 
 = What is the status of this plugin? =
 
 Implemented:
 
-* profile pages (JSON representation)
+* blog profile pages (JSON representation)
+* author profile pages (JSON representation)
 * custom links
 * functional inbox/outbox
 * follow (accept follows)
@@ -79,8 +71,8 @@ Implemented:
 
 To implement:
 
-* better configuration possibilities
 * threaded comments support
+* replace shortcodes with blocks for layout
 
 = What is "ActivityPub for WordPress" =
 
@@ -115,7 +107,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 
 = 1.0.0 =
 
-* Add: blog-wide Account (catchall, like `mydomain.com@mydomain.com`)
+* Add: blog-wide Account (catchall, like `example.com@example.com`)
 * Add: Signature Verification: https://docs.joinmastodon.org/spec/security/ .
 * Add: a Followers Block.
 * Add: Simple caching

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -6,7 +6,7 @@
 		<h1><?php \esc_html_e( 'ActivityPub', 'activitypub' ); ?></h1>
 	</div>
 
-	<nav class="activitypub-settings-tabs-wrapper hide-if-no-js" aria-label="<?php \esc_attr_e( 'Secondary menu', 'activitypub' ); ?>">
+	<nav class="activitypub-settings-tabs-wrapper" aria-label="<?php \esc_attr_e( 'Secondary menu', 'activitypub' ); ?>">
 		<a href="<?php echo \esc_url_raw( admin_url( 'options-general.php?page=activitypub' ) ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args['welcome'] ); ?>">
 			<?php \esc_html_e( 'Welcome', 'activitypub' ); ?>
 		</a>

--- a/templates/blog-user-followers-list.php
+++ b/templates/blog-user-followers-list.php
@@ -8,15 +8,13 @@
 		'followers' => 'active',
 	)
 );
+$table = new \Activitypub\Table\Followers();
+$follower_count = $table->get_user_count();
+// translators: The follower count.
+$followers_template = _n( 'Your blog profile currently has %s follower.', 'Your blog profile currently has %s followers.', $follower_count, 'activitypub' );
 ?>
-
 <div class="wrap activitypub-followers-page">
-	<h1><?php \esc_html_e( 'Followers', 'activitypub' ); ?></h1>
-
-	<?php $table = new \Activitypub\Table\Followers(); ?>
-
-	<?php // translators: The follower count. ?>
-	<p><?php \printf( \esc_html__( 'You currently have %s followers.', 'activitypub' ), \esc_attr( $table->get_user_count() ) ); ?></p>
+	<p><?php \printf( \esc_html( $followers_template ), \esc_attr( $follower_count ) ); ?></p>
 
 	<form method="get">
 		<input type="hidden" name="page" value="activitypub" />

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -11,60 +11,41 @@
 ?>
 
 <div class="activitypub-settings activitypub-settings-page hide-if-no-js">
-	<div class="box">
-		<h3><?php \esc_html_e( 'Troubleshooting', 'activitypub' ); ?></h3>
-		<p>
-			<?php
-			echo \wp_kses(
-				\sprintf(
-					// translators:
-					\__( 'If you have problems using this plugin, please check the <a href="%s">Site Health</a> to ensure that your site is compatible and/or use the "Help" tab (in the top right of the settings pages).', 'activitypub' ),
-					\esc_url_raw( \admin_url( 'site-health.php' ) )
-				),
-				'default'
-			);
-			?>
-		</p>
-	</div>
-
 	<form method="post" action="options.php">
 		<?php \settings_fields( 'activitypub' ); ?>
 
 		<div class="box">
-			<h3><?php \esc_html_e( 'Users', 'activitypub' ); ?></h3>
-
-			<p><?php \esc_html_e( 'All user related settings.', 'activitypub' ); ?></p>
-
+			<h3><?php \esc_html_e( 'Profiles', 'activitypub' ); ?></h3>
 			<table class="form-table">
 				<tbody>
 					<tr>
 						<th scope="row">
-							<?php \esc_html_e( 'Enable/disable Users by Type', 'activitypub' ); ?>
+							<?php \esc_html_e( 'Enable profiles by type', 'activitypub' ); ?>
 						</th>
 						<td>
 							<p>
 								<label>
 									<input type="checkbox" name="activitypub_enable_users" id="activitypub_enable_users" value="1" <?php echo \checked( '1', \get_option( 'activitypub_enable_users', '1' ) ); ?> />
-									<?php \esc_html_e( 'Enable Authors', 'activitypub' ); ?>
+									<?php \esc_html_e( 'Enable authors', 'activitypub' ); ?>
 								</label>
 							</p>
 							<p class="description">
-								<?php echo \wp_kses( \__( 'Every Author on this Blog (with the <code>publish_posts</code> capability) gets his own ActivityPub enabled Profile.', 'activitypub' ), array( 'code' => array() ) ); ?>
+								<?php echo \wp_kses( \__( 'Every author on this blog (with the <code>publish_posts</code> capability) gets their own ActivityPub profile.', 'activitypub' ), array( 'code' => array() ) ); ?>
 							</p>
 							<p>
 								<label>
 									<input type="checkbox" name="activitypub_enable_blog_user" id="activitypub_enable_blog_user" value="1" <?php echo \checked( '1', \get_option( 'activitypub_enable_blog_user', '0' ) ); ?> />
-									<?php \esc_html_e( 'Enable Blog-User', 'activitypub' ); ?>
+									<?php \esc_html_e( 'Enable blog', 'activitypub' ); ?>
 								</label>
 							</p>
 							<p class="description">
-								<?php \esc_html_e( 'Your Blog becomes an ActivityPub compatible Profile.', 'activitypub' ); ?>
+								<?php \esc_html_e( 'Your blog becomes an ActivityPub profile.', 'activitypub' ); ?>
 							</p>
 						</td>
 					</tr>
 					<tr>
 						<th scope="row">
-							<?php \esc_html_e( 'Change Blog-User Identifier', 'activitypub' ); ?>
+							<?php \esc_html_e( 'Change blog profile ID', 'activitypub' ); ?>
 						</th>
 						<td>
 							<label for="activitypub_blog_user_identifier">
@@ -72,7 +53,7 @@
 								@<?php echo esc_html( \wp_parse_url( \home_url(), PHP_URL_HOST ) ); ?>
 							</label>
 							<p class="description">
-								<?php \esc_html_e( 'This Blog-User will federate all posts written on your Blog, regardless of the User who posted it.', 'activitypub' ); ?>
+								<?php \esc_html_e( 'This profile name will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
 							</p>
 						</td>
 					</tr>
@@ -84,14 +65,11 @@
 
 		<div class="box">
 			<h3><?php \esc_html_e( 'Activities', 'activitypub' ); ?></h3>
-
-			<p><?php \esc_html_e( 'All activity related settings.', 'activitypub' ); ?></p>
-
 			<table class="form-table">
 				<tbody>
 					<tr>
 						<th scope="row">
-							<?php \esc_html_e( 'Post-Content', 'activitypub' ); ?>
+							<?php \esc_html_e( 'Post content', 'activitypub' ); ?>
 						</th>
 						<td>
 							<p>
@@ -130,7 +108,7 @@
 									<?php \esc_html_e( 'Custom', 'activitypub' ); ?>
 									-
 									<span class="description">
-										<?php \esc_html_e( 'Use the text-area below, to customize your activities.', 'activitypub' ); ?>
+										<?php \esc_html_e( 'Use the text area below, to customize your activities.', 'activitypub' ); ?>
 									</span>
 								</label>
 							</p>
@@ -237,7 +215,7 @@
 						</th>
 						<td>
 							<p>
-								<label><input type="checkbox" name="activitypub_use_hashtags" id="activitypub_use_hashtags" value="1" <?php echo \checked( '1', \get_option( 'activitypub_use_hashtags', '1' ) ); ?> /> <?php echo wp_kses( \__( 'Add hashtags in the content as native tags and replace the <code>#tag</code> with the tag-link. <strong>This feature is experimental! Please disable it, if you find any HTML or CSS errors.</strong>', 'activitypub' ), 'default' ); ?></label>
+								<label><input type="checkbox" name="activitypub_use_hashtags" id="activitypub_use_hashtags" value="1" <?php echo \checked( '1', \get_option( 'activitypub_use_hashtags', '1' ) ); ?> /> <?php echo wp_kses( \__( 'Add hashtags in the content as native tags and replace the <code>#tag</code> with the tag link. <strong>This feature is experimental! Please disable it, if you find any HTML or CSS errors.</strong>', 'activitypub' ), 'default' ); ?></label>
 							</p>
 						</td>
 					</tr>
@@ -249,9 +227,6 @@
 
 		<div class="box">
 			<h3><?php \esc_html_e( 'Server', 'activitypub' ); ?></h3>
-
-			<p><?php \esc_html_e( 'Server related settings.', 'activitypub' ); ?></p>
-
 			<table class="form-table">
 				<tbody>
 					<tr>

--- a/templates/user-followers-list.php
+++ b/templates/user-followers-list.php
@@ -1,7 +1,12 @@
+<?php
+
+$follower_count = \Activitypub\Collection\Followers::count_followers( \get_current_user_id() );
+// translators: The follower count.
+$followers_template = _n( 'Your author profile currently has %s follower.', 'Your author profile currently has %s followers.', $follower_count, 'activitypub' );
+?>
 <div class="wrap">
-	<h1><?php \esc_html_e( 'Followers', 'activitypub' ); ?></h1>
-	<?php // translators: The follower count. ?>
-	<p><?php \printf( \esc_html__( 'You currently have %s followers.', 'activitypub' ), \esc_attr( \Activitypub\Collection\Followers::count_followers( \get_current_user_id() ) ) ); ?></p>
+	<h1><?php \esc_html_e( 'Author Followers', 'activitypub' ); ?></h1>
+	<p><?php \printf( \esc_html( $followers_template ), \esc_attr( $follower_count ) ); ?></p>
 
 	<?php $table = new \Activitypub\Table\Followers(); ?>
 

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -7,7 +7,7 @@ $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 	<tbody>
 		<tr>
 			<th scope="row">
-				<label><?php \esc_html_e( 'Profile identifier', 'activitypub' ); ?></label>
+				<label><?php \esc_html_e( 'Profile URL', 'activitypub' ); ?></label>
 			</th>
 			<td>
 				<p>
@@ -15,7 +15,7 @@ $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 					<code><?php echo \esc_url( $user->get_url() ); ?></code>
 				</p>
 				<?php // translators: the webfinger resource ?>
-				<p class="description"><?php \printf( \esc_html__( 'Try to follow "@%s" by searching for it on Mastodon,Friendica & Co.', 'activitypub' ), \esc_html( $user->get_resource() ) ); ?></p>
+				<p class="description"><?php \printf( \esc_html__( 'Try to follow "@%s" by searching for it on Mastodon, Friendica, etc.', 'activitypub' ), \esc_html( $user->get_resource() ) ); ?></p>
 			</td>
 		</tr>
 		<tr class="activitypub-user-description-wrap">

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -15,7 +15,7 @@ $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 					<code><?php echo \esc_url( $user->get_url() ); ?></code>
 				</p>
 				<?php // translators: the webfinger resource ?>
-				<p class="description"><?php \printf( \esc_html__( 'Try to follow "@%s" by searching for it on Mastodon, Friendica, etc.', 'activitypub' ), \esc_html( $user->get_resource() ) ); ?></p>
+				<p class="description"><?php \printf( \esc_html__( 'Follow "@%s" by searching for it on Mastodon, Friendica, etc.', 'activitypub' ), \esc_html( $user->get_resource() ) ); ?></p>
 			</td>
 		</tr>
 		<tr class="activitypub-user-description-wrap">

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -14,7 +14,7 @@
 	<div class="box">
 		<h2><?php \esc_html_e( 'Welcome', 'activitypub' ); ?></h2>
 
-		<p><?php echo wp_kses( \__( 'With ActivityPub your blog becomes part of a federated social network. This means you can share and talk to everyone using the <strong>ActivityPub</strong> protocol, including users of <strong>Friendica</strong>, <strong>Pleroma</strong>, <strong>Pixelfed</strong> and <strong>Mastodon</strong>.', 'activitypub' ), array( 'strong' => array() ) ); ?></p>
+		<p><?php echo wp_kses( \__( 'Enter the fediverse with <strong>ActivityPub</strong>, broadcasting your blog to a wider audience. Attract followers, deliver updates, and receive comments from a diverse user base on <strong>Mastodon</strong>, <strong>Friendica</strong>, <strong>Pleroma</strong>, <strong>Pixelfed</strong>, and all <strong>ActivityPub</strong>-compliant platforms.', 'activitypub' ), array( 'strong' => array() ) ); ?></p>
 	</div>
 
 	<?php
@@ -22,9 +22,9 @@
 		$blog_user = new \Activitypub\Model\Blog_User();
 		?>
 	<div class="box">
-		<h3><?php \esc_html_e( 'Blog Account', 'activitypub' ); ?></h3>
+		<h3><?php \esc_html_e( 'Blog profile', 'activitypub' ); ?></h3>
 		<p>
-			<?php \esc_html_e( 'People can follow your Blog by using:', 'activitypub' ); ?>
+			<?php \esc_html_e( 'People can follow your blog by using:', 'activitypub' ); ?>
 		</p>
 		<p>
 			<label for="activitypub-blog-identifier"><?php \esc_html_e( 'Username', 'activitypub' ); ?></label>
@@ -33,17 +33,17 @@
 			<input type="text" class="regular-text" id="activitypub-blog-identifier" value="<?php echo \esc_attr( $blog_user->get_resource() ); ?>" readonly />
 		</p>
 		<p>
-			<label for="activitypub-blog-url"><?php \esc_html_e( 'Profile-URL', 'activitypub' ); ?></label>
+			<label for="activitypub-blog-url"><?php \esc_html_e( 'Profile URL', 'activitypub' ); ?></label>
 		</p>
 		<p>
 			<input type="text" class="regular-text" id="activitypub-blog-url" value="<?php echo \esc_attr( $blog_user->get_url() ); ?>" readonly />
 		</p>
 		<p>
-			<?php \esc_html_e( 'This Blog-User will federate all posts written on your Blog, regardless of the User who posted it.', 'activitypub' ); ?>
+			<?php \esc_html_e( 'This blog profile will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
 		<p>
 		<p>
 			<a href="<?php echo \esc_url_raw( \admin_url( '/options-general.php?page=activitypub&tab=settings' ) ); ?>">
-				<?php \esc_html_e( 'Customize Blog-User on Settings page.', 'activitypub' ); ?>
+				<?php \esc_html_e( 'Customize the blog profile', 'activitypub' ); ?>
 			</a>
 		</p>
 	</div>
@@ -54,9 +54,9 @@
 		$user = \Activitypub\Collection\Users::get_by_id( wp_get_current_user()->ID );
 		?>
 	<div class="box">
-		<h3><?php \esc_html_e( 'Personal Account', 'activitypub' ); ?></h3>
+		<h3><?php \esc_html_e( 'Author profile', 'activitypub' ); ?></h3>
 		<p>
-			<?php \esc_html_e( 'People can follow you by using your Username:', 'activitypub' ); ?>
+			<?php \esc_html_e( 'People can follow you by using your author name:', 'activitypub' ); ?>
 		</p>
 		<p>
 			<label for="activitypub-user-identifier"><?php \esc_html_e( 'Username', 'activitypub' ); ?></label>
@@ -65,17 +65,17 @@
 			<input type="text" class="regular-text" id="activitypub-user-identifier" value="<?php echo \esc_attr( $user->get_resource() ); ?>" readonly />
 		</p>
 		<p>
-			<label for="activitypub-user-url"><?php \esc_html_e( 'Profile-URL', 'activitypub' ); ?></label>
+			<label for="activitypub-user-url"><?php \esc_html_e( 'Profile URL', 'activitypub' ); ?></label>
 		</p>
 		<p>
 			<input type="text" class="regular-text" id="activitypub-user-url" value="<?php echo \esc_attr( $user->get_url() ); ?>" readonly />
 		</p>
 		<p>
-			<?php \esc_html_e( 'Users who can not access this settings page will find their username on the "Edit Profile" page.', 'activitypub' ); ?>
+			<?php \esc_html_e( 'Authors who can not access this settings page will find their username on the "Edit Profile" page.', 'activitypub' ); ?>
 		<p>
 		<p>
 			<a href="<?php echo \esc_url_raw( \admin_url( '/profile.php#activitypub' ) ); ?>">
-			<?php \esc_html_e( 'Customize Username on "Edit Profile" page.', 'activitypub' ); ?>
+			<?php \esc_html_e( 'Customize username on "Edit Profile" page.', 'activitypub' ); ?>
 			</a>
 		</p>
 	</div>
@@ -87,9 +87,8 @@
 			<?php
 			echo wp_kses(
 				\sprintf(
-					// translators:
 					\__(
-						'If you have problems using this plugin, please check the <a href="%s">Site Health</a> to ensure that your site is compatible and/or use the "Help" tab (in the top right of the settings pages).',
+						'If you have problems using this plugin, please check the <a href="%s">Site Health</a> page to ensure that your site is compatible and/or use the "Help" tab (in the top right of the settings pages).',
 						'activitypub'
 					),
 					\esc_url_raw( admin_url( 'site-health.php' ) )


### PR DESCRIPTION
The readme needed a lot of attention since we now have a blog-wide user since #342!

Otherwise, I have consolidated naming things as **Blog profile** and **Author profile** for user-facing documentation. We call them `Blog_User` and `User` in code but this seems to be better user-facing language.

I've also made some edits to make things more idiosyncratically English, such as removing hyphens and capitalizations that are typical *auf Deutsch*.

<table width="100%">
<thead>
<th width="100px">Screen</th>
<th>After</th>
<th>Before</th>
</thead>
<tbody>
<tr>
<td>
Welcome 
</td>
<td>

![Screenshot 2023-08-25 at 13-16-38 Welcome ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/06ced491-1dc9-463c-a8e7-5bfdaeb96270)
</td>
<td>

![Screenshot 2023-08-25 at 13-25-03 Welcome ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/e8e5923c-3f56-46bf-8c08-5e28b4211397)

</td>
</tr>
<tr>
<td>
Settings 
</td>
<td>

![Screenshot 2023-08-25 at 13-17-15 Welcome ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/de70dab3-a9ee-431e-885d-6d2afeb92240)
</td>
<td>

![Screenshot 2023-08-25 at 13-25-15 Welcome ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/1955c81e-7916-408e-bc34-6f5b5a408180)

</td>
</tr>
<tr>
<td>
Blog Followers 
</td>
<td>

![Screenshot 2023-08-25 at 13-17-59 Welcome ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/c358546f-96cb-4dea-90ad-b01c875b963a)
</td>
<td>

![Screenshot 2023-08-25 at 13-25-23 Welcome ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/a195eff2-ee9d-4ebe-8bbf-8e3659e93ad1)

</td>
</tr>
<tr>
<td>
Author Followers 
</td>
<td>

![Screenshot 2023-08-25 at 13-18-15 Followers ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/1c1cf520-d153-46cf-a436-d2b9bd90dffb)
</td>
<td>

![Screenshot 2023-08-25 at 13-25-44 Followers ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/1e67094c-ad94-4aaa-902a-59a14b275a1b)

</td>
</tr>
<tr>
<td>
User section 
</td>
<td>

![Screenshot 2023-08-25 at 13-18-55 Profile ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/7ba05e95-33a4-4c89-a790-d430a6a68c9c)
</td>
<td>

![Screenshot 2023-08-25 at 13-26-04 Profile ‹ WP Local Testing — WordPress](https://github.com/Automattic/wordpress-activitypub/assets/195089/7e2cd58f-d997-4abc-842a-65bba0ea3e9c)

</td>
</tr>
</tbody>
</table>
