### PR TITLE
Comment reply federation: support `is_single_user` sites

### DIFF
--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -2,9 +2,11 @@
 
 namespace Activitypub;
 
+use Activitypub\Collection\Users;
 use WP_Comment_Query;
 
 use function Activitypub\is_user_disabled;
+use function Activitypub\is_single_user;
 
 /**
  * ActivityPub Comment Class
@@ -83,6 +85,11 @@ class Comment {
 
 		if ( ! $current_user ) {
 			return false;
+		}
+
+		if ( is_single_user() && \user_can( $current_user, 'publish_posts' ) ) {
+			// On a single user site, comments by users with `publish_posts` will be federated as the blog user
+			$current_user = Users::BLOG_USER_ID;
 		}
 
 		$is_user_disabled = is_user_disabled( $current_user );
@@ -188,6 +195,11 @@ class Comment {
 		// comments without user can't be federated
 		if ( ! $user_id ) {
 			return false;
+		}
+
+		if ( is_single_user() && \user_can( $user_id, 'publish_posts' ) ) {
+			// On a single user site, comments by users with `publish_posts` will be federated as the blog user
+			$user_id = Users::BLOG_USER_ID;
 		}
 
 		$is_user_disabled = is_user_disabled( $user_id );

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -114,7 +114,7 @@ class Comment {
 		}
 
 		if ( is_single_user() && \user_can( $current_user, 'publish_posts' ) ) {
-			// On a single user site, comments by users with the `activitypub` capability will be federated as the blog user
+			// On a single user site, comments by users with the `publish_posts` capability will be federated as the blog user
 			$current_user = Users::BLOG_USER_ID;
 		}
 
@@ -223,8 +223,8 @@ class Comment {
 			return false;
 		}
 
-		if ( is_single_user() && \user_can( $user_id, 'activitypub' ) ) {
-			// On a single user site, comments by users with the `activitypub` capability will be federated as the blog user
+		if ( is_single_user() && \user_can( $user_id, 'publish_posts' ) ) {
+			// On a single user site, comments by users with the `publish_posts` capability will be federated as the blog user
 			$user_id = Users::BLOG_USER_ID;
 		}
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -87,8 +87,8 @@ class Comment {
 			return false;
 		}
 
-		if ( is_single_user() && \user_can( $current_user, 'publish_posts' ) ) {
-			// On a single user site, comments by users with `publish_posts` will be federated as the blog user
+		if ( is_single_user() && \user_can( $current_user, 'activitypub' ) ) {
+			// On a single user site, comments by users with the `activitypub` capability will be federated as the blog user
 			$current_user = Users::BLOG_USER_ID;
 		}
 
@@ -197,8 +197,8 @@ class Comment {
 			return false;
 		}
 
-		if ( is_single_user() && \user_can( $user_id, 'publish_posts' ) ) {
-			// On a single user site, comments by users with `publish_posts` will be federated as the blog user
+		if ( is_single_user() && \user_can( $user_id, 'activitypub' ) ) {
+			// On a single user site, comments by users with the `activitypub` capability will be federated as the blog user
 			$user_id = Users::BLOG_USER_ID;
 		}
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -113,7 +113,7 @@ class Comment {
 			return false;
 		}
 
-		if ( is_single_user() && \user_can( $current_user, 'activitypub' ) ) {
+		if ( is_single_user() && \user_can( $current_user, 'publish_posts' ) ) {
 			// On a single user site, comments by users with the `activitypub` capability will be federated as the blog user
 			$current_user = Users::BLOG_USER_ID;
 		}

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -30,6 +30,10 @@ class Comment extends Base {
 	 * @return int The User-ID of the WordPress Comment
 	 */
 	public function get_wp_user_id() {
+		if ( is_single_user() && \user_can( $this->wp_object->user_id, 'publish_posts' ) ) {
+			// Single user sites are federated with the Blog User.
+			return Users::BLOG_USER_ID;
+		}
 		return $this->wp_object->user_id;
 	}
 
@@ -174,7 +178,7 @@ class Comment extends Base {
 
 		$mentions = $this->get_mentions();
 		if ( $mentions ) {
-			foreach ( $mentions as $mention => $url ) {
+			foreach ( $mentions as $url ) {
 				$cc[] = $url;
 			}
 		}

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -30,7 +30,7 @@ class Comment extends Base {
 	 * @return int The User-ID of the WordPress Comment
 	 */
 	public function get_wp_user_id() {
-		if ( is_single_user() && \user_can( $this->wp_object->user_id, 'publish_posts' ) ) {
+		if ( is_single_user() && \user_can( $this->wp_object->user_id, 'activitypub' ) ) {
 			// Single user sites are federated with the Blog User.
 			return Users::BLOG_USER_ID;
 		}

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -30,10 +30,6 @@ class Comment extends Base {
 	 * @return int The User-ID of the WordPress Comment
 	 */
 	public function get_wp_user_id() {
-		if ( is_single_user() && \user_can( $this->wp_object->user_id, 'activitypub' ) ) {
-			// Single user sites are federated with the Blog User.
-			return Users::BLOG_USER_ID;
-		}
 		return $this->wp_object->user_id;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #711 

## Proposed changes:
Federate as the Blog User on `is_single_user` sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
1. Add `define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );` to your `wp-config.php`
2. Reply to a federated post from a Mastodon (or similar) service.
3. When logged in with a user with the `activitypub` capability, you should be able to reply to the post and have it federate - you should receive a notification on the service you used to make the comment in step 2.
