### PR TITLE
Prevent infinite loops in `get_comment_ancestors`

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -876,18 +876,20 @@ function get_comment_ancestors( $comment ) {
 
 	$ancestors = array();
 
-	$id          = $comment->comment_parent;
+	$id          = (int) $comment->comment_parent;
 	$ancestors[] = $id;
 
 	// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-	while ( $ancestor = \get_comment( $id ) ) {
+	while ( $id > 0 ) {
+		$ancestor = \get_comment( $id );
+		$parent_id = (int) $ancestor->comment_parent;
+
 		// Loop detection: If the ancestor has been seen before, break.
-		// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
-		if ( empty( $ancestor->comment_parent ) || ( $ancestor->comment_parent == $comment->comment_ID ) || in_array( $ancestor->comment_parent, $ancestors, true ) ) {
+		if ( empty( $parent_id ) || ( $parent_id === (int) $comment->comment_ID ) || in_array( $parent_id, $ancestors, true ) ) {
 			break;
 		}
 
-		$id          = $comment->comment_parent;
+		$id          = $parent_id;
 		$ancestors[] = $id;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

After deploying #740 on dotcom, I noticed some infinite loop errors. This PR tightens up our comparisons and should prevent them. It fixes a case against production data.

## Proposed changes:
* Tighter logic in `get_comment_ancestors` that ensures our comparisons will work properly and prevent infinite loops.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
I'm unsure how to replicate the error, my brain says it should have been ok but it definitely wasn't. It would get stuck iterating over the immediate comment ancestor, in a comment 4 levels deep.
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->



