### PR TITLE
More efficient `WP_User_Query` with `count_total=false`

### DIFF
--- a/includes/collection/class-users.php
+++ b/includes/collection/class-users.php
@@ -86,6 +86,7 @@ class Users {
 		// check for 'activitypub_username' meta
 		$user = new WP_User_Query(
 			array(
+				'count_total'    => false,
 				'number'         => 1,
 				'hide_empty'     => true,
 				'fields'         => 'ID',
@@ -110,6 +111,7 @@ class Users {
 		// check for login or nicename.
 		$user = new WP_User_Query(
 			array(
+				'count_total'    => false,
 				'search'         => $username,
 				'search_columns' => array( 'user_login', 'user_nicename' ),
 				'number'         => 1,


### PR DESCRIPTION
We have some extra protections on dotcom for counting users in User queries, since we have a lot of users. Since we don't the total count anyway, we can make our query more efficient for everyone by skipping it :)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `count_total => false` to our `WP_User_Query` instances