### PR TITLE
EMA: Fix fatal when account is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fediverse preview showing `preferredUsername` instead of `name`
+* Fixed a potential fatal error in Enable Mastodon Apps
 
 ## 4.2.1 - 2024-11-20
 

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -650,7 +650,7 @@ class Enable_Mastodon_Apps {
 			$object = $item;
 		}
 
-		if ( ! isset( $object['type'] ) || 'Note' !== $object['type'] ) {
+		if ( ! isset( $object['type'] ) || 'Note' !== $object['type'] || ! $account ) {
 			return null;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -141,6 +141,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Improved: Outsource Constants to a separate file
 * Improved: Better handling of `readme.txt` and `README.md`
 * Fixed: Fediverse preview showing `preferredUsername` instead of `name`
+* Fixed: Potential fatal error in Enable Mastodon Apps
 
 = 4.2.1 =
 


### PR DESCRIPTION
If, for whatever reason, there is no account available for a status, we try to assign null to account which is not ok:

```
[24-Nov-2024 10:38:33 UTC] PHP Fatal error:  Uncaught TypeError: Cannot assign null to property Enable_Mastodon_Apps\Entity\Status::$account of type Enable_Mastodon_Apps\Entity\Account in wp-content/plugins/activitypub/integration/class-enable-mastodon-apps.php:661
Stack trace:
#0 wp-content/plugins/activitypub/integration/class-enable-mastodon-apps.php(367): Activitypub\Integration\Enable_Mastodon_Apps::activity_to_status()
#1 wp-content/plugins/activitypub/integration/class-enable-mastodon-apps.php(351): Activitypub\Integration\Enable_Mastodon_Apps::api_post_status()
#2 wp-includes/class-wp-hook.php(326): Activitypub\Integration\Enable_Mastodon_Apps::api_status()
#3 wp-includes/plugin.php(205): WP_Hook->apply_filters()
#4 wp-content/plugins/enable-mastodon-apps/includes/handler/class-handler.php(106): apply_filters()
#5 wp-content/plugins/enable-mastodon-apps/includes/handler/class-timeline.php(58): Enable_Mastodon_Apps\Handler\Handler->get_posts()
```

So this hides the status instead of fataling.
