### PR TITLE
Repo Gardening: automatically label more PRs, & auto-label issues

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -53,5 +53,5 @@ jobs:
               {"path": "src/editor-plugin", "label": "[Block] Post settings"},
               {"path": "src", "label": "[Focus] Editor"},
               {"path": "integration", "label": "[Focus] Compatibility"},
-               {"path": "includes/collection", "label": "[Feature] Collections"}
+              {"path": "includes/collection", "label": "[Feature] Collections"}
             ]'

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -52,6 +52,7 @@ jobs:
               {"path": "src/reply-intent", "label": "[Block] Federated reply"},
               {"path": "src/editor-plugin", "label": "[Block] Post settings"},
               {"path": "src", "label": "[Focus] Editor"},
+              {"path": "includes/class-blocks.php", "label": "[Focus] Editor"},
               {"path": "integration", "label": "[Focus] Compatibility"},
               {"path": "includes/collection", "label": "[Feature] Collections"}
             ]'

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -43,8 +43,15 @@ jobs:
           slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
           slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
           slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
-          tasks: 'addLabels,cleanLabels,assignIssues,flagOss,gatherSupportReferences,replyToCustomersReminder'
+          tasks: 'addLabels,cleanLabels,assignIssues,flagOss,gatherSupportReferences,replyToCustomersReminder,triageIssues'
           add_labels: '[
               {"path": "src/followers", "label": "[Block] Followers"},
-              {"path": "src/follow-me", "label": "[Block] Follow Me"}
+              {"path": "src/follow-me", "label": "[Block] Follow Me"},
+              {"path": "src/remote-reply", "label": "[Block] Remote reply"},
+              {"path": "src/reply", "label": "[Block] Federated reply"},
+              {"path": "src/reply-intent", "label": "[Block] Federated reply"},
+              {"path": "src/editor-plugin", "label": "[Block] Post settings"},
+              {"path": "src", "label": "[Focus] Editor"},
+              {"path": "integration", "label": "[Focus] Compatibility"},
+               {"path": "includes/collection", "label": "[Feature] Collections"}
             ]'


### PR DESCRIPTION
## Proposed changes:

This change brings us more automations:

- More PRs will get automatically labeled.
- More issues will be automatically labeled upon their creation (or will invite you to add labels when you can).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This cannot be tested until this PR is merged, but you can see the changes in action in other repos, like the Jetpack repo.

You can check the labels mentioned in the changes to see if they make sense.
