### PR TITLE
Fix .htaccess issue with subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In order for webfinger to work, it must be mapped to the root directory of the U
 
 Add the following to the .htaccess file in the root directory:
 
-	RedirectMatch "^\/\.well-known/(webfinger|nodeinfo|x-nodeinfo2)(.*)$" "\/blog\/\.well-known$1$2"
+	RedirectMatch "^\/\.well-known/(webfinger|nodeinfo|x-nodeinfo2)(.*)$" /blog/.well-known/$1$2
 
 Where 'blog' is the path to the subdirectory at which your blog resides.
 

--- a/readme.txt
+++ b/readme.txt
@@ -86,7 +86,7 @@ In order for webfinger to work, it must be mapped to the root directory of the U
 
 Add the following to the .htaccess file in the root directory:
 
-	RedirectMatch "^\/\.well-known/(webfinger|nodeinfo|x-nodeinfo2)(.*)$" "\/blog\/\.well-known$1$2"
+	RedirectMatch "^\/\.well-known/(webfinger|nodeinfo|x-nodeinfo2)(.*)$" /blog/.well-known/$1$2
 
 Where 'blog' is the path to the subdirectory at which your blog resides.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #419 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Blogs in subdirectories didn't work with the previous `.htaccess` rule

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a blog in a subdirectory - for example `example.com/blog/`
* Try to use the original `.htaccess` file
* Note that visiting `https://example.com/.well-known/webfinger` gets redirected to `https://blog///.well-knownwebfinger`
* Try this new, improved, organic, fat free, low-sugar `.htaccess` file
* Rejoice as you are redirected correctly.

