### PR TITLE
Users: do not display submenus to users who cannot author posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Dev
+
+### Fixed
+
+* Do not display ActivityPub's user sub-menus to users who do not have the capabilities of writing posts.
+
 ## 4.1.0 - 2024-11-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ For reasons of data protection, it is not possible to see the followers of other
 
 ## Changelog ##
 
+### Dev ###
+
+* Fixed: do not display ActivityPub's user sub-menus to users who do not have the capabilities of writing posts.
+
 ### 4.1.0 ###
 
 * Added: Add custom Preview for "Fediverse"

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -72,7 +72,7 @@ class Admin {
 			$followers_list_page = \add_users_page(
 				\__( '⁂ Followers', 'activitypub' ),
 				\__( '⁂ Followers', 'activitypub' ),
-				'edit_posts',
+				'activitypub',
 				'activitypub-followers-list',
 				array(
 					self::class,
@@ -88,7 +88,7 @@ class Admin {
 			\add_users_page(
 				\__( '⁂ Extra Fields', 'activitypub' ),
 				\__( '⁂ Extra Fields', 'activitypub' ),
-				'edit_posts',
+				'activitypub',
 				\esc_url( \admin_url( '/edit.php?post_type=ap_extrafield' ) )
 			);
 		}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -72,7 +72,7 @@ class Admin {
 			$followers_list_page = \add_users_page(
 				\__( '⁂ Followers', 'activitypub' ),
 				\__( '⁂ Followers', 'activitypub' ),
-				'read',
+				'edit_posts',
 				'activitypub-followers-list',
 				array(
 					self::class,
@@ -88,7 +88,7 @@ class Admin {
 			\add_users_page(
 				\__( '⁂ Extra Fields', 'activitypub' ),
 				\__( '⁂ Extra Fields', 'activitypub' ),
-				'read',
+				'edit_posts',
 				\esc_url( \admin_url( '/edit.php?post_type=ap_extrafield' ) )
 			);
 		}


### PR DESCRIPTION
## Proposed changes:

Right now, subcribers, customers (when WooCommerce is installed) and any other registered users see the users's submenus created by the ActivityPub plugin. 

I believe only folks can author posts can be ActivityPub actors on the site, so I don't believe subscribers should have access to those menus.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Start with a site where you have 3 users: an admin, an author, and a subscriber.
* Activate the ActivityPub plugin
* Log in to the site as the admin
    * You should see the 2 extra menus displayed in the Users menu.
* Log in as the author
    * You should see those menus as well.
* Log in as the subscriber.
    * You should not see those submenus.
    
