### PR TITLE
Autoloader: log failure in addition to `wp_die()`

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -125,7 +125,9 @@ function plugin_init() {
 				require_once $file;
 			} else {
 				// translators: %s is the class name
-				\wp_die( sprintf( esc_html__( 'Required class not found or not readable: %s', 'activitypub' ), esc_html( $full_class ) ) );
+				$message = sprintf( esc_html__( 'Required class not found or not readable: %s', 'activitypub' ), esc_html( $full_class ) );
+				Debug::write_log( $message );
+				\wp_die( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		}
 	}


### PR DESCRIPTION
When the autoloader fails to find a class in the `Activipub\` namespace, it throws a `wp_die` but nothing in the error_log. Now it will do that, as well, to help poor hypothetical developers who have misspelled a class name (`ExtraFields` where it should have been `Extra_Fields`), possibly taking far too long to get to the bottom of it, theoretically…