### PR TITLE
Hashtags: 1MB limit for attempting to link

### DIFF
--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -43,6 +43,10 @@ class Hashtag {
 	 * @return string the filtered post-content
 	 */
 	public static function the_content( $the_content ) {
+		// small protection against execution timeouts: limit to 1 MB
+		if ( mb_strlen( $the_content ) > MB_IN_BYTES ) {
+			return $the_content;
+		}
 		$tag_stack = array();
 		$protected_tags = array(
 			'pre',

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 * Improved: audio and video attachments are now supported!
 * Improved: better error messages if remote profile is not accessible
 * Improved: PHP 8.1 compatibility
+* Fixed: don't try to parse mentions or hashtags for very large (>1MB) posts to prevent timeouts
 
 = 1.0.10 =
 


### PR DESCRIPTION
Following on from #540 , this will also bail early when attempting to link hashtags, to prevent fatal error timeouts that will fail to federate the published post.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* add a 1MB limit to attempting to link hashtags

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

