### PR TITLE
Clarifying what [ap_excerpt] does

### DIFF
--- a/includes/help.php
+++ b/includes/help.php
@@ -12,7 +12,7 @@
 				'<dt><code>[ap_content apply_filters="yes"]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s content. With <code>apply_filters</code> you can decide if filters (<code>apply_filters( \'the_content\', $content )</code>) should be applied or not (default is <code>yes</code>). The values can be <code>yes</code> or <code>no</code>. <code>apply_filters</code> attribute is optional.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_excerpt length="400"]</code></dt>' .
-				'<dd>' . \wp_kses( __( 'The post\'s excerpt (default 400 chars). <code>length</code> attribute is optional.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
+				'<dd>' . \wp_kses( __( 'The post\'s excerpt (uses <code>the_excerpt</code> if that is set). If no excerpt is provided, will truncate at <code>length</code> (optional, default = 400).', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_permalink type="url"]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s permalink. <code>type</code> can be either: <code>url</code> or <code>html</code> (an &lt;a /&gt; tag). <code>type</code> attribute is optional.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_shortlink type="url"]</code></dt>' .

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -93,7 +93,7 @@
 									<?php \esc_html_e( 'Excerpt', 'activitypub' ); ?>
 									-
 									<span class="description">
-										<?php \esc_html_e( 'A content summary, shortened to 400 characters and without markup.', 'activitypub' ); ?>
+										<?php \esc_html_e( 'A content summary without markup (truncated if no excerpt is provided).', 'activitypub' ); ?>
 									</span>
 								</label>
 							</p>
@@ -125,7 +125,7 @@
 										<ul>
 											<li><code>[ap_title]</code> - <?php \esc_html_e( 'The post\'s title.', 'activitypub' ); ?></li>
 											<li><code>[ap_content]</code> - <?php \esc_html_e( 'The post\'s content.', 'activitypub' ); ?></li>
-											<li><code>[ap_excerpt]</code> - <?php \esc_html_e( 'The post\'s excerpt (default 400 chars).', 'activitypub' ); ?></li>
+											<li><code>[ap_excerpt]</code> - <?php \esc_html_e( 'The post\'s excerpt (may be truncated).', 'activitypub' ); ?></li>
 											<li><code>[ap_permalink]</code> - <?php \esc_html_e( 'The post\'s permalink.', 'activitypub' ); ?></li>
 											<li><code>[ap_shortlink]</code> - <?php echo \wp_kses( \__( 'The post\'s shortlink. I can recommend <a href="https://wordpress.org/plugins/hum/" target="_blank">Hum</a>.', 'activitypub' ), 'default' ); ?></li>
 											<li><code>[ap_hashtags]</code> - <?php \esc_html_e( 'The post\'s tags as hashtags.', 'activitypub' ); ?></li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #577 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Clarifies what [ap_excerpt] does exactly in the relevant places (main Settings page and help.php)
* No change in behaviour, just a change to clarify documentation. It should be clear to users that this respects `the_excerpt` if available, and otherwise truncates the post at `length`.

### Other information:

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to ActivityPub > Settings
* The relevant descriptions should be updated to be more clear and less ambiguous about what it means to choose [ap_excerpt]. It will be clear to users that it respects `the_excerpt` if available, and otherwise truncates the post at `length`.

