### PR TITLE
Add "Header Image" support

### DIFF
--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -34,10 +34,10 @@
 
 .activitypub-settings-tabs-wrapper {
 	display: -ms-inline-grid;
-	-ms-grid-columns: auto auto auto;
+	-ms-grid-columns: auto auto auto auto;
 	vertical-align: top;
 	display: inline-grid;
-	grid-template-columns: auto auto auto;
+	grid-template-columns: auto auto auto auto;
 }
 
 .activitypub-settings-tab.active {

--- a/assets/js/activitypub-header-image.js
+++ b/assets/js/activitypub-header-image.js
@@ -1,0 +1,221 @@
+/**
+ * Handle the header image setting in
+ *
+ * This is based on site-icon.js
+ *
+ * @see wp-admin/js/site-icon.js
+ */
+
+/* global jQuery, wp */
+
+( function ( $ ) {
+	var $chooseButton = $( '#activitypub-choose-from-library-button' ),
+		$headerImagePreviewWrapper = $( '#activitypub-header-image-preview-wrapper' ),
+		$headerImagePreview = $( '#activitypub-header-image-preview' ),
+		$hiddenDataField = $( '#activitypub_header_image' ),
+		$removeButton = $( '#activitypub-remove-header-image' ),
+		frame;
+
+	/**
+	 * Calculate image selection options based on the attachment dimensions.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param {Object} attachment The attachment object representing the image.
+	 * @return {Object} The image selection options.
+	 */
+	function calculateImageSelectOptions( attachment ) {
+		var realWidth = attachment.get( 'width' ),
+			realHeight = attachment.get( 'height' ),
+			xInit = 1500,
+			yInit = 500,
+			ratio = xInit / yInit,
+			xImg = xInit,
+			yImg = yInit,
+			x1,
+			y1,
+			imgSelectOptions;
+
+		if ( realWidth / realHeight > ratio ) {
+			yInit = realHeight;
+			xInit = yInit * ratio;
+		} else {
+			xInit = realWidth;
+			yInit = xInit / ratio;
+		}
+
+		x1 = ( realWidth - xInit ) / 2;
+		y1 = ( realHeight - yInit ) / 2;
+
+		imgSelectOptions = {
+			aspectRatio: xInit + ':' + yInit,
+			handles: true,
+			keys: true,
+			instance: true,
+			persistent: true,
+			imageWidth: realWidth,
+			imageHeight: realHeight,
+			minWidth: xImg > xInit ? xInit : xImg,
+			minHeight: yImg > yInit ? yInit : yImg,
+			x1: x1,
+			y1: y1,
+			x2: xInit + x1,
+			y2: yInit + y1,
+		};
+
+		return imgSelectOptions;
+	}
+
+	/**
+	 * Initializes the media frame for selecting or cropping an image.
+	 *
+	 * @since 6.5.0
+	 */
+	$chooseButton.on( 'click', function () {
+		var $el = $( this );
+
+		// Create the media frame.
+		frame = wp.media( {
+			button: {
+				// Set the text of the button.
+				text: $el.data( 'update' ),
+
+				// Don't close, we might need to crop.
+				close: false,
+			},
+			states: [
+				new wp.media.controller.Library( {
+					title: $el.data( 'choose-text' ),
+					library: wp.media.query( { type: 'image' } ),
+					date: false,
+					suggestedWidth: $el.data( 'size' ),
+					suggestedHeight: $el.data( 'size' ),
+				} ),
+				new wp.media.controller.CustomizeImageCropper( {
+					control: {
+						params: {
+							width: $el.data( 'size' ),
+							height: $el.data( 'size' ),
+						},
+					},
+					imgSelectOptions: calculateImageSelectOptions,
+				} ),
+			],
+		} );
+
+		frame.on( 'cropped', function ( attachment ) {
+			$hiddenDataField.val( attachment.id );
+			switchToUpdate( attachment );
+			frame.close();
+
+			// Start over with a frame that is so fresh and so clean clean.
+			frame = null;
+		} );
+
+		// When an image is selected, run a callback.
+		frame.on( 'select', function () {
+			// Grab the selected attachment.
+			var attachment = frame.state().get( 'selection' ).first();
+
+			if (
+				attachment.attributes.height === $el.data( 'size' ) &&
+				$el.data( 'size' ) === attachment.attributes.width
+			) {
+				switchToUpdate( attachment.attributes );
+				frame.close();
+
+				// Set the value of the hidden input to the attachment id.
+				$hiddenDataField.val( attachment.id );
+			} else {
+				frame.setState( 'cropper' );
+			}
+		} );
+
+		frame.open();
+	} );
+
+	/**
+	 * Update the UI when a header is selected.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param {array} attributes The attributes for the attachment.
+	 */
+	function switchToUpdate( attributes ) {
+		var i18nAppAlternativeString, i18nBrowserAlternativeString;
+
+		if ( attributes.alt ) {
+			i18nBrowserAlternativeString = wp.i18n.sprintf(
+				/* translators: %s: The selected image alt text. */
+				wp.i18n.__( 'Header Image preview: Current image: %s' ),
+				attributes.alt
+			);
+		} else {
+			i18nAppAlternativeString = wp.i18n.sprintf(
+				/* translators: %s: The selected image filename. */
+				wp.i18n.__(
+					'Header Image preview: The current image has no alternative text. The file name is: %s'
+				),
+				attributes.filename
+			);
+			i18nBrowserAlternativeString = wp.i18n.sprintf(
+				/* translators: %s: The selected image filename. */
+				wp.i18n.__(
+					'Header Image preview: The current image has no alternative text. The file name is: %s'
+				),
+				attributes.filename
+			);
+		}
+
+		// Set activitypub-header-image-preview src.
+		$headerImagePreview.attr( {
+			src: attributes.url,
+			alt: i18nAppAlternativeString,
+		} );
+
+		// Remove hidden class from header image preview div and remove button.
+		$headerImagePreviewWrapper.removeClass( 'hidden' );
+		$removeButton.removeClass( 'hidden' );
+
+		// If the choose button is not in the update state, swap the classes.
+		if ( $chooseButton.attr( 'data-state' ) !== '1' ) {
+			$chooseButton.attr( {
+				class: $chooseButton.attr( 'data-alt-classes' ),
+				'data-alt-classes': $chooseButton.attr( 'class' ),
+				'data-state': '1',
+			} );
+		}
+
+		// Swap the text of the choose button.
+		$chooseButton.text( $chooseButton.attr( 'data-update-text' ) );
+	}
+
+	/**
+	 * Handles the click event of the remove button.
+	 *
+	 * @since 6.5.0
+	 */
+	$removeButton.on( 'click', function () {
+		$hiddenDataField.val( 'false' );
+		$( this ).toggleClass( 'hidden' );
+		$headerImagePreviewWrapper.toggleClass( 'hidden' );
+		$headerImagePreview.attr( {
+			src: '',
+			alt: '',
+		} );
+
+		/**
+		 * Resets state to the button, for correct visual style and state.
+		 * Updates the text of the button.
+		 * Sets focus state to the button.
+		 */
+		$chooseButton
+			.attr( {
+				class: $chooseButton.attr( 'data-alt-classes' ),
+				'data-alt-classes': $chooseButton.attr( 'class' ),
+				'data-state': '',
+			} )
+			.text( $chooseButton.attr( 'data-choose-text' ) )
+			.trigger( 'focus' );
+	} );
+} )( jQuery );

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -318,31 +318,6 @@ class Activitypub {
 	 * @return void
 	 */
 	public static function theme_compat() {
-		$site_icon = get_theme_support( 'custom-logo' );
-
-		if ( ! $site_icon ) {
-			// custom logo support
-			add_theme_support(
-				'custom-logo',
-				array(
-					'height' => 80,
-					'width'  => 80,
-				)
-			);
-		}
-
-		$custom_header = get_theme_support( 'custom-header' );
-
-		if ( ! $custom_header ) {
-			// This theme supports a custom header
-			$custom_header_args = array(
-				'width'       => 1250,
-				'height'      => 600,
-				'header-text' => true,
-			);
-			add_theme_support( 'custom-header', $custom_header_args );
-		}
-
 		// We assume that you want to use Post-Formats when enabling the setting
 		if ( 'wordpress-post-format' === \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE ) ) {
 			if ( ! get_theme_support( 'post-formats' ) ) {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -129,10 +129,13 @@ class Admin {
 
 		switch ( $tab ) {
 			case 'settings':
+				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php' );
+				break;
+			case 'blog-profile':
 				wp_enqueue_media();
 				wp_enqueue_script( 'activitypub-header-image' );
 
-				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php' );
+				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-user-settings.php' );
 				break;
 			case 'followers':
 				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-user-followers-list.php' );
@@ -246,6 +249,26 @@ class Admin {
 		);
 		\register_setting(
 			'activitypub',
+			'activitypub_enable_users',
+			array(
+				'type' => 'boolean',
+				'description' => \__( 'Every Author on this Blog (with the publish_posts capability) gets his own ActivityPub enabled Profile.', 'activitypub' ),
+				'default' => '1',
+			)
+		);
+		\register_setting(
+			'activitypub',
+			'activitypub_enable_blog_user',
+			array(
+				'type' => 'boolean',
+				'description' => \__( 'Your Blog becomes an ActivityPub compatible Profile.', 'activitypub' ),
+				'default' => '0',
+			)
+		);
+
+
+		\register_setting(
+			'activitypub_blog_user',
 			'activitypub_blog_user_identifier',
 			array(
 				'type'              => 'string',
@@ -290,25 +313,7 @@ class Admin {
 			)
 		);
 		\register_setting(
-			'activitypub',
-			'activitypub_enable_users',
-			array(
-				'type' => 'boolean',
-				'description' => \__( 'Every Author on this Blog (with the publish_posts capability) gets his own ActivityPub enabled Profile.', 'activitypub' ),
-				'default' => '1',
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_enable_blog_user',
-			array(
-				'type' => 'boolean',
-				'description' => \__( 'Your Blog becomes an ActivityPub compatible Profile.', 'activitypub' ),
-				'default' => '0',
-			)
-		);
-		\register_setting(
-			'activitypub',
+			'activitypub_blog_user',
 			'activitypub_header_image',
 			array(
 				'type' => 'integer',

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -266,7 +266,17 @@ class Admin {
 			)
 		);
 
-
+		// Blog-User Settings
+		\register_setting(
+			'activitypub_blog_user',
+			'activitypub_blog_user_description',
+			array(
+				'type' => 'string',
+				'description' => \esc_html__( 'The Description of the Blog-User', 'activitypub' ),
+				'show_in_rest' => true,
+				'default' => '',
+			)
+		);
 		\register_setting(
 			'activitypub_blog_user',
 			'activitypub_blog_user_identifier',

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -129,6 +129,9 @@ class Admin {
 
 		switch ( $tab ) {
 			case 'settings':
+				wp_enqueue_media();
+				wp_enqueue_script( 'activitypub-header-image' );
+
 				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php' );
 				break;
 			case 'followers':
@@ -295,6 +298,15 @@ class Admin {
 				'default' => '0',
 			)
 		);
+		\register_setting(
+			'activitypub',
+			'activitypub_header_image',
+			array(
+				'type' => 'integer',
+				'description' => \__( 'The Attachment-ID of the Sites Header-Image', 'activitypub' ),
+				'default' => null,
+			)
+		);
 	}
 
 	public static function add_settings_help_tab() {
@@ -335,6 +347,8 @@ class Admin {
 	}
 
 	public static function enqueue_scripts( $hook_suffix ) {
+		wp_register_script( 'activitypub-header-image', plugins_url( 'assets/js/activitypub-header-image.js', ACTIVITYPUB_PLUGIN_FILE ), array( 'jquery' ), get_plugin_version(), false );
+
 		if ( false !== strpos( $hook_suffix, 'activitypub' ) ) {
 			wp_enqueue_style( 'activitypub-admin-styles', plugins_url( 'assets/css/activitypub-admin.css', ACTIVITYPUB_PLUGIN_FILE ), array(), get_plugin_version() );
 			wp_enqueue_script( 'activitypub-admin-script', plugins_url( 'assets/js/activitypub-admin.js', ACTIVITYPUB_PLUGIN_FILE ), array( 'jquery' ), get_plugin_version(), false );

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -132,9 +132,15 @@ class Blog extends Actor {
 	 * @return string The User-Description.
 	 */
 	public function get_summary() {
+		$summary = \get_option( 'activitypub_blog_user_description', null );
+
+		if ( ! $summary ) {
+			$summary = \get_bloginfo( 'description' );
+		}
+
 		return \wpautop(
 			\wp_kses(
-				\get_bloginfo( 'description' ),
+				$summary,
 				'default'
 			)
 		);
@@ -231,10 +237,20 @@ class Blog extends Actor {
 	 * @return array|null The User-Header-Image.
 	 */
 	public function get_image() {
-		if ( \has_header_image() ) {
+		$header_image = get_option( 'activitypub_header_image' );
+
+		if ( $header_image ) {
+			$image_url = \wp_get_attachment_url( $header_image );
+		}
+
+		if ( ! $image_url && \has_header_image() ) {
+			$image_url = \get_header_image();
+		}
+
+		if ( $image_url ) {
 			return array(
 				'type' => 'Image',
-				'url'  => esc_url( \get_header_image() ),
+				'url'  => esc_url( $image_url ),
 			);
 		}
 

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -149,11 +149,20 @@ class User extends Actor {
 	}
 
 	public function get_image() {
-		if ( \has_header_image() ) {
-			$image = \esc_url( \get_header_image() );
+		$header_image = get_user_option( 'activitypub_header_image', $this->_id );
+
+		if ( $header_image ) {
+			$image_url = \wp_get_attachment_url( $header_image );
+		}
+
+		if ( ! $image_url && \has_header_image() ) {
+			$image_url = \get_header_image();
+		}
+
+		if ( $image_url ) {
 			return array(
 				'type' => 'Image',
-				'url'  => $image,
+				'url'  => esc_url( $image_url ),
 			);
 		}
 

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -17,6 +17,10 @@
 
 		<?php if ( ! \Activitypub\is_user_disabled( \Activitypub\Collection\Users::BLOG_USER_ID ) ) : ?>
 
+		<a href="<?php echo \esc_url_raw( admin_url( 'options-general.php?page=activitypub&tab=blog-profile' ) ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args['blog-profile'] ); ?>">
+			<?php \esc_html_e( 'Blog-Profile', 'activitypub' ); ?>
+		</a>
+
 		<a href="<?php echo \esc_url_raw( admin_url( 'options-general.php?page=activitypub&tab=followers' ) ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args['followers'] ); ?>">
 			<?php \esc_html_e( 'Followers', 'activitypub' ); ?>
 		</a>

--- a/templates/blog-user-followers-list.php
+++ b/templates/blog-user-followers-list.php
@@ -3,9 +3,10 @@
 	__DIR__ . '/admin-header.php',
 	true,
 	array(
-		'settings' => '',
-		'welcome' => '',
-		'followers' => 'active',
+		'settings'     => '',
+		'welcome'      => '',
+		'followers'    => 'active',
+		'blog-profile' => '',
 	)
 );
 $table = new \Activitypub\Table\Followers();

--- a/templates/blog-user-settings.php
+++ b/templates/blog-user-settings.php
@@ -27,7 +27,7 @@
 							<?php if ( \has_site_icon() ) : ?>
 							<p><img src="<?php echo esc_url( get_site_icon_url( '50' ) ); ?>" /></p>
 							<?php endif; ?>
-							<p>
+							<p class="description">
 								<?php
 								echo \wp_kses(
 									\sprintf(
@@ -91,7 +91,7 @@
 					</tr>
 					<tr>
 						<th scope="row">
-							<?php \esc_html_e( 'Change blog profile ID', 'activitypub' ); ?>
+							<?php \esc_html_e( 'Change profile ID', 'activitypub' ); ?>
 						</th>
 						<td>
 							<label for="activitypub_blog_user_identifier">
@@ -105,6 +105,25 @@
 								<strong>
 									<?php \esc_html_e( 'Please avoid using an existing author’s name as the blog profile ID. Fediverse platforms might use caching and this could break the functionality completely.', 'activitypub' ); ?>
 								</strong>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">
+							<?php \esc_html_e( 'Change Description', 'activitypub' ); ?>
+						</th>
+						<td>
+							<label for="activitypub_blog_user_description">
+								<textarea
+									class="blog-user-description large-text"
+									rows="5"
+									name="activitypub_blog_user_description"
+									id="activitypub_blog_user_description"
+									placeholder="<?php echo esc_attr( \get_bloginfo( 'description' ) ); ?>"
+								><?php echo \esc_html( \get_option( 'activitypub_blog_user_description' ) ); ?></textarea>
+							</label>
+							<p class="description">
+								<?php \esc_html_e( 'By default the ActivityPub plugin uses the WordPress tagline as a description for the blog profile.', 'activitypub' ); ?>
 							</p>
 						</td>
 					</tr>

--- a/templates/blog-user-settings.php
+++ b/templates/blog-user-settings.php
@@ -1,0 +1,119 @@
+<?php
+\load_template(
+	__DIR__ . '/admin-header.php',
+	true,
+	array(
+		'settings'     => '',
+		'welcome'      => '',
+		'blog-profile' => 'active',
+		'followers'    => '',
+	)
+);
+?>
+
+<div class="activitypub-settings activitypub-settings-page hide-if-no-js">
+	<form method="post" action="options.php">
+		<?php \settings_fields( 'activitypub_blog_user' ); ?>
+
+		<div class="box">
+			<h3><?php \esc_html_e( 'Blog-Profile', 'activitypub' ); ?></h3>
+			<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row">
+							<?php \esc_html_e( 'Manage Avatar', 'activitypub' ); ?>
+						</th>
+						<td>
+							<?php if ( \has_site_icon() ) : ?>
+							<p><img src="<?php echo esc_url( get_site_icon_url( '50' ) ); ?>" /></p>
+							<?php endif; ?>
+							<p>
+								<?php
+								echo \wp_kses(
+									\sprintf(
+										// translators: %s is a URL.
+										\__( 'The ActivityPub plugin uses the WordPress Site Icon as Avatar for the Blog-Profile, you can change the Site Icon in the "<a href="%s">General Settings</a>" of WordPress.', 'activitypub' ),
+										\esc_attr( \admin_url( 'options-general.php' ) )
+									),
+									'default'
+								);
+								?>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<th>
+							<?php \esc_html_e( 'Manage Header Image', 'activitypub' ); ?>
+						</th>
+						<td>
+							<?php
+							$classes_for_upload_button = 'button upload-button button-add-media button-add-header-image';
+							$classes_for_update_button = 'button';
+							$classes_for_wrapper       = '';
+
+							if ( (int) get_option( 'activitypub_header_image', 0 ) ) {
+								$classes_for_wrapper         .= ' has-header-image';
+								$classes_for_button           = $classes_for_update_button;
+								$classes_for_button_on_change = $classes_for_upload_button;
+							} else {
+								$classes_for_wrapper         .= ' hidden';
+								$classes_for_button           = $classes_for_upload_button;
+								$classes_for_button_on_change = $classes_for_update_button;
+							}
+							?>
+							<div id="activitypub-header-image-preview-wrapper" class='<?php echo esc_attr( $classes_for_wrapper ); ?>'>
+								<img id='activitypub-header-image-preview' src='<?php echo esc_url( wp_get_attachment_url( get_option( 'activitypub_header_image' ) ) ); ?>' style="max-width: 100%;" />
+							</div>
+							<button
+								type="button"
+								id="activitypub-choose-from-library-button"
+								type="button"
+								class="<?php echo esc_attr( $classes_for_button ); ?>"
+								data-alt-classes="<?php echo esc_attr( $classes_for_button_on_change ); ?>"
+								data-choose-text="<?php esc_attr_e( 'Choose a Header Image', 'activitypub' ); ?>"
+								data-update-text="<?php esc_attr_e( 'Change Header Icon', 'activitypub' ); ?>"
+								data-update="<?php esc_attr_e( 'Set as Header Image', 'activitypub' ); ?>"
+								data-state="<?php echo esc_attr( (int) get_option( 'activitypub_header_image', 0 ) ); ?>">
+								<?php if ( (int) get_option( 'activitypub_header_image', 0 ) ) : ?>
+									<?php esc_html_e( 'Change Header Image', 'activitypub' ); ?>
+								<?php else : ?>
+									<?php esc_html_e( 'Choose a Header Image', 'activitypub' ); ?>
+								<?php endif; ?>
+							</button>
+							<button
+								id="activitypub-remove-header-image"
+								type="button"
+								<?php echo (int) get_option( 'activitypub_header_image', 0 ) ? 'class="button button-secondary reset"' : 'class="button button-secondary reset hidden"'; ?>>
+								<?php esc_html_e( 'Remove Header Image', 'activitypub' ); ?>
+							</button>
+							<input type='hidden' name='activitypub_header_image' id='activitypub_header_image' value='<?php echo esc_attr( get_option( 'activitypub_header_image' ) ); ?>'>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">
+							<?php \esc_html_e( 'Change blog profile ID', 'activitypub' ); ?>
+						</th>
+						<td>
+							<label for="activitypub_blog_user_identifier">
+								<input class="blog-user-identifier" name="activitypub_blog_user_identifier" id="activitypub_blog_user_identifier" type="text" value="<?php echo esc_attr( \get_option( 'activitypub_blog_user_identifier', \Activitypub\Model\Blog::get_default_username() ) ); ?>" />
+								@<?php echo esc_html( \wp_parse_url( \home_url(), PHP_URL_HOST ) ); ?>
+							</label>
+							<p class="description">
+								<?php \esc_html_e( 'This profile name will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
+							</p>
+							<p>
+								<strong>
+									<?php \esc_html_e( 'Please avoid using an existing author’s name as the blog profile ID. Fediverse platforms might use caching and this could break the functionality completely.', 'activitypub' ); ?>
+								</strong>
+							</p>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<?php \do_settings_sections( 'activitypub_blog_profile' ); ?>
+
+		<?php \submit_button(); ?>
+	</form>
+</div>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -3,9 +3,10 @@
 	__DIR__ . '/admin-header.php',
 	true,
 	array(
-		'settings'  => 'active',
-		'welcome'   => '',
-		'followers' => '',
+		'settings'     => 'active',
+		'welcome'      => '',
+		'followers'    => '',
+		'blog-profile' => '',
 	)
 );
 ?>
@@ -13,102 +14,6 @@
 <div class="activitypub-settings activitypub-settings-page hide-if-no-js">
 	<form method="post" action="options.php">
 		<?php \settings_fields( 'activitypub' ); ?>
-
-		<div class="box">
-			<h3><?php \esc_html_e( 'Blog-Profile', 'activitypub' ); ?></h3>
-			<table class="form-table">
-				<tbody>
-					<tr>
-						<th scope="row">
-							<?php \esc_html_e( 'Manage Avatar', 'activitypub' ); ?>
-						</th>
-						<td>
-							<?php if ( \has_site_icon() ) : ?>
-							<p><img src="<?php echo esc_url( get_site_icon_url( '50' ) ); ?>" /></p>
-							<?php endif; ?>
-							<p>
-								<?php
-								echo \wp_kses(
-									\sprintf(
-										// translators: %s is a URL.
-										\__( 'The ActivityPub plugin uses the WordPress Site Icon as Avatar for the Blog-Profile, you can change the Site Icon in the "<a href="%s">General Settings</a>" of WordPress.', 'activitypub' ),
-										\esc_attr( \admin_url( 'options-general.php' ) )
-									),
-									'default'
-								);
-								?>
-							</p>
-						</td>
-					</tr>
-					<tr>
-						<th>
-							<?php \esc_html_e( 'Manage Header Image', 'activitypub' ); ?>
-						</th>
-						<td>
-							<?php
-							$classes_for_upload_button = 'button upload-button button-add-media button-add-header-image';
-							$classes_for_update_button = 'button';
-							$classes_for_wrapper       = '';
-
-							if ( (int) get_option( 'activitypub_header_image', 0 ) ) {
-								$classes_for_wrapper         .= ' has-header-image';
-								$classes_for_button           = $classes_for_update_button;
-								$classes_for_button_on_change = $classes_for_upload_button;
-							} else {
-								$classes_for_wrapper         .= ' hidden';
-								$classes_for_button           = $classes_for_upload_button;
-								$classes_for_button_on_change = $classes_for_update_button;
-							}
-							?>
-							<div id="activitypub-header-image-preview-wrapper" class='<?php echo esc_attr( $classes_for_wrapper ); ?>'>
-								<img id='activitypub-header-image-preview' src='<?php echo esc_url( wp_get_attachment_url( get_option( 'activitypub_header_image' ) ) ); ?>' style="max-width: 100%;" />
-							</div>
-							<button type="button"
-								id="activitypub-choose-from-library-button"
-								type="button"
-								class="<?php echo esc_attr( $classes_for_button ); ?>"
-								data-alt-classes="<?php echo esc_attr( $classes_for_button_on_change ); ?>"
-								data-choose-text="<?php esc_attr_e( 'Choose a Header Image', 'activitypub' ); ?>"
-								data-update-text="<?php esc_attr_e( 'Change Header Icon', 'activitypub' ); ?>"
-								data-update="<?php esc_attr_e( 'Set as Header Image', 'activitypub' ); ?>"
-								data-state="<?php echo esc_attr( (int) get_option( 'activitypub_header_image', 0 ) ); ?>">
-								<?php if ( (int) get_option( 'activitypub_header_image', 0 ) ) : ?>
-									<?php esc_html_e( 'Change Header Image', 'activitypub' ); ?>
-								<?php else : ?>
-									<?php esc_html_e( 'Choose a Header Image', 'activitypub' ); ?>
-								<?php endif; ?>
-							</button>
-							<button
-								id="activitypub-remove-header-image"
-								type="button"
-								<?php echo (int) get_option( 'activitypub_header_image', 0 ) ? 'class="button button-secondary reset"' : 'class="button button-secondary reset hidden"'; ?>>
-								<?php esc_html_e( 'Remove Header Image', 'activitypub' ); ?>
-							</button>
-							<input type='hidden' name='activitypub_header_image' id='activitypub_header_image' value='<?php echo esc_attr( get_option( 'activitypub_header_image' ) ); ?>'>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row">
-							<?php \esc_html_e( 'Change blog profile ID', 'activitypub' ); ?>
-						</th>
-						<td>
-							<label for="activitypub_blog_user_identifier">
-								<input class="blog-user-identifier" name="activitypub_blog_user_identifier" id="activitypub_blog_user_identifier" type="text" value="<?php echo esc_attr( \get_option( 'activitypub_blog_user_identifier', \Activitypub\Model\Blog::get_default_username() ) ); ?>" />
-								@<?php echo esc_html( \wp_parse_url( \home_url(), PHP_URL_HOST ) ); ?>
-							</label>
-							<p class="description">
-								<?php \esc_html_e( 'This profile name will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
-							</p>
-							<p>
-								<strong>
-									<?php \esc_html_e( 'Please avoid using an existing author’s name as the blog profile ID. Fediverse platforms might use caching and this could break the functionality completely.', 'activitypub' ); ?>
-								</strong>
-							</p>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-		</div>
 
 		<div class="box">
 			<h3><?php \esc_html_e( 'Profiles', 'activitypub' ); ?></h3>
@@ -122,7 +27,7 @@
 							<p>
 								<label>
 									<input type="checkbox" name="activitypub_enable_users" id="activitypub_enable_users" value="1" <?php echo \checked( '1', \get_option( 'activitypub_enable_users', '1' ) ); ?> />
-									<?php \esc_html_e( 'Enable authors', 'activitypub' ); ?>
+									<?php \esc_html_e( 'Enable Author-Profiles', 'activitypub' ); ?>
 								</label>
 							</p>
 							<p class="description">
@@ -134,7 +39,7 @@
 							<p>
 								<label>
 									<input type="checkbox" name="activitypub_enable_blog_user" id="activitypub_enable_blog_user" value="1" <?php echo \checked( '1', \get_option( 'activitypub_enable_blog_user', '0' ) ); ?> />
-									<?php \esc_html_e( 'Enable blog', 'activitypub' ); ?>
+									<?php \esc_html_e( 'Enable Blog-Profile', 'activitypub' ); ?>
 								</label>
 							</p>
 							<p class="description">

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -15,6 +15,102 @@
 		<?php \settings_fields( 'activitypub' ); ?>
 
 		<div class="box">
+			<h3><?php \esc_html_e( 'Blog-Profile', 'activitypub' ); ?></h3>
+			<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row">
+							<?php \esc_html_e( 'Manage Avatar', 'activitypub' ); ?>
+						</th>
+						<td>
+							<?php if ( \has_site_icon() ) : ?>
+							<p><img src="<?php echo esc_url( get_site_icon_url( '50' ) ); ?>" /></p>
+							<?php endif; ?>
+							<p>
+								<?php
+								echo \wp_kses(
+									\sprintf(
+										// translators: %s is a URL.
+										\__( 'The ActivityPub plugin uses the WordPress Site Icon as Avatar for the Blog-Profile, you can change the Site Icon in the "<a href="%s">General Settings</a>" of WordPress.', 'activitypub' ),
+										\esc_attr( \admin_url( 'options-general.php' ) )
+									),
+									'default'
+								);
+								?>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<th>
+							<?php \esc_html_e( 'Manage Header Image', 'activitypub' ); ?>
+						</th>
+						<td>
+							<?php
+							$classes_for_upload_button = 'button upload-button button-add-media button-add-header-image';
+							$classes_for_update_button = 'button';
+							$classes_for_wrapper       = '';
+
+							if ( (int) get_option( 'activitypub_header_image', 0 ) ) {
+								$classes_for_wrapper         .= ' has-header-image';
+								$classes_for_button           = $classes_for_update_button;
+								$classes_for_button_on_change = $classes_for_upload_button;
+							} else {
+								$classes_for_wrapper         .= ' hidden';
+								$classes_for_button           = $classes_for_upload_button;
+								$classes_for_button_on_change = $classes_for_update_button;
+							}
+							?>
+							<div id="activitypub-header-image-preview-wrapper" class='<?php echo esc_attr( $classes_for_wrapper ); ?>'>
+								<img id='activitypub-header-image-preview' src='<?php echo esc_url( wp_get_attachment_url( get_option( 'activitypub_header_image' ) ) ); ?>' style="max-width: 100%;" />
+							</div>
+							<button type="button"
+								id="activitypub-choose-from-library-button"
+								type="button"
+								class="<?php echo esc_attr( $classes_for_button ); ?>"
+								data-alt-classes="<?php echo esc_attr( $classes_for_button_on_change ); ?>"
+								data-choose-text="<?php esc_attr_e( 'Choose a Header Image', 'activitypub' ); ?>"
+								data-update-text="<?php esc_attr_e( 'Change Header Icon', 'activitypub' ); ?>"
+								data-update="<?php esc_attr_e( 'Set as Header Image', 'activitypub' ); ?>"
+								data-state="<?php echo esc_attr( (int) get_option( 'activitypub_header_image', 0 ) ); ?>">
+								<?php if ( (int) get_option( 'activitypub_header_image', 0 ) ) : ?>
+									<?php esc_html_e( 'Change Header Image', 'activitypub' ); ?>
+								<?php else : ?>
+									<?php esc_html_e( 'Choose a Header Image', 'activitypub' ); ?>
+								<?php endif; ?>
+							</button>
+							<button
+								id="activitypub-remove-header-image"
+								type="button"
+								<?php echo (int) get_option( 'activitypub_header_image', 0 ) ? 'class="button button-secondary reset"' : 'class="button button-secondary reset hidden"'; ?>>
+								<?php esc_html_e( 'Remove Header Image', 'activitypub' ); ?>
+							</button>
+							<input type='hidden' name='activitypub_header_image' id='activitypub_header_image' value='<?php echo esc_attr( get_option( 'activitypub_header_image' ) ); ?>'>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">
+							<?php \esc_html_e( 'Change blog profile ID', 'activitypub' ); ?>
+						</th>
+						<td>
+							<label for="activitypub_blog_user_identifier">
+								<input class="blog-user-identifier" name="activitypub_blog_user_identifier" id="activitypub_blog_user_identifier" type="text" value="<?php echo esc_attr( \get_option( 'activitypub_blog_user_identifier', \Activitypub\Model\Blog::get_default_username() ) ); ?>" />
+								@<?php echo esc_html( \wp_parse_url( \home_url(), PHP_URL_HOST ) ); ?>
+							</label>
+							<p class="description">
+								<?php \esc_html_e( 'This profile name will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
+							</p>
+							<p>
+								<strong>
+									<?php \esc_html_e( 'Please avoid using an existing author’s name as the blog profile ID. Fediverse platforms might use caching and this could break the functionality completely.', 'activitypub' ); ?>
+								</strong>
+							</p>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div class="box">
 			<h3><?php \esc_html_e( 'Profiles', 'activitypub' ); ?></h3>
 			<table class="form-table">
 				<tbody>
@@ -43,25 +139,6 @@
 							</p>
 							<p class="description">
 								<?php \esc_html_e( 'Your blog becomes an ActivityPub profile.', 'activitypub' ); ?>
-							</p>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row">
-							<?php \esc_html_e( 'Change blog profile ID', 'activitypub' ); ?>
-						</th>
-						<td>
-							<label for="activitypub_blog_user_identifier">
-								<input class="blog-user-identifier" name="activitypub_blog_user_identifier" id="activitypub_blog_user_identifier" type="text" value="<?php echo esc_attr( \get_option( 'activitypub_blog_user_identifier', \Activitypub\Model\Blog::get_default_username() ) ); ?>" />
-								@<?php echo esc_html( \wp_parse_url( \home_url(), PHP_URL_HOST ) ); ?>
-							</label>
-							<p class="description">
-								<?php \esc_html_e( 'This profile name will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
-							</p>
-							<p>
-								<strong>
-									<?php \esc_html_e( 'Please avoid using an existing author’s name as the blog profile ID. Fediverse platforms might use caching and this could break the functionality completely.', 'activitypub' ); ?>
-								</strong>
 							</p>
 						</td>
 					</tr>

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -3,6 +3,10 @@
 $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 <h2 id="activitypub"><?php \esc_html_e( 'ActivityPub', 'activitypub' ); ?></h2>
 
+<p><?php esc_html_e( 'Define what others can see on your public Fediverse profile and next to your posts. With a profile picture and a fully completed profile, you are more likely to gain interactions and followers.', 'activitypub' ); ?></p>
+
+<p><?php esc_html_e( 'The ActivityPub plugin tries to take as much information as possible from your profile settings. However, the following settings are not supported by WordPress or should be adjusted independently of the WordPress settings.', 'activitypub' ); ?></p>
+
 <table class="form-table">
 	<tbody>
 		<tr>
@@ -20,17 +24,66 @@ $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 		</tr>
 		<tr class="activitypub-user-description-wrap">
 			<th>
-				<label for="activitypub-user-description"><?php \esc_html_e( 'Biography', 'activitypub' ); ?></label>
+				<label for="activitypub_user_description"><?php \esc_html_e( 'Biography', 'activitypub' ); ?></label>
 			</th>
 			<td>
-				<textarea name="activitypub-user-description" id="activitypub-user-description" rows="5" cols="30" placeholder="<?php echo \esc_html( get_user_meta( \get_current_user_id(), 'description', true ) ); ?>"><?php echo \esc_html( $args['description'] ); ?></textarea>
+				<textarea name="activitypub_user_description" id="activitypub_user_description" rows="5" cols="30" placeholder="<?php echo \esc_html( get_user_meta( \get_current_user_id(), 'description', true ) ); ?>"><?php echo \esc_html( $args['description'] ); ?></textarea>
 				<p class="description"><?php \esc_html_e( 'If you wish to use different biographical info for the fediverse, enter your alternate bio here.', 'activitypub' ); ?></p>
 			</td>
-			<?php wp_nonce_field( 'activitypub-user-description', '_apnonce' ); ?>
 		</tr>
 		<tr scope="row">
 			<th>
-				<label><?php \esc_html_e( 'Extra fields', 'activitypub' ); ?></label>
+				<label><?php \esc_html_e( 'Header Image', 'activitypub' ); ?></label>
+			</th>
+			<td>
+				<?php
+				$classes_for_upload_button = 'button upload-button button-add-media button-add-header-image';
+				$classes_for_update_button = 'button';
+				$classes_for_wrapper       = '';
+
+				$header_image = \get_user_option( 'activitypub_header_image', \get_current_user_id() );
+
+				if ( (int) $header_image ) {
+					$classes_for_wrapper         .= ' has-header-image';
+					$classes_for_button           = $classes_for_update_button;
+					$classes_for_button_on_change = $classes_for_upload_button;
+				} else {
+					$classes_for_wrapper         .= ' hidden';
+					$classes_for_button           = $classes_for_upload_button;
+					$classes_for_button_on_change = $classes_for_update_button;
+				}
+				?>
+				<div id="activitypub-header-image-preview-wrapper" class='<?php echo esc_attr( $classes_for_wrapper ); ?>'>
+					<img id='activitypub-header-image-preview' src='<?php echo \esc_url( \wp_get_attachment_url( $header_image ) ); ?>' style="max-width: 100%;" />
+				</div>
+				<button
+					type="button"
+					id="activitypub-choose-from-library-button"
+					type="button"
+					class="<?php echo \esc_attr( $classes_for_button ); ?>"
+					data-alt-classes="<?php echo \esc_attr( $classes_for_button_on_change ); ?>"
+					data-choose-text="<?php \esc_attr_e( 'Choose a Header Image', 'activitypub' ); ?>"
+					data-update-text="<?php \esc_attr_e( 'Change Header Icon', 'activitypub' ); ?>"
+					data-update="<?php \esc_attr_e( 'Set as Header Image', 'activitypub' ); ?>"
+					data-state="<?php echo \esc_attr( (int) $header_image ); ?>">
+					<?php if ( (int) $header_image ) : ?>
+						<?php \esc_html_e( 'Change Header Image', 'activitypub' ); ?>
+					<?php else : ?>
+						<?php \esc_html_e( 'Choose a Header Image', 'activitypub' ); ?>
+					<?php endif; ?>
+				</button>
+				<button
+					id="activitypub-remove-header-image"
+					type="button"
+					<?php echo (int) $header_image ? 'class="button button-secondary reset"' : 'class="button button-secondary reset hidden"'; ?>>
+					<?php esc_html_e( 'Remove Header Image', 'activitypub' ); ?>
+				</button>
+				<input type='hidden' name='activitypub_header_image' id='activitypub_header_image' value='<?php echo esc_attr( $header_image ); ?>'>
+			</td>
+		</tr>
+		<tr scope="row">
+			<th>
+				<label><?php \esc_html_e( 'Extra Fields', 'activitypub' ); ?></label>
 			</th>
 			<td>
 				<p class="description"><?php \esc_html_e( 'Your homepage, social profiles, pronouns, age, anything you want.', 'activitypub' ); ?></p>
@@ -65,3 +118,5 @@ $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 		</tr>
 	</tbody>
 </table>
+
+<?php wp_nonce_field( 'activitypub-user-settings', '_apnonce' ); ?>

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -3,9 +3,10 @@
 	__DIR__ . '/admin-header.php',
 	true,
 	array(
-		'settings'  => '',
-		'welcome'   => 'active',
-		'followers' => '',
+		'settings'     => '',
+		'welcome'      => 'active',
+		'blog-profile' => '',
+		'followers'    => '',
 	)
 );
 ?>


### PR DESCRIPTION
Add "Header Image" support based on WordPress Site-Icon JS

Implements: #505 #768

Related: #584

See Blog-Settings:

<img width="828" alt="Screenshot 2024-07-18 at 11 25 01" src="https://github.com/user-attachments/assets/fe71b6d8-6c34-4372-94bb-d98b53c2a399">

See Author-Settings:

<img width="2383" alt="Screenshot 2024-07-19 at 15 21 24" src="https://github.com/user-attachments/assets/ed8291d0-50b8-4fbd-af8d-441b477bc39d">
