### PR TITLE
fix ActivityPub `@context`

### DIFF
--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -173,10 +173,13 @@ class Activity extends Base_Object {
 	 */
 	public function get_json_ld_context() {
 		if ( $this->object instanceof Base_Object ) {
-			// Without php 5.6 support this could be just: 'return  $this->object::JSON_LD_CONTEXT;'
-			return call_user_func( array( get_class( $this->object ), 'CONTEXT' ) );
-		} else {
-			return self::JSON_LD_CONTEXT;
+			$class = get_class( $this->object );
+			if ( $class && $class::JSON_LD_CONTEXT ) {
+				// Without php 5.6 support this could be just: 'return  $this->object::JSON_LD_CONTEXT;'
+				return $class::JSON_LD_CONTEXT;
+			}
 		}
+
+		return static::JSON_LD_CONTEXT;
 	}
 }


### PR DESCRIPTION
The `call_user_func` version seem to not work properly (returns `null` in this case https://github.com/Automattic/wordpress-activitypub/blob/master/includes/handler/class-follow.php#L98) in this case and this seems to break the follow flow.

/cc @Menrath