### PR TITLE
Add nodeinfo metadata

### DIFF
--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -106,8 +106,8 @@ class Nodeinfo {
 		);
 
 		$nodeinfo['metadata'] = array(
-			'nodeName' =>  \get_bloginfo( 'name' ),
-			'nodeDescription' =>  \get_bloginfo( 'description' ),
+			'nodeName' => \get_bloginfo( 'name' ),
+			'nodeDescription' => \get_bloginfo( 'description' ),
 			'nodeIcon' => \get_site_icon_url(),
 		);
 

--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -105,6 +105,12 @@ class Nodeinfo {
 			'outbound' => array(),
 		);
 
+		$nodeinfo['metadata'] = array(
+			'nodeName' =>  \get_bloginfo( 'name' ),
+			'nodeDescription' =>  \get_bloginfo( 'description' ),
+			'nodeIcon' => \get_site_icon_url(),
+		);
+
 		return new WP_REST_Response( $nodeinfo, 200 );
 	}
 


### PR DESCRIPTION
This is a very tiny pull request that adds some metadata fields for the nodeinfo representation.

Both `nodeName` and `nodeDescription` are already widely adopted.
More info to the current status can be found here: https://codeberg.org/thefederationinfo/nodeinfo_metadata_survey

`nodeIcon` is not used yet, I proposed it myself as it could yield to use cases later. Most WordPress sides are highly customized and styled. They have a favicon that people already identify the site with. Maybe other software will make use of this in the feature, like Mobilizon when following the application actor of a WordPress site (see https://framagit.org/framasoft/mobilizon/-/merge_requests/1513).