### PR TITLE
Shortcodes: Add support for only showing teaser in content shortcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 
 * Added screen reader text to the "Follow Me" block for improved accessibility
+* Added more tag support to content shortcode to control whether to show full post or teaser
 
 ### Fixed
 

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -157,7 +157,7 @@ class Shortcodes {
 		remove_shortcode( 'ap_content' );
 
 		$atts = shortcode_atts(
-			array( 
+			array(
 				'apply_filters' => 'yes',
 				'more_tag'      => 'no',
 			),

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -135,7 +135,12 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_content' Shortcode.
 	 *
-	 * @param array  $atts    The Shortcode attributes.
+	 * @param array  $atts {
+	 *      The Shortcode attributes.
+	 *
+	 *      @type string $apply_filters Whether to apply the `the_content` filter. Possible values are 'yes' or 'no'. Default 'yes'.
+	 *      @type string $more_tag      Whether to truncate the content after the more tag. Possible values are 'yes' or 'no'. Default 'no'.
+	 * }
 	 * @param string $content The ActivityPub post-content.
 	 * @param string $tag     The tag/name of the Shortcode.
 	 *
@@ -152,12 +157,13 @@ class Shortcodes {
 		remove_shortcode( 'ap_content' );
 
 		$atts = shortcode_atts(
-			array( 'apply_filters' => 'yes' ),
+			array( 
+				'apply_filters' => 'yes',
+				'more_tag'      => 'no',
+			),
 			$atts,
 			$tag
 		);
-
-		$content = '';
 
 		if ( 'attachment' === $item->post_type ) {
 			// Get title of attachment with fallback to alt text.
@@ -167,6 +173,11 @@ class Shortcodes {
 			}
 		} else {
 			$content = \get_post_field( 'post_content', $item );
+
+			if ( 'yes' === $atts['more_tag'] ) {
+				$parts   = \get_extended( $content );
+				$content = $parts['main'];
+			}
 
 			if ( 'yes' === $atts['apply_filters'] ) {
 				$content = \apply_filters( 'the_content', $content );

--- a/includes/help.php
+++ b/includes/help.php
@@ -14,8 +14,8 @@
 			'<dl>' .
 				'<dt><code>[ap_title]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s title.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
-				'<dt><code>[ap_content apply_filters="yes"]</code></dt>' .
-				'<dd>' . \wp_kses( __( 'The post\'s content. With <code>apply_filters</code> you can decide if filters (<code>apply_filters( \'the_content\', $content )</code>) should be applied or not (default is <code>yes</code>). The values can be <code>yes</code> or <code>no</code>. <code>apply_filters</code> attribute is optional.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
+				'<dt><code>[ap_content apply_filters="yes" more_tag="no"]</code></dt>' .
+				'<dd>' . \wp_kses( __( 'The post&#8217;s content. Optional attributes:<br><code>apply_filters</code>: Whether to apply WordPress content filters (default: yes).<br><code>more_tag</code>: Whether to show only the teaser (yes) or the full content (no, default).', 'activitypub' ), array( 'code' => array(), 'br' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_excerpt length="400"]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s excerpt (uses <code>the_excerpt</code> if that is set). If no excerpt is provided, will truncate at <code>length</code> (optional, default = 400).', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_permalink type="url"]</code></dt>' .

--- a/includes/help.php
+++ b/includes/help.php
@@ -15,7 +15,13 @@
 				'<dt><code>[ap_title]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s title.', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_content apply_filters="yes" more_tag="no"]</code></dt>' .
-				'<dd>' . \wp_kses( __( 'The post&#8217;s content. Optional attributes:<br><code>apply_filters</code>: Whether to apply WordPress content filters (default: yes).<br><code>more_tag</code>: Whether to show only the teaser (yes) or the full content (no, default).', 'activitypub' ), array( 'code' => array(), 'br' => array() ) ) . '</dd>' .
+				'<dd>' . \wp_kses(
+					__( 'The post&#8217;s content. Optional attributes:<br><code>apply_filters</code>: Whether to apply WordPress content filters (default: yes).<br><code>more_tag</code>: Whether to show only the teaser (yes) or the full content (no, default).', 'activitypub' ),
+					array(
+						'code' => array(),
+						'br'   => array(),
+					)
+				) . '</dd>' .
 				'<dt><code>[ap_excerpt length="400"]</code></dt>' .
 				'<dd>' . \wp_kses( __( 'The post\'s excerpt (uses <code>the_excerpt</code> if that is set). If no excerpt is provided, will truncate at <code>length</code> (optional, default = 400).', 'activitypub' ), array( 'code' => array() ) ) . '</dd>' .
 				'<dt><code>[ap_permalink type="url"]</code></dt>' .

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Added: Screen reader text for the "Follow Me" block for improved accessibility
+* Added: More tag support to content shortcode to control whether to show full post or teaser
 * Fixed: Prevent hex color codes in HTML attributes from being added as post tags
 * Fixed: A typo in the custom post content settings
 

--- a/tests/class-test-activitypub-shortcodes.php
+++ b/tests/class-test-activitypub-shortcodes.php
@@ -188,6 +188,26 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 			trim( $content )
 		);
 
+		// Create a post without a more tag.
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Test Post with More',
+				'post_content' => 'This is the full content without a more tag. Even if the attribute is set to "yes", the full content should be shown.',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_author'  => 1,
+			)
+		);
+
+		setup_postdata( $post );
+
+		// Test without more_tag attribute (should show full content).
+		$content = do_shortcode( '[ap_content apply_filters="yes"]' );
+		$this->assertEquals(
+			'<p>This is the full content without a more tag. Even if the attribute is set to &#8220;yes&#8221;, the full content should be shown.</p>',
+			trim( $content )
+		);
+
 		wp_reset_postdata();
 		Shortcodes::unregister();
 	}

--- a/tests/class-test-activitypub-shortcodes.php
+++ b/tests/class-test-activitypub-shortcodes.php
@@ -16,6 +16,8 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 
 	/**
 	 * Test the content shortcode.
+	 *
+	 * @covers ::content
 	 */
 	public function test_content() {
 		Shortcodes::register();
@@ -49,6 +51,8 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 
 	/**
 	 * Test the content shortcode with password protected content.
+	 *
+	 * @covers ::content
 	 */
 	public function test_password_protected_content() {
 		Shortcodes::register();
@@ -82,6 +86,8 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 
 	/**
 	 * Test the excerpt shortcode.
+	 *
+	 * @covers ::excerpt
 	 */
 	public function test_excerpt() {
 		Shortcodes::register();
@@ -137,5 +143,52 @@ class Test_Activitypub_Shortcodes extends WP_UnitTestCase {
 		Shortcodes::unregister();
 
 		$this->assertEquals( 'Test title for shortcode', $content );
+	}
+
+	/**
+	 * Test the content shortcode with more tag.
+	 *
+	 * @covers ::content
+	 */
+	public function test_content_with_more_tag() {
+		Shortcodes::register();
+		global $post;
+
+		// Create a post with more tag.
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Test Post with More',
+				'post_content' => 'This is the teaser content.<!--more-->This is the full content.',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_author'  => 1,
+			)
+		);
+
+		setup_postdata( $post );
+
+		// Test without more_tag attribute (should show full content).
+		$content = do_shortcode( '[ap_content apply_filters="no"]' );
+		$this->assertEquals(
+			'This is the teaser content.<!--more-->This is the full content.',
+			trim( $content )
+		);
+
+		// Test with more_tag attribute (should show only teaser).
+		$content = do_shortcode( '[ap_content more_tag="yes"]' );
+		$this->assertEquals(
+			'<p>This is the teaser content.</p>',
+			trim( $content )
+		);
+
+		// Test with more_tag=no and apply_filters=yes (should show full content with more tag replaced).
+		$content = do_shortcode( '[ap_content]' );
+		$this->assertEquals(
+			'<p>This is the teaser content.<!--more-->This is the full content.</p>',
+			trim( $content )
+		);
+
+		wp_reset_postdata();
+		Shortcodes::unregister();
 	}
 }


### PR DESCRIPTION
~~The ticket is asking for tagging support in the excerpt, which doesn't really go with how WordPress thinks of the excerpt's use (just text, no links etc), but we have something similar built-in to the content.~~

Looks like [the premise of this PR is moot](https://github.com/Automattic/wordpress-activitypub/pull/1039#issuecomment-2517813478). Not sure if this should still be merged.

The More tag let's users define a teaser for a post and only shows that teaser on index and archive pages. We can use the same mechanism to allow Activitypub users to limit the amount of the content that's getting sent out with the `[ap_content]` shortcode.

This PR introduces a new, undocumented, shortcode attribute called `more_tag`, that will split out the content to only return the teaser, if a more tag is defined in the content. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a shortcode attribute to selectively only show the post's teaser.
* Updates shortcode docs to account for the new attribute.
* Adds unit tests

Docs entry after:
<img width="735" alt="Screenshot 2024-12-04 at 9 16 44 AM" src="https://github.com/user-attachments/assets/f5427cea-efe4-40c1-a9f8-8a63ffe3c2ec">

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Activitypub settings, select "Note" as Activity-Object-Type, and save changes.
* In post content, insert a `ap_content` shortcode with the `more_tag` attribute set to "yes", and save changes.
* Create a new post that includes a more tag and publish.
* Make sure that it only shows the teaser in Outbox.
