### PR TITLE
Fix sending posts to at most ten instances

### DIFF
--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -267,7 +267,7 @@ class Followers {
 		// get all Followers of a ID of the WordPress User
 		$posts = new WP_Query(
 			array(
-				'nopaging' => true,
+				'nopaging'   => true,
 				'post_type'  => self::POST_TYPE,
 				'fields'     => 'ids',
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -267,6 +267,7 @@ class Followers {
 		// get all Followers of a ID of the WordPress User
 		$posts = new WP_Query(
 			array(
+				'pagination' => false,
 				'post_type'  => self::POST_TYPE,
 				'fields'     => 'ids',
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -267,7 +267,7 @@ class Followers {
 		// get all Followers of a ID of the WordPress User
 		$posts = new WP_Query(
 			array(
-				'pagination' => false,
+				'nopaging' => true,
 				'post_type'  => self::POST_TYPE,
 				'fields'     => 'ids',
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #587 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Disable pagination on the query in `Followers::get_inboxes()` that looks up follower IDs. This causes it to return all followers, rather than a paged list of ten of them. This means that we end up delivering our post to all followers, and not to the instances belonging to a subset of ten of them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You need an instance with more than ten followers from different instances for a profile (user or blog) to demonstrate the issue here.
* Log outgoing posts in some way.
* Prior to the fix, you'll see that when a post goes out, at most ten instances (and often fewer, if you have more than one follower per instance) actually get sent the message.
* With this fix, all should get them.
* Alternatively, use something like `wp shell` from `wp-cli` to run the queries in before and after fix forms directly and observe the difference.