### PR TITLE
Prevent draft posts from being federated when deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Prevent hex color codes in HTML attributes from being added as post tags
 * Fixed a typo in the custom post content settings
+* Prevent draft posts from being federated when bulk deleted
 
 ## [4.3.0] - 2024-12-02
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -138,24 +138,24 @@ class Scheduler {
 			return;
 		}
 
-		$type = false;
+		switch ( $new_status ) {
+			case 'publish':
+				$type = ( 'publish' === $old_status ) ? 'Update' : 'Create';
+				break;
 
-		if (
-			'publish' === $new_status &&
-			'publish' !== $old_status
-		) {
-			$type = 'Create';
-		} elseif (
-			'publish' === $new_status ||
-			// We want to send updates for posts that are published and then moved to draft.
-			( 'draft' === $new_status &&
-			'publish' === $old_status )
-		) {
-			$type = 'Update';
-		} elseif ( 'trash' === $new_status ) {
-			$type = 'Delete';
+			case 'draft':
+				$type = ( 'publish' === $old_status ) ? 'Update' : false;
+				break;
+
+			case 'trash':
+				$type = ( 'publish' === $old_status ) ? 'Delete' : false;
+				break;
+
+			default:
+				$type = false;
 		}
 
+		// No activity to schedule.
 		if ( empty( $type ) ) {
 			return;
 		}

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -148,7 +148,7 @@ class Scheduler {
 				break;
 
 			case 'trash':
-				$type = ( 'publish' === $old_status ) ? 'Delete' : false;
+				$type = 'federated' === get_wp_object_state( $post ) ? 'Delete' : false;
 				break;
 
 			default:

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: Screen reader text for the "Follow Me" block for improved accessibility
 * Fixed: Prevent hex color codes in HTML attributes from being added as post tags
 * Fixed: A typo in the custom post content settings
+* Fixed: Prevent draft posts from being federated when bulk deleted
 
 = 4.3.0 =
 

--- a/tests/class-test-scheduler.php
+++ b/tests/class-test-scheduler.php
@@ -214,4 +214,4 @@ class Test_Scheduler extends WP_UnitTestCase {
 			'Password protected posts should not schedule federation activities'
 		);
 	}
-} 
+}

--- a/tests/class-test-scheduler.php
+++ b/tests/class-test-scheduler.php
@@ -3,24 +3,16 @@
  * Test Scheduler class.
  *
  * @package ActivityPub
- * @subpackage Tests
  */
 
 namespace Activitypub;
 
-use WP_UnitTestCase;
-
 /**
  * Test cases for the Scheduler class.
  *
- * @package ActivityPub
- * @subpackage Tests
- *
  * @coversDefaultClass \Activitypub\Scheduler
- * @group activitypub
- * @group scheduler
  */
