### PR TITLE
fix outbox collection for blog and application user

### DIFF
--- a/includes/rest/class-outbox.php
+++ b/includes/rest/class-outbox.php
@@ -104,7 +104,7 @@ class Outbox {
 			$posts = \get_posts(
 				array(
 					'posts_per_page' => 10,
-					'author'         => $user_id,
+					'author'         => $user_id > 0 ? $user_id : null,
 					'paged'          => $page,
 					'post_type'      => $post_types,
 				)


### PR DESCRIPTION
## Little fix:
The outbox for the blog and the application user is currently empty, even if there are posts of a post type that have ActivityPub support enabled and the blog user is activated.