### PR TITLE
Fix Fediverse preview for "blog actor only" mode.

### DIFF
--- a/includes/collection/class-users.php
+++ b/includes/collection/class-users.php
@@ -187,17 +187,16 @@ class Users {
 				// Check for http(s)://blog.example.com/author/username.
 				$user_id = url_to_authorid( $uri );
 
-				if ( $user_id ) {
+				if ( \is_int( $user_id ) ) {
 					return self::get_by_id( $user_id );
 				}
 
 				// Check for http(s)://blog.example.com/.
-				$blog_actor     = new Blog();
 				$normalized_uri = normalize_url( $uri );
+
 				if (
 					normalize_url( site_url() ) === $normalized_uri ||
-					normalize_url( home_url() ) === $normalized_uri ||
-					normalize_url( $blog_actor->get_id() ) === $normalized_uri
+					normalize_url( home_url() ) === $normalized_uri
 				) {
 					return self::get_by_id( self::BLOG_USER_ID );
 				}

--- a/includes/collection/class-users.php
+++ b/includes/collection/class-users.php
@@ -192,9 +192,12 @@ class Users {
 				}
 
 				// Check for http(s)://blog.example.com/.
+				$blog_actor     = new Blog();
+				$normalized_uri = normalize_url( $uri );
 				if (
-					normalize_url( site_url() ) === normalize_url( $uri ) ||
-					normalize_url( home_url() ) === normalize_url( $uri )
+					normalize_url( site_url() ) === $normalized_uri ||
+					normalize_url( home_url() ) === $normalized_uri ||
+					normalize_url( $blog_actor->get_id() ) === $normalized_uri
 				) {
 					return self::get_by_id( self::BLOG_USER_ID );
 				}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -187,14 +187,14 @@ function count_followers( $user_id ) {
  *
  * @param string $url Permalink to check.
  *
- * @return int User ID, or 0 on failure.
+ * @return int|null User ID, or null on failure.
  */
 function url_to_authorid( $url ) {
 	global $wp_rewrite;
 
 	// Check if url hase the same host.
 	if ( \wp_parse_url( \home_url(), \PHP_URL_HOST ) !== \wp_parse_url( $url, \PHP_URL_HOST ) ) {
-		return 0;
+		return null;
 	}
 
 	// First, check to see if there is a 'author=N' to match against.
@@ -210,7 +210,7 @@ function url_to_authorid( $url ) {
 
 	// Not using rewrite rules, and 'author=N' method failed, so we're out of options.
 	if ( empty( $rewrite ) ) {
-		return 0;
+		return null;
 	}
 
 	// Generate rewrite rule for the author url.
@@ -225,7 +225,7 @@ function url_to_authorid( $url ) {
 		}
 	}
 
-	return 0;
+	return null;
 }
 
 /**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -101,7 +101,7 @@ class Post extends Base {
 	 *
 	 * @return \Activitypub\Activity\Actor The User-Object.
 	 */
-	protected function get_actor_object() {
+	public function get_actor_object() {
 		if ( $this->actor_object ) {
 			return $this->actor_object;
 		}

--- a/templates/post-preview.php
+++ b/templates/post-preview.php
@@ -15,10 +15,8 @@ if ( \is_wp_error( $transformer ) ) {
 	);
 }
 
-$object        = $transformer->to_object();
-$attributed_to = $object->get_attributed_to();
-$user_uri      = is_array( $attributed_to ) ? reset( $attributed_to )[0] : $attributed_to;
-$user          = \Activitypub\Collection\Users::get_by_resource( $user_uri );
+$object = $transformer->to_object();
+$user   = $transformer->get_actor_object();
 
 ?>
 <DOCTYPE html>

--- a/templates/post-preview.php
+++ b/templates/post-preview.php
@@ -14,8 +14,12 @@ if ( \is_wp_error( $transformer ) ) {
 		404
 	);
 }
-$user   = \Activitypub\Collection\Users::get_by_id( $post->post_author );
-$object = $transformer->to_object();
+
+$object        = $transformer->to_object();
+$attributed_to = $object->get_attributed_to();
+$user_uri      = is_array( $attributed_to ) ? reset( $attributed_to )[0] : $attributed_to;
+$user          = \Activitypub\Collection\Users::get_by_resource( $user_uri );
+
 ?>
 <DOCTYPE html>
 <html>


### PR DESCRIPTION
The Fediverse preview added in https://github.com/Automattic/wordpress-activitypub/pull/944 does not work when the WordPress site is in single actor mode, that is only the blog-user is enabled.

**Fixes:**
- Get the user for the `post-preview.php` template via the ActivityPub objects `attributedTo` property.
- Additional bug that the current  \Activitypub\Collection\Users::get_by_resource( $uri ) did not return the blog user when the new `https://example.com/?author=0` blog actor ID is used.

This solution should work, but if anyone knows a cleaner solution I am happy to just have reported the issue.

