### PR TITLE
Header Images: fix cropping for users without the 'customize' capability

### DIFF
--- a/assets/js/activitypub-header-image.js
+++ b/assets/js/activitypub-header-image.js
@@ -39,7 +39,6 @@
 				cropDetails.dst_height = control.params.flex_height ? control.params.width  / ratio : control.params.height;
 			}
 
-
 			return wp.ajax.post( 'crop-image', {
 				// where wp_customize: 'on' would be in Core, for no good reason I understand.
 				nonce: attachment.get( 'nonces' ).edit,
@@ -109,6 +108,11 @@
 	 */
 	$chooseButton.on( 'click', function () {
 		var $el = $( this );
+		var userId = $el.data( 'userId' );
+		var mediaQuery = { type: 'image' };
+		if ( userId ) {
+			mediaQuery.author = userId;
+		}
 
 		// Create the media frame.
 		frame = wp.media( {
@@ -122,7 +126,7 @@
 			states: [
 				new wp.media.controller.Library( {
 					title: $el.data( 'choose-text' ),
-					library: wp.media.query( { type: 'image' } ),
+					library: wp.media.query( mediaQuery ),
 					date: false,
 					suggestedWidth: $el.data( 'size' ),
 					suggestedHeight: $el.data( 'size' ),

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -65,6 +65,12 @@ $user = \Activitypub\Collection\Users::get_by_id( \get_current_user_id() ); ?>
 					data-choose-text="<?php \esc_attr_e( 'Choose a Header Image', 'activitypub' ); ?>"
 					data-update-text="<?php \esc_attr_e( 'Change Header Icon', 'activitypub' ); ?>"
 					data-update="<?php \esc_attr_e( 'Set as Header Image', 'activitypub' ); ?>"
+					<?php
+					// We only need to constrain the user_id for users who can't edit others' posts.
+					if ( ! \current_user_can( 'edit_others_posts' ) ) {
+						printf( 'data-user-id="%s"', esc_attr( \get_current_user_id() ) );
+					}
+					?>
 					data-state="<?php echo \esc_attr( (int) $header_image ); ?>">
 					<?php if ( (int) $header_image ) : ?>
 						<?php \esc_html_e( 'Change Header Image', 'activitypub' ); ?>


### PR DESCRIPTION
I think I found a Core bug here. There's absolutely no reason for the ajax request to include `wp_customize=on`, the logic is entirely handled in the `wp_ajax_crop_image()` handler.

[This commit](https://github.com/WordPress/wordpress-develop/commit/9fe59ced578169572f00d14a065aed22da165cab) appears to have moved the logic from the Customizer into a more general purpose context while [leaving the constraining `wp_customize=on` parameter](https://github.com/WordPress/wordpress-develop/commit/9fe59ced578169572f00d14a065aed22da165cab#diff-ce553f4ec6128c3384da17e519b3b0390203c996681ef1413ecf4b600fac5673R25).

I guess this could be a core patch

Fixes #846

## Proposed changes:

Make a custom controller but without `wp_customize=on`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Be logged in as an author-level user (or any other user who can create posts but not edit others' posts)
2. Ensure that this user is ActivityPub-enabled
3. Go to profile and attempt to upload and crop an image. Any image uploaded or chosen from the library should work (the library will now only show the author user's own posts)