### PR TITLE
Hashtags, Mentions: Use a tag stack instead of regex for protecting tags

### DIFF
--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -43,38 +43,42 @@ class Hashtag {
 	 * @return string the filtered post-content
 	 */
 	public static function the_content( $the_content ) {
-		$protected_tags = array();
-		$protect = function( $m ) use ( &$protected_tags ) {
-			$c = \wp_rand( 100000, 999999 );
-			$protect = '!#!#PROTECT' . $c . '#!#!';
-			while ( isset( $protected_tags[ $protect ] ) ) {
-				$c = \wp_rand( 100000, 999999 );
-				$protect = '!#!#PROTECT' . $c . '#!#!';
+		$tag_stack = array();
+		$protected_tags = array(
+			'pre',
+			'code',
+			'textarea',
+			'style',
+			'a',
+		);
+		$content_with_links = '';
+		$in_protected_tag = false;
+		foreach ( wp_html_split( $the_content ) as $chunk ) {
+			if ( preg_match( '#^<(/)?([a-z-]+)\b[^>]*>$#i', $chunk, $m ) ) {
+				$tag = strtolower( $m[2] );
+				if ( '/' === $m[1] ) {
+					$i = array_search( $tag, $tag_stack );
+					if ( false !== $i ) {
+						$tag_stack = array_slice( $tag_stack, 0, $i );
+					}
+				} else {
+					$tag_stack[] = $tag;
+				}
+
+				$in_protected_tag = count( array_intersect( $tag_stack, $protected_tags ) );
+				$content_with_links .= $chunk;
+				continue;
 			}
-			$protected_tags[ $protect ] = $m[0];
-			return $protect;
-		};
-		$the_content = preg_replace_callback(
-			'#<!\[CDATA\[.*?\]\]>#is',
-			$protect,
-			$the_content
-		);
-		$the_content = preg_replace_callback(
-			'#<(pre|code|textarea|style)\b[^>]*>.*?</\1[^>]*>#is',
-			$protect,
-			$the_content
-		);
-		$the_content = preg_replace_callback(
-			'#<[^>]+>#i',
-			$protect,
-			$the_content
-		);
 
-		$the_content = \preg_replace_callback( '/' . ACTIVITYPUB_HASHTAGS_REGEXP . '/i', array( '\Activitypub\Hashtag', 'replace_with_links' ), $the_content );
+			if ( $in_protected_tag ) {
+				$content_with_links .= $chunk;
+				continue;
+			}
 
-		$the_content = str_replace( array_reverse( array_keys( $protected_tags ) ), array_reverse( array_values( $protected_tags ) ), $the_content );
+			$content_with_links .= \preg_replace_callback( '/' . ACTIVITYPUB_HASHTAGS_REGEXP . '/i', array( '\Activitypub\Hashtag', 'replace_with_links' ), $chunk );
+		}
 
-		return $the_content;
+		return $content_with_links;
 	}
 
 	/**

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -54,6 +54,11 @@ class Hashtag {
 		$content_with_links = '';
 		$in_protected_tag = false;
 		foreach ( wp_html_split( $the_content ) as $chunk ) {
+			if ( preg_match( '#^<!--[\s\S]*-->$#i', $chunk, $m ) ) {
+				$content_with_links .= $chunk;
+				continue;
+			}
+
 			if ( preg_match( '#^<(/)?([a-z-]+)\b[^>]*>$#i', $chunk, $m ) ) {
 				$tag = strtolower( $m[2] );
 				if ( '/' === $m[1] ) {

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -57,8 +57,9 @@ class Hashtag {
 			if ( preg_match( '#^<(/)?([a-z-]+)\b[^>]*>$#i', $chunk, $m ) ) {
 				$tag = strtolower( $m[2] );
 				if ( '/' === $m[1] ) {
-					// Closing tag, remove the tag from the stack.
+					// Closing tag.
 					$i = array_search( $tag, $tag_stack );
+					// We can only remove the tag from the stack if it is in the stack.
 					if ( false !== $i ) {
 						$tag_stack = array_slice( $tag_stack, 0, $i );
 					}

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -25,43 +25,41 @@ class Mention {
 	 * @return string the filtered post-content
 	 */
 	public static function the_content( $the_content ) {
-		$protected_tags = array();
-		$protect = function( $m ) use ( &$protected_tags ) {
-			$c = \wp_rand( 100000, 999999 );
-			$protect = '!#!#PROTECT' . $c . '#!#!';
-			while ( isset( $protected_tags[ $protect ] ) ) {
-				$c = \wp_rand( 100000, 999999 );
-				$protect = '!#!#PROTECT' . $c . '#!#!';
+		$tag_stack = array();
+		$protected_tags = array(
+			'pre',
+			'code',
+			'textarea',
+			'style',
+			'a',
+		);
+		$content_with_links = '';
+		$in_protected_tag = false;
+		foreach ( wp_html_split( $the_content ) as $chunk ) {
+			if ( preg_match( '#^<(/)?([a-z-]+)\b[^>]*>$#i', $chunk, $m ) ) {
+				$tag = strtolower( $m[2] );
+				if ( '/' === $m[1] ) {
+					$i = array_search( $tag, $tag_stack );
+					if ( false !== $i ) {
+						$tag_stack = array_slice( $tag_stack, 0, $i );
+					}
+				} else {
+					$tag_stack[] = $tag;
+				}
+
+				$in_protected_tag = count( array_intersect( $tag_stack, $protected_tags ) );
+				$content_with_links .= $chunk;
+				continue;
 			}
-			$protected_tags[ $protect ] = $m[0];
-			return $protect;
-		};
-		$the_content = preg_replace_callback(
-			'#<!\[CDATA\[.*?\]\]>#is',
-			$protect,
-			$the_content
-		);
-		$the_content = preg_replace_callback(
-			'#<(pre|code|textarea|style)\b[^>]*>.*?</\1[^>]*>#is',
-			$protect,
-			$the_content
-		);
-		$the_content = preg_replace_callback(
-			'#<a.*?href=[^>]+>.*?</a>#i',
-			$protect,
-			$the_content
-		);
 
-		$the_content = preg_replace_callback(
-			'#<img.*?[^>]+>#i',
-			$protect,
-			$the_content
-		);
+			if ( $in_protected_tag ) {
+				$content_with_links .= $chunk;
+				continue;
+			}
+			$content_with_links .= \preg_replace_callback( '/@' . ACTIVITYPUB_USERNAME_REGEXP . '/', array( self::class, 'replace_with_links' ), $chunk );
+		}
 
-		$the_content = \preg_replace_callback( '/@' . ACTIVITYPUB_USERNAME_REGEXP . '/', array( self::class, 'replace_with_links' ), $the_content );
-		$the_content = \str_replace( array_reverse( array_keys( $protected_tags ) ), array_reverse( array_values( $protected_tags ) ), $the_content );
-
-		return $the_content;
+		return $content_with_links;
 	}
 
 	/**

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -39,8 +39,9 @@ class Mention {
 			if ( preg_match( '#^<(/)?([a-z-]+)\b[^>]*>$#i', $chunk, $m ) ) {
 				$tag = strtolower( $m[2] );
 				if ( '/' === $m[1] ) {
-					// Closing tag, remove the tag from the stack.
+					// Closing tag.
 					$i = array_search( $tag, $tag_stack );
+					// We can only remove the tag from the stack if it is in the stack.
 					if ( false !== $i ) {
 						$tag_stack = array_slice( $tag_stack, 0, $i );
 					}

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -36,6 +36,11 @@ class Mention {
 		$content_with_links = '';
 		$in_protected_tag = false;
 		foreach ( wp_html_split( $the_content ) as $chunk ) {
+			if ( preg_match( '#^<!--[\s\S]*-->$#i', $chunk, $m ) ) {
+				$content_with_links .= $chunk;
+				continue;
+			}
+
 			if ( preg_match( '#^<(/)?([a-z-]+)\b[^>]*>$#i', $chunk, $m ) ) {
 				$tag = strtolower( $m[2] );
 				if ( '/' === $m[1] ) {

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -39,23 +39,32 @@ class Mention {
 			if ( preg_match( '#^<(/)?([a-z-]+)\b[^>]*>$#i', $chunk, $m ) ) {
 				$tag = strtolower( $m[2] );
 				if ( '/' === $m[1] ) {
+					// Closing tag, remove the tag from the stack.
 					$i = array_search( $tag, $tag_stack );
 					if ( false !== $i ) {
 						$tag_stack = array_slice( $tag_stack, 0, $i );
 					}
 				} else {
+					// Opening tag, add it to the stack.
 					$tag_stack[] = $tag;
 				}
 
-				$in_protected_tag = count( array_intersect( $tag_stack, $protected_tags ) );
+				// If we're in a protected tag, the tag_stack contains at least one protected tag string.
+				// The protected tag state can only change when we encounter a start or end tag.
+				$in_protected_tag = array_intersect( $tag_stack, $protected_tags );
+
+				// Never inspect tags.
 				$content_with_links .= $chunk;
 				continue;
 			}
 
 			if ( $in_protected_tag ) {
+				// Don't inspect a chunk inside an inspected tag.
 				$content_with_links .= $chunk;
 				continue;
 			}
+
+			// Only reachable when there is no protected tag in the stack.
 			$content_with_links .= \preg_replace_callback( '/@' . ACTIVITYPUB_USERNAME_REGEXP . '/', array( self::class, 'replace_with_links' ), $chunk );
 		}
 

--- a/tests/test-class-activitypub-hashtag.php
+++ b/tests/test-class-activitypub-hashtag.php
@@ -43,6 +43,7 @@ ENDPRE;
 			array( '<div>hallo #object</div>', '<div>hallo <a rel="tag" class="hashtag u-tag u-category" href="%s">#object</a></div>' ),
 			array( '<div>#object</div>', '<div><a rel="tag" class="hashtag u-tag u-category" href="%s">#object</a></div>' ),
 			array( '<a>#object</a>', '<a>#object</a>' ),
+			array( '<!-- #object -->', '<!-- #object -->' ),
 			array( '<div style="color: #ccc;">object</a>', '<div style="color: #ccc;">object</a>' ),
 			array( $code, $code ),
 			array( $style, $style ),

--- a/tests/test-class-activitypub-hashtag.php
+++ b/tests/test-class-activitypub-hashtag.php
@@ -41,7 +41,7 @@ ENDPRE;
 			array( 'hallo <a href="http://test.test/#object">#test</a> test', 'hallo <a href="http://test.test/#object">#test</a> test' ),
 			array( '<div>hallo #object test</div>', '<div>hallo <a rel="tag" class="hashtag u-tag u-category" href="%s">#object</a> test</div>' ),
 			array( '<div>hallo #object</div>', '<div>hallo <a rel="tag" class="hashtag u-tag u-category" href="%s">#object</a></div>' ),
-			array( '<div>#object</div>', '<div>#object</div>' ),
+			array( '<div>#object</div>', '<div><a rel="tag" class="hashtag u-tag u-category" href="http://example.org/?tag=object">#object</a></div>' ),
 			array( '<a>#object</a>', '<a>#object</a>' ),
 			array( '<div style="color: #ccc;">object</a>', '<div style="color: #ccc;">object</a>' ),
 			array( $code, $code ),

--- a/tests/test-class-activitypub-hashtag.php
+++ b/tests/test-class-activitypub-hashtag.php
@@ -41,7 +41,7 @@ ENDPRE;
 			array( 'hallo <a href="http://test.test/#object">#test</a> test', 'hallo <a href="http://test.test/#object">#test</a> test' ),
 			array( '<div>hallo #object test</div>', '<div>hallo <a rel="tag" class="hashtag u-tag u-category" href="%s">#object</a> test</div>' ),
 			array( '<div>hallo #object</div>', '<div>hallo <a rel="tag" class="hashtag u-tag u-category" href="%s">#object</a></div>' ),
-			array( '<div>#object</div>', '<div><a rel="tag" class="hashtag u-tag u-category" href="http://example.org/?tag=object">#object</a></div>' ),
+			array( '<div>#object</div>', '<div><a rel="tag" class="hashtag u-tag u-category" href="%s">#object</a></div>' ),
 			array( '<a>#object</a>', '<a>#object</a>' ),
 			array( '<div style="color: #ccc;">object</a>', '<div style="color: #ccc;">object</a>' ),
 			array( $code, $code ),

--- a/tests/test-class-activitypub-mention.php
+++ b/tests/test-class-activitypub-mention.php
@@ -33,6 +33,7 @@ ENDPRE;
 			array( 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@pfefferle@notiz.blog</a> test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@pfefferle@notiz.blog</a> test' ),
 			array( 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/@pfefferle/">@pfefferle@notiz.blog</a> test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/@pfefferle/">@pfefferle@notiz.blog</a> test' ),
 			array( 'hallo <img src="abc" alt="https://notiz.blog/@pfefferle/" title="@pfefferle@notiz.blog"/> test', 'hallo <img src="abc" alt="https://notiz.blog/@pfefferle/" title="@pfefferle@notiz.blog"/> test' ),
+			array( '<!-- @pfefferle@notiz.blog -->', '<!-- @pfefferle@notiz.blog -->' ),
 			array( $code, $code ),
 			array( $pre, $pre ),
 		);


### PR DESCRIPTION
This provides a more solid approach for ensuring that mentions and hashtags are not applied within certain tags.

## Proposed changes:
* Use `wp_html_split()` and a tag stack to protect tags

### Other information:

- [x] Tests existed, one test was deemed wrong and updated in accordance with @pfefferle. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This doesn't change functionality.

* Run the unit tests to ensure they still pass.

