### PR TITLE
Use WP Autoloader class

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -30,6 +30,10 @@ use WP_CLI;
 require_once __DIR__ . '/includes/compat.php';
 require_once __DIR__ . '/includes/functions.php';
 require_once __DIR__ . '/includes/constants.php';
+require_once __DIR__ . '/integration/load.php';
+
+require_once __DIR__ . '/includes/class-autoloader.php';
+Autoloader::register_path( __NAMESPACE__, __DIR__ . '/includes' );
 
 /**
  * Initialize REST routes.
@@ -81,45 +85,6 @@ function plugin_init() {
 }
 \add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init' );
 
-
-/**
- * Class Autoloader.
- */
-\spl_autoload_register(
-	function ( $full_class ) {
-		$base_dir = __DIR__ . '/includes/';
-		$base     = 'Activitypub\\';
-
-		if ( strncmp( $full_class, $base, strlen( $base ) ) === 0 ) {
-			$maybe_uppercase = str_replace( $base, '', $full_class );
-			$class           = strtolower( $maybe_uppercase );
-			// All classes should be capitalized. If this is instead looking for a lowercase method, we ignore that.
-			if ( $maybe_uppercase === $class ) {
-				return;
-			}
-
-			if ( false !== strpos( $class, '\\' ) ) {
-				$parts    = explode( '\\', $class );
-				$class    = array_pop( $parts );
-				$sub_dir  = strtr( implode( '/', $parts ), '_', '-' );
-				$base_dir = $base_dir . $sub_dir . '/';
-			}
-
-			$filename = 'class-' . strtr( $class, '_', '-' );
-			$file     = $base_dir . $filename . '.php';
-
-			if ( file_exists( $file ) && is_readable( $file ) ) {
-				require_once $file;
-			} else {
-				// translators: %s is the class name.
-				$message = sprintf( esc_html__( 'Required class not found or not readable: %s', 'activitypub' ), esc_html( $full_class ) );
-				Debug::write_log( $message );
-				\wp_die( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
-		}
-	}
-);
-
 /**
  * Add plugin settings link.
  *
@@ -161,8 +126,6 @@ function plugin_settings_link( $actions ) {
 	)
 );
 
-// Load integrations.
-require_once __DIR__ . '/integration/load.php';
 
 /**
  * `get_plugin_data` wrapper.

--- a/activitypub.php
+++ b/activitypub.php
@@ -85,23 +85,6 @@ function plugin_init() {
 }
 \add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init' );
 
-/**
- * Add plugin settings link.
- *
- * @param array $actions The current actions.
- */
-function plugin_settings_link( $actions ) {
-	$settings_link   = array();
-	$settings_link[] = \sprintf(
-		'<a href="%1s">%2s</a>',
-		\menu_page_url( 'activitypub', false ),
-		\__( 'Settings', 'activitypub' )
-	);
-
-	return \array_merge( $settings_link, $actions );
-}
-\add_filter( 'plugin_action_links_' . ACTIVITYPUB_PLUGIN_BASENAME, __NAMESPACE__ . '\plugin_settings_link' );
-
 \register_activation_hook(
 	__FILE__,
 	array(

--- a/activitypub.php
+++ b/activitypub.php
@@ -27,12 +27,12 @@ use WP_CLI;
 \define( 'ACTIVITYPUB_PLUGIN_FILE', ACTIVITYPUB_PLUGIN_DIR . basename( __FILE__ ) );
 \define( 'ACTIVITYPUB_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
+require_once __DIR__ . '/includes/class-autoloader.php';
 require_once __DIR__ . '/includes/compat.php';
 require_once __DIR__ . '/includes/functions.php';
 require_once __DIR__ . '/includes/constants.php';
 require_once __DIR__ . '/integration/load.php';
 
-require_once __DIR__ . '/includes/class-autoloader.php';
 Autoloader::register_path( __NAMESPACE__, __DIR__ . '/includes' );
 
 /**

--- a/includes/class-autoloader.php
+++ b/includes/class-autoloader.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Autoloader for Activitypub.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub;
+
+/**
+ * An Autoloader that respects WordPress's filename standards.
+ */
+class Autoloader {
+
+	/**
+	 * Namespace separator.
+	 */
+	const NS_SEPARATOR = '\\';
+
+	/**
+	 * The prefix to compare classes against.
+	 *
+	 * @var string
+	 * @access protected
+	 */
+	protected $prefix;
+
+	/**
+	 * Length of the prefix string.
+	 *
+	 * @var int
+	 * @access protected
+	 */
+	protected $prefix_length;
+
+	/**
+	 * Path to the file to be loaded.
+	 *
+	 * @var string
+	 * @access protected
+	 */
+	protected $path;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $prefix Namespace prefix all classes have in common.
+	 * @param string $path   Path to the files to be loaded.
+	 */
+	public function __construct( $prefix, $path ) {
+		$this->prefix        = $prefix;
+		$this->prefix_length = strlen( $prefix );
+		$this->path          = rtrim( $path . '/' );
+	}
+
+	/**
+	 * Registers Autoloader's autoload function.
+	 *
+	 * @throws \Exception When autoload_function cannot be registered.
+	 *
+	 * @param string $prefix Namespace prefix all classes have in common.
+	 * @param string $path   Path to the files to be loaded.
+	 */
+	public static function register_path( $prefix, $path ) {
+		$loader = new Autoloader( $prefix, $path );
+		spl_autoload_register( array( $loader, 'load' ) );
+	}
+
+	/**
+	 * Loads a class if its namespace starts with `$this->prefix`.
+	 *
+	 * @param string $class_name The class to be loaded.
+	 */
+	public function load( $class_name ) {
+		if ( strpos( $class_name, $this->prefix . self::NS_SEPARATOR ) !== 0 ) {
+			return;
+		}
+
+		// Strip prefix from the start (ala PSR-4).
+		$class_name = substr( $class_name, $this->prefix_length + 1 );
+		$class_name = strtolower( $class_name );
+		$dir        = '';
+
+		$last_ns_pos = strripos( $class_name, self::NS_SEPARATOR );
+		if ( false !== $last_ns_pos ) {
+			$namespace  = substr( $class_name, 0, $last_ns_pos );
+			$namespace  = str_replace( '_', '-', $namespace );
+			$class_name = substr( $class_name, $last_ns_pos + 1 );
+			$dir        = str_replace( self::NS_SEPARATOR, DIRECTORY_SEPARATOR, $namespace ) . DIRECTORY_SEPARATOR;
+		}
+
+		$path = $this->path . $dir . 'class-' . str_replace( '_', '-', $class_name ) . '.php';
+
+		if ( ! file_exists( $path ) ) {
+			$path = $this->path . $dir . 'interface-' . str_replace( '_', '-', $class_name ) . '.php';
+		}
+
+		if ( ! file_exists( $path ) ) {
+			$path = $this->path . $dir . 'trait-' . str_replace( '_', '-', $class_name ) . '.php';
+		}
+
+		if ( file_exists( $path ) ) {
+			require_once $path;
+		}
+	}
+}

--- a/includes/class-autoloader.php
+++ b/includes/class-autoloader.php
@@ -62,7 +62,7 @@ class Autoloader {
 	 * @param string $path   Path to the files to be loaded.
 	 */
 	public static function register_path( $prefix, $path ) {
-		$loader = new Autoloader( $prefix, $path );
+		$loader = new self( $prefix, $path );
 		spl_autoload_register( array( $loader, 'load' ) );
 	}
 

--- a/includes/class-autoloader.php
+++ b/includes/class-autoloader.php
@@ -49,8 +49,8 @@ class Autoloader {
 	 */
 	public function __construct( $prefix, $path ) {
 		$this->prefix        = $prefix;
-		$this->prefix_length = strlen( $prefix );
-		$this->path          = rtrim( $path . '/' );
+		$this->prefix_length = \strlen( $prefix );
+		$this->path          = \rtrim( $path . '/' );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class Autoloader {
 	 */
 	public static function register_path( $prefix, $path ) {
 		$loader = new self( $prefix, $path );
-		spl_autoload_register( array( $loader, 'load' ) );
+		\spl_autoload_register( array( $loader, 'load' ) );
 	}
 
 	/**
@@ -72,34 +72,34 @@ class Autoloader {
 	 * @param string $class_name The class to be loaded.
 	 */
 	public function load( $class_name ) {
-		if ( strpos( $class_name, $this->prefix . self::NS_SEPARATOR ) !== 0 ) {
+		if ( \strpos( $class_name, $this->prefix . self::NS_SEPARATOR ) !== 0 ) {
 			return;
 		}
 
 		// Strip prefix from the start (ala PSR-4).
-		$class_name = substr( $class_name, $this->prefix_length + 1 );
-		$class_name = strtolower( $class_name );
+		$class_name = \substr( $class_name, $this->prefix_length + 1 );
+		$class_name = \strtolower( $class_name );
 		$dir        = '';
 
-		$last_ns_pos = strripos( $class_name, self::NS_SEPARATOR );
+		$last_ns_pos = \strripos( $class_name, self::NS_SEPARATOR );
 		if ( false !== $last_ns_pos ) {
-			$namespace  = substr( $class_name, 0, $last_ns_pos );
-			$namespace  = str_replace( '_', '-', $namespace );
-			$class_name = substr( $class_name, $last_ns_pos + 1 );
-			$dir        = str_replace( self::NS_SEPARATOR, DIRECTORY_SEPARATOR, $namespace ) . DIRECTORY_SEPARATOR;
+			$namespace  = \substr( $class_name, 0, $last_ns_pos );
+			$namespace  = \str_replace( '_', '-', $namespace );
+			$class_name = \substr( $class_name, $last_ns_pos + 1 );
+			$dir        = \str_replace( self::NS_SEPARATOR, DIRECTORY_SEPARATOR, $namespace ) . DIRECTORY_SEPARATOR;
 		}
 
-		$path = $this->path . $dir . 'class-' . str_replace( '_', '-', $class_name ) . '.php';
+		$path = $this->path . $dir . 'class-' . \str_replace( '_', '-', $class_name ) . '.php';
 
-		if ( ! file_exists( $path ) ) {
-			$path = $this->path . $dir . 'interface-' . str_replace( '_', '-', $class_name ) . '.php';
+		if ( ! \file_exists( $path ) ) {
+			$path = $this->path . $dir . 'interface-' . \str_replace( '_', '-', $class_name ) . '.php';
 		}
 
-		if ( ! file_exists( $path ) ) {
-			$path = $this->path . $dir . 'trait-' . str_replace( '_', '-', $class_name ) . '.php';
+		if ( ! \file_exists( $path ) ) {
+			$path = $this->path . $dir . 'trait-' . \str_replace( '_', '-', $class_name ) . '.php';
 		}
 
-		if ( file_exists( $path ) ) {
+		if ( \file_exists( $path ) ) {
 			require_once $path;
 		}
 	}

--- a/tests/class-test-autoloader.php
+++ b/tests/class-test-autoloader.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests for Autoloader class.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+use Activitypub\Autoloader;
+
+/**
+ * Class Test_Autoloader.
+ *
+ * @coversDefaultClass \Activitypub\Autoloader
+ */
+class Test_Autoloader extends \WP_UnitTestCase {
+
+	/**
+	 * Test__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test__construct() {
+		$autoloader = new Autoloader( 'Activitypub', __DIR__ );
+
+		$prefix = new \ReflectionProperty( '\Activitypub\Autoloader', 'prefix' );
+		$this->assertTrue( $prefix->isProtected() );
+		$prefix->setAccessible( true );
+		$this->assertSame( $prefix->getValue( $autoloader ), 'Activitypub' );
+
+		$prefix_length = new \ReflectionProperty( '\Activitypub\Autoloader', 'prefix_length' );
+		$this->assertTrue( $prefix_length->isProtected() );
+		$prefix_length->setAccessible( true );
+		$this->assertSame( $prefix_length->getValue( $autoloader ), strlen( 'Activitypub' ) );
+
+		$path = new \ReflectionProperty( '\Activitypub\Autoloader', 'path' );
+		$this->assertTrue( $path->isProtected() );
+		$path->setAccessible( true );
+		$this->assertSame( $path->getValue( $autoloader ), rtrim( __DIR__ . '/' ) );
+	}
+
+	/**
+	 * Test_register_path.
+	 *
+	 * @covers ::register_path
+	 */
+	public function test_register_path() {
+		Autoloader::register_path( 'Activitypub', __DIR__ );
+
+		foreach ( spl_autoload_functions() as $function ) {
+			if ( is_array( $function ) && $function[0] instanceof Autoloader ) {
+				$path = new \ReflectionProperty( '\Activitypub\Autoloader', 'path' );
+				$path->setAccessible( true );
+
+				if ( $path->getValue( $function[0] ) === rtrim( __DIR__ . '/' ) ) {
+					$this->assertTrue( true );
+					return;
+				}
+			}
+		}
+
+		$this->fail( 'Failed asserting that autoload function gets registered.' );
+	}
+
+	/**
+	 * Test_load.
+	 *
+	 * @covers ::load
+	 */
+	public function test_load() {
+		$autoloader = new Autoloader( __NAMESPACE__, __DIR__ );
+
+		// Wrong prefix.
+		$autoloader->load( 'Activitypub\Autoload_Test_File' );
+		$this->assertFalse( class_exists( 'Activitypub\Autoload_Test_File' ) );
+
+		// Right prefix but class doesn't exist.
+		$autoloader->load( 'Activitypub\Tests\Data\Non\Existent\Class' );
+		$this->assertFalse( class_exists( 'Activitypub\Tests\Data\Non\Existent\Class' ) );
+
+		// Class should load.
+		$autoloader->load( 'Activitypub\Tests\Data\Autoload_Test_File' );
+		$this->assertTrue( class_exists( 'Activitypub\Tests\Data\Autoload_Test_File' ) );
+	}
+}

--- a/tests/data/class-autoload-test-file.php
+++ b/tests/data/class-autoload-test-file.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Autoload test file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Data;
+
+/**
+ * Class Autoload_Test_File.
+ */
+class Autoload_Test_File {}


### PR DESCRIPTION
This is one of those changes I'm on the fence about as it doesn't strictly improve things, it just makes them "different".
The Autoloader class proposed here is based on [Dion's work for the WP.org Plugin Directory](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/plugins/plugin-directory/class-autoloader.php?rev=3083) and used in its proposed form in the `/lib/atomic-v2` library on Dotcom.

I was positively surprised that it seems to just be a drop-in replacement for the current Autoloader, which I didn't quite expect :)
It currently lacks the debug log for when a class is not readable or couldn't be loaded. Was that triggered at any point before?

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replaces inline Autoloader with a separate Autoloader class that can be re-used.
* Moves the integrations loader to be included with the other includes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure everything still works?

