### PR TITLE
Hashtag: Ignore tags within HTML attributes (like hex colors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Prevent hex color codes in HTML attributes from being added as post tags.
+
 ## [4.3.0] - 2024-12-02
 
 ### Added

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -55,17 +55,14 @@ class Hashtag {
 	public static function insert_post( $post_id, $post ) {
 		$tags = array();
 
-		if ( \preg_match_all( '/' . ACTIVITYPUB_HASHTAGS_REGEXP . '/i', $post->post_content, $match ) ) {
-			$tags = array_merge( $tags, $match[1] );
+		// Skip hashtags in HTML attributes, like hex colors.
+		$content = wp_strip_all_tags( $post->post_content . "\n" . $post->post_excerpt );
+
+		if ( \preg_match_all( '/' . ACTIVITYPUB_HASHTAGS_REGEXP . '/i', $content, $match ) ) {
+			$tags = array_unique( $match[1] );
 		}
 
-		if ( \preg_match_all( '/' . ACTIVITYPUB_HASHTAGS_REGEXP . '/i', $post->post_excerpt, $match ) ) {
-			$tags = array_merge( $tags, $match[1] );
-		}
-
-		$tags = \implode( ', ', $tags );
-
-		\wp_add_post_tags( $post->ID, $tags );
+		\wp_add_post_tags( $post->ID, \implode( ', ', $tags ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,10 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Fixed: Prevent hex color codes in HTML attributes from being added as post tags.
+
 = 4.3.0 =
 
 * Added: A `pre_activitypub_get_upload_baseurl` filter

--- a/tests/class-test-activitypub-hashtag.php
+++ b/tests/class-test-activitypub-hashtag.php
@@ -73,4 +73,84 @@ ENDPRE;
 			array( $pre, $pre ),
 		);
 	}
+
+	/**
+	 * Tests auto-converting hashtags to tags.
+	 *
+	 * @see https://github.com/Automattic/wordpress-activitypub/issues/955
+	 * @dataProvider hashtag_provider
+	 * @covers ::insert_post
+	 *
+	 * @param string   $content       The post content.
+	 * @param string   $excerpt       The post excerpt.
+	 * @param string[] $expected_tags The expected tags.
+	 * @param string   $message       The error message.
+	 */
+	public function test_hashtag_conversion( $content, $excerpt, $expected_tags, $message ) {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_content' => $content,
+				'post_excerpt' => $excerpt,
+			)
+		);
+
+		\Activitypub\Hashtag::insert_post( $post_id, get_post( $post_id ) );
+		$tags = wp_get_post_tags( $post_id, array( 'fields' => 'names' ) );
+
+		foreach ( $expected_tags as $tag ) {
+			$this->assertContains( $tag, $tags, $message );
+		}
+	}
+
+	/**
+	 * Data provider for hashtag tests.
+	 *
+	 * @return array[] The data.
+	 */
+	public function hashtag_provider() {
+		return array(
+			'basic_hashtags'         => array(
+				'Testing #php and #programming',
+				'',
+				array( 'php', 'programming' ),
+				'Basic hashtags should be converted',
+			),
+			'hashtags_in_attributes' => array(
+				'<div style="color: #fff">#validtag</div>',
+				'',
+				array( 'validtag' ),
+				'Hashtags in HTML attributes should be ignored',
+			),
+			'mixed_content'          => array(
+				'Color is #red <span style="color: #ff0000">#valid</span> #blue',
+				'',
+				array( 'red', 'blue', 'valid' ),
+				'Should handle mixed content correctly',
+			),
+			'hex_in_text'            => array(
+				'<span style="color: #ff0000">#f00</span> #fff #000000',
+				'',
+				array( 'f00', 'fff', '000000' ),
+				'Hex colors in text should be converted',
+			),
+			'excerpt_tags'           => array(
+				'',
+				'Testing #excerpt with #tags',
+				array( 'excerpt', 'tags' ),
+				'Should process excerpt hashtags',
+			),
+			'multiple_attributes'    => array(
+				'<div data-color="#123" style="border: 1px solid #456">#valid</div>',
+				'',
+				array( 'valid' ),
+				'Should ignore multiple attribute hashtags',
+			),
+			'quotes_in_content'      => array(
+				'Here is a "#quoted" #tag',
+				'',
+				array( 'tag' ),
+				'Should handle quotes in content correctly',
+			),
+		);
+	}
 }


### PR DESCRIPTION
Fixes #955.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Strips tags before searching for hashtags to convert to tags.
* Adds unit test for various scenarios where hashtags should and shouldn't be converted.

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new Post, use the code editor.
* Enter an HTML tag with a css hex color code in its style. e.g.: `<span style="color: #ffffff">` (Important: preceding whitespace)
* Save the post
* Make sure the post doesn't have a tag called `ffffff`.