### PR TITLE
Store keypairs as options keyed to user IDs.

### DIFF
--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -4,7 +4,6 @@ namespace Activitypub;
 use WP_Error;
 use DateTime;
 use DateTimeZone;
-use Activitypub\Model\User;
 use Activitypub\Collection\Users;
 
 /**
@@ -23,22 +22,14 @@ class Signature {
 	 *
 	 * @return mixed The public key.
 	 */
-	public static function get_public_key( $user_id, $force = false ) {
+	public static function get_public_key_for( $user_id, $force = false ) {
 		if ( $force ) {
-			self::generate_key_pair( $user_id );
+			self::generate_key_pair_for( $user_id );
 		}
 
-		if ( User::APPLICATION_USER_ID === $user_id ) {
-			$key = \get_option( 'activitypub_magic_sig_public_key' );
-		} else {
-			$key = \get_user_meta( $user_id, 'magic_sig_public_key', true );
-		}
+		$key_pair = self::get_keypair_for( $user_id );
 
-		if ( ! $key ) {
-			return self::get_public_key( $user_id, true );
-		}
-
-		return $key;
+		return $key_pair['public_key'];
 	}
 
 	/**
@@ -49,22 +40,31 @@ class Signature {
 	 *
 	 * @return mixed The private key.
 	 */
-	public static function get_private_key( $user_id, $force = false ) {
+	public static function get_private_key_for( $user_id, $force = false ) {
 		if ( $force ) {
-			self::generate_key_pair( $user_id );
+			self::generate_key_pair_for( $user_id );
 		}
 
-		if ( User::APPLICATION_USER_ID === $user_id ) {
-			$key = \get_option( 'activitypub_magic_sig_private_key' );
-		} else {
-			$key = \get_user_meta( $user_id, 'magic_sig_private_key', true );
+		$key_pair = self::get_keypair_for( $user_id );
+
+		return $key_pair['private_key'];
+	}
+
+	/**
+	 * Return the key pair for a given user.
+	 *
+	 * @param int $user_id The WordPress User ID.
+	 *
+	 * @return array The key pair.
+	 */
+	private static function get_keypair_for( $user_id ) {
+		$key_pair = \get_option( 'activitypub_keypair_for_' . $user_id );
+
+		if ( ! $key_pair ) {
+			$key_pair = self::generate_key_pair_for( $user_id );
 		}
 
-		if ( ! $key ) {
-			return self::get_private_key( $user_id, true );
-		}
-
-		return $key;
+		return $key_pair;
 	}
 
 	/**
@@ -72,9 +72,17 @@ class Signature {
 	 *
 	 * @param int $user_id The WordPress User ID.
 	 *
-	 * @return void
+	 * @return array The key pair.
 	 */
-	public static function generate_key_pair() {
+	protected static function generate_key_pair_for( $user_id ) {
+		$key_pair = self::check_legacy_key_pair_for( $user_id );
+
+		if ( $key_pair ) {
+			\add_option( 'activitypub_keypair_for_' . $user_id, $key_pair );
+
+			return $key_pair;
+		}
+
 		$config = array(
 			'digest_alg' => 'sha512',
 			'private_key_bits' => 2048,
@@ -88,10 +96,58 @@ class Signature {
 
 		$detail = \openssl_pkey_get_details( $key );
 
-		return array(
+		// check if keys are valid
+		if (
+			empty( $priv_key ) || ! is_string( $priv_key ) ||
+			! isset( $detail['key'] ) || ! is_string( $detail['key'] )
+		) {
+			return array(
+				'private_key' => null,
+				'public_key'  => null,
+			);
+		}
+
+		$key_pair = array(
 			'private_key' => $priv_key,
 			'public_key'  => $detail['key'],
 		);
+
+		// persist keys
+		\add_option( 'activitypub_keypair_for_' . $user_id, $key_pair );
+
+		return $key_pair;
+	}
+
+	/**
+	 * Check if there is a legacy key pair
+	 *
+	 * @param int $user_id The WordPress User ID.
+	 *
+	 * @return array|bool The key pair or false.
+	 */
+	protected static function check_legacy_key_pair_for( $user_id ) {
+		if ( 0 === $user_id ) {
+			$public_key = \get_option( 'activitypub_blog_user_public_key' );
+			$private_key = \get_option( 'activitypub_blog_user_private_key' );
+		} elseif ( -1 === $user_id ) {
+			$public_key = \get_option( 'activitypub_application_user_public_key' );
+			$private_key = \get_option( 'activitypub_application_user_private_key' );
+		} elseif ( $user_id > 0 ) {
+			$public_key = \get_user_meta( $user_id, 'magic_sig_public_key', true );
+			$private_key = \get_user_meta( $user_id, 'magic_sig_private_key', true );
+		} else {
+			$public_key = null;
+			$private_key = null;
+		}
+
+		if ( ! empty( $public_key ) && is_string( $public_key ) && ! empty( $private_key ) && is_string( $private_key ) ) {
+			return array(
+				'private_key' => $private_key,
+				'public_key'  => $public_key,
+			);
+		}
+
+		return false;
 	}
 
 	/**
@@ -107,7 +163,7 @@ class Signature {
 	 */
 	public static function generate_signature( $user_id, $http_method, $url, $date, $digest = null ) {
 		$user = Users::get_by_id( $user_id );
-		$key  = $user->get__private_key();
+		$key  = self::get_private_key_for( $user->get__id() );
 
 		$url_parts = \wp_parse_url( $url );
 
@@ -136,7 +192,6 @@ class Signature {
 		\openssl_sign( $signed_string, $signature, $key, \OPENSSL_ALGO_SHA256 );
 		$signature = \base64_encode( $signature ); // phpcs:ignore
 
-		$user   = Users::get_by_id( $user_id );
 		$key_id = $user->get_url() . '#main-key';
 
 		if ( ! empty( $digest ) ) {

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -57,7 +57,7 @@ class Signature {
 	 *
 	 * @return array The key pair.
 	 */
-	private static function get_keypair_for( $user_id ) {
+	public static function get_keypair_for( $user_id ) {
 		$key_pair = \get_option( 'activitypub_keypair_for_' . $user_id );
 
 		if ( ! $key_pair ) {
@@ -126,18 +126,19 @@ class Signature {
 	 * @return array|bool The key pair or false.
 	 */
 	protected static function check_legacy_key_pair_for( $user_id ) {
-		if ( 0 === $user_id ) {
-			$public_key = \get_option( 'activitypub_blog_user_public_key' );
-			$private_key = \get_option( 'activitypub_blog_user_private_key' );
-		} elseif ( -1 === $user_id ) {
-			$public_key = \get_option( 'activitypub_application_user_public_key' );
-			$private_key = \get_option( 'activitypub_application_user_private_key' );
-		} elseif ( $user_id > 0 ) {
-			$public_key = \get_user_meta( $user_id, 'magic_sig_public_key', true );
-			$private_key = \get_user_meta( $user_id, 'magic_sig_private_key', true );
-		} else {
-			$public_key = null;
-			$private_key = null;
+		switch ( $user_id ) {
+			case 0:
+				$public_key = \get_option( 'activitypub_blog_user_public_key' );
+				$private_key = \get_option( 'activitypub_blog_user_private_key' );
+				break;
+			case -1:
+				$public_key = \get_option( 'activitypub_application_user_public_key' );
+				$private_key = \get_option( 'activitypub_application_user_private_key' );
+				break;
+			default:
+				$public_key = \get_user_meta( $user_id, 'magic_sig_public_key', true );
+				$private_key = \get_user_meta( $user_id, 'magic_sig_private_key', true );
+				break;
 		}
 
 		if ( ! empty( $public_key ) && is_string( $public_key ) && ! empty( $private_key ) && is_string( $private_key ) ) {

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -58,7 +58,8 @@ class Signature {
 	 * @return array The key pair.
 	 */
 	public static function get_keypair_for( $user_id ) {
-		$key_pair = \get_option( 'activitypub_keypair_for_' . $user_id );
+		$option_key = self::get_signature_options_key_for( $user_id );
+		$key_pair = \get_option( $option_key );
 
 		if ( ! $key_pair ) {
 			$key_pair = self::generate_key_pair_for( $user_id );
@@ -75,10 +76,11 @@ class Signature {
 	 * @return array The key pair.
 	 */
 	protected static function generate_key_pair_for( $user_id ) {
+		$option_key = self::get_signature_options_key_for( $user_id );
 		$key_pair = self::check_legacy_key_pair_for( $user_id );
 
 		if ( $key_pair ) {
-			\add_option( 'activitypub_keypair_for_' . $user_id, $key_pair );
+			\add_option( $option_key, $key_pair );
 
 			return $key_pair;
 		}
@@ -113,9 +115,26 @@ class Signature {
 		);
 
 		// persist keys
-		\add_option( 'activitypub_keypair_for_' . $user_id, $key_pair );
+		\add_option( $option_key, $key_pair );
 
 		return $key_pair;
+	}
+
+	/**
+	 * Undocumented function
+	 *
+	 * @param [type] $user_id
+	 * @return void
+	 */
+	protected static function get_signature_options_key_for( $user_id ) {
+		$id = $user_id;
+
+		if ( $user_id > 0 ) {
+			$user = \get_userdata( $user_id );
+			$id = $user->user_login;
+		}
+
+		return 'activitypub_keypair_for_' . $id;
 	}
 
 	/**

--- a/includes/model/class-application-user.php
+++ b/includes/model/class-application-user.php
@@ -46,46 +46,6 @@ class Application_User extends Blog_User {
 		return $this::get_name();
 	}
 
-	public function get__public_key() {
-		$key = \get_option( 'activitypub_application_user_public_key' );
-
-		if ( $key ) {
-			return $key;
-		}
-
-		$this->generate_key_pair();
-
-		$key = \get_option( 'activitypub_application_user_public_key' );
-
-		return $key;
-	}
-
-	/**
-	 * @param int $user_id
-	 *
-	 * @return mixed
-	 */
-	public function get__private_key() {
-		$key = \get_option( 'activitypub_application_user_private_key' );
-
-		if ( $key ) {
-			return $key;
-		}
-
-		$this->generate_key_pair();
-
-		return \get_option( 'activitypub_application_user_private_key' );
-	}
-
-	private function generate_key_pair() {
-		$key_pair = Signature::generate_key_pair();
-
-		if ( ! is_wp_error( $key_pair ) ) {
-			\update_option( 'activitypub_application_user_public_key', $key_pair['public_key'] );
-			\update_option( 'activitypub_application_user_private_key', $key_pair['private_key'] );
-		}
-	}
-
 	public function get_followers() {
 		return null;
 	}

--- a/includes/model/class-blog-user.php
+++ b/includes/model/class-blog-user.php
@@ -189,7 +189,7 @@ class Blog_User extends User {
 
 	public function get__public_key() {
 		// back compat
-		if ( $this->get_id() === 0 ) {
+		if ( $this->get__id() === 0 ) {
 			$old_key = \get_option( 'activitypub_blog_user_public_key' );
 			if ( $old_key ) {
 				return $old_key;
@@ -209,7 +209,7 @@ class Blog_User extends User {
 	 */
 	public function get__private_key() {
 		// back compat
-		if ( $this->get_id() === 0 ) {
+		if ( $this->get__id() === 0 ) {
 			$old_key = \get_option( 'activitypub_blog_user_private_key' );
 			if ( $old_key ) {
 				return $old_key;

--- a/includes/model/class-blog-user.php
+++ b/includes/model/class-blog-user.php
@@ -188,17 +188,16 @@ class Blog_User extends User {
 	}
 
 	public function get__public_key() {
-		$key = \get_option( 'activitypub_blog_user_public_key' );
-
-		if ( $key ) {
-			return $key;
+		// back compat
+		if ( $this->get_id() === 0 ) {
+			$old_key = \get_option( 'activitypub_blog_user_public_key' );
+			if ( $old_key ) {
+				return $old_key;
+			}
 		}
 
-		$this->generate_key_pair();
-
-		$key = \get_option( 'activitypub_blog_user_public_key' );
-
-		return $key;
+		// new style
+		return parent::get__public_key();
 	}
 
 	/**
@@ -209,24 +208,16 @@ class Blog_User extends User {
 	 * @return mixed
 	 */
 	public function get__private_key() {
-		$key = \get_option( 'activitypub_blog_user_private_key' );
-
-		if ( $key ) {
-			return $key;
+		// back compat
+		if ( $this->get_id() === 0 ) {
+			$old_key = \get_option( 'activitypub_blog_user_private_key' );
+			if ( $old_key ) {
+				return $old_key;
+			}
 		}
 
-		$this->generate_key_pair();
-
-		return \get_option( 'activitypub_blog_user_private_key' );
-	}
-
-	private function generate_key_pair() {
-		$key_pair = Signature::generate_key_pair();
-
-		if ( ! is_wp_error( $key_pair ) ) {
-			\update_option( 'activitypub_blog_user_public_key', $key_pair['public_key'] );
-			\update_option( 'activitypub_blog_user_private_key', $key_pair['private_key'] );
-		}
+		// new style
+		return parent::get__private_key();
 	}
 
 	public function get_attachment() {

--- a/includes/model/class-blog-user.php
+++ b/includes/model/class-blog-user.php
@@ -187,39 +187,6 @@ class Blog_User extends User {
 		return \gmdate( 'Y-m-d\TH:i:s\Z', $time );
 	}
 
-	public function get__public_key() {
-		// back compat
-		if ( $this->get__id() === 0 ) {
-			$old_key = \get_option( 'activitypub_blog_user_public_key' );
-			if ( $old_key ) {
-				return $old_key;
-			}
-		}
-
-		// new style
-		return parent::get__public_key();
-	}
-
-	/**
-	 * Get the User-Private-Key.
-	 *
-	 * @param int $user_id
-	 *
-	 * @return mixed
-	 */
-	public function get__private_key() {
-		// back compat
-		if ( $this->get__id() === 0 ) {
-			$old_key = \get_option( 'activitypub_blog_user_private_key' );
-			if ( $old_key ) {
-				return $old_key;
-			}
-		}
-
-		// new style
-		return parent::get__private_key();
-	}
-
 	public function get_attachment() {
 		return array();
 	}

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -170,7 +170,7 @@ class User extends Actor {
 	 */
 	public function get__public_key() {
 		// back compat: if usermeta was already set, for a "real" user, use it
-		if ( $this->get_id() >= 1 ) {
+		if ( $this->get__id() >= 1 ) {
 			l( 'trying' );
 			$old_key = \get_user_meta( $this->get__id(), 'magic_sig_public_key', true );
 			if ( ! empty( $old_key ) && is_string( $old_key ) ) {
@@ -190,7 +190,7 @@ class User extends Actor {
 	 */
 	public function get__private_key() {
 		// back compat: if usermeta was already set, for a "real" user, use it
-		if ( $this->get_id() >= 1 ) {
+		if ( $this->get__id() >= 1 ) {
 			$old_key = \get_user_meta( $this->get__id(), 'magic_sig_private_key', true );
 			if ( ! empty( $old_key ) && is_string( $old_key ) ) {
 				return $old_key;

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -171,12 +171,13 @@ class User extends Actor {
 	public function get__public_key() {
 		// back compat: if usermeta was already set, for a "real" user, use it
 		if ( $this->get_id() >= 1 ) {
+			l( 'trying' );
 			$old_key = \get_user_meta( $this->get__id(), 'magic_sig_public_key', true );
-			if ( is_string( $old_key ) ) {
+			if ( ! empty( $old_key ) && is_string( $old_key ) ) {
 				return $old_key;
 			}
 		}
-
+		l( 'new style' );
 		// new style keypair
 		$keypair = $this->get_keypair();
 		return $keypair['public_key'];
@@ -191,7 +192,7 @@ class User extends Actor {
 		// back compat: if usermeta was already set, for a "real" user, use it
 		if ( $this->get_id() >= 1 ) {
 			$old_key = \get_user_meta( $this->get__id(), 'magic_sig_private_key', true );
-			if ( is_string( $old_key ) ) {
+			if ( ! empty( $old_key ) && is_string( $old_key ) ) {
 				return $old_key;
 			}
 		}

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -159,67 +159,8 @@ class User extends Actor {
 		return array(
 			'id'       => $this->get_id() . '#main-key',
 			'owner'    => $this->get_id(),
-			'publicKeyPem' => $this->get__public_key(),
+			'publicKeyPem' => Signature::get_public_key_for( $this->get__id() ),
 		);
-	}
-
-	/**
-	 * @param int $this->get__id()
-	 *
-	 * @return mixed
-	 */
-	public function get__public_key() {
-		// back compat: if usermeta was already set, for a "real" user, use it
-		if ( $this->get__id() >= 1 ) {
-			l( 'trying' );
-			$old_key = \get_user_meta( $this->get__id(), 'magic_sig_public_key', true );
-			if ( ! empty( $old_key ) && is_string( $old_key ) ) {
-				return $old_key;
-			}
-		}
-		l( 'new style' );
-		// new style keypair
-		$keypair = $this->get_keypair();
-		return $keypair['public_key'];
-	}
-
-	/**
-	 * @param int $this->get__id()
-	 *
-	 * @return mixed
-	 */
-	public function get__private_key() {
-		// back compat: if usermeta was already set, for a "real" user, use it
-		if ( $this->get__id() >= 1 ) {
-			$old_key = \get_user_meta( $this->get__id(), 'magic_sig_private_key', true );
-			if ( ! empty( $old_key ) && is_string( $old_key ) ) {
-				return $old_key;
-			}
-		}
-
-		// new style keypair
-		$keypair = $this->get_keypair();
-		return $keypair['private_key'];
-	}
-
-	private function get_keypair() {
-		$key_pair = \get_option( 'activitypub_keypair_for_' . $this->get__id() );
-
-		if ( ! $key_pair ) {
-			$key_pair = $this->generate_key_pair();
-		}
-
-		return $key_pair;
-	}
-
-	private function generate_key_pair() {
-		$key_pair = Signature::generate_key_pair();
-
-		if ( ! is_wp_error( $key_pair ) ) {
-			\update_option( 'activitypub_keypair_for_' . $this->get__id(), $key_pair );
-		}
-
-		return $key_pair;
 	}
 
 	/**

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -172,7 +172,7 @@ class User extends Actor {
 		// back compat: if usermeta was already set, for a "real" user, use it
 		if ( $this->get_id() >= 1 ) {
 			$old_key = \get_user_meta( $this->get__id(), 'magic_sig_public_key', true );
-			if ( typeof( $old_key ) === 'string' ) {
+			if ( is_string( $old_key ) ) {
 				return $old_key;
 			}
 		}
@@ -191,7 +191,7 @@ class User extends Actor {
 		// back compat: if usermeta was already set, for a "real" user, use it
 		if ( $this->get_id() >= 1 ) {
 			$old_key = \get_user_meta( $this->get__id(), 'magic_sig_private_key', true );
-			if ( typeof( $old_key ) === 'string' ) {
+			if ( is_string( $old_key ) ) {
 				return $old_key;
 			}
 		}

--- a/tests/test-class-activitypub-rest-post-signature-verification.php
+++ b/tests/test-class-activitypub-rest-post-signature-verification.php
@@ -45,7 +45,7 @@ class Test_Activitypub_Signature_Verification extends WP_UnitTestCase {
 
 		$user = Activitypub\Collection\Users::get_by_id( 1 );
 
-		$public_key = $user->get__public_key();
+		$public_key = Activitypub\Signature::get_public_key_for( $user->get__id() );
 
 		// signature_verification
 		$verified = \openssl_verify( $signed_data, $signature_block['signature'], $public_key, 'rsa-sha256' ) > 0;
@@ -57,7 +57,7 @@ class Test_Activitypub_Signature_Verification extends WP_UnitTestCase {
 			'pre_get_remote_metadata_by_actor',
 			function( $json, $actor ) {
 				$user = Activitypub\Collection\Users::get_by_id( 1 );
-				$public_key = $user->get__public_key();
+				$public_key = Activitypub\Signature::get_public_key_for( $user->get__id() );
 				// return ActivityPub Profile with signature
 				return array(
 					'id' => $actor,

--- a/tests/test-class-activitypub-signature.php
+++ b/tests/test-class-activitypub-signature.php
@@ -1,0 +1,110 @@
+<?php
+
+class Test_Activitypub_Signature extends WP_UnitTestCase {
+	public function test_signature_creation() {
+		$user = Activitypub\Collection\Users::get_by_id( 1 );
+
+		$key_pair = Activitypub\Signature::get_keypair_for( $user->get__id() );
+		$public_key = Activitypub\Signature::get_public_key_for( $user->get__id() );
+		$private_key = Activitypub\Signature::get_private_key_for( $user->get__id() );
+
+		$this->assertNotEmpty( $key_pair );
+		$this->assertEquals( $key_pair['public_key'], $public_key );
+		$this->assertEquals( $key_pair['private_key'], $private_key );
+	}
+
+	public function test_signature_legacy() {
+		// check user
+		$user = Activitypub\Collection\Users::get_by_id( 1 );
+
+		$public_key = 'public key ' . $user->get__id();
+		$private_key = 'private key ' . $user->get__id();
+
+		update_user_meta( $user->get__id(), 'magic_sig_public_key', $public_key );
+		update_user_meta( $user->get__id(), 'magic_sig_private_key', $private_key );
+
+		$key_pair = Activitypub\Signature::get_keypair_for( $user->get__id() );
+
+		$this->assertNotEmpty( $key_pair );
+		$this->assertEquals( $key_pair['public_key'], $public_key );
+		$this->assertEquals( $key_pair['private_key'], $private_key );
+
+		// check application user
+		$user = Activitypub\Collection\Users::get_by_id( -1 );
+
+		$public_key = 'public key ' . $user->get__id();
+		$private_key = 'private key ' . $user->get__id();
+
+		add_option( 'activitypub_application_user_public_key', $public_key );
+		add_option( 'activitypub_application_user_private_key', $private_key );
+
+		$key_pair = Activitypub\Signature::get_keypair_for( $user->get__id() );
+
+		$this->assertNotEmpty( $key_pair );
+		$this->assertEquals( $key_pair['public_key'], $public_key );
+		$this->assertEquals( $key_pair['private_key'], $private_key );
+
+		// check blog user
+		\define( 'ACTIVITYPUB_DISABLE_BLOG_USER', false );
+		$user = Activitypub\Collection\Users::get_by_id( 0 );
+
+		$public_key = 'public key ' . $user->get__id();
+		$private_key = 'private key ' . $user->get__id();
+
+		add_option( 'activitypub_blog_user_public_key', $public_key );
+		add_option( 'activitypub_blog_user_private_key', $private_key );
+
+		$key_pair = Activitypub\Signature::get_keypair_for( $user->get__id() );
+
+		$this->assertNotEmpty( $key_pair );
+		$this->assertEquals( $key_pair['public_key'], $public_key );
+		$this->assertEquals( $key_pair['private_key'], $private_key );
+	}
+
+	public function test_signature_consistancy() {
+		// check user
+		$user = Activitypub\Collection\Users::get_by_id( 1 );
+
+		$public_key = 'public key ' . $user->get__id();
+		$private_key = 'private key ' . $user->get__id();
+
+		update_user_meta( $user->get__id(), 'magic_sig_public_key', $public_key );
+		update_user_meta( $user->get__id(), 'magic_sig_private_key', $private_key );
+
+		$key_pair = Activitypub\Signature::get_keypair_for( $user->get__id() );
+
+		$this->assertNotEmpty( $key_pair );
+		$this->assertEquals( $key_pair['public_key'], $public_key );
+		$this->assertEquals( $key_pair['private_key'], $private_key );
+
+		update_user_meta( $user->get__id(), 'magic_sig_public_key', $public_key . '-update' );
+		update_user_meta( $user->get__id(), 'magic_sig_private_key', $private_key . '-update' );
+
+		$key_pair = Activitypub\Signature::get_keypair_for( $user->get__id() );
+
+		$this->assertNotEmpty( $key_pair );
+		$this->assertEquals( $key_pair['public_key'], $public_key );
+		$this->assertEquals( $key_pair['private_key'], $private_key );
+	}
+
+	public function test_signature_consistancy2() {
+		$user = Activitypub\Collection\Users::get_by_id( 1 );
+
+		$key_pair = Activitypub\Signature::get_keypair_for( $user->get__id() );
+		$public_key = Activitypub\Signature::get_public_key_for( $user->get__id() );
+		$private_key = Activitypub\Signature::get_private_key_for( $user->get__id() );
+
+		$this->assertNotEmpty( $key_pair );
+		$this->assertEquals( $key_pair['public_key'], $public_key );
+		$this->assertEquals( $key_pair['private_key'], $private_key );
+
+		update_user_meta( $user->get__id(), 'magic_sig_public_key', 'test' );
+		update_user_meta( $user->get__id(), 'magic_sig_private_key', 'test' );
+
+		$key_pair = Activitypub\Signature::get_keypair_for( $user->get__id() );
+
+		$this->assertNotEmpty( $key_pair );
+		$this->assertEquals( $key_pair['public_key'], $public_key );
+		$this->assertEquals( $key_pair['private_key'], $private_key );
+	}
+}


### PR DESCRIPTION
A problem we've run into for WP Multisite is that there is theoretical key leakage for a given user who is a member of more than one network blog.

Imagine `example.com` as a WP Multisite install. Two users, `foo` (ID 1) and `bar` (ID 2), have a shared site called `foobar.example.com`, while `foo` has a solo site, `foo.example.com`. Since usermeta is shared across the whole network, `bar` could be sneaky and retrieve `foo`'s private key from their shared site. `bar` could then use that private key to sign private messages on the fediverse _as though it was coming from `@foo@foo.example.com`_ rather than `foo@foobar.example.com`, or any other site on that network on which `foo` is a member.

What this patch does is to migrate keypair storage to be based on blog options instead, which will keep each keypair functioning only within a single blog context per user in the network. `foo` will have blog options of `activitypub_keypair_for_1` on both sites but it will be unique to each site.

There was no reason to not just standardize on this so I've made the Blog and Application Users use this style as well for consistency. They will receive `activitypub_keypair_for_0` and `activitypub_keypair_for_-1`, respectively.

This is a speculative PR, put up before I went to bed while the idea was still in my head. I have not tested it other than in my head, and that it doesn't throw fatals. I'm sure it needs unit tests.