### PR TITLE
Update class-create.php

### DIFF
--- a/includes/handler/class-create.php
+++ b/includes/handler/class-create.php
@@ -61,7 +61,7 @@ class Create {
 		$state    = Interactions::add_comment( $array );
 		$reaction = null;
 
-		if ( $state && ! \is_wp_error( $reaction ) ) {
+		if ( $state && ! \is_wp_error( $state ) ) {
 			$reaction = \get_comment( $state );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Think I came across this before ... Either way, in the original code, `$reaction` has literally just been set to `null`, so running `is_wp_error( $reaction )` makes little sense. `$state`, on the other hand, _can be_ an integer, or false, or a `WP_Error`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check `$state` (either false or the result of `wp_new_comment()` isn't an error.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Mostly ... not applicable?
