### PR TITLE
Simple Remote-Reply endpoint.

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -62,6 +62,7 @@ function rest_init() {
 	Rest\Comment::init();
 	Rest\Server::init();
 	Rest\Collection::init();
+	Rest\Interaction::init();
 
 	// load NodeInfo endpoints only if blog is public
 	if ( is_blog_public() ) {

--- a/includes/rest/class-interaction.php
+++ b/includes/rest/class-interaction.php
@@ -39,9 +39,9 @@ class Interaction {
 	/**
 	 * Handle GET request
 	 *
-	 * @param  WP_REST_Request   $request
+	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_REST_Response
+	 * @return wp_die|WP_REST_Response Redirect to the editor or die
 	 */
 	public static function get( $request ) {
 		$uri    = $request->get_param( 'uri' );

--- a/includes/rest/class-interaction.php
+++ b/includes/rest/class-interaction.php
@@ -70,27 +70,32 @@ class Interaction {
 			case 'Service':
 			case 'Application':
 			case 'Organization':
-				\do_action( 'activitypub_interactions_follow', $uri, $object );
-				// check if hook is implemented
-				if ( ! has_action( 'activitypub_interactions_follow' ) ) {
-					\wp_die(
-						esc_html__(
-							'You can\'t follow Fediverse Users yet.',
-							'activitypub'
-						),
-						400
-					);
-				}
+				$redirect_url = null;
+				$redirect_url = \apply_filters( 'activitypub_interactions_follow_url', $redirect_url, $uri, $object );
 				break;
 			default:
-				\do_action( 'activitypub_interactions_reply', $uri, $object );
-				return new WP_REST_Response(
-					null,
-					302,
-					array(
-						'Location' => \esc_url( \admin_url( 'post-new.php?in_reply_to=' . $uri ) ),
-					)
-				);
+				$redirect_url = \admin_url( 'post-new.php?in_reply_to=' . $uri );
+				$redirect_url = \apply_filters( 'activitypub_interactions_reply_url', $redirect_url, $uri, $object );
+
 		}
+
+		// check if hook is implemented
+		if ( ! $redirect_url ) {
+			\wp_die(
+				esc_html__(
+					'This Interaction type is not supported yet!',
+					'activitypub'
+				),
+				400
+			);
+		}
+
+		return new WP_REST_Response(
+			null,
+			302,
+			array(
+				'Location' => \esc_url( $redirect_url ),
+			)
+		);
 	}
 }

--- a/includes/rest/class-interaction.php
+++ b/includes/rest/class-interaction.php
@@ -26,8 +26,9 @@ class Interaction {
 					'permission_callback' => '__return_true',
 					'args'                => array(
 						'uri' => array(
-							'type'        => 'string',
-							'required'    => true,
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'esc_url',
 						),
 					),
 				),
@@ -43,9 +44,7 @@ class Interaction {
 	 * @return WP_REST_Response
 	 */
 	public static function get( $request ) {
-		$uri = $request->get_param( 'uri' );
-		$uri = \esc_url( $uri );
-
+		$uri    = $request->get_param( 'uri' );
 		$object = Http::get_remote_object( $uri );
 
 		if (

--- a/includes/rest/class-interaction.php
+++ b/includes/rest/class-interaction.php
@@ -1,0 +1,97 @@
+<?php
+namespace Activitypub\Rest;
+
+use WP_REST_Response;
+use Activitypub\Http;
+
+class Interaction {
+	/**
+	 * Initialize the class, registering WordPress hooks
+	 */
+	public static function init() {
+		self::register_routes();
+	}
+
+	/**
+	 * Register routes
+	 */
+	public static function register_routes() {
+		\register_rest_route(
+			ACTIVITYPUB_REST_NAMESPACE,
+			'/interactions',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( self::class, 'get' ),
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'uri' => array(
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle GET request
+	 *
+	 * @param  WP_REST_Request   $request
+	 *
+	 * @return WP_REST_Response
+	 */
+	public static function get( $request ) {
+		$uri = $request->get_param( 'uri' );
+		$uri = \esc_url( $uri );
+
+		$object = Http::get_remote_object( $uri );
+
+		if (
+			\is_wp_error( $object ) ||
+			! isset( $object['type'] )
+		) {
+			\wp_die(
+				\esc_html__(
+					'The URL is not supported!',
+					'activitypub'
+				),
+				400
+			);
+		}
+
+		if ( ! empty( $object['url'] ) ) {
+			$uri = \esc_url( $object['url'] );
+		}
+
+		switch ( $object['type'] ) {
+			case 'Group':
+			case 'Person':
+			case 'Service':
+			case 'Application':
+			case 'Organization':
+				\do_action( 'activitypub_interactions_follow', $uri, $object );
+				// check if hook is implemented
+				if ( ! has_action( 'activitypub_interactions_follow' ) ) {
+					\wp_die(
+						esc_html__(
+							'You can\'t follow Fediverse Users yet.',
+							'activitypub'
+						),
+						400
+					);
+				}
+				break;
+			default:
+				\do_action( 'activitypub_interactions_reply', $uri, $object );
+				return new WP_REST_Response(
+					null,
+					302,
+					array(
+						'Location' => \esc_url( \admin_url( 'post-new.php?in_reply_to=' . $uri ) ),
+					)
+				);
+		}
+	}
+}

--- a/includes/rest/class-interaction.php
+++ b/includes/rest/class-interaction.php
@@ -44,8 +44,9 @@ class Interaction {
 	 * @return wp_die|WP_REST_Response Redirect to the editor or die
 	 */
 	public static function get( $request ) {
-		$uri    = $request->get_param( 'uri' );
-		$object = Http::get_remote_object( $uri );
+		$uri          = $request->get_param( 'uri' );
+		$redirect_url = null;
+		$object       = Http::get_remote_object( $uri );
 
 		if (
 			\is_wp_error( $object ) ||
@@ -70,14 +71,15 @@ class Interaction {
 			case 'Service':
 			case 'Application':
 			case 'Organization':
-				$redirect_url = null;
 				$redirect_url = \apply_filters( 'activitypub_interactions_follow_url', $redirect_url, $uri, $object );
 				break;
 			default:
 				$redirect_url = \admin_url( 'post-new.php?in_reply_to=' . $uri );
 				$redirect_url = \apply_filters( 'activitypub_interactions_reply_url', $redirect_url, $uri, $object );
-
 		}
+
+		// generic Interaction hook
+		$redirect_url = \apply_filters( 'activitypub_interactions_url', $redirect_url, $uri, $object );
 
 		// check if hook is implemented
 		if ( ! $redirect_url ) {

--- a/integration/class-webfinger.php
+++ b/integration/class-webfinger.php
@@ -4,6 +4,8 @@ namespace Activitypub\Integration;
 use Activitypub\Rest\Webfinger as Webfinger_Rest;
 use Activitypub\Collection\Users as User_Collection;
 
+use function Activitypub\get_rest_url_by_path;
+
 /**
  * Compatibility with the WebFinger plugin
  *
@@ -45,6 +47,11 @@ class Webfinger {
 			'href' => $user->get_url(),
 		);
 
+		$array['links'][] = array(
+			'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+			'template' => get_rest_url_by_path( 'interactions?uri={uri}' ),
+		);
+
 		return $array;
 	}
 
@@ -84,6 +91,10 @@ class Webfinger {
 					'rel'  => 'http://webfinger.net/rel/profile-page',
 					'type' => 'text/html',
 					'href' => $user->get_url(),
+				),
+				array(
+					'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+					'template' => get_rest_url_by_path( 'interactions?uri={uri}' ),
 				),
 			),
 		);


### PR DESCRIPTION
implements #864

Adds the remote-reply feature to WebFinger using the OStatus reply feature `http://ostatus.org/schema/1.0/subscribe`.

Also adds a hook, so that maybe the Friends plugin can hook into the Remote-Follow feature:

`\do_action( 'activitypub_interactions_follow', $uri, $object );`

/cc @akirk 