### PR TITLE
Generate comment IDs for federation from `home_url`

### DIFF
--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -379,12 +379,7 @@ class Comment {
 		}
 
 		// generate URI based on comment ID
-		return \add_query_arg(
-			array(
-				'c' => $comment->comment_ID,
-			),
-			\trailingslashit( site_url() )
-		);
+		return \add_query_arg( 'c', $comment->comment_ID, \home_url() );
 	}
 
 	/**


### PR DESCRIPTION

## Proposed changes:
* Use `home_url` rather than `content_url` when generating comment IDs for federation

### Other information:

`site_url` is used for the WP install, not for the frontend URLs, which `home_url` is used for. This is the same in many/most cases, but it is not the same for us at WordPress.com, where the frontend (eg `altwiebe.blog`) can be different from the WP install (eg `altwiebe.wordpress.com`).

## Testing instructions:
* On sites where `home_url()` and `site_url()` are the same, nothing should change
* On sites where they differ, comment federation would be broken, and now work.
