### PR TITLE
Add support for The Events Calendar

### DIFF
--- a/includes/activity/extended-object/class-event.php
+++ b/includes/activity/extended-object/class-event.php
@@ -24,6 +24,7 @@ class Event extends Base_Object {
 		array(                                   // The keys here override/extend the context even more.
 			'pt'                            => 'https://joinpeertube.org/ns#',
 			'mz'                            => 'https://joinmobilizon.org/ns#',
+			'sc'                            => 'http://schema.org#',
 			'status'                        => 'http://www.w3.org/2002/12/cal/ical#status',
 			'commentsEnabled'               => 'pt:commentsEnabled',
 			'isOnline'                      => 'mz:isOnline',
@@ -46,6 +47,16 @@ class Event extends Base_Object {
 				'@id'   => 'mz:contacts',
 				'@type' => '@id',
 			),
+			'PostalAddress'                 => 'sc:PostalAddress',
+			'address'                       => array(
+				'@id'   => 'sc:address',
+				'@type' => 'sc:PostalAddress',
+			),
+			'addressCountry'                => 'sc:addressCountry',
+			'addressLocality'               => 'sc:addressLocality',
+			'addressRegion'                 => 'sc:addressRegion',
+			'postalCode'                    => 'sc:postalCode',
+			'streetAddress'                 => 'sc:streetAddress',
 		),
 	);
 
