### PR TITLE
Fix "Undefined variable $type in includes/class-scheduler.php on line 191"

### DIFF
--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -193,7 +193,7 @@ class Scheduler {
 			$type = 'Delete';
 		}
 
-		if ( ! $type ) {
+		if ( empty( $type ) ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes an "undefined variable `$type`" warning.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace `if ( ! $type )` (which throws a warning since I think PHP 8) with `if ( empty( $type ) )`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I got this when deleting and restoring comments
* Maybe when the old status was `trash` and the new one `pending` or whatever it's called
* Either way, there are scenarios where `$type` does not get initialized, ever

