### PR TITLE
Generate unique ID

### DIFF
--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -160,6 +160,14 @@ class Activity extends Base_Object {
 		// Set object.
 		$this->set( 'object', $data );
 
+		// Check if `$data` is a URL and use it to generate an ID then.
+		if ( is_string( $data ) && filter_var( $data, FILTER_VALIDATE_URL ) ) {
+			$this->set( 'id', $data . '#activity-' . strtolower( $this->get_type() ) . '-' . time() );
+
+			return;
+		}
+
+		// Check if `$data` is an object and copy some properties otherwise do nothing.
 		if ( ! is_object( $data ) ) {
 			return;
 		}

--- a/includes/class-activity-dispatcher.php
+++ b/includes/class-activity-dispatcher.php
@@ -143,6 +143,7 @@ class Activity_Dispatcher {
 		// Build the update.
 		$activity = new Activity();
 		$activity->set_type( 'Update' );
+		$activity->set_id( $user->get_id() . '#update-' . time() );
 		$activity->set_actor( $user->get_id() );
 		$activity->set_object( $user->get_id() );
 		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );

--- a/includes/class-activity-dispatcher.php
+++ b/includes/class-activity-dispatcher.php
@@ -143,7 +143,6 @@ class Activity_Dispatcher {
 		// Build the update.
 		$activity = new Activity();
 		$activity->set_type( 'Update' );
-		$activity->set_id( $user->get_id() . '#update-' . time() );
 		$activity->set_actor( $user->get_id() );
 		$activity->set_object( $user->get_id() );
 		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );

--- a/tests/class-test-activitypub-activity.php
+++ b/tests/class-test-activitypub-activity.php
@@ -86,4 +86,20 @@ class Test_Activitypub_Activity extends WP_UnitTestCase {
 		$this->assertEquals( 'Hello world!', $activity->get_object()->get_content() );
 		Assert::assertArraySubset( $test_array, $activity->to_array() );
 	}
+
+	/**
+	 * Test activity object.
+	 */
+	public function test_activity_object_url() {
+		$id = 'https://example.com/author/123';
+
+		// Build the update.
+		$activity = new \Activitypub\Activity\Activity();
+		$activity->set_type( 'Update' );
+		$activity->set_actor( $id );
+		$activity->set_object( $id );
+		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );
+
+		$this->assertTrue( str_starts_with( $activity->get_id(), 'https://example.com/author/123#activity-update-' ) );
+	}
 }


### PR DESCRIPTION
Fix #871

Normally the ID will be auto-generated based on the Object-ID, but in this case the `Object` is an URL itself.

This PR updates the ID logic, to also support Object-URLs.