### PR TITLE
Embeds: only revert to URL if there is one

### DIFF
--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -1067,6 +1067,9 @@ class Post extends Base {
 	 * @return string A block level link
 	 */
 	public static function revert_embed_links( $block_content, $block ) {
+		if ( ! isset( $block['attrs']['url'] ) ) {
+			return $block_content;
+		}
 		return '<p><a href="' . esc_url( $block['attrs']['url'] ) . '">' . $block['attrs']['url'] . '</a></p>';
 	}
 


### PR DESCRIPTION
Saw a burst of warnings like:

```
[08-Nov-2024 16:50:11 UTC] Warning: Undefined array key "url" in wp-content/plugins/activitypub/includes/transformer/class-post.php on line 1074
```

Although I couldn't replicate on the site in question, it's probably just an embed block with no URL set. This should stop that.

