### PR TITLE
Attachments: add support for audio 🔈 and video 📼

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -187,7 +187,7 @@ class Post {
 		}
 		$media_ids = \array_unique( $media_ids );
 
-		return array_map( array( self::class, 'wp_attachment_to_activity_attachment' ), $media_ids );
+		return \array_filter( \array_map( array( self::class, 'wp_attachment_to_activity_attachment' ), $media_ids ) );
 	}
 
 	/**
@@ -234,7 +234,7 @@ class Post {
 		}
 		$image_ids = \array_unique( $image_ids );
 
-		return array_map( array( self::class, 'wp_attachment_to_activity_attachment' ), $image_ids );
+		return \array_filter( \array_map( array( self::class, 'wp_attachment_to_activity_attachment' ), $image_ids ) );
 	}
 
 	/**
@@ -330,8 +330,8 @@ class Post {
 					if ( $alt ) {
 						$image['name'] = $alt;
 					}
+					$attachment = $image;
 				}
-				$attachment = $image;
 				break;
 
 			case 'audio':

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,10 @@ Where 'blog' is the path to the subdirectory at which your blog resides.
 
 Project maintained on GitHub at [automattic/wordpress-activitypub](https://github.com/automattic/wordpress-activitypub).
 
+= 1.1.0 =
+
+* Improved: audio and video attachments are now supported!
+
 = 1.0.10 =
 
 * Improved: better error messages if remote profile is not accessible

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -138,7 +138,7 @@
 					</tr>
 					<tr>
 						<th scope="row">
-							<?php \esc_html_e( 'Number of images', 'activitypub' ); ?>
+							<?php \esc_html_e( 'Media attachments', 'activitypub' ); ?>
 						</th>
 						<td>
 							<input value="<?php echo esc_attr( \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) ); ?>" name="activitypub_max_image_attachments" id="activitypub_max_image_attachments" type="number" min="0" />
@@ -147,12 +147,19 @@
 								echo \wp_kses(
 									\sprintf(
 										// translators:
-										\__( 'The number of images to attach to posts. Default: <code>%s</code>', 'activitypub' ),
+										\__( 'The number of media (images, audio, video) to attach to posts. Default: <code>%s</code>', 'activitypub' ),
 										\esc_html( ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS )
 									),
 									'default'
 								);
 								?>
+							</p>
+							<p class="description">
+								<em>
+									<?php
+										esc_html_e( 'Note: audio and video attachments are only supported from Block Editor.', 'activitypub' );
+									?>
+								</em>
 							</p>
 						</td>
 					</tr>


### PR DESCRIPTION
## Proposed changes:
* support attaching both audio and video uploads!

Note that audio and video are only supported in the block editor. 

Audio and video files are also currently constrained by our max_images number. That may lead to confusion?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?


## Testing instructions:
* upload a video and/or audio file to a post, they should show up in the activitypub version of the post. You can append `/activitypub/` to any given post URL and inspect the `attachment` value.
