### PR TITLE
show admin notice when permalink structure is plain

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -21,8 +21,8 @@ class Admin {
 		\add_action( 'personal_options_update', array( self::class, 'save_user_description' ) );
 		\add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_scripts' ) );
 
-		Admin::$admin_notices = Admin::get_admin_notices();
-		if ( !empty( Admin::$admin_notices ) ) {
+		self::$admin_notices = self::get_admin_notices();
+		if ( ! empty( self::$admin_notices ) ) {
 			\add_action( 'admin_notices', array( self::class, 'show_admin_notices' ) );
 		}
 
@@ -71,7 +71,7 @@ class Admin {
 	 * Display admin menu notices about configuration problems or conflicts
 	 */
 	public static function show_admin_notices() {
-		foreach ( Admin::$admin_notices as $admin_notice ) {
+		foreach ( self::$admin_notices as $admin_notice ) {
 			?>
 
 			<div class="notice notice-error">

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -10,8 +10,6 @@ use Activitypub\Model\Blog_User;
  * @author Matthias Pfefferle
  */
 class Admin {
-	private static $admin_notices = array();
-
 	/**
 	 * Initialize the class, registering WordPress hooks
 	 */

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -20,11 +20,7 @@ class Admin {
 		\add_action( 'admin_init', array( self::class, 'register_settings' ) );
 		\add_action( 'personal_options_update', array( self::class, 'save_user_description' ) );
 		\add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_scripts' ) );
-
-		self::$admin_notices = self::get_admin_notices();
-		if ( ! empty( self::$admin_notices ) ) {
-			\add_action( 'admin_notices', array( self::class, 'show_admin_notices' ) );
-		}
+		\add_action( 'admin_notices', array( self::class, 'admin_notices' ) );
 
 		if ( ! is_user_disabled( get_current_user_id() ) ) {
 			\add_action( 'show_user_profile', array( self::class, 'add_profile' ) );
@@ -54,32 +50,27 @@ class Admin {
 	}
 
 	/**
-	 * Collect admin menu notices about configuration problems or conflicts
+	 * Display admin menu notices about configuration problems or conflicts
 	 */
-	public static function get_admin_notices() {
-		$admin_notices = array();
-
+	public static function admin_notices() {
 		$permalink_structure = \get_option( 'permalink_structure' );
 		if ( empty( $permalink_structure ) ) {
-			array_push( $admin_notices, 'You are using the ActivityPub plugin without setting a permalink structure.  This will prevent ActivityPub from working.  Please set a permalink structure.' );
+			$admin_notice = \__( 'You are using the ActivityPub plugin without setting a permalink structure.  This will prevent ActivityPub from working.  Please set a permalink structure.', 'activitypub' );
+			self::show_admin_notice( $admin_notice, 'error' );
 		}
-
-		return $admin_notices;
 	}
 
 	/**
-	 * Display admin menu notices about configuration problems or conflicts
+	 * Display one admin menu notice about configuration problems or conflicts
 	 */
-	public static function show_admin_notices() {
-		foreach ( self::$admin_notices as $admin_notice ) {
-			?>
+	private static function show_admin_notice( $admin_notice, $level ) {
+		?>
 
-			<div class="notice notice-error">
-				<p><?php echo wp_kses( $admin_notice, 'data' ); ?></p>
-			</div>
+		<div class="notice notice-<?php echo wp_kses( $level, 'data' ); ?>">
+			<p><?php echo wp_kses( $admin_notice, 'data' ); ?></p>
+		</div>
 
-			<?php
-		}
+		<?php
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -50,23 +50,30 @@ class Admin {
 	}
 
 	/**
-	 * Display admin menu notices about configuration problems or conflicts
+	 * Display admin menu notices about configuration problems or conflicts.
+	 *
+	 * @return void
 	 */
 	public static function admin_notices() {
 		$permalink_structure = \get_option( 'permalink_structure' );
 		if ( empty( $permalink_structure ) ) {
-			$admin_notice = \__( 'You are using the ActivityPub plugin without setting a permalink structure.  This will prevent ActivityPub from working.  Please set a permalink structure.', 'activitypub' );
+			$admin_notice = \__( 'You are using the ActivityPub plugin without setting a permalink structure. This will prevent ActivityPub from working.  Please set a permalink structure.', 'activitypub' );
 			self::show_admin_notice( $admin_notice, 'error' );
 		}
 	}
 
 	/**
-	 * Display one admin menu notice about configuration problems or conflicts
+	 * Display one admin menu notice about configuration problems or conflicts.
+	 *
+	 * @param string $admin_notice The notice to display.
+	 * @param string $level The level of the notice (error, warning, success, info).
+	 *
+	 * @return void
 	 */
 	private static function show_admin_notice( $admin_notice, $level ) {
 		?>
 
-		<div class="notice notice-<?php echo wp_kses( $level, 'data' ); ?>">
+		<div class="notice notice-<?php echo esc_attr( $level ); ?>">
 			<p><?php echo wp_kses( $admin_notice, 'data' ); ?></p>
 		</div>
 

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -32,22 +32,18 @@ class Blocks {
 	}
 
 	public static function register_blocks() {
-		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'activitypub/followers' ) ) {
-			\register_block_type_from_metadata(
-				ACTIVITYPUB_PLUGIN_DIR . '/build/followers',
-				array(
-					'render_callback' => array( self::class, 'render_follower_block' ),
-				)
-			);
-		}
-		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'activitypub/follow-me' ) ) {
-			\register_block_type_from_metadata(
-				ACTIVITYPUB_PLUGIN_DIR . '/build/follow-me',
-				array(
-					'render_callback' => array( self::class, 'render_follow_me_block' ),
-				)
-			);
-		}
+		\register_block_type_from_metadata(
+			ACTIVITYPUB_PLUGIN_DIR . '/build/followers',
+			array(
+				'render_callback' => array( self::class, 'render_follower_block' ),
+			)
+		);
+		\register_block_type_from_metadata(
+			ACTIVITYPUB_PLUGIN_DIR . '/build/follow-me',
+			array(
+				'render_callback' => array( self::class, 'render_follow_me_block' ),
+			)
+		);
 	}
 
 	private static function get_user_id( $user_string ) {

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -32,18 +32,22 @@ class Blocks {
 	}
 
 	public static function register_blocks() {
-		\register_block_type_from_metadata(
-			ACTIVITYPUB_PLUGIN_DIR . '/build/followers',
-			array(
-				'render_callback' => array( self::class, 'render_follower_block' ),
-			)
-		);
-		\register_block_type_from_metadata(
-			ACTIVITYPUB_PLUGIN_DIR . '/build/follow-me',
-			array(
-				'render_callback' => array( self::class, 'render_follow_me_block' ),
-			)
-		);
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'activitypub/followers' ) ) {
+			\register_block_type_from_metadata(
+				ACTIVITYPUB_PLUGIN_DIR . '/build/followers',
+				array(
+					'render_callback' => array( self::class, 'render_follower_block' ),
+				)
+			);
+		}
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'activitypub/follow-me' ) ) {
+			\register_block_type_from_metadata(
+				ACTIVITYPUB_PLUGIN_DIR . '/build/follow-me',
+				array(
+					'render_callback' => array( self::class, 'render_follow_me_block' ),
+				)
+			);
+		}
 	}
 
 	private static function get_user_id( $user_string ) {

--- a/tests/test-class-admin.php
+++ b/tests/test-class-admin.php
@@ -2,7 +2,6 @@
 class Test_Admin extends WP_UnitTestCase {
 	public function test_no_permalink_structure_has_errors() {
 		\add_option( 'permalink_structure', '' );
-		\do_action( 'init' );
 		\do_action( 'admin_notices' );
 		$this->expectOutputRegex( "/notice-error/" );
 
@@ -11,7 +10,6 @@ class Test_Admin extends WP_UnitTestCase {
 
 	public function test_has_permalink_structure_no_errors() {
 		\add_option( 'permalink_structure', '/archives/%post_id%' );
-		\do_action( 'init' );
 		\do_action( 'admin_notices' );
 		$this->expectOutputRegex( "/^((?!notice-error).)*$/s" );
 

--- a/tests/test-class-admin.php
+++ b/tests/test-class-admin.php
@@ -1,0 +1,20 @@
+<?php
+class Test_Admin extends WP_UnitTestCase {
+	public function test_no_permalink_structure_has_errors() {
+		\add_option( 'permalink_structure', '' );
+		\do_action( 'init' );
+		\do_action( 'admin_notices' );
+		$this->expectOutputRegex( "/notice-error/" );
+
+		\delete_option( 'permalink_structure' );
+	}
+
+	public function test_has_permalink_structure_no_errors() {
+		\add_option( 'permalink_structure', '/archives/%post_id%' );
+		\do_action( 'init' );
+		\do_action( 'admin_notices' );
+		$this->expectOutputRegex( "/^((?!notice-error).)*$/s" );
+
+		\delete_option( 'permalink_structure' );
+	}
+}


### PR DESCRIPTION
Fixes #609

## Proposed changes:

This displays an admin notice if the permalink structure is plain.  This is because the plugin cannot function correctly with such a permalink structure, it prevents webfinger from working.

### Other information:

Tests have been added.

### Implementation notes

I am not sure about the implementation.  The admin notice is pretty bold.  Perhaps a more subtle notice makes sense?

The implementation is designed to allow for many warnings.  At the moment there is only this one.  I imagine in future other issues could be detected here.  For example there is currently conflicts with the One User Avatar and Comment Like Dislike plugins.  This would be an appropriate mechanism to flag those issues.

## Testing instructions:

Testing:

* Create a fresh wordpress instance, but do not set a permalink structure.
* Install the activitypub plugin
* Observe administrator console.  An error about the permalink structure should be displayed.
* Change the permalink structure to anything else.
* Observe that the error has disappeared.