### PR TITLE
Enable Mastodon Apps: Implement the account endpoint for an external account

### DIFF
--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -96,15 +96,15 @@ class Enable_Mastodon_Apps {
 		$account->display_name   = $data['name'];
 		$account->url            = $uri;
 		$account->note           = $data['summary'];
-		if ( isset( $data['icon']['type'] ) &&  isset( $data['icon']['url'] ) && 'Image' === $data['icon']['type']) {
-		$account->avatar         = $data['icon']['url'];
-		$account->avatar_static  = $data['icon']['url'];
+		if ( isset( $data['icon']['type'] ) && isset( $data['icon']['url'] ) && 'Image' === $data['icon']['type'] ) {
+			$account->avatar         = $data['icon']['url'];
+			$account->avatar_static  = $data['icon']['url'];
 		}
 		if ( isset( $data['image'] ) ) {
 			$account->header         = $data['image'];
 			$account->header_static  = $data['image'];
 		}
-		$account->created_at    = new \DateTime( $data['published'] );
+		$account->created_at = new \DateTime( $data['published'] );
 
 		return $account;
 	}

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -110,11 +110,11 @@ class Enable_Mastodon_Apps {
 			return $user_data;
 		}
 
-        if ( $user_data instanceOf \Enable_Mastodon_Apps\Entity\Account ) {
-         		$account = $user_data;
-        } else {
-        		$account = new Account();
-        }
+		if ( $user_data instanceof \Enable_Mastodon_Apps\Entity\Account ) {
+				$account = $user_data;
+		} else {
+				$account = new Account();
+		}
 
 		$account->id             = strval( $user_id );
 		$account->username       = $acct;

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -110,7 +110,7 @@ class Enable_Mastodon_Apps {
 			return $user_data;
 		}
 
-		if ( $user_data instanceof \Enable_Mastodon_Apps\Entity\Account ) {
+		if ( $user_data instanceof Account ) {
 				$account = $user_data;
 		} else {
 				$account = new Account();

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -2,7 +2,6 @@
 namespace Activitypub\Integration;
 
 use Activitypub\Webfinger as Webfinger_Util;
-use Activitypub\Webfinger;
 use Activitypub\Collection\Followers;
 
 class Enable_Mastodon_Apps {
@@ -79,7 +78,7 @@ class Enable_Mastodon_Apps {
 			return $user_data;
 		}
 
-		$uri = Webfinger::resolve( $user_id );
+		$uri = \ActivityPub\Webfinger::resolve( $user_id );
 		if ( ! $uri ) {
 			return $user_data;
 		}

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -78,12 +78,15 @@ class Enable_Mastodon_Apps {
 			return $user_data;
 		}
 
-		$uri = \ActivityPub\Webfinger::resolve( $user_id );
+		$uri = \Activitypub\Webfinger::resolve( $user_id );
 		if ( ! $uri ) {
 			return $user_data;
 		}
 		$acct = Webfinger_Util::uri_to_acct( $uri );
-		$data = \ActivityPub\get_remote_metadata_by_actor( $uri );
+		$data = \Activitypub\get_remote_metadata_by_actor( $uri );
+		if ( ! $data ) {
+			return $user_data;
+		}
 
 		$account = new \Enable_Mastodon_Apps\Entity\Account();
 
@@ -92,6 +95,16 @@ class Enable_Mastodon_Apps {
 		$account->acct           = $acct;
 		$account->display_name   = $data['name'];
 		$account->url            = $uri;
+		$account->note           = $data['summary'];
+		if ( isset( $data['icon']['type'] ) &&  isset( $data['icon']['url'] ) && 'Image' === $data['icon']['type']) {
+		$account->avatar         = $data['icon']['url'];
+		$account->avatar_static  = $data['icon']['url'];
+		}
+		if ( isset( $data['image'] ) ) {
+			$account->header         = $data['image'];
+			$account->header_static  = $data['image'];
+		}
+		$account->created_at    = new \DateTime( $data['published'] );
 
 		return $account;
 	}

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -110,7 +110,11 @@ class Enable_Mastodon_Apps {
 			return $user_data;
 		}
 
-		$account = new Account();
+        if ( $user_data instanceOf \Enable_Mastodon_Apps\Entity\Account ) {
+         		$account = $user_data;
+        } else {
+        		$account = new Account();
+        }
 
 		$account->id             = strval( $user_id );
 		$account->username       = $acct;

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -2,7 +2,7 @@
 namespace Activitypub\Integration;
 
 use Activitypub\Webfinger as Webfinger_Util;
-use Activitypub\Webfinger as Webfinger;
+use Activitypub\Webfinger;
 use Activitypub\Collection\Followers;
 
 class Enable_Mastodon_Apps {
@@ -75,7 +75,7 @@ class Enable_Mastodon_Apps {
 	}
 
 	public static function api_account_external( $user_data, $user_id ) {
-		if ( ! preg_match( '/^'. ACTIVITYPUB_USERNAME_REGEXP . '$/', $user_id ) ) {
+		if ( ! preg_match( '/^' . ACTIVITYPUB_USERNAME_REGEXP . '$/', $user_id ) ) {
 			return $user_data;
 		}
 

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -8,6 +8,13 @@ use Enable_Mastodon_Apps\Entity\Account;
 
 use function Activitypub\get_remote_metadata_by_actor;
 
+/**
+ * Class Enable_Mastodon_Apps
+ *
+ * This class is used to enable Mastodon Apps to work with ActivityPub
+ *
+ * @see https://github.com/akirk/enable-mastodon-apps
+ */
 class Enable_Mastodon_Apps {
 	/**
 	 * Initialize the class, registering WordPress hooks
@@ -77,6 +84,14 @@ class Enable_Mastodon_Apps {
 		return $followers;
 	}
 
+	/**
+	 * Resolve external accounts for Mastodon API
+	 *
+	 * @param Enable_Mastodon_Apps\Entity\Account $user_data The user data
+	 * @param string                              $user_id   The user id
+	 *
+	 * @return Enable_Mastodon_Apps\Entity\Account The filtered Account
+	 */
 	public static function api_account_external( $user_data, $user_id ) {
 		if ( ! preg_match( '/^' . ACTIVITYPUB_USERNAME_REGEXP . '$/', $user_id ) ) {
 			return $user_data;

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -1,8 +1,12 @@
 <?php
 namespace Activitypub\Integration;
 
+use DateTime;
 use Activitypub\Webfinger as Webfinger_Util;
 use Activitypub\Collection\Followers;
+use Enable_Mastodon_Apps\Entity\Account;
+
+use function Activitypub\get_remote_metadata_by_actor;
 
 class Enable_Mastodon_Apps {
 	/**
@@ -78,17 +82,20 @@ class Enable_Mastodon_Apps {
 			return $user_data;
 		}
 
-		$uri = \Activitypub\Webfinger::resolve( $user_id );
+		$uri = Webfinger_Util::resolve( $user_id );
+
 		if ( ! $uri ) {
 			return $user_data;
 		}
+
 		$acct = Webfinger_Util::uri_to_acct( $uri );
-		$data = \Activitypub\get_remote_metadata_by_actor( $uri );
+		$data = get_remote_metadata_by_actor( $uri );
+
 		if ( ! $data ) {
 			return $user_data;
 		}
 
-		$account = new \Enable_Mastodon_Apps\Entity\Account();
+		$account = new Account();
 
 		$account->id             = strval( $user_id );
 		$account->username       = $acct;
@@ -96,15 +103,18 @@ class Enable_Mastodon_Apps {
 		$account->display_name   = $data['name'];
 		$account->url            = $uri;
 		$account->note           = $data['summary'];
+
 		if ( isset( $data['icon']['type'] ) && isset( $data['icon']['url'] ) && 'Image' === $data['icon']['type'] ) {
 			$account->avatar         = $data['icon']['url'];
 			$account->avatar_static  = $data['icon']['url'];
 		}
+
 		if ( isset( $data['image'] ) ) {
 			$account->header         = $data['image'];
 			$account->header_static  = $data['image'];
 		}
-		$account->created_at = new \DateTime( $data['published'] );
+
+		$account->created_at = new DateTime( $data['published'] );
 
 		return $account;
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,13 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	require \dirname( __DIR__ ) . '/activitypub.php';
+	$enable_mastodon_apps_plugin = dirname( dirname( __DIR__ ) ) . '/enable-mastodon-apps/enable-mastodon-apps.php'; // phpcs:ignore
+	if ( file_exists( $enable_mastodon_apps_plugin ) ) {
+		require $enable_mastodon_apps_plugin;
+	}
 }
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
 \tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,8 +24,6 @@ function _manually_load_plugin() {
 		require $enable_mastodon_apps_plugin;
 	}
 }
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
-
 \tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.

--- a/tests/test-class-enable-mastodon-apps.php
+++ b/tests/test-class-enable-mastodon-apps.php
@@ -11,7 +11,7 @@ class Test_Enable_Mastodon_Apps extends WP_UnitTestCase {
 	public function test_api_account_external() {
 		$account = apply_filters( 'mastodon_api_account', array(), 'alex@kirk.at' );
 		$this->assertNotEmpty( $account );
-		$account = $account->to_array();
+		$account = $account->jsonSerialize();
 		$this->assertArrayHasKey( 'id', $account );
 		$this->assertArrayHasKey( 'username', $account );
 		$this->assertArrayHasKey( 'acct', $account );

--- a/tests/test-class-enable-mastodon-apps.php
+++ b/tests/test-class-enable-mastodon-apps.php
@@ -1,0 +1,23 @@
+<?php
+class Test_Enable_Mastodon_Apps extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! class_exists( '\Enable_Mastodon_Apps\Entity\Entity' ) ) {
+			self::markTestSkipped( 'The Enable_Mastodon_Apps plugin is not active.' );
+		}
+	}
+
+	public function test_api_account_external() {
+		$account = apply_filters( 'mastodon_api_account', array(), 'alex@kirk.at' );
+		$this->assertNotEmpty( $account );
+		$account = $account->to_array();
+		$this->assertArrayHasKey( 'id', $account );
+		$this->assertArrayHasKey( 'username', $account );
+		$this->assertArrayHasKey( 'acct', $account );
+		$this->assertArrayHasKey( 'display_name', $account );
+		$this->assertArrayHasKey( 'url', $account );
+		$this->assertEquals('https://alex.kirk.at/author/alex/', $account['url']);
+		$this->assertEquals('Alex Kirk', $account['display_name']);
+	}
+}

--- a/tests/test-class-enable-mastodon-apps.php
+++ b/tests/test-class-enable-mastodon-apps.php
@@ -17,7 +17,7 @@ class Test_Enable_Mastodon_Apps extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'acct', $account );
 		$this->assertArrayHasKey( 'display_name', $account );
 		$this->assertArrayHasKey( 'url', $account );
-		$this->assertEquals('https://alex.kirk.at/author/alex/', $account['url']);
-		$this->assertEquals('Alex Kirk', $account['display_name']);
+		$this->assertEquals( 'https://alex.kirk.at/author/alex/', $account['url'] );
+		$this->assertEquals( 'Alex Kirk', $account['display_name'] );
 	}
 }


### PR DESCRIPTION
This moves functionality from the Enable Mastodon Apps into ActivityPub. It allows retrieving the account of someone via ActivityPub with an API endpoint like `/api/v1/accounts/alex@kirk.at/`

The unit test currently needs network access, we should add the ability to mock the response.