### PR TITLE
replace `excerpt_more` with custom filter `activitypub_excerpt_more`  for better consistency

### DIFF
--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -127,8 +127,7 @@ class Shortcodes {
 		// Strip out any remaining tags.
 		$excerpt = \wp_strip_all_tags( $excerpt );
 
-		/** This filter is documented in wp-includes/formatting.php */
-		$excerpt_more = \apply_filters( 'excerpt_more', ' [...]' );
+		$excerpt_more = \apply_filters( 'activitypub_excerpt_more', ' [&hellip;]' );
 		$excerpt_more_len = strlen( $excerpt_more );
 
 		// We now have a excerpt, but we need to check it's length, it may be longer than we want for two reasons:

--- a/tests/test-class-activitypub-shortcodes.php
+++ b/tests/test-class-activitypub-shortcodes.php
@@ -62,4 +62,34 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 		$this->assertEquals( '', $content );
 		Shortcodes::unregister();
 	}
+
+	public function test_excerpt() {
+		Shortcodes::register();
+		global $post;
+
+		$post_id = -97; // negative ID, to avoid clash with a valid post
+		$post = new stdClass();
+		$post->ID = $post_id;
+		$post->post_author = 1;
+		$post->post_date = current_time( 'mysql' );
+		$post->post_date_gmt = current_time( 'mysql', 1 );
+		$post->post_title = 'Some title or other';
+		$post->post_content = '<script>test</script>Lorem ipsum dolor sit amet, consectetur.<script type="javascript">{"asdf": "qwerty"}</script><style></style>';
+		$post->post_status = 'publish';
+		$post->comment_status = 'closed';
+		$post->ping_status = 'closed';
+		$post->post_name = 'fake-page-' . rand( 1, 99999 ); // append random number to avoid clash
+		$post->post_type = 'page';
+		$post->filter = 'raw'; // important!
+
+		$content = '[ap_excerpt length="25"]';
+
+		// Fill in the shortcodes.
+		setup_postdata( $post );
+		$content = do_shortcode( $content );
+		wp_reset_postdata();
+
+		$this->assertEquals( "<p>Lorem ipsum [&hellip;]</p>\n", $content );
+		Shortcodes::unregister();
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #558 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `excerpt_more` might already be customized by themes. Using `activitypub_excerpt_more` to allow more specific control.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a theme with custom `excerpt_more` filter, for example twentyfiteen.
* The `[ap_excerpt]` shortcode should not be affected by the `excerpt_more` filter.

