### PR TITLE
add filter to check if blog is public

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -15,6 +15,7 @@
 
 namespace Activitypub;
 
+use function Activitypub\is_blog_public;
 use function Activitypub\site_supports_blocks;
 
 require_once __DIR__ . '/includes/compat.php';
@@ -52,7 +53,7 @@ function rest_init() {
 	Rest\Collection::init();
 
 	// load NodeInfo endpoints only if blog is public
-	if ( \get_option( 'blog_public', 1 ) ) {
+	if ( is_blog_public() ) {
 		Rest\NodeInfo::init();
 	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -472,3 +472,12 @@ function site_supports_blocks() {
 function is_json( $data ) {
 	return \is_array( \json_decode( $data, true ) ) ? true : false;
 }
+
+/**
+ * Check if a blog is public based on the `blog_public` option
+ *
+ * @return bollean True if public, false if not
+ */
+function is_blog_public() {
+	return (bool) apply_filters( 'activitypub_is_blog_public', \get_option( 'blog_public', 1 ) );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

To filter the `\get_option( 'blog_public', 1 )` output, this is important for the use in the `public-api` context of wp.com