### PR TITLE
Prevent scheduler overload

### DIFF
--- a/includes/class-activity-dispatcher.php
+++ b/includes/class-activity-dispatcher.php
@@ -27,6 +27,9 @@ class Activity_Dispatcher {
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
+		\add_action( 'activitypub_send_post', array( self::class, 'send_post' ), 10, 2 );
+		\add_action( 'activitypub_send_comment', array( self::class, 'send_comment' ), 10, 2 );
+
 		\add_action( 'activitypub_send_activity', array( self::class, 'send_activity' ), 10, 2 );
 		\add_action( 'activitypub_send_activity', array( self::class, 'send_activity_or_announce' ), 10, 2 );
 		\add_action( 'activitypub_send_update_profile_activity', array( self::class, 'send_profile_update' ), 10, 1 );
@@ -171,5 +174,55 @@ class Activity_Dispatcher {
 		}
 
 		set_wp_object_state( $wp_object, 'federated' );
+	}
+
+	/**
+	 * Send a "Create" or "Update" Activity for a WordPress Post.
+	 *
+	 * @param int    $id   The WordPress Post ID.
+	 * @param string $type The Activity-Type.
+	 *
+	 * @return void
+	 */
+	public static function send_post( $id, $type ) {
+		$post = get_post( $id );
+
+		if ( ! $post ) {
+			return;
+		}
+
+		do_action( 'activitypub_send_activity', $post, $type );
+		do_action(
+			sprintf(
+				'activitypub_send_%s_activity',
+				\strtolower( $type )
+			),
+			$post
+		);
+	}
+
+	/**
+	 * Send a "Create" or "Update" Activity for a WordPress Comment.
+	 *
+	 * @param int    $id   The WordPress Comment ID.
+	 * @param string $type The Activity-Type.
+	 *
+	 * @return void
+	 */
+	public static function send_comment( $id, $type ) {
+		$comment = get_comment( $id );
+
+		if ( ! $comment ) {
+			return;
+		}
+
+		do_action( 'activitypub_send_activity', $comment, $type );
+		do_action(
+			sprintf(
+				'activitypub_send_%s_activity',
+				\strtolower( $type )
+			),
+			$comment
+		);
 	}
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -341,7 +341,6 @@ class Admin {
 	public static function comment_row_actions( $actions, $comment ) {
 		if ( was_comment_received( $comment ) ) {
 			unset( $actions['edit'] );
-			unset( $actions['reply'] );
 			unset( $actions['quickedit'] );
 		}
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -145,20 +145,13 @@ class Scheduler {
 			return;
 		}
 
-		\wp_schedule_single_event(
-			\time(),
-			'activitypub_send_activity',
-			array( $post, $type )
-		);
+		$hook = 'activitypub_send_post';
+		$args = array( $post->ID, $type );
 
-		\wp_schedule_single_event(
-			\time(),
-			sprintf(
-				'activitypub_send_%s_activity',
-				\strtolower( $type )
-			),
-			array( $post )
-		);
+		if ( false === wp_next_scheduled( $hook, $args ) ) {
+			set_wp_object_state( $post, 'federate' );
+			\wp_schedule_single_event( \time(), $hook, $args );
+		}
 	}
 
 	/**
@@ -204,22 +197,13 @@ class Scheduler {
 			return;
 		}
 
-		set_wp_object_state( $comment, 'federate' );
+		$hook = 'activitypub_send_comment';
+		$args = array( $comment->comment_ID, $type );
 
-		\wp_schedule_single_event(
-			\time(),
-			'activitypub_send_activity',
-			array( $comment, $type )
-		);
-
-		\wp_schedule_single_event(
-			\time(),
-			sprintf(
-				'activitypub_send_%s_activity',
-				\strtolower( $type )
-			),
-			array( $comment )
-		);
+		if ( false === wp_next_scheduled( $hook, $args ) ) {
+			set_wp_object_state( $comment, 'federate' );
+			\wp_schedule_single_event( \time(), $hook, $args );
+		}
 	}
 
 	/**


### PR DESCRIPTION
The current version works around all core verification processes to prevent duplicate schedules, because of the use of the `WP_Post` and `WP_Comment` object.

> Note that scheduling an event to occur within 10 minutes of an existing event with the same action hook will be ignored unless you pass unique $args values for each scheduled event.
>
> https://developer.wordpress.org/reference/functions/wp_schedule_single_event/

Because the objects are never the same, because of the content change and different update date-times, this check will never be valid, so this PR changes the code to use the ID instead of the object.

It also uses a more strict `wp_next_scheduled` check, to not only prevent a duplicate within 10 mins!

/cc janboddez