### PR TITLE
Add Blog extra fields

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -81,7 +81,6 @@ function plugin_init() {
 	\add_action( 'init', array( __NAMESPACE__ . '\Health_Check', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Comment', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Collection\Extra_Fields', 'init' ) );
 
 	if ( site_supports_blocks() ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\Blocks', 'init' ) );

--- a/activitypub.php
+++ b/activitypub.php
@@ -81,6 +81,7 @@ function plugin_init() {
 	\add_action( 'init', array( __NAMESPACE__ . '\Health_Check', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Comment', 'init' ) );
+	\add_action( 'init', array( __NAMESPACE__ . '\Collection\Extra_Fields', 'init' ) );
 
 	if ( site_supports_blocks() ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\Blocks', 'init' ) );

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -48,6 +48,8 @@ class Activitypub {
 
 		\add_action( 'tool_box', array( self::class, 'tool_box' ) );
 
+		\add_filter( 'activitypub_get_actor_extra_fields', array( Extra_Fields::class, 'default_actor_extra_fields' ), 10, 2 );
+
 		// register several post_types
 		self::register_post_types();
 	}
@@ -500,6 +502,36 @@ class Activitypub {
 				},
 			)
 		);
+
+		// Both User and Blog Extra Fields types have the same args.
+		$args = array(
+			'labels'           => array(
+				'name'          => _x( 'Extra fields', 'post_type plural name', 'activitypub' ),
+				'singular_name' => _x( 'Extra field', 'post_type single name', 'activitypub' ),
+				'add_new'       => __( 'Add new', 'activitypub' ),
+				'add_new_item'  => __( 'Add new extra field', 'activitypub' ),
+				'new_item'      => __( 'New extra field', 'activitypub' ),
+				'edit_item'     => __( 'Edit extra field', 'activitypub' ),
+				'view_item'     => __( 'View extra field', 'activitypub' ),
+				'all_items'     => __( 'All extra fields', 'activitypub' ),
+			),
+			'public'              => false,
+			'hierarchical'        => false,
+			'query_var'           => false,
+			'has_archive'         => false,
+			'publicly_queryable'  => false,
+			'show_in_menu'        => false,
+			'delete_with_user'    => true,
+			'can_export'          => true,
+			'exclude_from_search' => true,
+			'show_in_rest'        => true,
+			'map_meta_cap'        => true,
+			'show_ui'             => true,
+			'supports'            => array( 'title', 'editor', 'page-attributes' ),
+		);
+
+		\register_post_type( Extra_Fields::USER_POST_TYPE, $args );
+		\register_post_type( Extra_Fields::BLOG_POST_TYPE, $args );
 
 		\do_action( 'activitypub_after_register_post_type' );
 	}

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -5,6 +5,7 @@ use Exception;
 use Activitypub\Signature;
 use Activitypub\Collection\Users;
 use Activitypub\Collection\Followers;
+use Activitypub\Collection\Extra_Fields;
 
 use function Activitypub\is_comment;
 use function Activitypub\sanitize_url;
@@ -502,34 +503,7 @@ class Activitypub {
 			)
 		);
 
-		\register_post_type(
-			'ap_extrafield',
-			array(
-				'labels'           => array(
-					'name'          => _x( 'Extra fields', 'post_type plural name', 'activitypub' ),
-					'singular_name' => _x( 'Extra field', 'post_type single name', 'activitypub' ),
-					'add_new'       => __( 'Add new', 'activitypub' ),
-					'add_new_item'  => __( 'Add new extra field', 'activitypub' ),
-					'new_item'      => __( 'New extra field', 'activitypub' ),
-					'edit_item'     => __( 'Edit extra field', 'activitypub' ),
-					'view_item'     => __( 'View extra field', 'activitypub' ),
-					'all_items'     => __( 'All extra fields', 'activitypub' ),
-				),
-				'public'              => false,
-				'hierarchical'        => false,
-				'query_var'           => false,
-				'has_archive'         => false,
-				'publicly_queryable'  => false,
-				'show_in_menu'        => false,
-				'delete_with_user'    => true,
-				'can_export'          => true,
-				'exclude_from_search' => true,
-				'show_in_rest'        => true,
-				'map_meta_cap'        => true,
-				'show_ui'             => true,
-				'supports'            => array( 'title', 'editor' ),
-			)
-		);
+		Extra_Fields::register_post_types();
 
 		\do_action( 'activitypub_after_register_post_type' );
 	}
@@ -557,7 +531,7 @@ class Activitypub {
 	 * @return array The extra fields.
 	 */
 	public static function default_actor_extra_fields( $extra_fields, $user_id ) {
-		if ( $extra_fields || ! $user_id ) {
+		if ( $extra_fields || ! $user_id ) { // @todo allow 0 as user_id
 			return $extra_fields;
 		}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -5,6 +5,7 @@ use WP_User_Query;
 use Activitypub\Model\Blog;
 use Activitypub\Activitypub;
 use Activitypub\Collection\Users;
+use Activitypub\Collection\Extra_Fields;
 
 use function Activitypub\count_followers;
 use function Activitypub\is_user_disabled;
@@ -108,7 +109,7 @@ class Admin {
 
 		$current_screen = get_current_screen();
 
-		if ( isset( $current_screen->id ) && 'edit-ap_extrafield' === $current_screen->id ) {
+		if ( 'edit' === $current_screen->base && Extra_Fields::is_post_type( $current_screen->post_type ) ) {
 			?>
 			<div class="notice" style="margin: 0; background: none; border: none; box-shadow: none; padding: 15px 0 0 0; font-size: 14px;">
 				<?php esc_html_e( 'These are extra fields that are used for your ActivityPub profile. You can use your homepage, social profiles, pronouns, age, anything you want.', 'activitypub' ); ?>
@@ -496,7 +497,7 @@ class Admin {
 
 				$post = get_post( $arg[2] );
 
-				if ( 'ap_extrafield' !== $post->post_type ) {
+				if ( Extra_Fields::is_post_type( $post->post_type ) ) {
 					return $allcaps;
 				}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -107,8 +107,10 @@ class Admin {
 		}
 
 		$current_screen = get_current_screen();
-
-		if ( 'edit' === $current_screen->base && $current_screen->post_type && Extra_Fields::is_extra_fields_post_type( $current_screen->post_type ) ) {
+		if ( ! $current_screen ) {
+			return;
+		}
+		if ( 'edit' === $current_screen->base && Extra_Fields::is_extra_fields_post_type( $current_screen->post_type ) ) {
 			?>
 			<div class="notice" style="margin: 0; background: none; border: none; box-shadow: none; padding: 15px 0 0 0; font-size: 14px;">
 				<?php esc_html_e( 'These are extra fields that are used for your ActivityPub profile. You can use your homepage, social profiles, pronouns, age, anything you want.', 'activitypub' ); ?>

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -11,7 +11,6 @@ use function Activitypub\count_followers;
 use function Activitypub\is_user_disabled;
 use function Activitypub\was_comment_received;
 use function Activitypub\is_comment_federatable;
-use function Activitypub\add_default_actor_extra_fields;
 
 /**
  * ActivityPub Admin Class
@@ -109,7 +108,7 @@ class Admin {
 
 		$current_screen = get_current_screen();
 
-		if ( 'edit' === $current_screen->base && Extra_Fields::is_post_type( $current_screen->post_type ) ) {
+		if ( 'edit' === $current_screen->base && $current_screen->post_type && Extra_Fields::is_extra_fields_post_type( $current_screen->post_type ) ) {
 			?>
 			<div class="notice" style="margin: 0; background: none; border: none; box-shadow: none; padding: 15px 0 0 0; font-size: 14px;">
 				<?php esc_html_e( 'These are extra fields that are used for your ActivityPub profile. You can use your homepage, social profiles, pronouns, age, anything you want.', 'activitypub' ); ?>
@@ -497,7 +496,7 @@ class Admin {
 
 				$post = get_post( $arg[2] );
 
-				if ( Extra_Fields::is_post_type( $post->post_type ) ) {
+				if ( Extra_Fields::is_extra_fields_post_type( $post->post_type ) ) {
 					return $allcaps;
 				}
 
@@ -534,7 +533,7 @@ class Admin {
 		add_filter(
 			"views_{$screen_id}",
 			function ( $views ) {
-				if ( Extra_Fields::is_post_type( get_current_screen()->post_type ) ) {
+				if ( Extra_Fields::is_extra_fields_post_type( get_current_screen()->post_type ) ) {
 					return array();
 				}
 
@@ -585,7 +584,7 @@ class Admin {
 	 * @param string $post_type The post type.
 	 */
 	public static function manage_post_columns( $columns, $post_type ) {
-		if ( Extra_Fields::is_post_type( $post_type ) ) {
+		if ( Extra_Fields::is_extra_fields_post_type( $post_type ) ) {
 			$after_key = 'title';
 			$index     = array_search( $after_key, array_keys( $columns ), true );
 			$columns   = array_slice( $columns, 0, $index + 1 ) + array( 'extra_field_content' => esc_attr__( 'Content', 'activitypub' ) ) + $columns;
@@ -648,7 +647,7 @@ class Admin {
 
 		if ( 'extra_field_content' === $column_name ) {
 			$post = get_post( $post_id );
-			if ( Extra_Fields::is_post_type( $post->post_type ) ) {
+			if ( Extra_Fields::is_extra_fields_post_type( $post->post_type ) ) {
 				echo esc_attr( wp_strip_all_tags( $post->post_content ) );
 			}
 		}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -534,18 +534,13 @@ class Admin {
 		add_filter(
 			"views_{$screen_id}",
 			function ( $views ) {
-				if ( 'ap_extrafield' === get_post_type() ) {
+				if ( Extra_Fields::is_post_type( get_current_screen()->post_type ) ) {
 					return array();
 				}
 
 				return $views;
 			}
 		);
-
-		// Set defaults for new extra fields.
-		if ( 'edit-ap_extrafield' === $screen_id ) {
-			Activitypub::default_actor_extra_fields( array(), get_current_user_id() );
-		}
 	}
 
 	public static function comment_row_actions( $actions, $comment ) {
@@ -590,7 +585,7 @@ class Admin {
 	 * @param string $post_type The post type.
 	 */
 	public static function manage_post_columns( $columns, $post_type ) {
-		if ( 'ap_extrafield' === $post_type ) {
+		if ( Extra_Fields::is_post_type( $post_type ) ) {
 			$after_key = 'title';
 			$index     = array_search( $after_key, array_keys( $columns ), true );
 			$columns   = array_slice( $columns, 0, $index + 1 ) + array( 'extra_field_content' => esc_attr__( 'Content', 'activitypub' ) ) + $columns;
@@ -653,7 +648,7 @@ class Admin {
 
 		if ( 'extra_field_content' === $column_name ) {
 			$post = get_post( $post_id );
-			if ( 'ap_extrafield' === $post->post_type ) {
+			if ( Extra_Fields::is_post_type( $post->post_type ) ) {
 				echo esc_attr( wp_strip_all_tags( $post->post_content ) );
 			}
 		}

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -122,6 +122,11 @@ class Scheduler {
 			return;
 		}
 
+		if ( 'ap_extrafield_blog' === $post->post_type ) {
+			self::schedule_profile_update( 0 );
+			return;
+		}
+
 		// Do not send activities if post is password protected.
 		if ( \post_password_required( $post ) ) {
 			return;

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -44,7 +44,7 @@ class Extra_Fields {
 			'show_in_rest'        => true,
 			'map_meta_cap'        => true,
 			'show_ui'             => true,
-			'supports'            => array( 'title', 'editor' ),
+			'supports'            => array( 'title', 'editor', 'page-attributes' ),
 		);
 
 		\register_post_type( self::USER_POST_TYPE, $args );
@@ -64,6 +64,8 @@ class Extra_Fields {
 		$args = array(
 			'post_type' => $post_type,
 			'nopaging'  => true,
+			'orderby'   => 'menu_order',
+			'order'     => 'ASC',
 		);
 		if ( ! $is_blog ) {
 			$args['author'] = $user_id;
@@ -185,7 +187,8 @@ class Extra_Fields {
 			}
 		}
 
-		$post_type = $is_blog ? self::BLOG_POST_TYPE : self::USER_POST_TYPE;
+		$post_type  = $is_blog ? self::BLOG_POST_TYPE : self::USER_POST_TYPE;
+		$menu_order = 10;
 
 		foreach ( $defaults as $title => $url ) {
 			if ( ! $url ) {
@@ -204,8 +207,10 @@ class Extra_Fields {
 					\wp_parse_url( $url, \PHP_URL_HOST )
 				),
 				'comment_status' => 'closed',
+				'menu_order'     => $menu_order,
 			);
 
+			$menu_order += 10;
 			$extra_field_id = wp_insert_post( $extra_field );
 			$extra_fields[] = get_post( $extra_field_id );
 		}

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -185,13 +185,15 @@ class Extra_Fields {
 			}
 		}
 
+		$post_type = $is_blog ? self::BLOG_POST_TYPE : self::USER_POST_TYPE;
+
 		foreach ( $defaults as $title => $url ) {
 			if ( ! $url ) {
 				continue;
 			}
 
 			$extra_field = array(
-				'post_type'      => 'ap_extrafield',
+				'post_type'      => $post_type,
 				'post_title'     => $title,
 				'post_status'    => 'publish',
 				'post_author'    => $user_id,

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -2,54 +2,13 @@
 
 namespace Activitypub\Collection;
 
-use Activitypub\Collection\Users;
 use WP_Query;
+use Activitypub\Collection\Users;
 
 class Extra_Fields {
 
 	const USER_POST_TYPE = 'ap_extrafield';
-
 	const BLOG_POST_TYPE = 'ap_extrafield_blog';
-
-	public static function init() {
-		self::register_post_types();
-		\add_filter( 'activitypub_get_actor_extra_fields', array( self::class, 'default_actor_extra_fields' ), 10, 2 );
-	}
-
-	/**
-	 * Register the post types for extra fields.
-	 */
-	public static function register_post_types() {
-		// Both User and Blog Extra Fields types have the same args.
-		$args = array(
-			'labels'           => array(
-				'name'          => _x( 'Extra fields', 'post_type plural name', 'activitypub' ),
-				'singular_name' => _x( 'Extra field', 'post_type single name', 'activitypub' ),
-				'add_new'       => __( 'Add new', 'activitypub' ),
-				'add_new_item'  => __( 'Add new extra field', 'activitypub' ),
-				'new_item'      => __( 'New extra field', 'activitypub' ),
-				'edit_item'     => __( 'Edit extra field', 'activitypub' ),
-				'view_item'     => __( 'View extra field', 'activitypub' ),
-				'all_items'     => __( 'All extra fields', 'activitypub' ),
-			),
-			'public'              => false,
-			'hierarchical'        => false,
-			'query_var'           => false,
-			'has_archive'         => false,
-			'publicly_queryable'  => false,
-			'show_in_menu'        => false,
-			'delete_with_user'    => true,
-			'can_export'          => true,
-			'exclude_from_search' => true,
-			'show_in_rest'        => true,
-			'map_meta_cap'        => true,
-			'show_ui'             => true,
-			'supports'            => array( 'title', 'editor', 'page-attributes' ),
-		);
-
-		\register_post_type( self::USER_POST_TYPE, $args );
-		\register_post_type( self::BLOG_POST_TYPE, $args );
-	}
 
 	/**
 	 * Get the extra fields for a user.

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -146,7 +146,14 @@ class Extra_Fields {
 		return $attachments;
 	}
 
-	public static function is_post_type( $post_type ) {
+	/**
+	 * Check if a post type is an extra fields post type.
+	 *
+	 * @param string $post_type The post type.
+	 *
+	 * @return bool True if the post type is an extra fields post type, otherwise false.
+	 */
+	public static function is_extra_fields_post_type( $post_type ) {
 		return \in_array( $post_type, array( self::USER_POST_TYPE, self::BLOG_POST_TYPE ), true );
 	}
 

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Activitypub\Collection;
+
+use Activitypub\Collection\Users;
+use WP_Query;
+
+class Extra_Fields {
+
+	const USER_POST_TYPE = 'ap_extrafield';
+
+	const BLOG_POST_TYPE = 'ap_extrafield_blog';
+
+	/**
+	 * Register the post types for extra fields.
+	 */
+	public static function register_post_types() {
+		// Both User and Blog Extra Fields types have the same args.
+		$args = array(
+			'labels'           => array(
+				'name'          => _x( 'Extra fields', 'post_type plural name', 'activitypub' ),
+				'singular_name' => _x( 'Extra field', 'post_type single name', 'activitypub' ),
+				'add_new'       => __( 'Add new', 'activitypub' ),
+				'add_new_item'  => __( 'Add new extra field', 'activitypub' ),
+				'new_item'      => __( 'New extra field', 'activitypub' ),
+				'edit_item'     => __( 'Edit extra field', 'activitypub' ),
+				'view_item'     => __( 'View extra field', 'activitypub' ),
+				'all_items'     => __( 'All extra fields', 'activitypub' ),
+			),
+			'public'              => false,
+			'hierarchical'        => false,
+			'query_var'           => false,
+			'has_archive'         => false,
+			'publicly_queryable'  => false,
+			'show_in_menu'        => false,
+			'delete_with_user'    => true,
+			'can_export'          => true,
+			'exclude_from_search' => true,
+			'show_in_rest'        => true,
+			'map_meta_cap'        => true,
+			'show_ui'             => true,
+			'supports'            => array( 'title', 'editor' ),
+		);
+
+		\register_post_type( self::USER_POST_TYPE, $args );
+		\register_post_type( self::BLOG_POST_TYPE, $args );
+	}
+
+	/**
+	 * Get the extra fields for a user.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return WP_Post[] The extra fields.
+	 */
+	public static function get_actor_fields( $user_id ) {
+		$is_blog = Users::BLOG_USER_ID === $user_id;
+		$post_type = $is_blog ? self::BLOG_POST_TYPE : self::USER_POST_TYPE;
+		$args = array(
+			'post_type' => $post_type,
+			'nopaging'  => true,
+		);
+		if ( ! $is_blog ) {
+			$args['author'] = $user_id;
+		}
+
+		$query = new \WP_Query( $args );
+		$fields = $query->posts ?? array();
+
+		return apply_filters( 'activitypub_get_actor_extra_fields', $fields, $user_id );
+	}
+
+	public static function fields_to_attachments( $fields ) {
+		$attachments = array();
+
+		foreach ( $fields as $post ) {
+			$content = \get_the_content( null, false, $post );
+			$content = \make_clickable( $content );
+			$content = \do_blocks( $content );
+			$content = \wptexturize( $content );
+			$content = \wp_filter_content_tags( $content );
+			// replace script and style elements
+			$content = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $content );
+			$content = \strip_shortcodes( $content );
+			$content = \trim( \preg_replace( '/[\n\r\t]/', '', $content ) );
+
+			$attachments[] = array(
+				'type' => 'PropertyValue',
+				'name' => \get_the_title( $post ),
+				'value' => \html_entity_decode(
+					$content,
+					\ENT_QUOTES,
+					'UTF-8'
+				),
+			);
+
+			$link_added = false;
+
+			// Add support for FEP-fb2a, for more information see FEDERATION.md
+			if ( \class_exists( '\WP_HTML_Tag_Processor' ) ) {
+				$tags = new \WP_HTML_Tag_Processor( $content );
+				$tags->next_tag();
+
+				if ( 'P' === $tags->get_tag() ) {
+					$tags->next_tag();
+				}
+
+				if ( 'A' === $tags->get_tag() ) {
+					$tags->set_bookmark( 'link' );
+					if ( ! $tags->next_tag() ) {
+						$tags->seek( 'link' );
+						$attachment = array(
+							'type' => 'Link',
+							'name' => \get_the_title( $post ),
+							'href' => \esc_url( $tags->get_attribute( 'href' ) ),
+							'rel'  => explode( ' ', $tags->get_attribute( 'rel' ) ),
+						);
+
+						$link_added = true;
+					}
+				}
+			}
+
+			if ( ! $link_added ) {
+				$attachment = array(
+					'type'    => 'Note',
+					'name'    => \get_the_title( $post ),
+					'content' => \html_entity_decode(
+						$content,
+						\ENT_QUOTES,
+						'UTF-8'
+					),
+				);
+			}
+
+			$attachments[] = $attachment;
+		}
+
+		return $attachments;
+	}
+
+	public static function is_post_type( $post_type ) {
+		return \in_array( $post_type, array( self::USER_POST_TYPE, self::BLOG_POST_TYPE ), true );
+	}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1040,17 +1040,6 @@ function normalize_host( $host ) {
 }
 
 /**
- * Get the Extra Fields of an Actor
- *
- * @param int $user_id The User-ID.
- *
- * @return array The extra fields.
- */
-function get_actor_extra_fields( $user_id ) {
-	return Extra_Fields::get_actor_fields( $user_id );
-}
-
-/**
  * Get the reply intent URI.
  *
  * @return string The reply intent URI.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -9,6 +9,7 @@ use Activitypub\Webfinger;
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Users;
+use Activitypub\Collection\Extra_Fields;
 
 /**
  * Returns the ActivityPub default JSON-context
@@ -1046,22 +1047,7 @@ function normalize_host( $host ) {
  * @return array The extra fields.
  */
 function get_actor_extra_fields( $user_id ) {
-	$extra_fields = new WP_Query(
-		array(
-			'post_type' => 'ap_extrafield',
-			'nopaging'  => true,
-			'status'    => 'publish',
-			'author'    => $user_id,
-		)
-	);
-
-	if ( $extra_fields->have_posts() ) {
-		$extra_fields = $extra_fields->posts;
-	} else {
-		$extra_fields = array();
-	}
-
-	return apply_filters( 'activitypub_get_actor_extra_fields', $extra_fields, $user_id );
+	return Extra_Fields::get_actor_fields( $user_id );
 }
 
 /**

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -7,11 +7,13 @@ use WP_Error;
 use Activitypub\Signature;
 use Activitypub\Activity\Actor;
 use Activitypub\Collection\Users;
+use Activitypub\Collection\Extra_Fields;
 
 use function Activitypub\esc_hashtag;
 use function Activitypub\is_single_user;
 use function Activitypub\is_user_disabled;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\get_actor_extra_fields;
 
 class Blog extends Actor {
 	/**
@@ -424,32 +426,5 @@ class Blog extends Actor {
 	public function get_attachment() {
 		$extra_fields = get_actor_extra_fields( $this->_id );
 		return Extra_Fields::fields_to_attachments( $extra_fields );
-		// @todo: refactor these to be in the migration thing.
-		$array = array();
-
-		$array[] = array(
-			'type' => 'PropertyValue',
-			'name' => \__( 'Blog', 'activitypub' ),
-			'value' => \html_entity_decode(
-				sprintf(
-					'<a rel="me" title="%s" target="_blank" href="%s">%s</a>',
-					\esc_attr( \home_url( '/' ) ),
-					\esc_url( \home_url( '/' ) ),
-					\wp_parse_url( \home_url( '/' ), \PHP_URL_HOST )
-				),
-				\ENT_QUOTES,
-				'UTF-8'
-			),
-		);
-
-		// Add support for FEP-fb2a, for more information see FEDERATION.md
-		$array[] = array(
-			'type' => 'Link',
-			'name' => \__( 'Blog', 'activitypub' ),
-			'href' => \esc_url( \home_url( '/' ) ),
-			'rel'  => array( 'me' ),
-		);
-
-		return $array;
 	}
 }

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -422,6 +422,9 @@ class Blog extends Actor {
 	 * @return array The extended User-Output.
 	 */
 	public function get_attachment() {
+		$extra_fields = get_actor_extra_fields( $this->_id );
+		return Extra_Fields::fields_to_attachments( $extra_fields );
+		// @todo: refactor these to be in the migration thing.
 		$array = array();
 
 		$array[] = array(

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -13,7 +13,6 @@ use function Activitypub\esc_hashtag;
 use function Activitypub\is_single_user;
 use function Activitypub\is_user_disabled;
 use function Activitypub\get_rest_url_by_path;
-use function Activitypub\get_actor_extra_fields;
 
 class Blog extends Actor {
 	/**
@@ -424,7 +423,7 @@ class Blog extends Actor {
 	 * @return array The extended User-Output.
 	 */
 	public function get_attachment() {
-		$extra_fields = get_actor_extra_fields( $this->_id );
+		$extra_fields = Extra_Fields::get_actor_fields( $this->_id );
 		return Extra_Fields::fields_to_attachments( $extra_fields );
 	}
 }

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -12,7 +12,6 @@ use Activitypub\Collection\Extra_Fields;
 
 use function Activitypub\is_user_disabled;
 use function Activitypub\get_rest_url_by_path;
-use function Activitypub\get_actor_extra_fields;
 
 class User extends Actor {
 	/**
@@ -246,7 +245,7 @@ class User extends Actor {
 	 * @return array The extended User-Output.
 	 */
 	public function get_attachment() {
-		$extra_fields = get_actor_extra_fields( $this->_id );
+		$extra_fields = Extra_Fields::get_actor_fields( $this->_id );
 		return Extra_Fields::fields_to_attachments( $extra_fields );
 	}
 

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -8,6 +8,7 @@ use Activitypub\Signature;
 use Activitypub\Model\Blog;
 use Activitypub\Activity\Actor;
 use Activitypub\Collection\Users;
+use Activitypub\Collection\Extra_Fields;
 
 use function Activitypub\is_user_disabled;
 use function Activitypub\get_rest_url_by_path;
@@ -246,73 +247,7 @@ class User extends Actor {
 	 */
 	public function get_attachment() {
 		$extra_fields = get_actor_extra_fields( $this->_id );
-
-		$attachments = array();
-
-		foreach ( $extra_fields as $post ) {
-			$content = \get_the_content( null, false, $post );
-			$content = \make_clickable( $content );
-			$content = \do_blocks( $content );
-			$content = \wptexturize( $content );
-			$content = \wp_filter_content_tags( $content );
-			// replace script and style elements
-			$content = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $content );
-			$content = \strip_shortcodes( $content );
-			$content = \trim( \preg_replace( '/[\n\r\t]/', '', $content ) );
-
-			$attachments[] = array(
-				'type' => 'PropertyValue',
-				'name' => \get_the_title( $post ),
-				'value' => \html_entity_decode(
-					$content,
-					\ENT_QUOTES,
-					'UTF-8'
-				),
-			);
-
-			$link_added = false;
-
-			// Add support for FEP-fb2a, for more information see FEDERATION.md
-			if ( \class_exists( '\WP_HTML_Tag_Processor' ) ) {
-				$tags = new \WP_HTML_Tag_Processor( $content );
-				$tags->next_tag();
-
-				if ( 'P' === $tags->get_tag() ) {
-					$tags->next_tag();
-				}
-
-				if ( 'A' === $tags->get_tag() ) {
-					$tags->set_bookmark( 'link' );
-					if ( ! $tags->next_tag() ) {
-						$tags->seek( 'link' );
-						$attachment = array(
-							'type' => 'Link',
-							'name' => \get_the_title( $post ),
-							'href' => \esc_url( $tags->get_attribute( 'href' ) ),
-							'rel'  => explode( ' ', $tags->get_attribute( 'rel' ) ),
-						);
-
-						$link_added = true;
-					}
-				}
-			}
-
-			if ( ! $link_added ) {
-				$attachment = array(
-					'type'    => 'Note',
-					'name'    => \get_the_title( $post ),
-					'content' => \html_entity_decode(
-						$content,
-						\ENT_QUOTES,
-						'UTF-8'
-					),
-				);
-			}
-
-			$attachments[] = $attachment;
-		}
-
-		return $attachments;
+		return Extra_Fields::fields_to_attachments( $extra_fields );
 	}
 
 	/**

--- a/templates/blog-settings.php
+++ b/templates/blog-settings.php
@@ -127,6 +127,50 @@
 							</p>
 						</td>
 					</tr>
+					<tr scope="row">
+						<th>
+							<label><?php \esc_html_e( 'Extra Fields', 'activitypub' ); ?></label>
+						</th>
+						<td>
+							<p class="description"><?php \esc_html_e( 'Your homepage, social profiles, pronouns, age, anything you want.', 'activitypub' ); ?></p>
+
+							<table class="widefat striped activitypub-extra-fields" role="presentation" style="margin: 15px 0;">
+							<?php
+							$extra_fields = \Activitypub\get_actor_extra_fields( \Activitypub\Collection\Users::BLOG_USER_ID );
+
+							if ( empty( $extra_fields ) ) {
+								?>
+							<tr>
+								<td colspan="3">
+									<?php \esc_html_e( 'No extra fields found.', 'activitypub' ); ?>
+								</td>
+							</tr>
+								<?php
+							}
+							foreach ( $extra_fields as $extra_field ) {
+								?>
+							<tr>
+								<td><?php echo \esc_html( $extra_field->post_title ); ?></td>
+								<td><?php echo \wp_kses_post( \get_the_excerpt( $extra_field ) ); ?></td>
+								<td>
+									<a href="<?php echo \esc_url( \get_edit_post_link( $extra_field->ID ) ); ?>" class="button">
+										<?php \esc_html_e( 'Edit', 'activitypub' ); ?>
+									</a>
+								</td>
+							</tr>
+							<?php } ?>
+							</table>
+
+							<p>
+								<a href="<?php echo esc_url( admin_url( '/post-new.php?post_type=ap_extrafield_blog' ) ); ?>" class="button">
+									<?php esc_html_e( 'Add new', 'activitypub' ); ?>
+								</a>
+								<a href="<?php echo esc_url( admin_url( '/edit.php?post_type=ap_extrafield_blog' ) ); ?>">
+									<?php esc_html_e( 'Manage all', 'activitypub' ); ?>
+								</a>
+							</p>
+						</td>
+					</tr>
 				</tbody>
 			</table>
 		</div>

--- a/templates/blog-settings.php
+++ b/templates/blog-settings.php
@@ -136,7 +136,7 @@
 
 							<table class="widefat striped activitypub-extra-fields" role="presentation" style="margin: 15px 0;">
 							<?php
-							$extra_fields = \Activitypub\Collection\get_actor_fields( \Activitypub\Collection\Users::BLOG_USER_ID );
+							$extra_fields = \Activitypub\Collection\Extra_Fields::get_actor_fields( \Activitypub\Collection\Users::BLOG_USER_ID );
 
 							if ( empty( $extra_fields ) ) {
 								?>

--- a/templates/blog-settings.php
+++ b/templates/blog-settings.php
@@ -136,7 +136,7 @@
 
 							<table class="widefat striped activitypub-extra-fields" role="presentation" style="margin: 15px 0;">
 							<?php
-							$extra_fields = \Activitypub\get_actor_extra_fields( \Activitypub\Collection\Users::BLOG_USER_ID );
+							$extra_fields = \Activitypub\Collection\get_actor_fields( \Activitypub\Collection\Users::BLOG_USER_ID );
 
 							if ( empty( $extra_fields ) ) {
 								?>

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -90,7 +90,7 @@ $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 
 				<table class="widefat striped activitypub-extra-fields" role="presentation" style="margin: 15px 0;">
 				<?php
-				$extra_fields = \Activitypub\Collection\get_actor_fields( \get_current_user_id() );
+				$extra_fields = \Activitypub\Collection\Extra_Fields::get_actor_fields( \get_current_user_id() );
 
 				foreach ( $extra_fields as $extra_field ) {
 					?>

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -90,7 +90,7 @@ $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 
 				<table class="widefat striped activitypub-extra-fields" role="presentation" style="margin: 15px 0;">
 				<?php
-				$extra_fields = \Activitypub\get_actor_extra_fields( \get_current_user_id() );
+				$extra_fields = \Activitypub\Collection\get_actor_fields( \get_current_user_id() );
 
 				foreach ( $extra_fields as $extra_field ) {
 					?>


### PR DESCRIPTION
Following the pattern of User extra fields, we bring you: Blog extra fields!

Since we can't assign `post_author=0` directly in the post editor, we instead register a separate `ap_extrafield_blog` `post_type` for the Blog User.

I moved a bunch of stuff into an `Extra_Fields` class. This will come in handy for #788 😁 

<img width="802" alt="Screenshot 2024-08-01 at 17 44 01" src="https://github.com/user-attachments/assets/d2215a78-415c-488a-9837-d7af28efb0d3">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
1. Go to Settings -> ActivityPub -> Blog-Profile. 
2. The Extra Fields functionality should be there as shown above.
3. `curl -H 'Accept: application/activity+json' http://your.blog/@your.blog | jq .attachment` should reflect the state of the Blog Extra Fields. In the case of the screenshot above:

```json
[
  {
    "type": "PropertyValue",
    "name": "Blog",
    "value": "<p><a rel=\"me noopener\" title=\"http://wp.test/\" target=\"_blank\" href=\"http://wp.test/\">wp.test</a></p>"
  },
  {
    "type": "Link",
    "name": "Blog",
    "href": "http://wp.test/",
    "rel": [
      "me",
      "noopener"
    ]
  }
]
```

