### PR TITLE
Use Sync for Jetpack notifications

### DIFF
--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -4,21 +4,18 @@ namespace Activitypub\Integration;
 class Jetpack {
 
 	public static function init() {
-		\add_action( 'activitypub_notification', [ self::class, 'send' ] );
+		\add_filter( 'jetpack_sync_post_meta_whitelist', [ __CLASS__, 'add_sync_meta' ] );
 	}
 
-	public static function send( $notification ) {
-		\Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
-			sprintf( '/sites/%d/activitypub/notify', \Jetpack_Options::get_option( 'id' ) ),
-			'2',
-			[ 'method' => 'POST' ],
-			[
-				'actor'  => $notification->actor,
-				'object' => $notification->object,
-				'target' => $notification->target,
-				'type'   => $notification->type,
-			],
-			'wpcom'
-		);
+	public static function add_sync_meta( $whitelist ) {
+		if ( ! is_array( $whitelist ) ) {
+			return $whitelist;
+		}
+		$activitypub_meta_keys = [
+			'activitypub_user_id',
+			'activitypub_inbox',
+			'activitypub_actor_json',
+		];
+		return \array_merge( $whitelist, $activitypub_meta_keys );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follows on from #761

Sending notifications directly to wpcom didn't work as well, we can instead react on the server when the `ap_follower` post is received via Jetpack Sync. This ensures that the required metadata is sent.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

With this patch running, on a site that's Jetpack-connected, try to receive a new follower. It should get Synced to wpcom and we should see the required metatdata on that side.

Requires D148889-code on wpcom server side to work. See full details there for testing, where it's working!

![image](https://github.com/Automattic/wordpress-activitypub/assets/195089/23159a1b-4d2c-42e8-92ee-f4072d0dd9ac)
