### PR TITLE
Shortcodes: only register when needed

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -69,7 +69,6 @@ function plugin_init() {
 	\add_action( 'init', array( __NAMESPACE__ . '\Collection\Followers', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Admin', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Hashtag', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Shortcodes', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Mention', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Health_Check', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ) );

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -5,17 +5,23 @@ use function Activitypub\esc_hashtag;
 
 class Shortcodes {
 	/**
-	 * Class constructor, registering WordPress then Shortcodes
+	 * Register the shortcodes
 	 */
-	public static function init() {
-		// do not load on admin pages
-		if ( is_admin() ) {
-			return;
-		}
-
+	public static function register() {
 		foreach ( get_class_methods( self::class ) as $shortcode ) {
 			if ( 'init' !== $shortcode ) {
 				add_shortcode( 'ap_' . $shortcode, array( self::class, $shortcode ) );
+			}
+		}
+	}
+
+	/**
+	 * Unregister the shortcodes
+	 */
+	public static function unregister() {
+		foreach ( get_class_methods( self::class ) as $shortcode ) {
+			if ( 'init' !== $shortcode ) {
+				remove_shortcode( 'ap_' . $shortcode );
 			}
 		}
 	}

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -5,6 +5,7 @@ use WP_Post;
 use Activitypub\Collection\Users;
 use Activitypub\Model\Blog_User;
 use Activitypub\Activity\Base_Object;
+use Activitypub\Shortcodes;
 
 use function Activitypub\esc_hashtag;
 use function Activitypub\is_single_user;
@@ -466,6 +467,8 @@ class Post {
 		$post    = $this->wp_post;
 		$content = $this->get_post_content_template();
 
+		// Register our shortcodes just in time.
+		Shortcodes::register();
 		// Fill in the shortcodes.
 		setup_postdata( $post );
 		$content = do_shortcode( $content );
@@ -476,6 +479,9 @@ class Post {
 		$content = \trim( $content );
 
 		$content = \apply_filters( 'activitypub_the_content', $content, $post );
+
+		// Don't need these any more, should never appear in a post.
+		Shortcodes::unregister();
 
 		return $content;
 	}

--- a/tests/test-class-activitypub-shortcodes.php
+++ b/tests/test-class-activitypub-shortcodes.php
@@ -3,15 +3,8 @@ use Activitypub\Shortcodes;
 
 class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 
-	public function setUp() {
-		Shortcodes::register();
-	}
-
-	public function tearDown() {
-		Shortcodes::unregister();
-	}
-
 	public function test_content() {
+		Shortcodes::register();
 		global $post;
 
 		$post_id = -99; // negative ID, to avoid clash with a valid post
@@ -37,9 +30,11 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 		wp_reset_postdata();
 
 		$this->assertEquals( '<p>hallo</p>', $content );
+		Shortcodes::unregister();
 	}
 
 	public function test_password_protected_content() {
+		Shortcodes::register();
 		global $post;
 
 		$post_id = -98; // negative ID, to avoid clash with a valid post
@@ -65,5 +60,6 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 		wp_reset_postdata();
 
 		$this->assertEquals( '', $content );
+		Shortcodes::unregister();
 	}
 }

--- a/tests/test-class-activitypub-shortcodes.php
+++ b/tests/test-class-activitypub-shortcodes.php
@@ -3,11 +3,11 @@ use Activitypub\Shortcodes;
 
 class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
+	public function setUp() {
 		Shortcodes::register();
 	}
 
-	public static function tearDownAfterClass() {
+	public function tearDown() {
 		Shortcodes::unregister();
 	}
 

--- a/tests/test-class-activitypub-shortcodes.php
+++ b/tests/test-class-activitypub-shortcodes.php
@@ -1,5 +1,16 @@
 <?php
+use Activitypub\Shortcodes;
+
 class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
+
+	public static function setUpBeforeClass() {
+		Shortcodes::register();
+	}
+
+	public static function tearDownAfterClass() {
+		Shortcodes::unregister();
+	}
+
 	public function test_content() {
 		global $post;
 


### PR DESCRIPTION
I was poking around with post rendering and I thought it would be better to make sure that our shortcodes are never available outside of our own rendering context.

And of course I pushed these changes to `master` accidentally. 🤦 

I'll have to see if this breaks tests.