### PR TITLE
Fix typo "lenght" in help page

### DIFF
--- a/includes/help.php
+++ b/includes/help.php
@@ -11,7 +11,7 @@
 				'<dd>' . \wp_kses( __( 'The post\'s title.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_content apply_filters="yes"]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s content. With <code>apply_filters</code> you can decide if filters (<code>apply_filters( \'the_content\', $content )</code>) should be applied or not (default is <code>yes</code>). The values can be <code>yes</code> or <code>no</code>. <code>apply_filters</code> attribute is optional.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
-				'<dt><code>[ap_excerpt lenght="400"]</code></dt>' .
+				'<dt><code>[ap_excerpt length="400"]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s excerpt (default 400 chars). <code>length</code> attribute is optional.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_permalink type="url"]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s permalink. <code>type</code> can be either: <code>url</code> or <code>html</code> (an &lt;a /&gt; tag). <code>type</code> attribute is optional.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .


### PR DESCRIPTION
## Proposed changes:

* Just fixing a typo "lenght" -> "length"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Go to the help page.
* Make sure it says `[ap_excerpt length="400"]`

