### PR TITLE
Enable Mastodon Apps: Add support for fetching external statuses without replies

### DIFF
--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -387,20 +387,46 @@ class Enable_Mastodon_Apps {
 		if ( ! $account ) {
 			return $statuses;
 		}
+		$limit = 10;
+		if ( isset( $args['posts_per_page'] ) ) {
+			$limit = $args['posts_per_page'];
+		}
+		if ( $limit > 40 ) {
+			$limit = 40;
+		}
+		$activitypub_statuses = array();
+		$url = $outbox['first'];
+		$tries = 0;
+		while ( $url ) {
+			if ( ++$tries > 3 ) {
+				break;
+			}
 
-		$posts = Http::get_remote_object( $outbox['first'], true );
-		if ( is_wp_error( $posts ) ) {
-			return $statuses;
+			$posts = Http::get_remote_object( $url, true );
+			if ( is_wp_error( $posts ) ) {
+				return $statuses;
+			}
+
+			$new_statuses = array_map(
+				function ( $item ) use ( $account, $args ) {
+					if ( $args['exclude_replies'] ) {
+						if ( isset( $item['object']['inReplyTo'] ) && $item['object']['inReplyTo'] ) {
+							return null;
+						}
+					}
+					return self::activity_to_status( $item, $account );
+				},
+				$posts['orderedItems']
+			);
+			$activitypub_statuses = array_merge( $activitypub_statuses, array_filter( $new_statuses ) );
+			$url = $posts['next'];
+
+			if ( count( $activitypub_statuses ) >= $limit ) {
+				break;
+			}
 		}
 
-		$activitypub_statuses = array_map(
-			function ( $item ) use ( $account ) {
-				return self::activity_to_status( $item, $account );
-			},
-			$posts['orderedItems']
-		);
-
-		return $activitypub_statuses;
+		return array_slice( $activitypub_statuses, 0, $limit );
 	}
 
 	public static function api_get_replies( $context, $post_id, $url ) {


### PR DESCRIPTION
Before, we'd just fetch any statuses. Now this supports paging and distinguishes between replies and non-replies.