### PR TITLE
PHPCS: Enable LongNotCapital sniff

### DIFF
--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -176,7 +176,7 @@ class Scheduler {
 	/**
 	 * Schedule Comment Activities
 	 *
-	 * transition_comment_status()
+	 * @see transition_comment_status()
 	 *
 	 * @param string     $new_status New comment status.
 	 * @param string     $old_status Old comment status.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,7 +25,6 @@
 
 	<rule ref="WordPress">
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter"/>
-		<exclude name="Generic.Commenting.DocComment.LongNotCapital"/>
 		<exclude name="Squiz.Commenting"/>
 		<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames"/>


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses phpdoc label for function reference.
* Removes sniff exception.

See #905.