### PR TITLE
Be more defensive when openssl

### DIFF
--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -94,10 +94,12 @@ class Signature {
 
 		$key = \openssl_pkey_new( $config );
 		$priv_key = null;
+		$detail = array();
+		if ( $key ) {
+			\openssl_pkey_export( $key, $priv_key );
 
-		\openssl_pkey_export( $key, $priv_key );
-
-		$detail = \openssl_pkey_get_details( $key );
+			$detail = \openssl_pkey_get_details( $key );
+		}
 
 		// check if keys are valid
 		if (


### PR DESCRIPTION
When running in WordPress Playground with possibly imperfect OpenSSL support, it fatals like this:

```
Warning: openssl_pkey_export(): Cannot get key from parameter 1 in /var/www/html/wp-content/plugins/activitypub/includes/class-signature.php on line 98

Fatal error: Uncaught TypeError: openssl_pkey_get_details(): Argument #1 ($key) must be of type OpenSSLAsymmetricKey, bool given in /var/www/html/wp-content/plugins/activitypub/includes/class-signature.php:100 Stack trace: #0 /var/www/html/wp-content/plugins/activitypub/includes/class-signature.php(100): openssl_pkey_get_details(false) #1 /var/www/html/wp-content/plugins/activitypub/includes/class-signature.php(66): Activitypub\Signature::generate_key_pair_for(-1) #2 /var/www/html/wp-content/plugins/activitypub/includes/class-signature.php(49): Activitypub\Signature::get_keypair_for(-1) #3 /var/www/html/wp-content/plugins/activitypub/includes/class-signature.php(189): Activitypub\Signature::get_private_key_for(-1) #4 /var/www/html/wp-content/plugins/activitypub/includes/class-http.php(90): Activitypub\Signature::generate_signature(-1, 'get', 'https://alex.ki...', 'Wed, 18 Sep 202...') #5 /var/www/html/wp-content/plugins/activitypub/includes/functions.php(94): Activitypub\Http::get('https://alex.ki...') #6 /var/www/html/wp-content/plugins/friends/feed-parsers/class-feed-parser-activitypub.php(492): Activitypub\get_remote_metadata_by_actor('https://alex.ki...') #7 /var/www/html/wp-content/plugins/friends/feed-parsers/class-feed-parser-activitypub.php(289): Friends\Feed_Parser_ActivityPub::get_metadata('https://alex.ki...') #8 /var/www/html/wp-includes/class-wp-hook.php(324): Friends\Feed_Parser_ActivityPub->suggest_display_name('alex.kirk.at', 'https://alex.ki...') #9 /var/www/html/wp-includes/plugin.php(205): WP_Hook->apply_filters('alex.kirk.at', Array) #10 /var/www/html/wp-content/plugins/friends/includes/class-admin.php(1722): apply_filters('friends_suggest...', 'alex.kirk.at', 'https://alex.ki...') #11 /var/www/html/wp-content/plugins/friends/includes/class-admin.php(2012): Friends\Admin->process_admin_add_friend(Array) #12 /var/www/html/wp-includes/class-wp-hook.php(324): Friends\Admin->render_admin_add_friend('') #13 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array) #14 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #15 /var/www/html/wp-admin/admin.php(259): do_action('friends_page_ad...') #16 {main} thrown in /var/www/html/wp-content/plugins/activitypub/includes/class-signature.php on line 100
```

## Proposed changes:
* Don't invoke more openssl calls if already `openssl_pkey_new()` fails.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

I've reproduced this with [WordPress Studio](https://developer.wordpress.com/studio/) that uses Playground and has curl support where, when trying to follow someone via ActivityPub the error occurs.
