### PR TITLE
Add generic get_comment_ancestors function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -854,3 +854,42 @@ function get_masked_wp_version() {
 
 	return implode( '.', $version );
 }
+
+/**
+ * Retrieves the IDs of the ancestors of a comment.
+ *
+ * Adaption of `get_post_ancestors` from WordPress core.
+ *
+ * @see https://developer.wordpress.org/reference/functions/get_post_ancestors/
+ *
+ * @param int|WP_Comment $comment Comment ID or comment object.
+ *
+ * @return WP_Comment[] Array of ancestor Comments or empty array if there are none.
+ */
+function get_comment_ancestors( $comment ) {
+	$comment = get_comment( $comment );
+
+	// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+	if ( ! $comment || empty( $comment->comment_parent ) || $comment->comment_parent == $comment->comment_ID ) {
+		return array();
+	}
+
+	$ancestors = array();
+
+	$id          = $comment->comment_parent;
+	$ancestors[] = $comment;
+
+	// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+	while ( $ancestor = \get_comment( $id ) ) {
+		// Loop detection: If the ancestor has been seen before, break.
+		// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		if ( empty( $ancestor->comment_parent ) || ( $ancestor->comment_parent == $comment->comment_ID ) || in_array( $ancestor->comment_parent, $ancestors, true ) ) {
+			break;
+		}
+
+		$id          = $ancestor->comment_parent;
+		$ancestors[] = $comment;
+	}
+
+	return $ancestors;
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -864,7 +864,7 @@ function get_masked_wp_version() {
  *
  * @param int|WP_Comment $comment Comment ID or comment object.
  *
- * @return WP_Comment[] Array of ancestor Comments or empty array if there are none.
+ * @return WP_Comment[] Array of ancestor comments or empty array if there are none.
  */
 function get_comment_ancestors( $comment ) {
 	$comment = get_comment( $comment );
@@ -876,19 +876,19 @@ function get_comment_ancestors( $comment ) {
 
 	$ancestors = array();
 
-	$id          = $comment->comment_parent;
-	$ancestors[] = $comment;
+	$ancestor    = \get_comment( $comment->comment_parent );
+	$ancestors[] = $ancestor;
 
 	// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-	while ( $ancestor = \get_comment( $id ) ) {
+	while ( $ancestor ) {
 		// Loop detection: If the ancestor has been seen before, break.
 		// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 		if ( empty( $ancestor->comment_parent ) || ( $ancestor->comment_parent == $comment->comment_ID ) || in_array( $ancestor->comment_parent, $ancestors, true ) ) {
 			break;
 		}
 
-		$id          = $ancestor->comment_parent;
-		$ancestors[] = $comment;
+		$ancestor    = \get_comment( $comment->comment_parent );
+		$ancestors[] = $ancestor;
 	}
 
 	return $ancestors;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -867,7 +867,7 @@ function get_masked_wp_version() {
  * @return WP_Comment[] Array of ancestor comments or empty array if there are none.
  */
 function get_comment_ancestors( $comment ) {
-	$comment = get_comment( $comment );
+	$comment = \get_comment( $comment );
 
 	// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 	if ( ! $comment || empty( $comment->comment_parent ) || $comment->comment_parent == $comment->comment_ID ) {
@@ -876,19 +876,19 @@ function get_comment_ancestors( $comment ) {
 
 	$ancestors = array();
 
-	$ancestor    = \get_comment( $comment->comment_parent );
-	$ancestors[] = $ancestor;
+	$id          = $comment->comment_parent;
+	$ancestors[] = $id;
 
 	// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-	while ( $ancestor ) {
+	while ( $ancestor = \get_comment( $id ) ) {
 		// Loop detection: If the ancestor has been seen before, break.
 		// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 		if ( empty( $ancestor->comment_parent ) || ( $ancestor->comment_parent == $comment->comment_ID ) || in_array( $ancestor->comment_parent, $ancestors, true ) ) {
 			break;
 		}
 
-		$ancestor    = \get_comment( $comment->comment_parent );
-		$ancestors[] = $ancestor;
+		$id          = $comment->comment_parent;
+		$ancestors[] = $id;
 	}
 
 	return $ancestors;

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -12,6 +12,7 @@ use Activitypub\Transformer\Base;
 
 use function Activitypub\is_single_user;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\get_comment_ancestors;
 
 /**
  * WordPress Comment Transformer
@@ -224,24 +225,7 @@ class Comment extends Base {
 	 * @return array The list of ancestors.
 	 */
 	protected function get_comment_ancestors() {
-		$ancestors = [];
-		$parent_id = (int) $this->wp_object->comment_parent;
-		$max_iters = 20;
-		$iters     = 0;
-
-		while ( $parent_id > 0 ) {
-			++$iters;
-			if ( $iters > $max_iters ) {
-				break;
-			}
-			$parent_comment = \get_comment( $parent_id );
-			if ( ! $parent_comment ) {
-				break;
-			}
-
-			$ancestors[] = $parent_comment;
-			$parent_id   = (int) $parent_comment->comment_parent;
-		}
+		$ancestors = get_comment_ancestors( $this->wp_object );
 
 		// Now that we have the full tree of ancestors, only return the ones received from the fediverse
 		return array_filter(

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -230,8 +230,8 @@ class Comment extends Base {
 		// Now that we have the full tree of ancestors, only return the ones received from the fediverse
 		return array_filter(
 			$ancestors,
-			function( $comment ) {
-				return \get_comment_meta( $comment->comment_ID, 'protocol', true ) === 'activitypub';
+			function( $comment_id ) {
+				return \get_comment_meta( $comment_id, 'protocol', true ) === 'activitypub';
 			}
 		);
 	}
@@ -255,8 +255,9 @@ class Comment extends Base {
 			return $mentions;
 		}
 
-		foreach ( $ancestors as $comment ) {
-			if ( ! empty( $comment->comment_author_url ) ) {
+		foreach ( $ancestors as $comment_id ) {
+			$comment = \get_comment( $comment_id );
+			if ( $comment && ! empty( $comment->comment_author_url ) ) {
 				$acct = Webfinger::uri_to_acct( $comment->comment_author_url );
 				if ( $acct && ! is_wp_error( $acct ) ) {
 					$acct = str_replace( 'acct:', '@', $acct );

--- a/tests/test-class-activitypub-comment.php
+++ b/tests/test-class-activitypub-comment.php
@@ -45,7 +45,7 @@ class Test_Activitypub_Comment extends WP_UnitTestCase {
 
 		$parent_comment_id = wp_insert_comment(
 			array(
-				'comment_type' => 'comment',
+				'comment_type' => 'parent comment',
 				'comment_content' => 'This is a comment.',
 				'comment_author_url' => 'https://example.com',
 				'comment_author_email' => '',

--- a/tests/test-class-activitypub-comment.php
+++ b/tests/test-class-activitypub-comment.php
@@ -26,6 +26,44 @@ class Test_Activitypub_Comment extends WP_UnitTestCase {
 		$this->assertEquals( $expected['should_be_federated'], \Activitypub\Comment::should_be_federated( $comment ) );
 	}
 
+	public function test_get_comment_ancestors() {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_type' => 'comment',
+				'comment_content' => 'This is a comment.',
+				'comment_author_url' => 'https://example.com',
+				'comment_author_email' => '',
+				'comment_meta' => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+
+		$this->assertEquals( array(), \Activitypub\get_comment_ancestors( $comment_id ) );
+
+		$comment_array = get_comment( $comment_id, ARRAY_A );
+
+		$parent_comment_id = wp_insert_comment(
+			array(
+				'comment_type' => 'comment',
+				'comment_content' => 'This is a comment.',
+				'comment_author_url' => 'https://example.com',
+				'comment_author_email' => '',
+				'comment_meta' => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+
+		$comment_array['comment_parent'] = $parent_comment_id;
+
+		wp_update_comment( $comment_array );
+
+		$parent_comment = get_comment( $parent_comment_id );
+
+		$this->assertEquals( array( $parent_comment ), \Activitypub\get_comment_ancestors( $comment_id ) );
+	}
+
 	public function ability_to_federate_comment() {
 		return array(
 			array(

--- a/tests/test-class-activitypub-comment.php
+++ b/tests/test-class-activitypub-comment.php
@@ -59,9 +59,7 @@ class Test_Activitypub_Comment extends WP_UnitTestCase {
 
 		wp_update_comment( $comment_array );
 
-		$parent_comment = get_comment( $parent_comment_id );
-
-		$this->assertEquals( array( $parent_comment ), \Activitypub\get_comment_ancestors( $comment_id ) );
+		$this->assertEquals( array( $parent_comment_id ), \Activitypub\get_comment_ancestors( $comment_id ) );
 	}
 
 	public function ability_to_federate_comment() {


### PR DESCRIPTION
based in the `get_post_ancestors` method!

I have to test that a bit more, but I tried to adapt the `get_post_ancestors` to not have to use a limit!

What do you think @mattwiebe 