### PR TITLE
Add improved classic editor image detection

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -188,7 +188,7 @@ class Post extends Base {
 		$image_ids = array();
 		$query = new \WP_Query(
 			array(
-				'post_parent' => $id,
+				'post_parent' => $this->object->ID,
 				'post_status' => 'inherit',
 				'post_type' => 'attachment',
 				'post_mime_type' => 'image',
@@ -221,6 +221,9 @@ class Post extends Base {
 		$base = \wp_get_upload_dir()['baseurl'];
 		$content = \get_post_field( 'post_content', $this->object );
 		$tags = new \WP_HTML_Tag_Processor( $content );
+		// This linter warning is a false positive - we have to
+		// re-count each time here as we modify $image_ids.
+		// phpcs:ignore Squiz.PHP.DisallowSizeFunctionsInLoops.Found
 		while ( $tags->next_tag( 'img' ) && ( \count( $image_ids ) < $max_images ) ) {
 			$src = $tags->get_attribute( 'src' );
 			// If the img source is in our uploads dir, get the
@@ -269,13 +272,13 @@ class Post extends Base {
 
 		if ( \count( $image_ids ) < $max_images ) {
 			if ( \class_exists( '\WP_HTML_Tag_Processor' ) ) {
-				$image_ids = \array_merge ($image_ids, $this->get_classic_editor_image_embeds( $max_images ) );
+				$image_ids = \array_merge( $image_ids, $this->get_classic_editor_image_embeds( $max_images ) );
 			} else {
-				$image_ids = \array_merge ($image_ids, $this->get_classic_editor_image_attachments( $max_images ) );
+				$image_ids = \array_merge( $image_ids, $this->get_classic_editor_image_attachments( $max_images ) );
 			}
 		}
 		// unique then slice as the thumbnail may duplicate another image
-		$image_ids = \array_slice ( \array_unique( $image_ids ), 0, $max_images );
+		$image_ids = \array_slice( \array_unique( $image_ids ), 0, $max_images );
 
 		return \array_filter( \array_map( array( self::class, 'wp_attachment_to_activity_attachment' ), $image_ids ) );
 	}

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -235,7 +235,9 @@ class Post extends Base {
 					$img_id = \attachment_url_to_postid( $src_repl );
 				}
 				if ( $img_id !== 0 ) {
-					$image_ids[] = $img_id;
+					if ( ! \in_array( $img_id, $image_ids, true ) ) {
+						$image_ids[] = $img_id;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #612 
Fixes #553 

I note that work on this issue hasn't been officially prioritised due to the deprecation of the classic editor, but we're still using it so here we are.

## Proposed changes:

* If we're using the classic editor on a new enough version of WordPress to have the `WP_HTML_Tag_Processor` available, use this to pull all `<img>` tags out of the post. Grab their sources, and if they point at our uploads directory, use them in the federated representation of the post.
* There's a slightly hairy bit of code to handle different-sized versions of images - I played around with a few options here including trying to parse `srcset` but decided the simplest and most reliable option is to attempt to look the URL up directly, and _iff_ that fails use a regex to drop suffixes of the type `-500x500` or `-scaled` and look that up. If that also fails, give up. (This works fine if you're using a plugin for alternate `.webp` representations as well, as these show up in a different bit of the `<picture>` tag in this case.)
* If you don't have WP6.2+ for some reason, the old behaviour is retained.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
1. Use the classic editor.
2. Create a post.
3. Upload and add an image to the post.
4. Remove the image.
5. Add a different, previously uploaded image to the post.
6. Publish and look at the federated version.

Prior to this patch, you'll see the uploaded image and not the added image. With this patch, you correctly see the image(s) which are actually present in the post. (Note: We still preserve showing the featured/thumbnail image first, even if it's not actually in the post.)

