### PR TITLE
Add setting to enable/disable the `fediverse:creator` OGP tag

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -101,8 +101,10 @@ function plugin_init() {
 	require_once __DIR__ . '/integration/class-enable-mastodon-apps.php';
 	Integration\Enable_Mastodon_Apps::init();
 
-	require_once __DIR__ . '/integration/class-opengraph.php';
-	Integration\Opengraph::init();
+	if ( '1' === \get_option( 'activitypub_use_opengraph', '1' ) ) {
+		require_once __DIR__ . '/integration/class-opengraph.php';
+		Integration\Opengraph::init();
+	}
 
 	if ( \defined( 'JETPACK__VERSION' ) && ! \defined( 'IS_WPCOM' ) ) {
 		require_once __DIR__ . '/integration/class-jetpack.php';

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -224,6 +224,15 @@ class Admin {
 		);
 		\register_setting(
 			'activitypub',
+			'activitypub_use_opengraph',
+			array(
+				'type' => 'boolean',
+				'description' => \__( 'Automatically add "fediverse:creator" OpenGraph tags for Authors and the Blog-User.', 'activitypub' ),
+				'default' => '1',
+			)
+		);
+		\register_setting(
+			'activitypub',
 			'activitypub_support_post_types',
 			array(
 				'type'         => 'string',

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -245,7 +245,7 @@
 						</th>
 						<td>
 							<p>
-								<label><input type="checkbox" name="activitypub_use_opengraph" id="activitypub_use_opengraph" value="1" <?php echo \checked( '1', \get_option( 'activitypub_use_opengraph', '1' ) ); ?> /> <?php echo wp_kses( \__( 'Automatically add <code>&lt;meta name="fediverse:creator" /&gt;</code> tags for Authors and the Blog-User. You can read more about the feature on the <a href="https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/">Mastodon Blog</a>.', 'activitypub' ), 'default' ); ?></label>
+								<label><input type="checkbox" name="activitypub_use_opengraph" id="activitypub_use_opengraph" value="1" <?php echo \checked( '1', \get_option( 'activitypub_use_opengraph', '1' ) ); ?> /> <?php echo wp_kses( \__( 'Automatically add <code>&lt;meta name="fediverse:creator" /&gt;</code> tags for Authors and the Blog-User. You can read more about the feature on the <a href="https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/" target="_blank">Mastodon Blog</a>.', 'activitypub' ), 'post' ); ?></label>
 							</p>
 						</td>
 					</tr>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -236,15 +236,25 @@
 		</div>
 
 		<div class="box">
-			<h3><?php \esc_html_e( 'Server', 'activitypub' ); ?></h3>
+			<h3><?php \esc_html_e( 'General', 'activitypub' ); ?></h3>
 			<table class="form-table">
 				<tbody>
+					<tr>
+						<th scope="row">
+							<?php \esc_html_e( 'OpenGraph', 'activitypub' ); ?>
+						</th>
+						<td>
+							<p>
+								<label><input type="checkbox" name="activitypub_use_opengraph" id="activitypub_use_opengraph" value="1" <?php echo \checked( '1', \get_option( 'activitypub_use_opengraph', '1' ) ); ?> /> <?php echo wp_kses( \__( 'Automatically add <code>&lt;meta name="fediverse:creator" /&gt;</code> tags for Authors and the Blog-User. You can read more about the feature on the <a href="https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/">Mastodon Blog</a>.', 'activitypub' ), 'default' ); ?></label>
+							</p>
+						</td>
+					</tr>
 					<tr>
 						<th scope="row">
 							<?php \esc_html_e( 'Blocklist', 'activitypub' ); ?>
 						</th>
 						<td>
-							<p class="description">
+							<p>
 								<?php
 								echo \wp_kses(
 									\sprintf(
@@ -260,7 +270,7 @@
 					</tr>
 				</tbody>
 			</table>
-
+			<?php \do_settings_fields( 'activitypub', 'general' ); ?>
 			<?php \do_settings_fields( 'activitypub', 'server' ); ?>
 		</div>
 		<?php \do_settings_sections( 'activitypub' ); ?>


### PR DESCRIPTION
Fix #796

To be backwards compatible it is opt-out, but we can change it to opt-in if this is requested.
