### PR TITLE
Make Intent-URL filterable

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1153,20 +1153,17 @@ function get_reply_intent_js() {
  * @return string The reply intent URI.
  */
 function get_reply_intent_url() {
-	$params = array(
-		'in_reply_to' => '',
-	);
-
 	/**
 	 * Filters the reply intent parameters.
 	 *
 	 * @param array $params The reply intent parameters.
 	 */
-	$params = \apply_filters( 'activitypub_reply_intent_params', $params );
+	$params = \apply_filters( 'activitypub_reply_intent_params', array() );
 
-	$query = \http_build_query( $params );
-	$path  = 'post-new.php?' . $query;
-	$url   = \admin_url( $path );
+	$params += array( 'in_reply_to' => '' );
+	$query   = \http_build_query( $params );
+	$path    = 'post-new.php?' . $query;
+	$url     = \admin_url( $path );
 
 	/**
 	 * Filters the reply intent URL.
@@ -1175,7 +1172,7 @@ function get_reply_intent_url() {
 	 */
 	$url = \apply_filters( 'activitypub_reply_intent_url', $url );
 
-	return esc_url( $url );
+	return esc_url_raw( $url );
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1136,15 +1136,46 @@ function normalize_host( $host ) {
 }
 
 /**
+ * Get the reply intent URI as a JavaScript URI.
+ *
+ * @return string The reply intent URI.
+ */
+function get_reply_intent_js() {
+	return sprintf(
+		'javascript:(()=>{window.open(\'%s\'+encodeURIComponent(window.location.href));})();',
+		get_reply_intent_url()
+	);
+}
+
+/**
  * Get the reply intent URI.
  *
  * @return string The reply intent URI.
  */
-function get_reply_intent_uri() {
-	return sprintf(
-		'javascript:(()=>{window.open(\'%s\'+encodeURIComponent(window.location.href));})();',
-		esc_url( \admin_url( 'post-new.php?in_reply_to=' ) )
+function get_reply_intent_url() {
+	$params = array(
+		'in_reply_to' => '',
 	);
+
+	/**
+	 * Filters the reply intent parameters.
+	 *
+	 * @param array $params The reply intent parameters.
+	 */
+	$params = \apply_filters( 'activitypub_reply_intent_params', $params );
+
+	$query = \http_build_query( $params );
+	$path  = 'post-new.php?' . $query;
+	$url   = \admin_url( $path );
+
+	/**
+	 * Filters the reply intent URL.
+	 *
+	 * @param string $url The reply intent URL.
+	 */
+	$url = \apply_filters( 'activitypub_reply_intent_url', $url );
+
+	return esc_url( $url );
 }
 
 /**

--- a/templates/toolbox.php
+++ b/templates/toolbox.php
@@ -16,7 +16,7 @@
 		<h3><?php esc_html_e( 'Install Bookmarklet', 'activitypub' ); ?></h3>
 		<p><?php esc_html_e( 'Drag and drop this button to your browser’s bookmark bar or save this bookmarklet to reply to posts on other websites from your blog! When visiting a post on another site, click the bookmarklet to start a reply.', 'activitypub' ); ?></p>
 		<p class="activitypub-bookmarklet-wrapper">
-			<a class="activitypub-bookmarklet button" onclick="return false;" href="<?php echo esc_url( \Activitypub\get_reply_intent_uri() ); ?>" style="cursor: grab;">
+			<a class="activitypub-bookmarklet button" onclick="return false;" href="<?php echo esc_attr( \Activitypub\get_reply_intent_js() ); ?>" style="cursor: grab;">
 				<?php // translators: The host (domain) of the Blog. ?>
 				<?php printf( esc_html__( 'Reply from %s', 'activitypub' ), esc_attr( \wp_parse_url( \home_url(), PHP_URL_HOST ) ) ); ?>
 			</a>
@@ -26,7 +26,7 @@
 				<?php esc_html_e( 'Or copy the following code and create a new bookmark. Paste the code into the new bookmark&#8217;s URL field.', 'activitypub' ); ?>
 			</p>
 			<p>
-				<textarea id="activitypub-bookmarklet-code" class="large-text activitypub-code" rows="5" readonly="readonly" aria-labelledby="activitypub-code-desc"><?php echo esc_textarea( \Activitypub\get_reply_intent_uri() ); ?></textarea>
+				<textarea id="activitypub-bookmarklet-code" class="large-text activitypub-code" rows="5" readonly="readonly" aria-labelledby="activitypub-code-desc"><?php echo esc_textarea( \Activitypub\get_reply_intent_js() ); ?></textarea>
 			</p>
 			<p><span class="dashicons dashicons-clipboard"></span> <a href="javascript:;" class="copy-activitypub-bookmarklet-code" style="cursor: copy;"><?php esc_html_e( 'Copy to clipboard', 'activitypub' ); ?></a></p>
 		</div>
@@ -67,6 +67,10 @@
 			<tr>
 				<td>in_reply_to</td>
 				<td><?php esc_html_e( 'The URL of the content you want to reply to.', 'activitypub' ); ?></td>
+			</tr>
+			<tr>
+				<td>post_type</td>
+				<td><?php esc_html_e( 'The Post-Type you want to use for replies.', 'activitypub' ); ?></td>
 			</tr>
 		</tbody>
 	</table>

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -27,13 +27,13 @@
 
 		<p>
 			<?php
-			$bookmarklet_url = \Activitypub\get_reply_intent_uri();
+			$bookmarklet_js = \Activitypub\get_reply_intent_js();
 
 			/* translators: %s is the domain of this site */
 			$reply_from_template = __( 'Reply from %s', 'activitypub' );
 			$button              = sprintf(
 				'<a href="%s" class="button">%s</a>',
-				esc_url( $bookmarklet_url ), // Need to escape quotes for the bookmarklet.
+				esc_attr( $bookmarklet_js ), // Need to escape quotes for the bookmarklet.
 				sprintf( $reply_from_template, \wp_parse_url( \home_url(), PHP_URL_HOST ) )
 			);
 			/* translators: %s is where the button HTML will be rendered. */


### PR DESCRIPTION
Allow plugins to extend the Intent-URL with a custom-post type for example.

This PR also adds `post_type` to the "Query parameters" section.

<img width="529" alt="Screenshot 2024-10-11 at 08 52 03" src="https://github.com/user-attachments/assets/0f15392a-301a-4831-8742-d116dc64adc2">

We might also want to have a Post-Type dropdown in the future, as @mattwiebe suggested.

Also: https://github.com/Automattic/jetpack/pull/39738
