### PR TITLE
Repository maintenance: add GitHub Repo Gardening action and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Helps us improve our product!
+labels: "Needs triage, [Type] Bug"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for contributing!
+
+        Please write a clear title, then fill in the fields below and submit.
+
+        Please **do not** link to image hosting services such as Cloudup, Droplr, Imgur, etc…
+        Instead, directly embed screenshot(s) or recording(s) in any of the text areas below: click, then drag and drop.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Core Information
+  - type: textarea
+    id: summary
+    attributes:
+        label: Quick summary
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start at `site-domain.com/blog`.
+        2. Click on any blog post.
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+      placeholder: |
+        e.g. The post should appear.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      placeholder: |
+        e.g. The post did not appear.
+    validations:
+      required: true
+  - type: dropdown
+    id: users-affected
+    attributes:
+      label: Impact
+      description: Approximately how many users are impacted?
+      options:
+        - One
+        - Some (< 50%)
+        - Most (> 50%)
+        - All
+    validations:
+      required: true
+  - type: dropdown
+    id: workarounds
+    attributes:
+      label: Available workarounds?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable
+        - Yes, difficult to implement
+        - Yes, easy to implement
+        - There is no user impact
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+
+        ## Optional Information
+
+        The following section is optional.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or notes
+      placeholder: |
+        Add any information that may be relevant, such as:
+          - Browser/Platform
+          - Theme
+          - Logs/Errors

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Suggest an idea for the ActivityPub plugin!
+title: "Feature Request:"
+labels: ["[Type] Feature Request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please, be as descriptive as possible. Issues lacking detail, or for any other reason than to request a feature, may be closed without action.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: Add a concise description of the feature being requested.
+      placeholder: eg. I would like a new dropdown at <xyz>...
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Add a description of the problem this feature solves.
+      placeholder: |
+        eg. This will solve my accessibility needs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: How
+      description: If applicable, add screenshots, mockup, animations and/or videos to help illustrate how the feature could be done.

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,0 +1,50 @@
+# Repo gardening. Automate some of the triage tasks in the repo.
+name: Repo Gardening
+
+on:
+  pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
+    types: [opened, reopened, synchronize, edited, labeled, closed]
+  issues: # For auto-triage of issues.
+    types: [opened, labeled, reopened, edited, closed]
+  issue_comment: # To gather support references in issue comments.
+    types: [created]
+concurrency:
+  # For pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
+  # Don't cancel any for other events, accomplished by grouping on the unique run_id.
+  group: gardening-${{ github.event_name }}-${{ github.event.action }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  repo-gardening:
+    name: 'Automated repo gardening.'
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 10
+
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v3
+
+     - name: Setup Node
+       uses: actions/setup-node@v3
+       with:
+          node-version: lts/*
+
+     - name: Wait for prior instances of the workflow to finish
+       uses: softprops/turnstyle@v1
+       env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: 'Automate triage (add labels, clean labels, ...).'
+       uses: automattic/action-repo-gardening@trunk
+       with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
+          slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
+          slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
+          tasks: 'addLabels,cleanLabels,assignIssues,flagOss,gatherSupportReferences,replyToCustomersReminder'
+          add_labels: '[
+              {"path": "src/followers", "label": "[Block] Followers"},
+              {"path": "src/follow-me", "label": "[Block] Follow Me"},
+            ]'


### PR DESCRIPTION
## Proposed changes:

The Repo Gardening action is a tool that one can use to automate some of the tasks that you can perform to monitor activity in your repository.
https://github.com/marketplace/actions/repository-gardening

It includes different tasks, that can be enabled based on your needs.

This PR gets us started with the action by enabling a few tasks.

- This action relies on a few secrets that have already been added to this repo.
- Of note, `gatherSupportReferences` and `replyToCustomersReminder` aren't too useful right now, but will become useful once the plugin is released on WordPress.com and once we start receiving feedback from WordPress.com site owners.
- The `flagOss` task will point to #fediverse for now. This can be updated later on.
- I've added mapping for our 2 block directories, but that mapping can be extended for more automatic labeling later on.

This PR also brings in issue templates that are commonly used across Automattic repos.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This cannot really be tested befre the PR is merged, since it is only triggered on issues and PR events that happen once it has been merged.
