### PR TITLE
Post images: fix a typo in the hook name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ActivityPub #
-**Contributors:** [automattic](https://profiles.wordpress.org/automattic/), [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [mattwiebe](https://profiles.wordpress.org/mattwiebe/), [akirk](https://profiles.wordpress.org/akirk/), [jeherve](https://profiles.wordpress.org/jeherve/), [nuriapena](https://profiles.wordpress.org/nuriapena/), [cavalierlife](https://profiles.wordpress.org/cavalierlife/)
-**Tags:** OStatus, fediverse, activitypub, activitystream
-**Requires at least:** 4.7
-**Tested up to:** 6.3
-**Stable tag:** 1.0.0
-**Requires PHP:** 5.6
-**License:** MIT
-**License URI:** http://opensource.org/licenses/MIT
+**Contributors:** [automattic](https://profiles.wordpress.org/automattic/), [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [mattwiebe](https://profiles.wordpress.org/mattwiebe/), [akirk](https://profiles.wordpress.org/akirk/), [jeherve](https://profiles.wordpress.org/jeherve/), [nuriapena](https://profiles.wordpress.org/nuriapena/), [cavalierlife](https://profiles.wordpress.org/cavalierlife/)  
+**Tags:** OStatus, fediverse, activitypub, activitystream  
+**Requires at least:** 4.7  
+**Tested up to:** 6.3  
+**Stable tag:** 1.0.0  
+**Requires PHP:** 5.6  
+**License:** MIT  
+**License URI:** http://opensource.org/licenses/MIT  
 
 The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ActivityPub #
-**Contributors:** [automattic](https://profiles.wordpress.org/automattic/), [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [mattwiebe](https://profiles.wordpress.org/mattwiebe/), [akirk](https://profiles.wordpress.org/akirk/), [jeherve](https://profiles.wordpress.org/jeherve/), [nuriapena](https://profiles.wordpress.org/nuriapena/), [cavalierlife](https://profiles.wordpress.org/cavalierlife/)  
-**Tags:** OStatus, fediverse, activitypub, activitystream  
-**Requires at least:** 4.7  
-**Tested up to:** 6.3  
-**Stable tag:** 1.0.0  
-**Requires PHP:** 5.6  
-**License:** MIT  
-**License URI:** http://opensource.org/licenses/MIT  
+**Contributors:** [automattic](https://profiles.wordpress.org/automattic/), [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [mattwiebe](https://profiles.wordpress.org/mattwiebe/), [akirk](https://profiles.wordpress.org/akirk/), [jeherve](https://profiles.wordpress.org/jeherve/), [nuriapena](https://profiles.wordpress.org/nuriapena/), [cavalierlife](https://profiles.wordpress.org/cavalierlife/)
+**Tags:** OStatus, fediverse, activitypub, activitystream
+**Requires at least:** 4.7
+**Tested up to:** 6.3
+**Stable tag:** 1.0.0
+**Requires PHP:** 5.6
+**License:** MIT
+**License URI:** http://opensource.org/licenses/MIT
 
 The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
 
@@ -104,6 +104,10 @@ Where 'blog' is the path to the subdirectory at which your blog resides.
 ## Changelog ##
 
 Project maintained on GitHub at [automattic/wordpress-activitypub](https://github.com/automattic/wordpress-activitypub).
+
+### Next ###
+
+* Fixed: fix a typo in a hook name.
 
 ### 1.0.0 ###
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -275,7 +275,7 @@ class Post {
 		 * @param int    $id         The attachment ID.
 		 * @param string $image_size The image size to retrieve. Set to 'full' by default.
 		 */
-		do_action( 'activitypub_get_image_pre', $id, $image_size );
+		do_action( 'activitypub_get_image_post', $id, $image_size );
 
 		return $thumbnail;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,10 @@ Where 'blog' is the path to the subdirectory at which your blog resides.
 
 Project maintained on GitHub at [automattic/wordpress-activitypub](https://github.com/automattic/wordpress-activitypub).
 
+= Next =
+
+* Fixed: fix a typo in a hook name.
+
 = 1.0.0 =
 
 * Add: blog-wide Account (catchall, like `example.com@example.com`)


### PR DESCRIPTION
## Proposed changes:

Follow-up to #309

It should be '_post', not twice '_pre'.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

Not much to test here, that was just a stupid typo of mine...
