### PR TITLE
Work around race condition when publishing local only posts

### DIFF
--- a/includes/class-activity-dispatcher.php
+++ b/includes/class-activity-dispatcher.php
@@ -195,7 +195,7 @@ class Activity_Dispatcher {
 	public static function send_post( $id, $type ) {
 		$post = get_post( $id );
 
-		if ( ! $post ) {
+		if ( ! $post || is_post_disabled( $post ) ) {
 			return;
 		}
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -165,7 +165,7 @@ class Scheduler {
 
 		if ( false === wp_next_scheduled( $hook, $args ) ) {
 			set_wp_object_state( $post, 'federate' );
-			\wp_schedule_single_event( \time(), $hook, $args );
+			\wp_schedule_single_event( \time() + 10, $hook, $args );
 		}
 	}
 
@@ -350,7 +350,7 @@ class Scheduler {
 	 */
 	public static function schedule_profile_update( $user_id ) {
 		\wp_schedule_single_event(
-			\time(),
+			\time() + 10,
 			'activitypub_send_update_profile_activity',
 			array( $user_id )
 		);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -409,10 +409,7 @@ function is_activitypub_request() {
  * @return boolean True if the post is disabled, false otherwise.
  */
 function is_post_disabled( $post ) {
-	$post = \get_post( $post );
-
-	\clean_post_cache( $post );
-
+	$post       = \get_post( $post );
 	$disabled   = false;
 	$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -409,7 +409,10 @@ function is_activitypub_request() {
  * @return boolean True if the post is disabled, false otherwise.
  */
 function is_post_disabled( $post ) {
-	$post       = \get_post( $post );
+	$post = \get_post( $post );
+
+	\clean_post_cache( $post );
+
 	$disabled   = false;
 	$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -78,10 +78,17 @@ class Post extends Base {
 			$object->set_summary_map( null );
 		}
 
-		// Change order if visibility is "Quiet public".
-		if ( ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC === get_content_visibility( $post ) ) {
-			$object->set_to( $this->get_cc() );
-			$object->set_cc( $this->get_to() );
+		$visibility = get_content_visibility( $post );
+
+		switch ( $visibility ) {
+			case ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC:
+				$object->set_to( $this->get_cc() );
+				$object->set_cc( $this->get_to() );
+				break;
+			case ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL:
+				$object->set_to( array() );
+				$object->set_cc( array() );
+				break;
 		}
 
 		return $object;

--- a/tests/test-class-activitypub-post.php
+++ b/tests/test-class-activitypub-post.php
@@ -24,4 +24,32 @@ class Test_Activitypub_Post extends WP_UnitTestCase {
 
 		$this->assertEquals( $cached, $activitypub_post->get_id() );
 	}
+
+	public function test_content_visibility() {
+		$post_id = \wp_insert_post(
+			array(
+				'post_author' => 1,
+				'post_content' => 'test content visibility',
+			)
+		);
+
+		\update_post_meta( $post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+
+		$this->assertFalse( \Activitypub\is_post_disabled( $post_id ) );
+		$object = \Activitypub\Transformer\Post::transform( get_post( $post_id ) )->to_object();
+		$this->assertContains( 'https://www.w3.org/ns/activitystreams#Public', $object->get_to() );
+
+		\update_post_meta( $post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
+
+		$this->assertFalse( \Activitypub\is_post_disabled( $post_id ) );
+		$object = \Activitypub\Transformer\Post::transform( get_post( $post_id ) )->to_object();
+		$this->assertContains( 'https://www.w3.org/ns/activitystreams#Public', $object->get_cc() );
+
+		\update_post_meta( $post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
+
+		$this->assertTrue( \Activitypub\is_post_disabled( $post_id ) );
+		$object = \Activitypub\Transformer\Post::transform( get_post( $post_id ) )->to_object();
+		$this->assertEquals( array(), $object->get_to() );
+		$this->assertEquals( array(), $object->get_cc() );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It seems that the meta-information might not always be stored when saving a new post.

See discussion here: https://sueden.social/@freuwesen/113378039196820044 (it is in german but mastodon can translate).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* clear audience fields, so that post will not be listed in any timeline when accidentally shared
* check a second time, right before federating it