### PR TITLE
Address some of things found in #633

### DIFF
--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -102,7 +102,7 @@ class Interactions {
 	 *
 	 * @param array $activity The activity-object
 	 *
-	 * @return array|string|false The commentdata or false on failure
+	 * @return array|string|int|\WP_Error|false The commentdata or false on failure
 	 */
 	public static function update_comment( $activity ) {
 		$meta = get_remote_metadata_by_actor( $activity['actor'] );
@@ -135,14 +135,18 @@ class Interactions {
 		);
 		\add_filter( 'wp_kses_allowed_html', array( self::class, 'allowed_comment_html' ), 10, 2 );
 
-		\wp_update_comment( $commentdata, true );
+		$state = \wp_update_comment( $commentdata, true );
 
 		\remove_filter( 'wp_kses_allowed_html', array( self::class, 'allowed_comment_html' ), 10 );
 		\remove_filter( 'pre_option_require_name_email', '__return_false' );
 		// re-add flood control
 		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
 
-		return $commentdata;
+		if ( 1 === $state ) {
+			return $commentdata;
+		} else {
+			return $state; // Either `false` or a `WP_Error` instance or `0` or `1`!
+		}
 	}
 
 	/**

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -102,7 +102,7 @@ class Interactions {
 	 *
 	 * @param array $activity The activity-object
 	 *
-	 * @return array|false The commentdata or false on failure
+	 * @return array|string|false The commentdata or false on failure
 	 */
 	public static function update_comment( $activity ) {
 		$meta = get_remote_metadata_by_actor( $activity['actor'] );
@@ -135,14 +135,14 @@ class Interactions {
 		);
 		\add_filter( 'wp_kses_allowed_html', array( self::class, 'allowed_comment_html' ), 10, 2 );
 
-		$comment = \wp_update_comment( $commentdata, true );
+		\wp_update_comment( $commentdata, true );
 
 		\remove_filter( 'wp_kses_allowed_html', array( self::class, 'allowed_comment_html' ), 10 );
 		\remove_filter( 'pre_option_require_name_email', '__return_false' );
 		// re-add flood control
 		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
 
-		return $comment;
+		return $commentdata;
 	}
 
 	/**

--- a/includes/handler/class-update.php
+++ b/includes/handler/class-update.php
@@ -66,11 +66,16 @@ class Update {
 	 * @return void
 	 */
 	public static function update_interaction( $activity ) {
-		$state    = Interactions::update_comment( $activity );
-		$reaction = null;
+		$commentdata = Interactions::update_comment( $activity );
+		$reaction    = null;
 
-		if ( $state && ! \is_wp_error( $reaction ) ) {
-			$reaction = \get_comment( $state );
+		if ( ! empty( $commentdata['comment_ID'] ) ) {
+			$state    = 1;
+			$reaction = \get_comment( $commentdata['comment_ID'] );
+		} elseif ( 'inactive' === $commentdata ) {
+			$state = $commentdata;
+		} else {
+			$state = 0;
 		}
 
 		\do_action( 'activitypub_handled_update', $activity, null, $state, $reaction );

--- a/includes/handler/class-update.php
+++ b/includes/handler/class-update.php
@@ -72,10 +72,8 @@ class Update {
 		if ( ! empty( $commentdata['comment_ID'] ) ) {
 			$state    = 1;
 			$reaction = \get_comment( $commentdata['comment_ID'] );
-		} elseif ( 'inactive' === $commentdata ) {
-			$state = $commentdata;
 		} else {
-			$state = 0;
+			$state = $commentdata;
 		}
 
 		\do_action( 'activitypub_handled_update', $activity, null, $state, $reaction );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes some of the things found in #633

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* So, `wp_update_comment()` doesn't actual return a comment ID.
* So I made it so that `Interactions::update_comment()` takes this into account and returns the `$commentdata` array, but only when the update was successful.
* If the update somehow failed, `Interactions::update_comment()` either returns `false` or `'invalid'` (just like before) or whatever is returned by `wp_update_comment()` (which can be an error, or `0`, or even `false`). Actually, in this case, the function behaves just like it did before.
* Subsequently, in the "update handler," I replaced `\get_comment( $state )` with something that I think makes a bit more sense (as mentioned, `$state` isn't actually a comment ID).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The way I tested this, is I created a callback in a separate mu-plugin like so:
```
add_action( 'activitypub_handled_update', function( $activity, $second_param, $state, $reaction ) {
	if ( $reaction instanceof \WP_Comment ) {
		wp_set_comment_status( $reaction, 'hold' );
	}
}, 99, 4 );
```
Thing is, and this might be another bug but I left it untouched for now, I have no clue what the second param really is.

Prior to this PR, `$reaction` would always be `null` or the comment with ID `1` (but, as mentioned, the `1` returned by `wp_update_comment()` isn't actually a comment ID).

With this PR, `$reaction` is either a comment object or `null`. And `$state` basically the result of the `wp_update_comment()` call, kind of like before.

Either way, this short callback addresses #633. So if this PR were merged, site admins or developers would be able to much more easily force re-approval of updated comments.
