### PR TITLE
Settings: Fix styles to align with rest of wp-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Do not display ActivityPub's user sub-menus to users who do not have the capabilities of writing posts.
+* Proper margins for notices and font size for page title in settings screen
 
 ### Removed
 

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -5,8 +5,7 @@
 
 .settings_page_activitypub .notice {
 	max-width: 800px;
-	margin: auto;
-	margin: 0px auto 30px;
+	margin: 25px 20px 15px 22px;
 }
 
 .settings_page_activitypub .wrap {
@@ -18,6 +17,15 @@
 	margin: 0 0 1rem;
 	background: #fff;
 	border-bottom: 1px solid #dcdcde;
+}
+
+.activitypub-settings-header h1 {
+	display: inline-block;
+	font-weight: 600;
+	margin: 0 0.8rem 1rem;
+	font-size: 23px;
+	padding: 9px 0 4px;
+	line-height: 1.3;
 }
 
 .activitypub-settings-title-section {

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -5,6 +5,10 @@
 
 .settings_page_activitypub .notice {
 	max-width: 800px;
+	margin: 0 auto 30px;
+}
+
+.settings_page_activitypub .update-nag {
 	margin: 25px 20px 15px 22px;
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -154,7 +154,8 @@ For reasons of data protection, it is not possible to see the followers of other
 
 * Improved: Reuse constants once they're defined
 * Improved: "FEP-b2b8: Long-form Text" support
-* Fixed: do not display ActivityPub's user sub-menus to users who do not have the capabilities of writing posts.
+* Fixed: Do not display ActivityPub's user sub-menus to users who do not have the capabilities of writing posts.
+* Fixed: Proper margins for notices and font size for page title in settings screen.
 
 = 4.1.1 =
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes the display of update nags and brings the font size of the settings heading en par with other wp-admin screens.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds margins for update nag.
* Adds heading styles for settings title.

### Other information:

Before | After
--- | ---
<img width="1582" alt="Screenshot 2024-11-13 at 8 34 31 PM" src="https://github.com/user-attachments/assets/e69b0bd6-9a4b-4c78-9414-a1290eebc8c7"> | <img width="1582" alt="Screenshot 2024-11-13 at 5 26 15 PM" src="https://github.com/user-attachments/assets/ccd421bc-5846-4017-886a-7fe054883bc0">


## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visit the settings page on a WP install with a pending Core update.
* Make sure the nag has proper margins.
* Navigate to Privacy settings page.
* Make sure the title font sizes are the same between the two screens.