### PR TITLE
PHPCS: Enable NonceVerification sniff

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -52,6 +52,7 @@ class Blocks {
 	 */
 	public static function handle_in_reply_to_get_param() {
 		// only load the script if the in_reply_to GET param is set, action happens there, not here.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET['in_reply_to'] ) ) {
 			return;
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -30,7 +30,6 @@
 		<exclude name="Squiz.Commenting"/>
 		<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames"/>
-		<exclude name="WordPress.Security.NonceVerification.Recommended"/>
 		<exclude name="WordPress.WP.GetMetaSingle.Missing"/>
 		<exclude name="WordPress.DB.PreparedSQL.NotPrepared"/>
 	</rule>


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added inline exception for the one instance of handling request parameters without nonce.
* Removed sniff exception.

See #905.