### PR TITLE
Adds a core/embed block filter to transform iframes to links 

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -704,6 +704,7 @@ class Post extends Base {
 
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$post    = $this->wp_object;
+		add_filter( 'render_block_core/embed', array( self::class, 'revert_embed_links' ), 10, 2 );
 		$content = $this->get_post_content_template();
 
 		// Register our shortcodes just in time.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -788,7 +788,7 @@ class Post extends Base {
 	}
 
 	/**
-	 * Transform Embed blocks to simple url.
+	 * Transform Embed blocks to block level link.
 	 *
 	 * Remote servers will simply drop iframe elements, rendering incomplete content.
 	 *
@@ -798,9 +798,9 @@ class Post extends Base {
 	 * @param string $block_content The block content (html)
 	 * @param object $block The block object
 	 *
-	 * @return string The plain url
+	 * @return string A block level link
 	 */
 	public static function revert_embed_links( $block_content, $block ) {
-		return '<p><a href="' . esc_url( $block['attrs']['url'] ) .'">' . $block['attrs']['url'] .'</a></p>';
+		return '<p><a href="' . esc_url( $block['attrs']['url'] ) . '">' . $block['attrs']['url'] . '</a></p>';
 	}
 }

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -786,4 +786,21 @@ class Post extends Base {
 		 */
 		return apply_filters( 'activitypub_post_locale', $lang, $post_id, $this->wp_object );
 	}
+
+	/**
+	 * Transform Embed blocks to simple url.
+	 *
+	 * Remote servers will simply drop iframe elements, rendering incomplete content.
+	 *
+	 * @see https://www.w3.org/TR/activitypub/#security-sanitizing-content
+	 * @see https://www.w3.org/wiki/ActivityPub/Primer/HTML
+	 *
+	 * @param string $block_content The block content (html)
+	 * @param object $block The block object
+	 *
+	 * @return string The plain url
+	 */
+	public static function revert_embed_links( $block_content, $block ) {
+		return '<p><a href="' . esc_url( $block['attrs']['url'] ) .'">' . $block['attrs']['url'] .'</a></p>';
+	}
 }

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -702,9 +702,10 @@ class Post extends Base {
 		 */
 		do_action( 'activitypub_before_get_content', $post );
 
+		add_filter( 'render_block_core/embed', array( self::class, 'revert_embed_links' ), 10, 2 );
+
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$post    = $this->wp_object;
-		add_filter( 'render_block_core/embed', array( self::class, 'revert_embed_links' ), 10, 2 );
 		$content = $this->get_post_content_template();
 
 		// Register our shortcodes just in time.


### PR DESCRIPTION
Remote servers are expected to [sanitize content](https://www.w3.org/wiki/ActivityPub/Primer/HTML). 
In the case of `iframe` elements Mastodon and others simply drop them.

This PR pre-sanitizes the content, ensuring iframes display as links for remote servers.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #359 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This uses the core/embed block filter to revert the iframe markup into a simple link block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a post inserting a youtube link (or from any of the [whitelisted providers](https://developer.wordpress.org/reference/classes/wp_oembed/__construct/) ), 
* The post content should display normally on site, showing the embedded iframe content
* The ActivityPub representation of the post should show the original link inside a paragraph

