### PR TITLE
Update object_id_to_comment's PHPDoc

### DIFF
--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -241,7 +241,7 @@ class Comment {
 	 *
 	 * @param string $id ActivityPub object ID (usually a URL) to check.
 	 *
-	 * @return int|boolean Comment ID, or false on failure.
+	 * @return \WP_Comment|false Comment object, or false on failure.
 	 */
 	public static function object_id_to_comment( $id ) {
 		$comment_query = new WP_Comment_Query(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

A really silly one, but I ran into it. :-)

`Comment::object_id_to_comment` returns either a `WP_Comment` (not an `int`, as I found out the hard way), or `false` (in which case I thought it's okay to make this explicit, although `boolean` isn't wrong)!

## Proposed changes:
* Fix PHPDoc `@return` type

