### PR TITLE
PHPCS: Enable CommentedOutCode sniff

### DIFF
--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -28,7 +28,7 @@ class Hashtag {
 	 * @return array the activity object array
 	 */
 	public static function filter_activity_object( $object_array ) {
-		/*
+		/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		Removed until this is merged: https://github.com/mastodon/mastodon/pull/28629
 		if ( ! empty( $object_array['summary'] ) ) {
 			$object_array['summary'] = self::the_content( $object_array['summary'] );

--- a/includes/class-link.php
+++ b/includes/class-link.php
@@ -24,7 +24,7 @@ class Link {
 	 * @return array the activity object array
 	 */
 	public static function filter_activity_object( $object_array ) {
-		/*
+		/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		Removed until this is merged: https://github.com/mastodon/mastodon/pull/28629
 		if ( ! empty( $object_array['summary'] ) ) {
 			$object_array['summary'] = self::the_content( $object_array['summary'] );

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -310,7 +310,7 @@ class Interactions {
 		if ( 1 === $state ) {
 			return $commentdata;
 		} else {
-			return $state; // Either `WP_Comment`, `false` or a `WP_Error` instance or `0` or `1`!
+			return $state; // Either WP_Comment, false, a WP_Error, 0, or 1!
 		}
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,7 +27,6 @@
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter"/>
 		<exclude name="Generic.Commenting.DocComment.LongNotCapital"/>
 		<exclude name="Squiz.Commenting"/>
-		<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames"/>
 		<exclude name="WordPress.WP.GetMetaSingle.Missing"/>
 	</rule>


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds inline ignores for the two exceptions introduced in #893.
* Updates comment to make it not appear as commented out code (Could probably be removed, too. Function docs cover possible return types).
* Removes sniff exception.

See #905.
