### PR TITLE
add Attribution-Domains support

### DIFF
--- a/includes/activity/class-actor.php
+++ b/includes/activity/class-actor.php
@@ -43,6 +43,10 @@ class Actor extends Base_Object {
 				'@id'   => 'lemmy:moderators',
 				'@type' => '@id',
 			),
+			'attributionDomains'        => array(
+				'@id'   => 'toot:attributionDomains',
+				'@type' => '@id',
+			),
 			'postingRestrictedToMods'   => 'lemmy:postingRestrictedToMods',
 			'discoverable'              => 'toot:discoverable',
 			'indexable'                 => 'toot:indexable',
@@ -184,4 +188,14 @@ class Actor extends Base_Object {
 	 * @var boolean
 	 */
 	protected $sensitive = null;
+
+	/**
+	 * Domains allowed to use `fediverse:creator` for this actor in
+	 * published articles.
+	 *
+	 * @see https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/
+	 *
+	 * @var array
+	 */
+	protected $attribution_domains = null;
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -285,6 +285,23 @@ class Admin {
 				'default'     => '0',
 			)
 		);
+		\register_setting(
+			'activitypub',
+			'activitypub_attribution_domains',
+			array(
+				'type'              => 'string',
+				'description'       => \__( 'Websites allowed to credit you.', 'activitypub' ),
+				'default'           => home_host(),
+				'sanitize_callback' => function ( $value ) {
+					$value = explode( PHP_EOL, $value );
+					$value = array_filter( array_map( 'trim', $value ) );
+					$value = array_filter( array_map( 'esc_attr', $value ) );
+					$value = implode( PHP_EOL, $value );
+
+					return $value;
+				},
+			)
+		);
 
 		// Blog-User Settings.
 		\register_setting(

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1378,8 +1378,7 @@ function is_same_domain( $url ) {
 	}
 
 	$remote = normalize_host( $remote );
-	$self   = \wp_parse_url( \home_url(), PHP_URL_HOST );
-	$self   = normalize_host( $self );
+	$self   = normalize_host( home_host() );
 
 	return $remote === $self;
 }
@@ -1409,4 +1408,35 @@ function get_content_visibility( $post_id ) {
 	}
 
 	return \apply_filters( 'activitypub_content_visibility', $_visibility, $post );
+}
+
+/**
+ * Retrieves the Host for the current site where the front end is accessible.
+ *
+ * @return string The host for the current site.
+ */
+function home_host() {
+	return \wp_parse_url( \home_url(), PHP_URL_HOST );
+}
+
+/**
+ * Returns the website hosts allowed to credit this blog.
+ *
+ * @return array|null The attribution domains or null if not found.
+ */
+function get_attribution_domains() {
+	if ( '1' !== \get_option( 'activitypub_use_opengraph', '1' ) ) {
+		return null;
+	}
+
+	$domains = \get_option( 'activitypub_attribution_domains', home_host() );
+	$domains = explode( PHP_EOL, $domains );
+	$domains = array_filter( array_map( 'trim', $domains ) );
+	$domains = array_filter( array_map( 'esc_attr', $domains ) );
+
+	if ( ! $domains ) {
+		$domains = null;
+	}
+
+	return $domains;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1431,8 +1431,6 @@ function get_attribution_domains() {
 
 	$domains = \get_option( 'activitypub_attribution_domains', home_host() );
 	$domains = explode( PHP_EOL, $domains );
-	$domains = array_filter( array_map( 'trim', $domains ) );
-	$domains = array_filter( array_map( 'esc_attr', $domains ) );
 
 	if ( ! $domains ) {
 		$domains = null;

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -532,6 +532,11 @@ class Blog extends Actor {
 		return Extra_Fields::fields_to_attachments( $extra_fields );
 	}
 
+	/**
+	 * Returns the website hosts allowed to credit this blog.
+	 *
+	 * @return array|null The attribution domains or null if not found.
+	 */
 	public function get_attribution_domains() {
 		return get_attribution_domains();
 	}

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -18,6 +18,7 @@ use function Activitypub\esc_hashtag;
 use function Activitypub\is_single_user;
 use function Activitypub\is_blog_public;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\get_attribution_domains;
 
 /**
  * Blog class.
@@ -529,5 +530,9 @@ class Blog extends Actor {
 	public function get_attachment() {
 		$extra_fields = Extra_Fields::get_actor_fields( $this->_id );
 		return Extra_Fields::fields_to_attachments( $extra_fields );
+	}
+
+	public function get_attribution_domains() {
+		return get_attribution_domains();
 	}
 }

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -405,6 +405,11 @@ class User extends Actor {
 		return \update_user_option( $this->_id, 'activitypub_header_image', $value );
 	}
 
+	/**
+	 * Returns the website hosts allowed to credit this blog.
+	 *
+	 * @return array|null The attribution domains or null if not found.
+	 */
 	public function get_attribution_domains() {
 		return get_attribution_domains();
 	}

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -15,6 +15,7 @@ use Activitypub\Collection\Extra_Fields;
 use function Activitypub\is_blog_public;
 use function Activitypub\is_user_disabled;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\get_attribution_domains;
 
 /**
  * User class.
@@ -402,5 +403,9 @@ class User extends Actor {
 			return false;
 		}
 		return \update_user_option( $this->_id, 'activitypub_header_image', $value );
+	}
+
+	public function get_attribution_domains() {
+		return get_attribution_domains();
 	}
 }

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -231,7 +231,17 @@
 						</th>
 						<td>
 							<p>
-								<label><input type="checkbox" name="activitypub_use_opengraph" id="activitypub_use_opengraph" value="1" <?php echo \checked( '1', \get_option( 'activitypub_use_opengraph', '1' ) ); ?> /> <?php echo wp_kses( \__( 'Automatically add <code>&lt;meta name="fediverse:creator" /&gt;</code> tags for Authors and the Blog-User. You can read more about the feature on the <a href="https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/" target="_blank">Mastodon Blog</a>.', 'activitypub' ), 'post' ); ?></label>
+								<label>
+									<input type="checkbox" name="activitypub_use_opengraph" id="activitypub_use_opengraph" value="1" <?php echo \checked( '1', \get_option( 'activitypub_use_opengraph', '1' ) ); ?> />
+									<?php echo wp_kses( \__( 'Automatically add <code>&lt;meta name="fediverse:creator" /&gt;</code> tags for Authors and the Blog-User. You can read more about the feature on the <a href="https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/" target="_blank">Mastodon Blog</a>.', 'activitypub' ), 'post' ); ?>
+								</label>
+							</p>
+							<p>
+								<label for="activitypub_attribution_domains">
+									<?php esc_html_e( 'Websites allowed to credit you.', 'activitypub' ); ?>
+								</label>
+								<textarea id="activitypub_attribution_domains" name="activitypub_attribution_domains" class="large-text" cols="50" rows="5" placeholder="<?php echo \esc_textarea( \Activitypub\home_host() ); ?>"><?php echo esc_textarea( \get_option( 'activitypub_attribution_domains', \Activitypub\home_host() ) ); ?></textarea>
+								<?php esc_html_e( 'One per line. Protects from false attributions.', 'activitypub' ); ?>
 							</p>
 						</td>
 					</tr>


### PR DESCRIPTION
Adds the needed Attribution-Domains support to be able to show the Open Graph Creator Tag.

Fixes #945

Some context: https://github.com/mastodon/mastodon/issues/32574