### PR TITLE
Revert to @wordpress/scripts@27

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@wordpress/data": "^10.0.0",
     "@wordpress/dom-ready": "^4.0.0",
     "@wordpress/element": "^6.0.0",
-    "@wordpress/scripts": "^28.0.0",
+    "@wordpress/scripts": "^27.0.0",
     "classnames": "^2.3.2",
     "grunt": "^1.1.0",
     "grunt-checktextdomain": "^1.0.1",


### PR DESCRIPTION
It turns out that v28 is only compatible with WP 6.6 and up. So we'll have to hold off for a while.

Previously reported in https://github.com/WordPress/gutenberg/issues/62202

Everything seems to build properly again after this. Just run `npm install` again.
