### PR TITLE
Fix typo in custom post content settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Prevent hex color codes in HTML attributes from being added as post tags
+* Fixed a typo in the custom post content settings
 
 ## [4.3.0] - 2024-12-02
 

--- a/readme.txt
+++ b/readme.txt
@@ -136,7 +136,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 * Added: Screen reader text for the "Follow Me" block for improved accessibility
 * Fixed: Prevent hex color codes in HTML attributes from being added as post tags
-
+* Fixed: A typo in the custom post content settings
 
 = 4.3.0 =
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -112,7 +112,7 @@
 											<li><code>[ap_content]</code> - <?php \esc_html_e( 'The post&#8217;s content.', 'activitypub' ); ?></li>
 											<li><code>[ap_excerpt]</code> - <?php \esc_html_e( 'The post&#8217;s excerpt (may be truncated).', 'activitypub' ); ?></li>
 											<li><code>[ap_permalink]</code> - <?php \esc_html_e( 'The post&#8217;s permalink.', 'activitypub' ); ?></li>
-											<li><code>[ap_shortlink]</code> - <?php echo \wp_kses( \__( 'The pos&#8217;s shortlink. I can recommend <a href="https://wordpress.org/plugins/hum/" target="_blank">Hum</a>.', 'activitypub' ), 'default' ); ?></li>
+											<li><code>[ap_shortlink]</code> - <?php echo \wp_kses( \__( 'The post&#8217;s shortlink. I can recommend <a href="https://wordpress.org/plugins/hum/" target="_blank">Hum</a>.', 'activitypub' ), 'default' ); ?></li>
 											<li><code>[ap_hashtags]</code> - <?php \esc_html_e( 'The post&#8217;s tags as hashtags.', 'activitypub' ); ?></li>
 										</ul>
 										<p><?php \esc_html_e( 'You can find the full list with all possible attributes in the help section on the top-right of the screen.', 'activitypub' ); ?></p>


### PR DESCRIPTION
Introduced in #930.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `t` in the translation string.
