### PR TITLE
Minimum WP 5.9 for the plugin

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -8,9 +8,11 @@
  * Author URI: https://automattic.com/
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
+ * Requires at least: 5.9
  * Requires PHP: 5.6
  * Text Domain: activitypub
  * Domain Path: /languages
+ *
  */
 
 namespace Activitypub;


### PR DESCRIPTION
Activating the plugin on WP 4.8.7 creates a fatal error, something having to do with registering block assets.

So let's ensure that folks aren't able to activate the plugin on an incompatible version of WP. I tested in `5.9.0` and it activated ok.

Closes #482

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bump minimum WP version to 5.9

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
We can't test this until it's in the directory, but it's the documented way to do this https://developer.wordpress.org/plugins/plugin-basics/header-requirements/