### PR TITLE
Users: do not display submenus to users who cannot author posts

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -72,7 +72,7 @@ class Admin {
 			$followers_list_page = \add_users_page(
 				\__( '⁂ Followers', 'activitypub' ),
 				\__( '⁂ Followers', 'activitypub' ),
-				'edit_posts',
+				'activitypub',
 				'activitypub-followers-list',
 				array(
 					self::class,
@@ -88,7 +88,7 @@ class Admin {
 			\add_users_page(
 				\__( '⁂ Extra Fields', 'activitypub' ),
 				\__( '⁂ Extra Fields', 'activitypub' ),
-				'edit_posts',
+				'activitypub',
 				\esc_url( \admin_url( '/edit.php?post_type=ap_extrafield' ) )
 			);
 		}


### PR DESCRIPTION
Sorry if I was not precise enough: We already set the `activitypub` capability (but without a user-role) and I was not sure if this will work. Seems to :)
