### PR TITLE
Fix undefined `get_sample_permalink`

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -99,13 +99,21 @@ class Post extends Base {
 	public function get_url() {
 		$post = $this->wp_object;
 
-		if ( 'trash' === \get_post_status( $post ) ) {
-			$permalink = \get_post_meta( $post->ID, 'activitypub_canonical_url', true );
-		} elseif ( 'draft' === \get_post_status( $post ) && \get_sample_permalink( $post->ID ) ) {
-			$sample    = \get_sample_permalink( $post->ID );
-			$permalink = \str_replace( array( '%pagename%', '%postname%' ), $sample[1], $sample[0] );
-		} else {
-			$permalink = \get_permalink( $post );
+		switch ( \get_post_status( $post ) ) {
+			case 'trash':
+				$permalink = \get_post_meta( $post->ID, 'activitypub_canonical_url', true );
+				break;
+			case 'draft':
+				// get_sample_permalink is in wp-admin, not always loaded
+				if ( ! \function_exists( '\get_sample_permalink' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/post.php';
+				}
+				$sample    = \get_sample_permalink( $post->ID );
+				$permalink = \str_replace( array( '%pagename%', '%postname%' ), $sample[1], $sample[0] );
+				break;
+			default:
+				$permalink = \get_permalink( $post );
+				break;
 		}
 
 		return \esc_url( $permalink );


### PR DESCRIPTION
Even after https://github.com/Automattic/wordpress-activitypub/commit/12cb73bcd678f3d2bde3c92f46a7dcb500e6e4f7 we are seeing fatal errors when saving drafts. 

This is also exposing an unintended problem with sending `Update` Activities for new drafts introduced in #780. I think we should only be sending those for previously-published posts?

## Proposed changes:
* Include `wp-admin/includes/post.php` when needed

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

