### PR TITLE
Add a `ACTIVITYPUB_DISABLE_REWRITES` constant

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -31,6 +31,7 @@ function define_constants() {
 	\defined( 'ACTIVITYPUB_USERNAME_REGEXP' ) || \define( 'ACTIVITYPUB_USERNAME_REGEXP', '(?:([A-Za-z0-9_-]+)@((?:[A-Za-z0-9_-]+\.)+[A-Za-z]+))' );
 	\defined( 'ACTIVITYPUB_CUSTOM_POST_CONTENT' ) || \define( 'ACTIVITYPUB_CUSTOM_POST_CONTENT', "<strong>[ap_title]</strong>\n\n[ap_content]\n\n[ap_hashtags]\n\n[ap_shortlink]" );
 	\defined( 'ACTIVITYPUB_AUTHORIZED_FETCH' ) || \define( 'ACTIVITYPUB_AUTHORIZED_FETCH', false );
+	\defined( 'ACTIVITYPUB_DISABLE_REWRITES' ) || \define( 'ACTIVITYPUB_DISABLE_REWRITES', false );
 
 	\define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 	\define( 'ACTIVITYPUB_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -227,6 +227,12 @@ class Activitypub {
 	 * Add rewrite rules
 	 */
 	public static function add_rewrite_rules() {
+		// If another system needs to take precedence over the ActivityPub rewrite rules,
+		// they can define their own and will manually call the appropriate functions as required.
+		if ( ACTIVITYPUB_DISABLE_REWRITES ) {
+			return;
+		}
+
 		if ( ! \class_exists( 'Webfinger' ) ) {
 			\add_rewrite_rule(
 				'^.well-known/webfinger',


### PR DESCRIPTION
We are running into problems on dotcom, where we need to use a different rewrites setup than the plugin for esoteric reasons I won't get into here. This may not be the best way, but it's just the blunt force tool we need right now.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If you set `ACTIVITYPUB_DISABLE_REWRITES` to `true`, the plugin will not add rewrites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