-class Test_Scheduler extends WP_UnitTestCase {
+class Test_Scheduler extends \WP_UnitTestCase {
 	/**
 	 * Test post.
 	 *

--- a/tests/class-test-scheduler.php
+++ b/tests/class-test-scheduler.php
@@ -63,18 +63,28 @@ class Test_Scheduler extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that moving a published post to trash schedules a delete activity.
+	 * Test that moving a published post to trash schedules a delete activity only if federated.
 	 *
 	 * @covers ::schedule_post_activity
 	 */
-	public function test_publish_to_trash_should_schedule_delete() {
+	public function test_publish_to_trash_should_schedule_delete_only_if_federated() {
 		wp_publish_post( $this->post->ID );
 		$this->post = get_post( $this->post->ID );
+
+		// Test without federation state.
+		Scheduler::schedule_post_activity( 'trash', 'publish', $this->post );
+		$this->assertFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Delete' ) ),
+			'Published to trash transition should not schedule delete activity when not federated'
+		);
+
+		// Test with federation state.
+		set_wp_object_state( $this->post, 'federated' );
 		Scheduler::schedule_post_activity( 'trash', 'publish', $this->post );
 
 		$this->assertNotFalse(
 			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Delete' ) ),
-			'Published to trash transition should schedule delete activity'
+			'Published to trash transition should schedule delete activity when federated'
 		);
 	}
 

--- a/tests/class-test-scheduler.php
+++ b/tests/class-test-scheduler.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Test Scheduler class.
+ *
+ * @package ActivityPub
+ * @subpackage Tests
+ */
+
+namespace Activitypub;
+
+use WP_UnitTestCase;
+
+/**
+ * Test cases for the Scheduler class.
+ *
+ * @package ActivityPub
+ * @subpackage Tests
+ *
+ * @coversDefaultClass \Activitypub\Scheduler
+ * @group activitypub
+ * @group scheduler
+ */
+class Test_Scheduler extends WP_UnitTestCase {
+	/**
+	 * Test post.
+	 *
+	 * @var \WP_Post
+	 */
+	protected $post;
+
+	/**
+	 * Set up test resources before each test.
+	 *
+	 * Creates a test post in draft status.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test Content',
+				'post_status'  => 'draft',
+				'post_author'  => 1,
+			)
+		);
+	}
+
+	/**
+	 * Clean up test resources after each test.
+	 *
+	 * Deletes the test post.
+	 */
+	public function tear_down() {
+		wp_delete_post( $this->post->ID, true );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that moving a draft post to trash does not schedule federation.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_draft_to_trash_should_not_schedule_federation() {
+		Scheduler::schedule_post_activity( 'trash', 'draft', $this->post );
+
+		$this->assertFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Delete' ) ),
+			'Draft to trash transition should not schedule federation'
+		);
+	}
+
+	/**
+	 * Test that moving a published post to trash schedules a delete activity.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_publish_to_trash_should_schedule_delete() {
+		wp_publish_post( $this->post->ID );
+		$this->post = get_post( $this->post->ID );
+		Scheduler::schedule_post_activity( 'trash', 'publish', $this->post );
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Delete' ) ),
+			'Published to trash transition should schedule delete activity'
+		);
+	}
+
+	/**
+	 * Test that updating a draft post does not schedule federation.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_draft_to_draft_should_not_schedule_federation() {
+		Scheduler::schedule_post_activity( 'draft', 'draft', $this->post );
+
+		$this->assertFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Update' ) ),
+			'Draft to draft transition should not schedule federation'
+		);
+	}
+
+	/**
+	 * Test that moving a published post to draft schedules an update activity.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_publish_to_draft_should_schedule_update() {
+		wp_publish_post( $this->post->ID );
+		$this->post = get_post( $this->post->ID );
+		Scheduler::schedule_post_activity( 'draft', 'publish', $this->post );
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Update' ) ),
+			'Published to draft transition should schedule update activity'
+		);
+	}
+
+	/**
+	 * Test that publishing a draft post schedules a create activity.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_draft_to_publish_should_schedule_create() {
+		Scheduler::schedule_post_activity( 'publish', 'draft', $this->post );
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Create' ) ),
+			'Draft to publish transition should schedule create activity'
+		);
+	}
+
+	/**
+	 * Test that updating a published post schedules an update activity.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_publish_to_publish_should_schedule_update() {
+		wp_publish_post( $this->post->ID );
+		$this->post = get_post( $this->post->ID );
+		Scheduler::schedule_post_activity( 'publish', 'publish', $this->post );
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Update' ) ),
+			'Published to published transition should schedule update activity'
+		);
+	}
+
+	/**
+	 * Test that various non-standard status transitions do not schedule federation.
+	 *
+	 * Tests transitions from pending, private, and future statuses.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_other_status_transitions_should_not_schedule_federation() {
+		// Test pending to draft.
+		Scheduler::schedule_post_activity( 'draft', 'pending', $this->post );
+
+		$this->assertFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Update' ) ),
+			'Pending to draft transition should not schedule federation'
+		);
+
+		// Test private to draft.
+		Scheduler::schedule_post_activity( 'draft', 'private', $this->post );
+
+		$this->assertFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Update' ) ),
+			'Private to draft transition should not schedule federation'
+		);
+
+		// Test future to draft.
+		Scheduler::schedule_post_activity( 'draft', 'future', $this->post );
+
+		$this->assertFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Update' ) ),
+			'Future to draft transition should not schedule federation'
+		);
+	}
+
+	/**
+	 * Test that disabled posts do not schedule federation activities.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_disabled_post_should_not_schedule_federation() {
+		update_post_meta( $this->post->ID, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
+		Scheduler::schedule_post_activity( 'publish', 'draft', $this->post );
+
+		$this->assertFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Create' ) ),
+			'Disabled posts should not schedule federation activities'
+		);
+	}
+
+	/**
+	 * Test that password protected posts do not schedule federation activities.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_password_protected_post_should_not_schedule_federation() {
+		wp_update_post(
+			array(
+				'ID'            => $this->post->ID,
+				'post_password' => 'test-password',
+			)
+		);
+		$this->post = get_post( $this->post->ID );
+		Scheduler::schedule_post_activity( 'publish', 'draft', $this->post );
+
+		$this->assertFalse(
+			wp_next_scheduled( 'activitypub_send_post', array( $this->post->ID, 'Create' ) ),
+			'Password protected posts should not schedule federation activities'
+		);
+	}
+} 


### PR DESCRIPTION
Fixes #1030.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added status transition handling in `schedule_post_activity()` to prevent federation of draft posts.
* Added test coverage for post status transitions.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a draft post
* Create a published post
* Select both posts in the admin list view
* Bulk delete them
* Verify that:
  * The published post sends a Delete activity to followers
  * The draft post is deleted without federation