### PR TITLE
Some fixes to be compatible with discourse

### DIFF
--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -379,10 +379,10 @@ class Signature {
 		if ( \preg_match( '/keyId="(.*?)"/ism', $signature, $matches ) ) {
 			$parsed_header['keyId'] = trim( $matches[1] );
 		}
-		if ( \preg_match( '/created=([0-9]*)/ism', $signature, $matches ) ) {
+		if ( \preg_match( '/created=["|\']*([0-9]*)["|\']*/ism', $signature, $matches ) ) {
 			$parsed_header['(created)'] = trim( $matches[1] );
 		}
-		if ( \preg_match( '/expires=([0-9]*)/ism', $signature, $matches ) ) {
+		if ( \preg_match( '/expires=["|\']*([0-9]*)["|\']*/ism', $signature, $matches ) ) {
 			$parsed_header['(expires)'] = trim( $matches[1] );
 		}
 		if ( \preg_match( '/algorithm="(.*?)"/ism', $signature, $matches ) ) {
@@ -434,11 +434,21 @@ class Signature {
 					// created in future
 					return false;
 				}
+
+				if ( ! array_key_exists( '(created)', $headers ) ) {
+					$signed_data .= $header . ': ' . $signature_block['(created)'] . "\n";
+					continue;
+				}
 			}
 			if ( '(expires)' === $header ) {
 				if ( ! empty( $signature_block['(expires)'] ) && \intval( $signature_block['(expires)'] ) < \time() ) {
 					// expired in past
 					return false;
+				}
+
+				if ( ! array_key_exists( '(expires)', $headers ) ) {
+					$signed_data .= $header . ': ' . $signature_block['(expires)'] . "\n";
+					continue;
 				}
 			}
 			if ( 'date' === $header ) {

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -4,6 +4,7 @@ namespace Activitypub\Collection;
 use WP_Error;
 use WP_Comment_Query;
 
+use function Activitypub\object_to_uri;
 use function Activitypub\url_to_commentid;
 use function Activitypub\object_id_to_comment;
 use function Activitypub\get_remote_metadata_by_actor;
@@ -46,7 +47,8 @@ class Interactions {
 			return false;
 		}
 
-		$meta = get_remote_metadata_by_actor( $activity['actor'] );
+		$actor = object_to_uri( $activity['actor'] );
+		$meta  = get_remote_metadata_by_actor( $actor );
 
 		if ( ! $meta || \is_wp_error( $meta ) ) {
 			return false;

--- a/includes/collection/class-users.php
+++ b/includes/collection/class-users.php
@@ -7,6 +7,7 @@ use Activitypub\Model\User;
 use Activitypub\Model\Blog_User;
 use Activitypub\Model\Application_User;
 
+use function Activitypub\object_to_uri;
 use function Activitypub\url_to_authorid;
 use function Activitypub\is_user_disabled;
 
@@ -136,6 +137,8 @@ class Users {
 	 * @return \Acitvitypub\Model\User The User.
 	 */
 	public static function get_by_resource( $resource ) {
+		$resource = object_to_uri( $resource );
+
 		$scheme = 'acct';
 		$match = array();
 		// try to extract the scheme and the host

--- a/includes/handler/class-undo.php
+++ b/includes/handler/class-undo.php
@@ -4,6 +4,8 @@ namespace Activitypub\Handler;
 use Activitypub\Collection\Users;
 use Activitypub\Collection\Followers;
 
+use function Activitypub\object_to_uri;
+
 /**
  * Handle Undo requests
  */
@@ -28,10 +30,10 @@ class Undo {
 		if (
 			isset( $activity['object']['type'] ) &&
 			'Follow' === $activity['object']['type'] &&
-			isset( $activity['object']['object'] ) &&
-			filter_var( $activity['object']['object'], FILTER_VALIDATE_URL )
+			isset( $activity['object']['object'] )
 		) {
-			$user = Users::get_by_resource( $activity['object']['object'] );
+			$user_id = object_to_uri( $activity['object']['object'] );
+			$user = Users::get_by_resource( $user_id );
 
 			if ( ! $user || is_wp_error( $user ) ) {
 				// If we can not find a user,
@@ -40,8 +42,9 @@ class Undo {
 			}
 
 			$user_id = $user->get__id();
+			$actor   = object_to_uri( $activity['actor'] );
 
-			Followers::remove_follower( $user_id, $activity['actor'] );
+			Followers::remove_follower( $user_id, $actor );
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

See

* https://socialhub.activitypub.rocks/t/filtering-contents-from-the-fediverse-report/4061/25?u=pfefferle
* https://mastodon.social/@laurenshof@indieweb.social/112315027237003058

## Proposed changes:

* Discourse uses Actor Objects instead of URIs
* Discourse adds the `expires` and `created` header only to the the signature header.

See headers

```
Array
(
    [signature] => Array
        (
            [0] => keyId="https://socialhub.activitypub.rocks/ap/actor/...#main-key",algorithm="hs2019",headers="host date digest (request-target) (created) (expires)",signature="...",created="1713868503",expires="1713872103"
        )

    [content_type] => Array
        (
            [0] => application/ld+json; profile="https://www.w3.org/ns/activitystreams"
        )

    [digest] => Array
        (
            [0] => SHA-256=...
        )

    [date] => Array
        (
            [0] => Tue, 23 Apr 2024 10:35:03 GMT
        )

    [content_length] => Array
        (
            [0] => ...
        )

    [x_forwarded_for_anon] => Array
        (
            [0] => ...
        )

    [x_forwarded_for] => Array
        (
            [0] => ...
        )

    [x_forwarded_port] => Array
        (
            [0] => 443
        )

    [x_forwarded_proto] => Array
        (
            [0] => https
        )

    [host] => Array
        (
            [0] => pfefferle.org
        )

    [connection] => Array
        (
            [0] => close
        )

    [authorization] => Array
        (
            [0] => 
        )

    [(request-target)] => Array
        (
            [0] => post /wp-json/activitypub/1.0/users/1/inbox
        )

)
```