### PR TITLE
Mentions: 1MB limit for attempting to link mentions, otherwise bail

### DIFF
--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -26,6 +26,10 @@ class Mention {
 	 * @return string the filtered post-content
 	 */
 	public static function the_content( $the_content ) {
+		// small protection against execution timeouts: limit to 1 MB
+		if ( mb_strlen( $the_content ) > MB_IN_BYTES ) {
+			return $the_content;
+		}
 		$tag_stack = array();
 		$protected_tags = array(
 			'pre',


### PR DESCRIPTION
At scale, we begin to see some odd use-cases. There is one particular individual with a 2MB post that is failing repeatedly (our jobs system continually retries after fatal errors) while trying to convert mentions into links due to execution timeouts.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* add a 1MB limit to attempting to link

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
I don't really suggest trying to federate a post this large! 
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

