### PR TITLE
Fix: missing featured image when using blocks

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -229,7 +229,8 @@ class Post {
 		if ( $max_images > 0 ) {
 			// first try to get images that are actually in the post content
 			if ( site_supports_blocks() && \has_blocks( $this->wp_post->post_content ) ) {
-				$image_ids = $this->get_block_image_ids( $max_images, $image_ids );
+				$block_image_ids = $this->get_block_image_ids( $max_images, $image_ids );
+				$image_ids = \array_merge( $image_ids, $block_image_ids );
 			} else {
 				// fallback to images attached to the post
 				$query = new \WP_Query(


### PR DESCRIPTION
do not overwrite $image_ids to include post thumbnail also for block-parser.

<!--- Provide a general summary of your changes in the Title above -->

Fixes https://wordpress.org/support/topic/setting-number-of-images-sends-one-less-than-intended/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The current version replaces the `$image_ids`, so the featured image will be replaced and the number of images does not match any more.

