### PR TITLE
Make plain permalink notice more actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Reuse constants once they're defined
 * "FEP-b2b8: Long-form Text" support
+* Admin notice for plain permalink settings is more user-friendly and actionable
 
 ### Fixed
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -100,7 +100,11 @@ class Admin {
 	public static function admin_notices() {
 		$permalink_structure = \get_option( 'permalink_structure' );
 		if ( empty( $permalink_structure ) ) {
-			$admin_notice = \__( 'You are using the ActivityPub plugin with a permalink structure of "plain". This will prevent ActivityPub from working.  Please go to "Settings" / "Permalinks" and choose a permalink structure other than "plain".', 'activitypub' );
+			$admin_notice = sprintf(
+				/* translators: %s: Permalink settings URL. */
+				\__( 'ActivityPub needs SEO-friendly URLs to work properly. Please <a href="%s">update your permalink structure</a> to an option other than Plain.', 'activitypub' ),
+				esc_url( admin_url( 'options-permalink.php' ) )
+			);
 			self::show_admin_notice( $admin_notice, 'error' );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: Unit tests for the `ActivityPub\Transformer\Post` class
 * Improved: Reuse constants once they're defined
 * Improved: "FEP-b2b8: Long-form Text" support
+* Improved: Admin notice for plain permalink settings is more user-friendly and actionable
 * Fixed: Do not display ActivityPub's user sub-menus to users who do not have the capabilities of writing posts.
 * Fixed: Proper margins for notices and font size for page title in settings screen.
 


### PR DESCRIPTION
Adds some context for why the setting needs changing and a link to permalink settings to make it easier to do.



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates error message and adds link to permalink settings.

### Other information:

Before:
<img width="1510" alt="Screenshot 2024-11-14 at 3 28 02 PM" src="https://github.com/user-attachments/assets/301ebf7d-e24d-46fc-a163-52b5e8f60a8e"> 

After:
<img width="1510" alt="Screenshot 2024-11-14 at 3 27 48 PM" src="https://github.com/user-attachments/assets/fd8f6fd4-55e3-4e7a-9945-919e903da3c5">

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Permalink and set permalink structure to plain.
* The message should show up.
* Link should lead to permalink settings.

