### PR TITLE
Ensure that `?author=0` resolves to blog user

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -199,10 +199,7 @@ function url_to_authorid( $url ) {
 
 	// First, check to see if there is a 'author=N' to match against.
 	if ( \preg_match( '/[?&]author=(\d+)/i', $url, $values ) ) {
-		$id = \absint( $values[1] );
-		if ( $id ) {
-			return $id;
-		}
+		return \absint( $values[1] );
 	}
 
 	// Check to see if we are using rewrite rules.


### PR DESCRIPTION
When we recently introduced the move to `?author=user_id` style Actor URLs, we got caught on a check that failed on `?author=0` IDs for the Blog User.

Fixes #981

## Proposed changes:
* Always just return from the regex that parses the author URL. The regex has already confirmed there's a number there.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

