### PR TITLE
npm: add @wordpress/icons to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@wordpress/data": "^10.0.0",
     "@wordpress/dom-ready": "^4.0.0",
     "@wordpress/element": "^6.0.0",
+    "@wordpress/icons": "^10.10.0",
     "@wordpress/scripts": "^27.0.0",
     "classnames": "^2.3.2",
     "grunt": "^1.1.0",


### PR DESCRIPTION
I noticed that while running `npm run (dev|build)` that I was getting the following error:

```
WARNING in ./src/editor-plugin/plugin.js 48:65-75
export 'notAllowed' (imported as 'notAllowed') was not found in '@wordpress/icons'
```

I thought that maybe we hadn't updated our version of `@wordpress/icons` to a recent enough version, only to find we hadn't added it. Now we have.