### PR TITLE
Fire an action before a follower is removed

### DIFF
--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -80,6 +80,15 @@ class Followers {
 			return false;
 		}
 
+		/**
+		 * Fires before a Follower is removed.
+		 *
+		 * @param \Activitypub\Model\Follower $follower The Follower object.
+		 * @param int                         $user_id  The ID of the WordPress User.
+		 * @param string                      $actor    The Actor URL.
+		 */
+		do_action( 'activitypub_followers_pre_remove_follower', $follower, $user_id, $actor );
+
 		return delete_post_meta( $follower->get__id(), 'activitypub_user_id', $user_id );
 	}
 


### PR DESCRIPTION
This adds a new action `activitypub_followers_pre_remove_follower` to allow monitoring when a follower unfollows you ([see this implementation in the Friends plugin](https://github.com/akirk/friends/pull/358)). This is analog to the already existing `activitypub_followers_post_follow` action.

