### PR TITLE
WP_Error: add status message if it might be returned by API

### DIFF
--- a/includes/class-http.php
+++ b/includes/class-http.php
@@ -53,7 +53,7 @@ class Http {
 		$code     = \wp_remote_retrieve_response_code( $response );
 
 		if ( $code >= 400 ) {
-			$response = new WP_Error( $code, __( 'Failed HTTP Request', 'activitypub' ) );
+			$response = new WP_Error( $code, __( 'Failed HTTP Request', 'activitypub' ), array( 'status' => $code ) );
 		}
 
 		\do_action( 'activitypub_safe_remote_post_response', $response, $url, $body, $user_id );
@@ -101,7 +101,7 @@ class Http {
 		$code     = \wp_remote_retrieve_response_code( $response );
 
 		if ( $code >= 400 ) {
-			$response = new WP_Error( $code, __( 'Failed HTTP Request', 'activitypub' ) );
+			$response = new WP_Error( $code, __( 'Failed HTTP Request', 'activitypub' ), array( 'status' => $code ) );
 		}
 
 		\do_action( 'activitypub_safe_remote_get_response', $response, $url );

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -247,7 +247,7 @@ class Signature {
 		}
 
 		if ( ! isset( $headers['signature'] ) ) {
-			return new WP_Error( 'activitypub_signature', 'Request not signed', array( 'status' => 403 ) );
+			return new WP_Error( 'activitypub_signature', __( 'Request not signed', 'activitypub' ), array( 'status' => 403 ) );
 		}
 
 		if ( array_key_exists( 'signature', $headers ) ) {
@@ -257,7 +257,7 @@ class Signature {
 		}
 
 		if ( ! isset( $signature_block ) || ! $signature_block ) {
-			return new WP_Error( 'activitypub_signature', 'Incompatible request signature. keyId and signature are required', array( 'status' => 403 ) );
+			return new WP_Error( 'activitypub_signature', __( 'Incompatible request signature. keyId and signature are required', 'activitypub' ), array( 'status' => 403 ) );
 		}
 
 		$signed_headers = $signature_block['headers'];
@@ -267,12 +267,12 @@ class Signature {
 
 		$signed_data = self::get_signed_data( $signed_headers, $signature_block, $headers );
 		if ( ! $signed_data ) {
-			return new WP_Error( 'activitypub_signature', 'Signed request date outside acceptable time window', array( 'status' => 403 ) );
+			return new WP_Error( 'activitypub_signature', __( 'Signed request date outside acceptable time window', 'activitypub' ), array( 'status' => 403 ) );
 		}
 
 		$algorithm = self::get_signature_algorithm( $signature_block );
 		if ( ! $algorithm ) {
-			return new WP_Error( 'activitypub_signature', 'Unsupported signature algorithm (only rsa-sha256 and hs2019 are supported)', array( 'status' => 403 ) );
+			return new WP_Error( 'activitypub_signature', __( 'Unsupported signature algorithm (only rsa-sha256 and hs2019 are supported)', 'activitypub' ), array( 'status' => 403 ) );
 		}
 
 		if ( \in_array( 'digest', $signed_headers, true ) && isset( $body ) ) {
@@ -288,7 +288,7 @@ class Signature {
 			}
 
 			if ( \base64_encode( \hash( $hashalg, $body, true ) ) !== $digest[1] ) { // phpcs:ignore
-				return new WP_Error( 'activitypub_signature', 'Invalid Digest header', array( 'status' => 403 ) );
+				return new WP_Error( 'activitypub_signature', __( 'Invalid Digest header', 'activitypub' ), array( 'status' => 403 ) );
 			}
 		}
 
@@ -301,7 +301,7 @@ class Signature {
 		$verified = \openssl_verify( $signed_data, $signature_block['signature'], $public_key, $algorithm ) > 0;
 
 		if ( ! $verified ) {
-			return new WP_Error( 'activitypub_signature', 'Invalid signature', array( 'status' => 403 ) );
+			return new WP_Error( 'activitypub_signature', __( 'Invalid signature', 'activitypub' ), array( 'status' => 403 ) );
 		}
 		return $verified;
 	}
@@ -321,7 +321,7 @@ class Signature {
 		if ( isset( $actor['publicKey']['publicKeyPem'] ) ) {
 			return \rtrim( $actor['publicKey']['publicKeyPem'] ); // phpcs:ignore
 		}
-		return new WP_Error( 'activitypub_no_remote_key_found', 'No Public-Key found' );
+		return new WP_Error( 'activitypub_no_remote_key_found', __( 'No Public-Key found', 'activitypub' ), array( 'status' => 403 ) );
 	}
 
 	/**

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -170,7 +170,7 @@ class Followers {
 		}
 
 		if ( empty( $meta ) || ! is_array( $meta ) || is_wp_error( $meta ) ) {
-			return new WP_Error( 'activitypub_invalid_follower', __( 'Invalid Follower', 'activitypub' ) );
+			return new WP_Error( 'activitypub_invalid_follower', __( 'Invalid Follower', 'activitypub' ), array( 'status' => 400 ) );
 		}
 
 		$error = null;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -54,7 +54,7 @@ function get_remote_metadata_by_actor( $actor, $cached = true ) {
 	}
 
 	if ( ! $actor ) {
-		return new WP_Error( 'activitypub_no_valid_actor_identifier', \__( 'The "actor" identifier is not valid', 'activitypub' ), $actor );
+		return new WP_Error( 'activitypub_no_valid_actor_identifier', \__( 'The "actor" identifier is not valid', 'activitypub' ), array( 'status' => 404, 'actor' => $actor ) );
 	}
 
 	if ( is_wp_error( $actor ) ) {
@@ -73,7 +73,7 @@ function get_remote_metadata_by_actor( $actor, $cached = true ) {
 	}
 
 	if ( ! \wp_http_validate_url( $actor ) ) {
-		$metadata = new WP_Error( 'activitypub_no_valid_actor_url', \__( 'The "actor" is no valid URL', 'activitypub' ), $actor );
+		$metadata = new WP_Error( 'activitypub_no_valid_actor_url', \__( 'The "actor" is no valid URL', 'activitypub' ), array( 'status' => 400, 'actor' => $actor ) );
 		\set_transient( $transient_key, $metadata, HOUR_IN_SECONDS ); // Cache the error for a shorter period.
 		return $metadata;
 	}
@@ -95,7 +95,7 @@ function get_remote_metadata_by_actor( $actor, $cached = true ) {
 	\set_transient( $transient_key, $metadata, WEEK_IN_SECONDS );
 
 	if ( ! $metadata ) {
-		$metadata = new WP_Error( 'activitypub_invalid_json', \__( 'No valid JSON data', 'activitypub' ), $actor );
+		$metadata = new WP_Error( 'activitypub_invalid_json', \__( 'No valid JSON data', 'activitypub' ), array( 'status' => 400, 'actor' => $actor ) );
 		\set_transient( $transient_key, $metadata, HOUR_IN_SECONDS ); // Cache the error for a shorter period.
 		return $metadata;
 	}
@@ -416,7 +416,7 @@ function is_user_type_disabled( $type ) {
 			$return = false;
 			break;
 		default:
-			$return = new WP_Error( 'activitypub_wrong_user_type', __( 'Wrong user type', 'activitypub' ) );
+			$return = new WP_Error( 'activitypub_wrong_user_type', __( 'Wrong user type', 'activitypub' ), array( 'status' => 400 ) );
 			break;
 	}
 

--- a/includes/model/class-follower.php
+++ b/includes/model/class-follower.php
@@ -142,7 +142,7 @@ class Follower extends Actor {
 	 */
 	public function save() {
 		if ( ! $this->is_valid() ) {
-			return new WP_Error( 'activitypub_invalid_follower', __( 'Invalid Follower', 'activitypub' ) );
+			return new WP_Error( 'activitypub_invalid_follower', __( 'Invalid Follower', 'activitypub' ), array( 'status' => 400 ) );
 		}
 
 		if ( ! $this->get__id() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It seems that version 1.0.0 produces a higher amount of http 500 errors. It seems that this is the case if you return an WP_Error without defining the status code.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add status code to most of the WP_Error messages

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

