### PR TITLE
Use version constant directly

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -255,15 +255,13 @@ function get_plugin_meta( $default_headers = array() ) {
 
 /**
  * Plugin Version Number used for caching.
+ *
+ * @deprecated 4.2.0 Use constant ACTIVITYPUB_PLUGIN_VERSION directly.
  */
 function get_plugin_version() {
-	if ( \defined( 'ACTIVITYPUB_PLUGIN_VERSION' ) ) {
-		return ACTIVITYPUB_PLUGIN_VERSION;
-	}
+	_deprecated_function( __FUNCTION__, '4.2.0', 'Use constant ACTIVITYPUB_PLUGIN_VERSION directly.' );
 
-	$meta = get_plugin_meta( array( 'Version' => 'Version' ) );
-
-	return $meta['Version'];
+	return ACTIVITYPUB_PLUGIN_VERSION;
 }
 
 // Check for CLI env, to add the CLI commands.

--- a/activitypub.php
+++ b/activitypub.php
@@ -259,7 +259,7 @@ function get_plugin_meta( $default_headers = array() ) {
  * @deprecated 4.2.0 Use constant ACTIVITYPUB_PLUGIN_VERSION directly.
  */
 function get_plugin_version() {
-	_deprecated_function( __FUNCTION__, '4.2.0', 'Use constant ACTIVITYPUB_PLUGIN_VERSION directly.' );
+	_deprecated_function( __FUNCTION__, '4.2.0', 'ACTIVITYPUB_PLUGIN_VERSION' );
 
 	return ACTIVITYPUB_PLUGIN_VERSION;
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -444,7 +444,7 @@ class Admin {
 				ACTIVITYPUB_PLUGIN_FILE
 			),
 			array( 'jquery' ),
-			get_plugin_version(),
+			ACTIVITYPUB_PLUGIN_VERSION,
 			false
 		);
 
@@ -456,7 +456,7 @@ class Admin {
 					ACTIVITYPUB_PLUGIN_FILE
 				),
 				array(),
-				get_plugin_version()
+				ACTIVITYPUB_PLUGIN_VERSION
 			);
 			wp_enqueue_script(
 				'activitypub-admin-script',
@@ -465,7 +465,7 @@ class Admin {
 					ACTIVITYPUB_PLUGIN_FILE
 				),
 				array( 'jquery' ),
-				get_plugin_version(),
+				ACTIVITYPUB_PLUGIN_VERSION,
 				false
 			);
 		}
@@ -478,7 +478,7 @@ class Admin {
 					ACTIVITYPUB_PLUGIN_FILE
 				),
 				array(),
-				get_plugin_version()
+				ACTIVITYPUB_PLUGIN_VERSION
 			);
 		}
 	}

--- a/includes/class-health-check.php
+++ b/includes/class-health-check.php
@@ -363,7 +363,7 @@ class Health_Check {
 				),
 				'plugin_version' => array(
 					'label'   => __( 'Plugin Version', 'activitypub' ),
-					'value'   => get_plugin_version(),
+					'value'   => ACTIVITYPUB_PLUGIN_VERSION,
 					'private' => true,
 				),
 			),

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -36,7 +36,7 @@ class Migration {
 	 * @return string The target version.
 	 */
 	public static function get_target_version() {
-		_deprecated_function( __FUNCTION__, '4.2.0', 'Use constant ACTIVITYPUB_PLUGIN_VERSION directly.' );
+		_deprecated_function( __FUNCTION__, '4.2.0', 'ACTIVITYPUB_PLUGIN_VERSION' );
 
 		return ACTIVITYPUB_PLUGIN_VERSION;
 	}

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -31,10 +31,14 @@ class Migration {
 	 * This is the version that the database structure will be updated to.
 	 * It is the same as the plugin version.
 	 *
+	 * @deprecated 4.2.0 Use constant ACTIVITYPUB_PLUGIN_VERSION directly.
+	 *
 	 * @return string The target version.
 	 */
 	public static function get_target_version() {
-		return get_plugin_version();
+		_deprecated_function( __FUNCTION__, '4.2.0', 'Use constant ACTIVITYPUB_PLUGIN_VERSION directly.' );
+
+		return ACTIVITYPUB_PLUGIN_VERSION;
 	}
 
 	/**
@@ -90,7 +94,7 @@ class Migration {
 	public static function is_latest_version() {
 		return (bool) \version_compare(
 			self::get_version(),
-			self::get_target_version(),
+			ACTIVITYPUB_PLUGIN_VERSION,
 			'=='
 		);
 	}
@@ -114,7 +118,7 @@ class Migration {
 		// Check for inital migration.
 		if ( ! $version_from_db ) {
 			self::add_default_settings();
-			$version_from_db = self::get_target_version();
+			$version_from_db = ACTIVITYPUB_PLUGIN_VERSION;
 		}
 
 		// Schedule the async migration.
@@ -149,9 +153,9 @@ class Migration {
 		 * @param string $version_from_db The version from which to migrate.
 		 * @param string $target_version  The target version to migrate to.
 		 */
-		\do_action( 'activitypub_migrate', $version_from_db, self::get_target_version() );
+		\do_action( 'activitypub_migrate', $version_from_db, ACTIVITYPUB_PLUGIN_VERSION );
 
-		\update_option( 'activitypub_db_version', self::get_target_version() );
+		\update_option( 'activitypub_db_version', ACTIVITYPUB_PLUGIN_VERSION );
 
 		self::unlock();
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Since `ACTIVITYPUB_PLUGIN_VERSION` gets defined at the top of `activitypub.php`, `get_plugin_version()` will always return that and never fall back to the plugin meta information.

Not sure if 4.2.0 is the right version number in the deprecation documentation.
Not sure even if deprecating function is something this plugin does, or if it breaks back compat.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Deprecates `Activitypub\get_plugin_version()` and `Activitypub\Migration::get_target_version()` in favor of `ACTIVITYPUB_PLUGIN_VERSION`.
* Replaces all uses of the deprecated function with the constant.


