### PR TITLE
Try to lookup local users first

### DIFF
--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -150,6 +150,12 @@ class Enable_Mastodon_Apps {
 			return $user_data;
 		}
 
+		$user = Users::get_by_various( $user_id );
+
+		if ( $user && ! is_wp_error( $user ) ) {
+			return $user_data;
+		}
+
 		$uri = Webfinger_Util::resolve( $user_id );
 
 		if ( ! $uri || is_wp_error( $uri ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Sometimes the `$user_id` might be the WebFinger handle. With this PR the plugin tries to resolve these cases internally first, before trying to look them up remotely.