### PR TITLE
Federated replies: improved UX for "your reply will federate"

### DIFF
--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -75,7 +75,7 @@ class Comment {
 	 * to the original author.
 	 *
 	 * @param string $link The HTML markup for the comment reply link.
-	 * @param array  $args An array of arguments overriding the defaults.
+	 * @param array  $args The args provided by the `comment_reply_link` filter.
 	 *
 	 * @return string The modified HTML markup for the comment reply link.
 	 */

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -84,7 +84,7 @@ class Comment {
 		$replace_with = sprintf(
 			' title="%s">%s<',
 			esc_attr__( 'This comment was received from the fediverse and your reply will be sent to the original author', 'activitypub' ),
-			__( 'Reply with federation', 'activitypub' )
+			esc_html__( 'Reply with federation', 'activitypub' )
 		);
 		return str_replace( $str_to_replace, $replace_with, $link );
 	}

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -46,7 +46,7 @@ class Comment {
 	public static function comment_reply_link( $link, $args, $comment ) {
 		if ( self::are_comments_allowed( $comment ) ) {
 			$user_id = get_current_user_id();
-			if ( $user_id && self::was_received( $comment ) && \user_can( $user_id, 'publish_posts' ) ) {
+			if ( $user_id && self::was_received( $comment ) && \user_can( $user_id, 'activitypub' ) ) {
 				return self::create_fediverse_reply_link( $link, $args );
 			}
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -45,6 +45,11 @@ class Comment {
 	 */
 	public static function comment_reply_link( $link, $args, $comment ) {
 		if ( self::are_comments_allowed( $comment ) ) {
+			$user_id = get_current_user_id();
+			if ( $user_id && self::was_received( $comment ) && \user_can( $user_id, 'publish_posts' ) ) {
+				return self::create_fediverse_reply_link( $link, $args );
+			}
+
 			return $link;
 		}
 
@@ -61,6 +66,27 @@ class Comment {
 		);
 
 		return apply_filters( 'activitypub_comment_reply_link', $div );
+	}
+
+	/**
+	 * Create a link to reply to a federated comment.
+	 * This function adds a title attribute to the reply link to inform the user
+	 * that the comment was received from the fediverse and the reply will be sent
+	 * to the original author.
+	 *
+	 * @param string $link The HTML markup for the comment reply link.
+	 * @param array  $args An array of arguments overriding the defaults.
+	 *
+	 * @return string The modified HTML markup for the comment reply link.
+	 */
+	private static function create_fediverse_reply_link( $link, $args ) {
+		$str_to_replace = sprintf( '>%s<', $args['reply_text'] );
+		$replace_with = sprintf(
+			' title="%s">%s<',
+			esc_attr__( 'This comment was received from the fediverse and your reply will be sent to the original author', 'activitypub' ),
+			__( 'Reply with federation', 'activitypub' )
+		);
+		return str_replace( $str_to_replace, $replace_with, $link );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change comment reply link from "Reply" to "Reply with federation"
* Also adds a `title` attribute that currently says "is comment was received from the fediverse and your reply will be sent to the original author"

### Other information:
<img width="497" alt="Screenshot 2024-03-25 at 16 26 54" src="https://github.com/Automattic/wordpress-activitypub/assets/195089/366438ab-7dfb-4f75-a124-74fd9ffa9d13">

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
Try this on a post that has received a reply from the fediverse. The reply link, for a logged-in user who will be able to federate, will be changed like the screenshot above

* Go to '..'
*

