### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,11 +15,9 @@ jobs:
        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
     strategy:
       matrix:
-        php-versions: ['5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         include:
           - wp-version: latest
-          - wp-version: '6.2'
-            php-versions: '5.6'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 5.5  
 **Tested up to:** 6.5  
 **Stable tag:** 2.5.0  
-**Requires PHP:** 5.6  
+**Requires PHP:** 7.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 

--- a/activitypub.php
+++ b/activitypub.php
@@ -8,7 +8,7 @@
  * Author URI: https://automattic.com/
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
- * Requires PHP: 5.6
+ * Requires PHP: 7.0
  * Text Domain: activitypub
  * Domain Path: /languages
  */

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.",
     "type": "wordpress-plugin",
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.0",
         "composer/installers": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,7 +10,7 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*.asset.php</exclude-pattern>
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.0-"/>
 	<rule ref="PHPCompatibilityWP"/>
 	<config name="minimum_supported_wp_version" value="4.7"/>
 	<rule ref="WordPress-Core">

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: OStatus, fediverse, activitypub, activitystream
 Requires at least: 5.5
 Tested up to: 6.5
 Stable tag: 2.5.0
-Requires PHP: 5.6
+Requires PHP: 7.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 


### PR DESCRIPTION
* Drop PHP 5.6 support

See compatibility matrix: https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/