### PR TITLE
Attachments: dedupe earlier to prevent incorrect max_media

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -185,7 +185,6 @@ class Post {
 			$blocks = \parse_blocks( $this->wp_post->post_content );
 			$media_ids = self::get_media_ids_from_blocks( $blocks, $media_ids, $max_media );
 		}
-		$media_ids = \array_unique( $media_ids );
 
 		return \array_filter( \array_map( array( self::class, 'wp_attachment_to_activity_attachment' ), $media_ids ) );
 	}
@@ -278,6 +277,9 @@ class Post {
 					}
 					break;
 			}
+
+			// depupe
+			$media_ids = \array_unique( $media_ids );
 
 			// stop doing unneeded work
 			if ( count( $media_ids ) >= $max_media ) {


### PR DESCRIPTION
Our dedupe logic ran too late, after already scoping to max_media, which would sometimes result in fewer attachments than warranted by `max_media`. 

This would happen especially in the case of a Featured Image also appearing in the `post_content`.

Fixes #560 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* dedupe attachments before cutting to max_media

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
Make a post with more images than your max media. Add a feature image and also add it as a standalone image in post_content. The ActivityPub representation will have one fewer attachment than it should have without this patch, the correct number with it.

Eg, with a local post and `max_images=3`:

```
curl -H 'Accept: application/activity+json' http://wp.test/2023/10/301/ | jq .attachment
## Before:
[
  {
    "type": "Image",
    "url": "http://wp.test/wp-content/uploads/2023/08/avatar-2017-large-upsidedown.jpeg",
    "mediaType": "image/jpeg"
  },
  {
    "type": "Image",
    "url": "http://wp.test/wp-content/uploads/2023/09/Screenshot-2023-09-20-at-15.33.15.png",
    "mediaType": "image/png"
  }
]

## After:
[
  {
    "type": "Image",
    "url": "http://wp.test/wp-content/uploads/2023/08/avatar-2017-large-upsidedown.jpeg",
    "mediaType": "image/jpeg"
  },
  {
    "type": "Image",
    "url": "http://wp.test/wp-content/uploads/2023/09/Screenshot-2023-09-20-at-15.33.15.png",
    "mediaType": "image/png"
  },
  {
    "type": "Image",
    "url": "http://wp.test/wp-content/uploads/2023/09/Screenshot-2023-09-20-at-15.40.13.png",
    "mediaType": "image/png"
  }
]
```