### PR TITLE
Add `activitypub_update_followers_number` filter

### DIFF
--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -220,6 +220,7 @@ class Scheduler {
 			$number = 50;
 		}
 
+		$number    = apply_filters( 'activitypub_update_followers_number', $number );
 		$followers = Followers::get_outdated_followers( $number );
 
 		foreach ( $followers as $follower ) {
@@ -246,6 +247,7 @@ class Scheduler {
 			$number = 50;
 		}
 
+		$number    = apply_filters( 'activitypub_update_followers_number', $number );
 		$followers = Followers::get_faulty_followers( $number );
 
 		foreach ( $followers as $follower ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds a `activitypub_update_followers_number` filter. May be silly, but for sites that _do not_ have `DISABLE_WP_CRON` set to true _yet do_ regularly trigger `wp-cron.php` via an actual cron job, the number of followers that are updated will _currently_ never be more than 5 at a time.

Having this number filterable allows site owners to set a number that may be more approiate for their install, or they can---in their callback---employ a different kind of check to see whether PHP is run directly, like `if ( 'cli' === php_sapi_name() )`.

May not be _that_ relevant if the server can act on follower updates, but I thought it wouldn't hurt either.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a filter to allow devs to change the max number of followers that can be updated at once.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* N/A

