### PR TITLE
Fix: ActivityPub type property does not set correctly on actor classes

### DIFF
--- a/includes/activity/class-actor.php
+++ b/includes/activity/class-actor.php
@@ -52,7 +52,7 @@ class Actor extends Base_Object {
 	/**
 	 * @var string
 	 */
-	protected $type = 'Person';
+	protected $type;
 
 	/**
 	 * A reference to an ActivityStreams OrderedCollection comprised of


### PR DESCRIPTION
Fixes that the get_type function is not called for extended classes, when the property is already set.

There would have been two straight-forward solutions:

1. the proposed one
2. set`protected $type = '...'` in all extended classes of `Actor` and remove the `get_type` functions. 

I guess a test-case for this might be of good use. I will gladly add one if agreed.

