### PR TITLE
Admin: Move plugin settings link into Admin class

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -120,23 +120,6 @@ function plugin_init() {
 	}
 );
 
-/**
- * Add plugin settings link.
- *
- * @param array $actions The current actions.
- */
-function plugin_settings_link( $actions ) {
-	$settings_link   = array();
-	$settings_link[] = \sprintf(
-		'<a href="%1s">%2s</a>',
-		\menu_page_url( 'activitypub', false ),
-		\__( 'Settings', 'activitypub' )
-	);
-
-	return \array_merge( $settings_link, $actions );
-}
-\add_filter( 'plugin_action_links_' . ACTIVITYPUB_PLUGIN_BASENAME, __NAMESPACE__ . '\plugin_settings_link' );
-
 \register_activation_hook(
 	__FILE__,
 	array(

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -50,6 +50,7 @@ class Admin {
 		}
 
 		\add_filter( 'dashboard_glance_items', array( self::class, 'dashboard_glance_items' ) );
+		\add_filter( 'plugin_action_links_' . ACTIVITYPUB_PLUGIN_BASENAME, array( self::class, 'add_plugin_settings_link' ) );
 	}
 
 	/**
@@ -833,6 +834,21 @@ class Admin {
 			'<a href="%s" target="_blank">%s</a>',
 			\esc_url( $preview_url ),
 			\esc_html__( '⁂ Fediverse Preview', 'activitypub' )
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * Add plugin settings link.
+	 *
+	 * @param array $actions The current actions.
+	 */
+	public static function add_plugin_settings_link( $actions ) {
+		$actions[] = \sprintf(
+			'<a href="%1s">%2s</a>',
+			\menu_page_url( 'activitypub', false ),
+			\__( 'Settings', 'activitypub' )
 		);
 
 		return $actions;


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves settings link callback into Admin class to consolidate it with other wp-admin changes.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the diff
* Go to the Plugins screen and make sure there's still a "Settings" action link for Activitypub.

