### PR TITLE
Add ordering for Extra fields

### DIFF
--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -527,7 +527,7 @@ class Activitypub {
 				'show_in_rest'        => true,
 				'map_meta_cap'        => true,
 				'show_ui'             => true,
-				'supports'            => array( 'title', 'editor' ),
+				'supports'            => array( 'title', 'editor', 'page-attributes' ),
 			)
 		);
 
@@ -573,6 +573,7 @@ class Activitypub {
 			\__( 'Homepage', 'activitypub' ) => \get_the_author_meta( 'user_url', $user_id ),
 		);
 
+		$menu_order = 10;
 		foreach ( $defaults as $title => $url ) {
 			if ( ! $url ) {
 				continue;
@@ -590,8 +591,10 @@ class Activitypub {
 					\wp_parse_url( $url, \PHP_URL_HOST )
 				),
 				'comment_status' => 'closed',
+				'menu_order'     => $menu_order,
 			);
 
+			$menu_order += 10;
 			$extra_field_id = wp_insert_post( $extra_field );
 			$extra_fields[] = get_post( $extra_field_id );
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1052,6 +1052,8 @@ function get_actor_extra_fields( $user_id ) {
 			'nopaging'  => true,
 			'status'    => 'publish',
 			'author'    => $user_id,
+			'orderby'   => 'menu_order',
+			'order'     => 'ASC',
 		)
 	);
 


### PR DESCRIPTION

Added menu_order to ap_extrafield so that user can decide in with order the Extra filds will be displayed.

## Proposed changes:

* Add Support to Posttype for PAge attributes
* Add sorting to fields query
* Add a sorting on fields creation for user the first time

### Other information:

- [x] Have you written new tests for your changes, if applicable? No, post type core functionality.

## Testing instructions:

* Go to Users Profile and see the Extra fields in a sorted order
* On editing an Extra field have the option to change the order 
* In quick edit of the Extra fields have the option to change the order

