### PR TITLE
PHPCS: Enable NotPrepared check

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -649,9 +649,14 @@ function get_active_users( $duration = 1 ) {
 
 	if ( false === $count ) {
 		global $wpdb;
-		$query = "SELECT COUNT( DISTINCT post_author ) FROM {$wpdb->posts} WHERE post_type = 'post' AND post_status = 'publish' AND post_date <= DATE_SUB( NOW(), INTERVAL %d MONTH )";
-		$query = $wpdb->prepare( $query, $duration );
-		$count = $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT( DISTINCT post_author ) FROM {$wpdb->posts} WHERE post_type = 'post' AND post_status = 'publish' AND post_date <= DATE_SUB( NOW(), INTERVAL %d MONTH )",
+				$duration
+			)
+		);
 
 		set_transient( $transient_key, $count, DAY_IN_SECONDS );
 	}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -32,7 +32,6 @@
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames"/>
 		<exclude name="WordPress.Security.NonceVerification.Recommended"/>
 		<exclude name="WordPress.WP.GetMetaSingle.Missing"/>
-		<exclude name="WordPress.DB.PreparedSQL.NotPrepared"/>
 	</rule>
 	<rule ref="VariableAnalysis">
 		<exclude name="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Looks like the sniff expects everything to happen within nested function calls.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves SQL query and prepare call within the nested calls.
* Removes the sniff exclusion.

See #905.