### PR TITLE
Always fall back to `get_by_username`

### DIFF
--- a/includes/collection/class-users.php
+++ b/includes/collection/class-users.php
@@ -229,18 +229,26 @@ class Users {
 	 * @return \Acitvitypub\Model\User The User.
 	 */
 	public static function get_by_various( $id ) {
+		$user = null;
+
 		if ( is_numeric( $id ) ) {
-			return self::get_by_id( $id );
+			$user = self::get_by_id( $id );
 		} elseif (
 			// is URL
 			filter_var( $id, FILTER_VALIDATE_URL ) ||
 			// is acct
-			str_starts_with( $id, 'acct:' )
+			str_starts_with( $id, 'acct:' ) ||
+			// is email
+			filter_var( $id, FILTER_VALIDATE_EMAIL )
 		) {
-			return self::get_by_resource( $id );
-		} else {
-			return self::get_by_username( $id );
+			$user = self::get_by_resource( $id );
 		}
+
+		if ( $user && ! is_wp_error( $user ) ) {
+			return $user;
+		}
+
+		return self::get_by_username( $id );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Always fall back to `get_by_username`, even if `get_by_id` and `get_by_resource` fail.

This would allow us to also handle WebFinger resources without `acct:` scheme and still fall back to emails as user-names.