### PR TITLE
PHPCS: Enable UnusedFunctionParameter sniff

### DIFF
--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -392,7 +392,6 @@ class Shortcodes {
 
 		$datetime   = \get_post_datetime( $item );
 		$dateformat = \get_option( 'date_format' );
-		$timeformat = \get_option( 'time_format' );
 
 		$date = $datetime->format( $dateformat );
 
@@ -416,7 +415,6 @@ class Shortcodes {
 		}
 
 		$datetime   = \get_post_datetime( $item );
-		$dateformat = \get_option( 'date_format' );
 		$timeformat = \get_option( 'time_format' );
 
 		$date = $datetime->format( $timeformat );

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -73,13 +73,9 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_title' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The post title.
 	 */
-	public static function title( $atts, $content, $tag ) {
+	public static function title() {
 		$item = self::get_item();
 
 		if ( ! $item ) {

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Shortcodes for ActivityPub.
+ *
+ * phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+ *
+ * @package Activitypub
+ */
+
 namespace Activitypub;
 
 use function Activitypub\esc_hashtag;

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Shortcodes for ActivityPub.
- *
- * phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
- *
- * @package Activitypub
- */
-
 namespace Activitypub;
 
 use function Activitypub\esc_hashtag;
@@ -287,13 +279,9 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_hashcats' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The post categories as hashtags.
 	 */
-	public static function hashcats( $atts, $content, $tag ) {
+	public static function hashcats() {
 		$item = self::get_item();
 
 		if ( ! $item ) {
@@ -322,13 +310,9 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_author' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The author name.
 	 */
-	public static function author( $atts, $content, $tag ) {
+	public static function author() {
 		$item = self::get_item();
 
 		if ( ! $item ) {
@@ -348,13 +332,9 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_authorurl' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The author URL.
 	 */
-	public static function authorurl( $atts, $content, $tag ) {
+	public static function authorurl() {
 		$item = self::get_item();
 
 		if ( ! $item ) {
@@ -374,52 +354,36 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_blogurl' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The site URL.
 	 */
-	public static function blogurl( $atts, $content, $tag ) {
+	public static function blogurl() {
 		return \esc_url( \get_bloginfo( 'url' ) );
 	}
 
 	/**
 	 * Generates output for the 'ap_blogname' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string
 	 */
-	public static function blogname( $atts, $content, $tag ) {
+	public static function blogname() {
 		return \wp_strip_all_tags( \get_bloginfo( 'name' ) );
 	}
 
 	/**
 	 * Generates output for the 'ap_blogdesc' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The site description.
 	 */
-	public static function blogdesc( $atts, $content, $tag ) {
+	public static function blogdesc() {
 		return \wp_strip_all_tags( \get_bloginfo( 'description' ) );
 	}
 
 	/**
 	 * Generates output for the 'ap_date' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The post date.
 	 */
-	public static function date( $atts, $content, $tag ) {
+	public static function date() {
 		$item = self::get_item();
 
 		if ( ! $item ) {
@@ -442,13 +406,9 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_time' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The post time.
 	 */
-	public static function time( $atts, $content, $tag ) {
+	public static function time() {
 		$item = self::get_item();
 
 		if ( ! $item ) {
@@ -471,13 +431,9 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_datetime' Shortcode
 	 *
-	 * @param array  $atts    The Shortcode attributes.
-	 * @param string $content The ActivityPub post-content.
-	 * @param string $tag     The tag/name of the Shortcode.
-	 *
 	 * @return string The post date/time.
 	 */
-	public static function datetime( $atts, $content, $tag ) {
+	public static function datetime() {
 		$item = self::get_item();
 
 		if ( ! $item ) {

--- a/includes/rest/class-collection.php
+++ b/includes/rest/class-collection.php
@@ -256,11 +256,9 @@ class Collection {
 	/**
 	 * Moderators endpoint
 	 *
-	 * @param WP_REST_Request $request The request object.
-	 *
 	 * @return WP_REST_Response The response object.
 	 */
-	public static function moderators_get( $request ) {
+	public static function moderators_get() {
 		$response = array(
 			'@context'     => Actor::JSON_LD_CONTEXT,
 			'id'           => get_rest_url_by_path( 'collections/moderators' ),

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -80,8 +80,6 @@ class Inbox {
 			return $user;
 		}
 
-		$page = $request->get_param( 'page', 0 );
-
 		/*
 		 * Action triggerd prior to the ActivityPub profile being created and sent to the client
 		 */

--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -67,11 +67,9 @@ class Nodeinfo {
 	/**
 	 * Render NodeInfo file
 	 *
-	 * @param  WP_REST_Request $request
-	 *
 	 * @return WP_REST_Response
 	 */
-	public static function nodeinfo( $request ) {
+	public static function nodeinfo() {
 		/*
 		 * Action triggerd prior to the ActivityPub profile being created and sent to the client
 		 */
@@ -118,11 +116,9 @@ class Nodeinfo {
 	/**
 	 * Render NodeInfo file
 	 *
-	 * @param  WP_REST_Request $request
-	 *
 	 * @return WP_REST_Response
 	 */
-	public static function nodeinfo2( $request ) {
+	public static function nodeinfo2() {
 		/*
 		 * Action triggerd prior to the ActivityPub profile being created and sent to the client
 		 */
@@ -165,11 +161,9 @@ class Nodeinfo {
 	/**
 	 * Render NodeInfo discovery file
 	 *
-	 * @param  WP_REST_Request $request
-	 *
 	 * @return WP_REST_Response
 	 */
-	public static function discovery( $request ) {
+	public static function discovery() {
 		$discovery          = array();
 		$discovery['links'] = array(
 			array(

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,7 +24,6 @@
 	<config name="text_domain" value="activitypub,default"/>
 
 	<rule ref="WordPress">
-		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter"/>
 		<exclude name="Generic.Commenting.DocComment.LongNotCapital"/>
 		<exclude name="Squiz.Commenting"/>
 		<exclude name="Squiz.PHP.CommentedOutCode.Found"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -30,9 +30,7 @@
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames"/>
 		<exclude name="WordPress.WP.GetMetaSingle.Missing"/>
 	</rule>
-	<rule ref="VariableAnalysis">
-		<exclude name="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable"/>
-	</rule>
+	<rule ref="VariableAnalysis"/>
 
 	<rule ref="WordPress.WP.Capabilities">
 		<properties>

--- a/tests/test-class-activitypub-shortcodes.php
+++ b/tests/test-class-activitypub-shortcodes.php
@@ -92,4 +92,30 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 		$this->assertEquals( "<p>Lorem ipsum dolor […]</p>\n", $content );
 		Shortcodes::unregister();
 	}
+
+	/**
+	 * Tests 'ap_title' shortcode.
+	 *
+	 * @covers Activitypub\Shortcodes::title
+	 */
+	public function test_title() {
+		Shortcodes::register();
+		global $post;
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'Test title for shortcode',
+			)
+		);
+
+		$content = '[ap_title]';
+
+		// Fill in the shortcodes.
+		setup_postdata( $post );
+		$content = do_shortcode( $content );
+		wp_reset_postdata();
+		Shortcodes::unregister();
+
+		$this->assertEquals( 'Test title for shortcode', $content );
+	}
 }


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes unused function parameters and their docs.
* Adds a unit test for `at_title` shortcode to make sure that still works.
* Removes sniff exception.

See #905.
