### PR TITLE
PHPCS: Update workflow to fail on warnings

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
       - name: Detect coding standard violations
-        run: ./vendor/bin/phpcs -n -q
+        run: ./vendor/bin/phpcs


### PR DESCRIPTION
With all warnings and errors fixed, we can now fail for new warnings and errors.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the flags to hide output and ignore warnings.
