### PR TITLE
Follow redirects in class-webfinger.php

### DIFF
--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -63,7 +63,7 @@ class Webfinger {
 			$url,
 			array(
 				'headers' => array( 'Accept' => 'application/jrd+json' ),
-				'redirection' => 0,
+				'redirection' => 2,
 				'timeout' => 2,
 			)
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #422

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Authors who use a subdirectory have to redirect `/.well-known` - this allows the health check to pass.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a blog at example.com/blog/
* Install the plugin
* Configure .htaccess as described to redirect `/.well-known/` to `/blog/.well-known/`
* Run the WordPress health check
* Note that it fails.
* Apply this patch.
* Success!

