### PR TITLE
Move [ap_hashtags] last in post in Content

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -513,7 +513,7 @@ class Post {
 		}
 
 		if ( 'content' === \get_option( 'activitypub_post_content_type', 'content' ) ) {
-			return "[ap_content]\n\n[ap_hashtags]\n\n[ap_permalink type=\"html\"]";
+			return "[ap_content]\n\n[ap_permalink type=\"html\"]\n\n[ap_hashtags]";
 		}
 
 		return \get_option( 'activitypub_custom_post_content', ACTIVITYPUB_CUSTOM_POST_CONTENT );


### PR DESCRIPTION
Hashtags to be displayed separately when they are the last line of a post in Mastodon 4.2+

<!--- Provide a general summary of your changes in the Title above -->

Fixes #432

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves `[ap_hashtags]` last in post in Content

