### PR TITLE
reduce number of checks when system cron is not used

### DIFF
--- a/includes/class-health-check.php
+++ b/includes/class-health-check.php
@@ -1,6 +1,12 @@
 <?php
 namespace Activitypub;
 
+use WP_Error;
+use Activitypub\Webfinger;
+
+use function Activitypub\get_plugin_version;
+use function Activitypub\get_webfinger_resource;
+
 /**
  * ActivityPub Health_Check Class
  *
@@ -27,6 +33,11 @@ class Health_Check {
 		$tests['direct']['activitypub_test_webfinger'] = array(
 			'label' => __( 'WebFinger Test', 'activitypub' ),
 			'test'  => array( self::class, 'test_webfinger' ),
+		);
+
+		$tests['direct']['activitypub_test_system_cron'] = array(
+			'label' => __( 'System Cron Test', 'activitypub' ),
+			'test'  => array( self::class, 'test_system_cron' ),
 		);
 
 		return $tests;
@@ -65,6 +76,42 @@ class Health_Check {
 		$result['description']    = \sprintf(
 			'<p>%s</p>',
 			$check->get_error_message()
+		);
+
+		return $result;
+	}
+
+	/**
+	 * System Cron tests
+	 *
+	 * @return array
+	 */
+	public static function test_system_cron() {
+		$result = array(
+			'label'       => \__( 'System Task Scheduler configured', 'activitypub' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => \__( 'ActivityPub', 'activitypub' ),
+				'color' => 'green',
+			),
+			'description' => \sprintf(
+				'<p>%s</p>',
+				\esc_html__( 'You seem to use the System Task Scheduler to process WP_Cron tasks.', 'activitypub' )
+			),
+			'actions'     => '',
+			'test'        => 'test_system_cron',
+		);
+
+		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
+			return $result;
+		}
+
+		$result['status']         = 'recommended';
+		$result['label']          = \__( 'System Task Scheduler not configured', 'activitypub' );
+		$result['badge']['color'] = 'orange';
+		$result['description']    = \sprintf(
+			'<p>%s</p>',
+			\__( 'It is highly recommended to use your Systems Task Scheduler instead of the default <code>WP_Cron</code> setup. For further informations, check the "<a href="https://developer.wordpress.org/plugins/cron/hooking-wp-cron-into-the-system-task-scheduler/" target="_blank">Hooking WP-Cron Into the System Task Scheduler</a>" from the Plugin Handbook.', 'activitypub' )
 		);
 
 		return $result;
@@ -111,7 +158,7 @@ class Health_Check {
 	/**
 	 * Check if `author_posts_url` is accessible and that request returns correct JSON
 	 *
-	 * @return boolean|\WP_Error
+	 * @return boolean|WP_Error
 	 */
 	public static function is_author_url_accessible() {
 		$user = \wp_get_current_user();
@@ -120,7 +167,7 @@ class Health_Check {
 
 		// check for "author" in URL
 		if ( $author_url !== $reference_author_url ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'author_url_not_accessible',
 				\sprintf(
 					// translators: %s: Author URL
@@ -143,7 +190,7 @@ class Health_Check {
 		);
 
 		if ( \is_wp_error( $response ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'author_url_not_accessible',
 				\sprintf(
 					// translators: %s: Author URL
@@ -160,7 +207,7 @@ class Health_Check {
 
 		// check for redirects
 		if ( \in_array( $response_code, array( 301, 302, 307, 308 ), true ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'author_url_not_accessible',
 				\sprintf(
 					// translators: %s: Author URL
@@ -177,7 +224,7 @@ class Health_Check {
 		$body = \wp_remote_retrieve_body( $response );
 
 		if ( ! \is_string( $body ) || ! \is_array( \json_decode( $body, true ) ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'author_url_not_accessible',
 				\sprintf(
 					// translators: %s: Author URL
@@ -196,13 +243,13 @@ class Health_Check {
 	/**
 	 * Check if WebFinger endpoint is accessible and profile request returns correct JSON
 	 *
-	 * @return boolean|\WP_Error
+	 * @return boolean|WP_Error
 	 */
 	public static function is_webfinger_endpoint_accessible() {
 		$user    = \wp_get_current_user();
-		$account = \Activitypub\get_webfinger_resource( $user->ID );
+		$account = get_webfinger_resource( $user->ID );
 
-		$url = \Activitypub\Webfinger::resolve( $account );
+		$url = Webfinger::resolve( $account );
 		if ( \is_wp_error( $url ) ) {
 			$allowed = array( 'code' => array() );
 			$not_accessible = wp_kses(
@@ -237,7 +284,7 @@ class Health_Check {
 			if ( isset( $health_messages[ $url->get_error_code() ] ) ) {
 				$message = $health_messages[ $url->get_error_code() ];
 			}
-			return new \WP_Error(
+			return new WP_Error(
 				$url->get_error_code(),
 				$message,
 				$url->get_error_data()
@@ -291,12 +338,17 @@ class Health_Check {
 			'fields' => array(
 				'webfinger' => array(
 					'label'   => __( 'WebFinger Resource', 'activitypub' ),
-					'value'   => \Activitypub\Webfinger::get_user_resource( wp_get_current_user()->ID ),
+					'value'   => Webfinger::get_user_resource( wp_get_current_user()->ID ),
 					'private' => true,
 				),
 				'author_url' => array(
 					'label'   => __( 'Author URL', 'activitypub' ),
 					'value'   => get_author_posts_url( wp_get_current_user()->ID ),
+					'private' => true,
+				),
+				'plugin_version' => array(
+					'label'   => __( 'Plugin Version', 'activitypub' ),
+					'value'   => get_plugin_version(),
 					'private' => true,
 				),
 			),

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -105,7 +105,13 @@ class Scheduler {
 	 * @return void
 	 */
 	public static function update_followers() {
-		$followers = Followers::get_outdated_followers();
+		$number = 5;
+
+		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
+			$number = 50;
+		}
+
+		$followers = Followers::get_outdated_followers( $number );
 
 		foreach ( $followers as $follower ) {
 			$meta = get_remote_metadata_by_actor( $follower->get_url(), false );
@@ -125,7 +131,13 @@ class Scheduler {
 	 * @return void
 	 */
 	public static function cleanup_followers() {
-		$followers = Followers::get_faulty_followers();
+		$number = 5;
+
+		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
+			$number = 50;
+		}
+
+		$followers = Followers::get_faulty_followers( $number );
 
 		foreach ( $followers as $follower ) {
 			$meta = get_remote_metadata_by_actor( $follower->get_url(), false );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes high load on page visits for users, that use the default setup of WP_Cron.

* WP_Cron on page visit: 5 checks
* Systems Cron: 50 checks

Context: https://wordpress.org/support/topic/upgraded-to-1-0-user-account-can-no-longer-be-followed-replies-broken/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reduce default to 5 checks and increase up to 50 if `DISABLE_WP_CRON` is true.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