@@ -227,6 +238,46 @@ class Event extends Base_Object {
 	 * @var int
 	 */
 	protected $remaining_attendee_capacity;
+
+	/**
+	 * @context https://schema.org/PostalAddress
+	 * @see https://docs.joinmobilizon.org/contribute/activity_pub/#location
+	 * @var array[
+	 * 'address' => [
+	 *      'addressCountry' => 'France',
+	 *      'addressLocality' => 'Lyon',
+	 *      'addressRegion' => 'Auvergne-Rhône-Alpes',
+	 *      'postalCode' => '69007',
+	 *      'streetAddress' => '10 Rue Jangot',
+	 *      'type' => 'PostalAddress'
+	 * ],
+	 * 'latitude' => 4.8425657,
+	 * 'longitude' => 45.7517141,
+	 * 'id' => 'http://mobilizon2.com/address/bdf7fb53-7177-46f3-8fb3-93c25a802522',
+	 * 'name' => '10 Rue Jangot',
+	 * 'type' => 'Place'
+	 * ]
+	 */
+	protected $location;
+
+	/**
+	 * Setter for location
+	 *
+	 * @return $this
+	 */
+	public function set_location( $id, $name, array $address = [], $latitude = 0, $longitude = 0 ) {
+		$this->location = array(
+			'id' => $id,
+			'name' => $name,
+			'latitude' => $latitude,
+			'longitude' => $longitude,
+			'address' => $address,
+		);
+		$this->location['address']['type'] = 'PostalAddress';
+		$this->location['type'] = 'Place';
+
+		return $this;
+	}
 
 	/**
 	 * Setter for the timezone.

--- a/includes/activity/extended-object/class-event.php
+++ b/includes/activity/extended-object/class-event.php
@@ -24,7 +24,6 @@ class Event extends Base_Object {
 		array(                                   // The keys here override/extend the context even more.
 			'pt'                            => 'https://joinpeertube.org/ns#',
 			'mz'                            => 'https://joinmobilizon.org/ns#',
-			'sc'                            => 'http://schema.org#',
 			'status'                        => 'http://www.w3.org/2002/12/cal/ical#status',
 			'commentsEnabled'               => 'pt:commentsEnabled',
 			'isOnline'                      => 'mz:isOnline',
@@ -47,16 +46,6 @@ class Event extends Base_Object {
 				'@id'   => 'mz:contacts',
 				'@type' => '@id',
 			),
-			'PostalAddress'                 => 'sc:PostalAddress',
-			'address'                       => array(
-				'@id'   => 'sc:address',
-				'@type' => 'sc:PostalAddress',
-			),
-			'addressCountry'                => 'sc:addressCountry',
-			'addressLocality'               => 'sc:addressLocality',
-			'addressRegion'                 => 'sc:addressRegion',
-			'postalCode'                    => 'sc:postalCode',
-			'streetAddress'                 => 'sc:streetAddress',
 		),
 	);
 
@@ -238,46 +227,6 @@ class Event extends Base_Object {
 	 * @var int
 	 */
 	protected $remaining_attendee_capacity;
-
-	/**
-	 * @context https://schema.org/PostalAddress
-	 * @see https://docs.joinmobilizon.org/contribute/activity_pub/#location
-	 * @var array[
-	 * 'address' => [
-	 *      'addressCountry' => 'France',
-	 *      'addressLocality' => 'Lyon',
-	 *      'addressRegion' => 'Auvergne-Rhône-Alpes',
-	 *      'postalCode' => '69007',
-	 *      'streetAddress' => '10 Rue Jangot',
-	 *      'type' => 'PostalAddress'
-	 * ],
-	 * 'latitude' => 4.8425657,
-	 * 'longitude' => 45.7517141,
-	 * 'id' => 'http://mobilizon2.com/address/bdf7fb53-7177-46f3-8fb3-93c25a802522',
-	 * 'name' => '10 Rue Jangot',
-	 * 'type' => 'Place'
-	 * ]
-	 */
-	protected $location;
-
-	/**
-	 * Setter for location
-	 *
-	 * @return $this
-	 */
-	public function set_location( $id, $name, array $address = [], $latitude = 0, $longitude = 0 ) {
-		$this->location = array(
-			'id' => $id,
-			'name' => $name,
-			'latitude' => $latitude,
-			'longitude' => $longitude,
-			'address' => $address,
-		);
-		$this->location['address']['type'] = 'PostalAddress';
-		$this->location['type'] = 'Place';
-
-		return $this;
-	}
 
 	/**
 	 * Setter for the timezone.

--- a/integration/class-the-events-calendar.php
+++ b/integration/class-the-events-calendar.php
@@ -1,0 +1,39 @@
+<?php
+namespace Activitypub\Integration;
+
+use Activitypub\Transformer\Post;
+
+/**
+ * Compatibility with the Tribe The Events Calendar plugin.
+ *
+ * This is a transformer for the Tribe The Events Calendar plugin,
+ * that extends the default transformer for WordPress posts.
+ *
+ * @see https://wordpress.org/plugins/the-events-calendar/
+ */
+class The_Events_Calendar extends Post {
+	/**
+	 * Gets the attachment for a podcast episode.
+	 *
+	 * This method is overridden to add the audio file as an attachment.
+	 *
+	 * @return array The attachments array.
+	 */
+	public function get_attachment() {
+		$post        = $this->wp_object;
+		$attachments = parent::get_attachment();
+
+		return $attachments;
+	}
+
+	/**
+	 * Gets the object type for a Event.
+	 *
+	 * Always returns 'Note' for the best possible compatibility with ActivityPub.
+	 *
+	 * @return string The object type.
+	 */
+	public function get_type() {
+		return 'Event';
+	}
+}

--- a/integration/class-the-events-calendar.php
+++ b/integration/class-the-events-calendar.php
@@ -2,6 +2,7 @@
 namespace Activitypub\Integration;
 
 use Activitypub\Activity\Extended_Object\Event;
+use Activitypub\Transformer\Base;
 use Activitypub\Transformer\Post;
 
 /**
@@ -14,13 +15,24 @@ use Activitypub\Transformer\Post;
  */
 class The_Events_Calendar extends Post {
 
+	/**
+	 * Base constructor.
+	 *
+	 * @param WP_Post|WP_Comment $wp_object The WordPress object
+	 */
+	public function __construct( $wp_object ) {
+		$this->wp_object = \tribe_get_event( $wp_object );
+	}
 
-	public function to_activity( $type ) {
+	public function to_object() {
 		$event = $this->wp_object;
-		$object = $this->to_object();
+		//print_r($this->wp_object);
+		$object = new Event();
 
-		$activity = new Event();
+		if ( 'canceled' === $event->event_status ) {
+			$object->set_status( 'CANCELLED' );
+		}
 
-		return $activity;
+		return $object;
 	}
 }

--- a/integration/class-the-events-calendar.php
+++ b/integration/class-the-events-calendar.php
@@ -1,6 +1,7 @@
 <?php
 namespace Activitypub\Integration;
 
+use Activitypub\Activity\Extended_Object\Event;
 use Activitypub\Transformer\Post;
 
 /**
@@ -12,28 +13,14 @@ use Activitypub\Transformer\Post;
  * @see https://wordpress.org/plugins/the-events-calendar/
  */
 class The_Events_Calendar extends Post {
-	/**
-	 * Gets the attachment for a podcast episode.
-	 *
-	 * This method is overridden to add the audio file as an attachment.
-	 *
-	 * @return array The attachments array.
-	 */
-	public function get_attachment() {
-		$post        = $this->wp_object;
-		$attachments = parent::get_attachment();
 
-		return $attachments;
-	}
 
-	/**
-	 * Gets the object type for a Event.
-	 *
-	 * Always returns 'Note' for the best possible compatibility with ActivityPub.
-	 *
-	 * @return string The object type.
-	 */
-	public function get_type() {
-		return 'Event';
+	public function to_activity( $type ) {
+		$event = $this->wp_object;
+		$object = $this->to_object();
+
+		$activity = new Event();
+
+		return $activity;
 	}
 }

--- a/integration/load.php
+++ b/integration/load.php
@@ -96,6 +96,12 @@ function plugin_init() {
 	 * @see https://wordpress.org/plugins/the-events-calendar/
 	 */
 	if ( \defined( 'TRIBE_EVENTS_FILE' ) ) {
+		add_action(
+			'init',
+			function() {
+				\add_post_type_support( 'tribe_events', 'activitypub' );
+			}
+		);
 		add_filter(
 			'activitypub_transformer',
 			// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound

--- a/integration/load.php
+++ b/integration/load.php
@@ -87,6 +87,32 @@ function plugin_init() {
 			3
 		);
 	}
+
+	/**
+	 * Adds Tribe The Events Calendar support.
+	 *
+	 * This class handles the compatibility with Tribe The Events Calendar.
+	 *
+	 * @see https://wordpress.org/plugins/the-events-calendar/
+	 */
+	if ( \defined( 'TRIBE_EVENTS_FILE' ) ) {
+		add_filter(
+			'activitypub_transformer',
+			// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
+			function( $transformer, $object, $object_class ) {
+				if (
+					'WP_Post' === $object_class &&
+					'tribe_events' === $object->post_type
+				) {
+					require_once __DIR__ . '/class-the-events-calendar.php';
+					return new The_Events_Calendar( $object );
+				}
+				return $transformer;
+			},
+			10,
+			3
+		);
+	}
 }
 \add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init' );
 


### PR DESCRIPTION
This PR adds a transformer for [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/) Plugin.
So event activity will be implemented for that post type.