### PR TITLE
Improve the property names of the transformer classes

### DIFF
--- a/includes/transformer/class-attachment.php
+++ b/includes/transformer/class-attachment.php
@@ -20,7 +20,7 @@ class Attachment extends Post {
 	 * @return array The Attachments.
 	 */
 	protected function get_attachment() {
-		$mime_type  = get_post_mime_type( $this->object->ID );
+		$mime_type  = get_post_mime_type( $this->wp_object->ID );
 		$media_type = preg_replace( '/(\/[a-zA-Z]+)/i', '', $mime_type );
 
 		switch ( $media_type ) {
@@ -35,11 +35,11 @@ class Attachment extends Post {
 
 		$attachment = array(
 			'type'      => $type,
-			'url'       => wp_get_attachment_url( $this->object->ID ),
+			'url'       => wp_get_attachment_url( $this->wp_object->ID ),
 			'mediaType' => $mime_type,
 		);
 
-		$alt = \get_post_meta( $this->object->ID, '_wp_attachment_image_alt', true );
+		$alt = \get_post_meta( $this->wp_object->ID, '_wp_attachment_image_alt', true );
 		if ( $alt ) {
 			$attachment['name'] = $alt;
 		}

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -1,6 +1,9 @@
 <?php
 namespace Activitypub\Transformer;
 
+use WP_Post;
+use WP_Comment;
+
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
 
@@ -12,18 +15,20 @@ use Activitypub\Activity\Base_Object;
  */
 abstract class Base {
 	/**
-	 * The WP_Post object.
+	 * The WP_Post or WP_Comment object.
 	 *
-	 * @var
+	 * This is the source object of the transformer.
+	 *
+	 * @var WP_Post|WP_Comment
 	 */
-	protected $object;
+	protected $wp_object;
 
 	/**
 	 * Static function to Transform a WordPress Object.
 	 *
 	 * This helps to chain the output of the Transformer.
 	 *
-	 * @param stdClass $object The WP_Post object
+	 * @param WP_Object|WP_Comment $object The WP_Post object
 	 *
 	 * @return void
 	 */
@@ -34,10 +39,10 @@ abstract class Base {
 	/**
 	 * Base constructor.
 	 *
-	 * @param stdClass $object
+	 * @param WP_Object|WP_Comment $wp_object
 	 */
-	public function __construct( $object ) {
-		$this->object = $object;
+	public function __construct( $wp_object ) {
+		$this->wp_object = $wp_object;
 	}
 
 	/**
@@ -46,9 +51,9 @@ abstract class Base {
 	 * @return Activitypub\Activity\Base_Object
 	 */
 	public function to_object() {
-		$object = new Base_Object();
+		$activitypub_object = new Base_Object();
 
-		$vars = $object->get_object_var_keys();
+		$vars = $activitypub_object->get_object_var_keys();
 
 		foreach ( $vars as $var ) {
 			$getter = 'get_' . $var;
@@ -59,12 +64,12 @@ abstract class Base {
 				if ( isset( $value ) ) {
 					$setter = 'set_' . $var;
 
-					call_user_func( array( $object, $setter ), $value );
+					call_user_func( array( $activitypub_object, $setter ), $value );
 				}
 			}
 		}
 
-		return $object;
+		return $activitypub_object;
 	}
 
 	/**

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -19,7 +19,7 @@ abstract class Base {
 	 *
 	 * This is the source object of the transformer.
 	 *
-	 * @var WP_Post|WP_Comment
+	 * @var stdClass|WP_Post|WP_Comment
 	 */
 	protected $wp_object;
 
@@ -28,7 +28,7 @@ abstract class Base {
 	 *
 	 * This helps to chain the output of the Transformer.
 	 *
-	 * @param WP_Object|WP_Comment $object The WP_Post object
+	 * @param stdClass|WP_Post|WP_Comment $wp_object The WordPress object
 	 *
 	 * @return void
 	 */
@@ -39,7 +39,7 @@ abstract class Base {
 	/**
 	 * Base constructor.
 	 *
-	 * @param WP_Object|WP_Comment $wp_object
+	 * @param stdClass|WP_Post|WP_Comment $wp_object The WordPress object
 	 */
 	public function __construct( $wp_object ) {
 		$this->wp_object = $wp_object;

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -19,7 +19,7 @@ abstract class Base {
 	 *
 	 * This is the source object of the transformer.
 	 *
-	 * @var stdClass|WP_Post|WP_Comment
+	 * @var WP_Post|WP_Comment
 	 */
 	protected $wp_object;
 
@@ -28,7 +28,7 @@ abstract class Base {
 	 *
 	 * This helps to chain the output of the Transformer.
 	 *
-	 * @param stdClass|WP_Post|WP_Comment $wp_object The WordPress object
+	 * @param WP_Post|WP_Comment $wp_object The WordPress object
 	 *
 	 * @return void
 	 */
@@ -39,7 +39,7 @@ abstract class Base {
 	/**
 	 * Base constructor.
 	 *
-	 * @param stdClass|WP_Post|WP_Comment $wp_object The WordPress object
+	 * @param WP_Post|WP_Comment $wp_object The WordPress object
 	 */
 	public function __construct( $wp_object ) {
 		$this->wp_object = $wp_object;

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -3,14 +3,11 @@ namespace Activitypub\Transformer;
 
 use WP_Comment;
 use WP_Comment_Query;
-use Activitypub\Hashtag;
-use Activitypub\Webfinger;
+
 use Activitypub\Model\Blog_User;
 use Activitypub\Collection\Users;
 use Activitypub\Transformer\Base;
-use Activitypub\Activity\Base_Object;
 
-use function Activitypub\esc_hashtag;
 use function Activitypub\is_single_user;
 use function Activitypub\get_rest_url_by_path;
 
@@ -31,7 +28,7 @@ class Comment extends Base {
 	 * @return int The User-ID of the WordPress Comment
 	 */
 	public function get_wp_user_id() {
-		return $this->object->user_id;
+		return $this->wp_object->user_id;
 	}
 
 	/**
@@ -40,7 +37,7 @@ class Comment extends Base {
 	 * @return int The User-ID of the WordPress Comment
 	 */
 	public function change_wp_user_id( $user_id ) {
-		$this->object->user_id = $user_id;
+		$this->wp_object->user_id = $user_id;
 	}
 
 	/**
@@ -51,7 +48,7 @@ class Comment extends Base {
 	 * @return \Activitypub\Activity\Base_Object The ActivityPub Object
 	 */
 	public function to_object() {
-		$comment = $this->object;
+		$comment = $this->wp_object;
 		$object  = parent::to_object();
 
 		$object->set_url( \get_comment_link( $comment->comment_ID ) );
@@ -95,7 +92,7 @@ class Comment extends Base {
 			return $user->get_url();
 		}
 
-		return Users::get_by_id( $this->object->user_id )->get_url();
+		return Users::get_by_id( $this->wp_object->user_id )->get_url();
 	}
 
 	/**
@@ -107,7 +104,7 @@ class Comment extends Base {
 	 */
 	protected function get_content() {
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$comment = $this->object;
+		$comment = $this->wp_object;
 		$content = $comment->comment_content;
 
 		$content = \wpautop( $content );
@@ -124,7 +121,7 @@ class Comment extends Base {
 	 * @return int The URL of the in-reply-to.
 	 */
 	protected function get_in_reply_to() {
-		$comment = $this->object;
+		$comment = $this->wp_object;
 
 		$parent_comment = \get_comment( $comment->comment_parent );
 
@@ -154,7 +151,7 @@ class Comment extends Base {
 	 * @return string ActivityPub URI for comment
 	 */
 	protected function get_id() {
-		$comment = $this->object;
+		$comment = $this->wp_object;
 		return $this->generate_id( $comment );
 	}
 
@@ -195,7 +192,7 @@ class Comment extends Base {
 
 		$comment_query = new WP_Comment_Query(
 			array(
-				'post_id'    => $this->object->comment_post_ID,
+				'post_id'    => $this->wp_object->comment_post_ID,
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query' => array(
 					array(
@@ -251,7 +248,7 @@ class Comment extends Base {
 	 * @return array The list of @-Mentions.
 	 */
 	protected function get_mentions() {
-		return apply_filters( 'activitypub_extract_mentions', array(), $this->object->comment_content, $this->object );
+		return apply_filters( 'activitypub_extract_mentions', array(), $this->wp_object->comment_content, $this->wp_object );
 	}
 
 	/**
@@ -260,7 +257,7 @@ class Comment extends Base {
 	 * @return string The locale of the post.
 	 */
 	public function get_locale() {
-		$comment_id = $this->object->ID;
+		$comment_id = $this->wp_object->ID;
 		$lang       = \strtolower( \strtok( \get_locale(), '_-' ) );
 
 		/**
@@ -272,6 +269,6 @@ class Comment extends Base {
 		 *
 		 * @return string The filtered locale of the comment.
 		 */
-		return apply_filters( 'activitypub_comment_locale', $lang, $comment_id, $this->object );
+		return apply_filters( 'activitypub_comment_locale', $lang, $comment_id, $this->wp_object );
 	}
 }

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -30,7 +30,7 @@ class Post extends Base {
 	 * @return int The ID of the WordPress Post
 	 */
 	public function get_wp_user_id() {
-		return $this->object->post_author;
+		return $this->wp_object->post_author;
 	}
 
 	/**
@@ -39,7 +39,7 @@ class Post extends Base {
 	 * @return int The User-ID of the WordPress Post
 	 */
 	public function change_wp_user_id( $user_id ) {
-		$this->object->post_author = $user_id;
+		$this->wp_object->post_author = $user_id;
 
 		return $this;
 	}
@@ -52,7 +52,7 @@ class Post extends Base {
 	 * @return \Activitypub\Activity\Base_Object The ActivityPub Object
 	 */
 	public function to_object() {
-		$post = $this->object;
+		$post = $this->wp_object;
 		$object = parent::to_object();
 
 		$published = \strtotime( $post->post_date_gmt );
@@ -97,7 +97,7 @@ class Post extends Base {
 	 * @return string The Posts URL.
 	 */
 	public function get_url() {
-		$post = $this->object;
+		$post = $this->wp_object;
 
 		if ( 'trash' === get_post_status( $post ) ) {
 			$permalink = \get_post_meta( $post->ID, 'activitypub_canonical_url', true );
@@ -121,7 +121,7 @@ class Post extends Base {
 			return $user->get_url();
 		}
 
-		return Users::get_by_id( $this->object->post_author )->get_url();
+		return Users::get_by_id( $this->wp_object->post_author )->get_url();
 	}
 
 	/**
@@ -134,7 +134,7 @@ class Post extends Base {
 		// We maintain the image-centric naming for backwards compatibility.
 		$max_media = intval( \apply_filters( 'activitypub_max_image_attachments', \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) ) );
 
-		if ( site_supports_blocks() && \has_blocks( $this->object->post_content ) ) {
+		if ( site_supports_blocks() && \has_blocks( $this->wp_object->post_content ) ) {
 			return $this->get_block_attachments( $max_media );
 		}
 
@@ -154,7 +154,7 @@ class Post extends Base {
 			return array();
 		}
 
-		$id = $this->object->ID;
+		$id = $this->wp_object->ID;
 
 		$media_ids = array();
 
@@ -164,7 +164,7 @@ class Post extends Base {
 		}
 
 		if ( $max_media > 0 ) {
-			$blocks = \parse_blocks( $this->object->post_content );
+			$blocks = \parse_blocks( $this->wp_object->post_content );
 			$media_ids = self::get_media_ids_from_blocks( $blocks, $media_ids, $max_media );
 		}
 
@@ -188,7 +188,7 @@ class Post extends Base {
 		$image_ids = array();
 		$query = new \WP_Query(
 			array(
-				'post_parent' => $this->object->ID,
+				'post_parent' => $this->wp_object->ID,
 				'post_status' => 'inherit',
 				'post_type' => 'attachment',
 				'post_mime_type' => 'image',
@@ -225,7 +225,7 @@ class Post extends Base {
 
 		$image_ids = array();
 		$base      = \wp_get_upload_dir()['baseurl'];
-		$content   = \get_post_field( 'post_content', $this->object );
+		$content   = \get_post_field( 'post_content', $this->wp_object );
 		$tags      = new \WP_HTML_Tag_Processor( $content );
 
 		// This linter warning is a false positive - we have to
@@ -271,7 +271,7 @@ class Post extends Base {
 			return array();
 		}
 
-		$id = $this->object->ID;
+		$id = $this->wp_object->ID;
 
 		$image_ids = array();
 
@@ -459,10 +459,10 @@ class Post extends Base {
 
 		// Default to Article.
 		$object_type = 'Article';
-		$post_type = \get_post_type( $this->object );
+		$post_type = \get_post_type( $this->wp_object );
 		switch ( $post_type ) {
 			case 'post':
-				$post_format = \get_post_format( $this->object );
+				$post_format = \get_post_format( $this->wp_object );
 				switch ( $post_format ) {
 					case 'aside':
 					case 'status':
@@ -541,7 +541,7 @@ class Post extends Base {
 	protected function get_tag() {
 		$tags = array();
 
-		$post_tags = \get_the_tags( $this->object->ID );
+		$post_tags = \get_the_tags( $this->wp_object->ID );
 		if ( $post_tags ) {
 			foreach ( $post_tags as $post_tag ) {
 				$tag = array(
@@ -588,7 +588,7 @@ class Post extends Base {
 		do_action( 'activitypub_before_get_content', $post );
 
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$post    = $this->object;
+		$post    = $this->wp_object;
 		$content = $this->get_post_content_template();
 
 		// Register our shortcodes just in time.
@@ -633,7 +633,7 @@ class Post extends Base {
 				break;
 		}
 
-		return apply_filters( 'activitypub_object_content_template', $template, $this->object );
+		return apply_filters( 'activitypub_object_content_template', $template, $this->wp_object );
 	}
 
 	/**
@@ -642,7 +642,7 @@ class Post extends Base {
 	 * @return array The list of @-Mentions.
 	 */
 	protected function get_mentions() {
-		return apply_filters( 'activitypub_extract_mentions', array(), $this->object->post_content, $this->object );
+		return apply_filters( 'activitypub_extract_mentions', array(), $this->wp_object->post_content, $this->wp_object );
 	}
 
 	/**
@@ -651,7 +651,7 @@ class Post extends Base {
 	 * @return string The locale of the post.
 	 */
 	public function get_locale() {
-		$post_id = $this->object->ID;
+		$post_id = $this->wp_object->ID;
 		$lang    = \strtolower( \strtok( \get_locale(), '_-' ) );
 
 		/**
@@ -663,6 +663,6 @@ class Post extends Base {
 		 *
 		 * @return string The filtered locale of the post.
 		 */
-		return apply_filters( 'activitypub_post_locale', $lang, $post_id, $this->object );
+		return apply_filters( 'activitypub_post_locale', $lang, $post_id, $this->wp_object );
 	}
 }


### PR DESCRIPTION
I tried to improve the readability and the efficiency of certain custom transformers via:

- Renaming the property 'object' to 'wp_object' of the _Transformer_ classes  to indicate that its the source
- Adding an optional property 'activitypub_object' which may make already transformed parts available to other "getter" functions.
- Enhancing some PHP-Docs
