### PR TITLE
Only send `Update` for previously-published posts

### DIFF
--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -142,8 +142,9 @@ class Scheduler {
 			$type = 'Create';
 		} elseif (
 			'publish' === $new_status ||
+			// We want to send updates for posts that are published and then moved to draft.
 			( 'draft' === $new_status &&
-			'draft' !== $old_status )
+			'publish' === $old_status )
 		) {
 			$type = 'Update';
 		} elseif ( 'trash' === $new_status ) {


### PR DESCRIPTION
In #780 we started sending `Update` Activities for drafts. But we should only be sending those if the post was previously published. The previous logic would always send for all draft status updates, which is probably spamming a bunch of instances with an update for a post that never existed.

## Proposed changes:
* Fix `Update` logic to only send for posts transitioning from `publish` to `draft`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

