### PR TITLE
Issue templates: add new issue type option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Helps us improve our product!
-labels: "Needs triage, [Type] Bug"
+labels: [ 'Needs triage', '[Type] Bug' ]
+type: 'Bug'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature Request
 description: Suggest an idea for the ActivityPub plugin!
 title: "Feature Request:"
 labels: ["[Type] Feature Request"]
+type: 'Enhancement'
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION

## Proposed changes:

This was added as an option as part of this set of changes to GitHub issues:
https://github.blog/changelog/2024-10-01-evolving-github-issues-public-preview/

### Other information:

Related post: pdWQjU-WT-p2

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

We cannot test this until this PR is merged and we can see the results when creating a new issue:

<img width="351" alt="Screenshot 2024-10-03 at 18 34 28" src="https://github.com/user-attachments/assets/eae034c7-b5ad-4b07-88d4-bde09fa447f5">


