### PR TITLE
Add all repliers as Mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 * Fixed: Remove old/abandoned Crons
 * Added: Various endpoints for the "Enable Mastodon Apps" plugin
 * Added: Event Objects
-* Improved: Post-Type support
+* Added: Send notification to all Repliers if a new Comment was added
 
 ### 2.0.1 ###
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 * Fixed: Remove old/abandoned Crons
 * Added: Various endpoints for the "Enable Mastodon Apps" plugin
 * Added: Event Objects
-* Added: Send notification to all Repliers if a new Comment was added
+* Added: Send notification to all Repliers if a new Comment is added
 * Added: Vary-Header support behind feature flag
 
 ### 2.0.1 ###

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 * Fixed: Remove old/abandoned Crons
 * Added: Various endpoints for the "Enable Mastodon Apps" plugin
 * Added: Event Objects
-* Improved: Post-Type support
+* Added: Send notification to all Repliers if a new Comment was added
 
 = 2.0.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -141,7 +141,7 @@ Project maintained on GitHub at [automattic/wordpress-activitypub](https://githu
 * Fixed: Remove old/abandoned Crons
 * Added: Various endpoints for the "Enable Mastodon Apps" plugin
 * Added: Event Objects
-* Added: Send notification to all Repliers if a new Comment was added
+* Added: Send notification to all Repliers if a new Comment is added
 * Added: Vary-Header support behind feature flag
 
 = 2.0.1 =


### PR DESCRIPTION
Add all repliers as Mentions so that they receive notifications.

See: https://wordpress.org/support/topic/ux-deviation-from-expected-behaviour-in-2-0/

