### PR TITLE
Change E-Mail templates to match new comment-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
-* Email templates for "likes" and "reposts"
+* Email templates for Likes and Reposts
 
 ## [4.4.0] - 2024-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Send "new follower" emails
+
+### Improved
+
+* Email templates for "likes" and "reposts"
+
 ## [4.4.0] - 2024-12-09
 
 ### Added

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -539,7 +539,12 @@ class Comment {
 	}
 
 	/**
-	 * Get a comment type.
+	 * Get the custom comment type.
+	 *
+	 * Check if the type is registered, if not, check if it is a custom type.
+	 *
+	 * It looks for the array key in the registered types and returns the array.
+	 * If it is not found, it looks for the type in the custom types and returns the array.
 	 *
 	 * @param string $type The comment type.
 	 *
@@ -550,10 +555,18 @@ class Comment {
 		$type  = sanitize_key( $type );
 		$types = self::get_comment_types();
 
+		$type_array = array();
+
+		// Check array keys.
 		if ( in_array( $type, array_keys( $types ), true ) ) {
 			$type_array = $types[ $type ];
-		} else {
-			$type_array = array();
+		} else { // Fall back to type attribute.
+			foreach ( $types as $item ) {
+				if ( $type === $item['type'] ) {
+					$type_array = $item;
+					break;
+				}
+			}
 		}
 
 		/**

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -603,7 +603,6 @@ class Comment {
 				'icon'        => '♻️',
 				'class'       => 'p-repost',
 				'type'        => 'repost',
-				// translators: %1$s username, %2$s object format (post, audio, ...), %3$s URL, %4$s domain.
 				'excerpt'     => __( '&hellip; reposted this!', 'activitypub' ),
 			)
 		);
@@ -617,7 +616,6 @@ class Comment {
 				'icon'        => '👍',
 				'class'       => 'p-like',
 				'type'        => 'like',
-				// translators: %1$s username, %2$s object format (post, audio, ...), %3$s URL, %4$s domain.
 				'excerpt'     => __( '&hellip; liked this!', 'activitypub' ),
 			)
 		);

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -135,4 +135,3 @@ class Mailer {
 		\wp_mail( $email, $subject, $message );
 	}
 }
-

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -104,9 +104,8 @@ class Mailer {
 	 * @param Notification $notification The notification object.
 	 */
 	public static function new_follower( $notification ) {
-		$actor  = get_remote_metadata_by_actor( $notification->actor );
-		$object = $notification->object['object'];
-		$user   = \get_user_by( 'id', $notification->target );
+		$actor = get_remote_metadata_by_actor( $notification->actor );
+		$user  = \get_user_by( 'id', $notification->target );
 
 		if ( ! $actor || \is_wp_error( $actor ) || ! $user ) {
 			return;

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Mailer Class.
+ *
+ * @package ActivityPub
+ */
+
+namespace Activitypub;
+
+/**
+ * Mailer Class
+ */
+class Mailer {
+	/**
+	 * Initialize the Mailer.
+	 */
+	public static function init() {
+		add_filter( 'comment_notification_subject', array( self::class, 'comment_notification_subject' ), 10, 2 );
+		add_filter( 'comment_notification_text', array( self::class, 'comment_notification_text' ), 10, 2 );
+
+		// New follower notification.
+		add_action( 'activitypub_notification_follow', array( self::class, 'new_follower' ) );
+	}
+
+	/**
+	 * Filter the mail-subject for Like and Announce notifications.
+	 *
+	 * @param string     $subject    The default mail-subject.
+	 * @param int|string $comment_id The comment ID.
+	 *
+	 * @return string The filtered mail-subject
+	 */
+	public static function comment_notification_subject( $subject, $comment_id ) {
+		$comment = get_comment( $comment_id );
+
+		if ( ! $comment ) {
+			return $subject;
+		}
+
+		$type = get_comment_meta( $comment->comment_ID, 'protocol', true );
+
+		if ( 'activitypub' !== $type ) {
+			return $subject;
+		}
+
+		$singular = Comment::get_comment_type_attr( $comment->comment_type, 'singular' );
+
+		if ( ! $singular ) {
+			return $subject;
+		}
+
+		$post = get_post( $comment->comment_post_ID );
+
+		/* translators: %1$s: Blog name, %2$s: Post title */
+		return sprintf( __( '[%1$s] %2$s: %3$s', 'activitypub' ), get_option( 'blogname' ), $singular, $post->post_title );
+	}
+
+	/**
+	 * Filter the mail-content for Like and Announce notifications.
+	 *
+	 * @param string     $message    The default mail-content.
+	 * @param int|string $comment_id The comment ID.
+	 *
+	 * @return string The filtered mail-content
+	 */
+	public static function comment_notification_text( $message, $comment_id ) {
+		$comment = get_comment( $comment_id );
+
+		if ( ! $comment ) {
+			return $message;
+		}
+
+		$type = get_comment_meta( $comment->comment_ID, 'protocol', true );
+
+		if ( 'activitypub' !== $type ) {
+			return $message;
+		}
+
+		$comment_type = Comment::get_comment_type( $comment->comment_type );
+
+		if ( ! $comment_type ) {
+			return $message;
+		}
+
+		$post                  = get_post( $comment->comment_post_ID );
+		$comment_author_domain = gethostbyaddr( $comment->comment_author_IP );
+
+		/* translators: %1$s: Comment type, %2$s: Post title */
+		$notify_message = \sprintf( __( 'New %1$s on your post "%2$s"', 'activitypub' ), $comment_type['singular'], $post->post_title ) . "\r\n";
+		/* translators: 1: Trackback/pingback website name, 2: Website IP address, 3: Website hostname. */
+		$notify_message .= \sprintf( __( 'Website: %1$s (IP address: %2$s, %3$s)', 'activitypub' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+		/* translators: %s: Trackback/pingback/comment author URL. */
+		$notify_message .= \sprintf( __( 'URL: %s', 'activitypub' ), $comment->comment_author_url ) . "\r\n\r\n";
+		/* translators: %s: Comment type label */
+		$notify_message .= \sprintf( __( 'You can see all %s on this post here:', 'activitypub' ), $comment_type['label'] ) . "\r\n";
+		$notify_message .= \get_permalink( $comment->comment_post_ID ) . "#" . $comment_type['singular'] . "\r\n\r\n";
+
+		return $notify_message;
+	}
+
+	/**
+	 * Send a Mail for every new follower.
+	 *
+	 * @param Notification $notification The notification object.
+	 */
+	public static function new_follower( $notification ) {
+		$actor  = get_remote_metadata_by_actor( $notification->actor );
+		$object = $notification->object['object'];
+		$user   = \get_user_by( 'id', $notification->target );
+
+		if ( ! $actor || \is_wp_error( $actor ) || ! $user ) {
+			return;
+		}
+
+		/* translators: %1$s: Blog name, %2$s: Follower name */
+		$subject = \sprintf( __( '[%1$s] Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
+
+		/* translators: %1$s: Blog name, %2$s: Follower name */
+		$message = \sprintf( __( 'New follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] ) . "\r\n";
+		/* translators: %s: Follower URL */
+		$message .= \sprintf( __( 'URL: %s', 'activitypub' ), $actor['url'] ) . "\r\n\r\n";
+		$message .= \sprintf( __( 'You can see all followers here:', 'activitypub' ) ) . "\r\n";
+		$message .= \esc_url( \admin_url( '/users.php?page=activitypub-followers-list' ) ) . "\r\n\r\n";
+
+		\wp_mail( $user->user_email, $subject, $message );
+	}
+}
+

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -93,7 +93,7 @@ class Mailer {
 		$notify_message .= \sprintf( __( 'URL: %s', 'activitypub' ), $comment->comment_author_url ) . "\r\n\r\n";
 		/* translators: %s: Comment type label */
 		$notify_message .= \sprintf( __( 'You can see all %s on this post here:', 'activitypub' ), $comment_type['label'] ) . "\r\n";
-		$notify_message .= \get_permalink( $comment->comment_post_ID ) . "#" . $comment_type['singular'] . "\r\n\r\n";
+		$notify_message .= \get_permalink( $comment->comment_post_ID ) . '#' . $comment_type['singular'] . "\r\n\r\n";
 
 		return $notify_message;
 	}
@@ -125,4 +125,3 @@ class Mailer {
 		\wp_mail( $user->user_email, $subject, $message );
 	}
 }
-

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub;
 
+use Activitypub\Collection\Actors;
 /**
  * Mailer Class
  */
@@ -105,22 +106,28 @@ class Mailer {
 	 */
 	public static function new_follower( $notification ) {
 		$actor = get_remote_metadata_by_actor( $notification->actor );
-		$user  = \get_user_by( 'id', $notification->target );
 
-		if ( ! $actor || \is_wp_error( $actor ) || ! $user ) {
+		if ( ! $actor || \is_wp_error( $actor ) ) {
 			return;
 		}
 
-		/* translators: %1$s: Blog name, %2$s: Follower name */
-		$subject = \sprintf( __( '[%1$s] Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
+		$email = \get_option( 'admin_email' );
+
+		if ( $notification->target > Actors::BLOG_USER_ID ) {
+			$user  = \get_user_by( 'id', $notification->target );
+			$email = $user->user_email;
+		}
 
 		/* translators: %1$s: Blog name, %2$s: Follower name */
-		$message = \sprintf( __( 'New follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] ) . "\r\n";
+		$subject = \sprintf( \__( '[%1$s] Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
+		/* translators: %1$s: Blog name, %2$s: Follower name */
+		$message = \sprintf( \__( 'New follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] ) . "\r\n";
 		/* translators: %s: Follower URL */
-		$message .= \sprintf( __( 'URL: %s', 'activitypub' ), $actor['url'] ) . "\r\n\r\n";
-		$message .= \sprintf( __( 'You can see all followers here:', 'activitypub' ) ) . "\r\n";
+		$message .= \sprintf( \__( 'URL: %s', 'activitypub' ), $actor['url'] ) . "\r\n\r\n";
+		$message .= \sprintf( \__( 'You can see all followers here:', 'activitypub' ) ) . "\r\n";
 		$message .= \esc_url( \admin_url( '/users.php?page=activitypub-followers-list' ) ) . "\r\n\r\n";
 
-		\wp_mail( $user->user_email, $subject, $message );
+		\wp_mail( $email, $subject, $message );
 	}
 }
+

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -113,8 +113,13 @@ class Mailer {
 
 		$email = \get_option( 'admin_email' );
 
-		if ( $notification->target > Actors::BLOG_USER_ID ) {
-			$user  = \get_user_by( 'id', $notification->target );
+		if ( (int) $notification->target > Actors::BLOG_USER_ID ) {
+			$user = \get_user_by( 'id', $notification->target );
+
+			if ( ! $user ) {
+				return;
+			}
+
 			$email = $user->user_email;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -135,7 +135,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Added: Send "new follower" emails
-* Improved: Email templates for "likes" and "reposts"
+* Improved: Email templates for Likes and Reposts
 
 = 4.4.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,11 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Added: Send "new follower" emails
+* Improved: Email templates for "likes" and "reposts"
+
 = 4.4.0 =
 
 * Added: Setting to enable/disable Authorized-Fetch

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -80,7 +80,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Test Post', $subject );
 		$this->assertStringContainsString( get_option( 'blogname' ), $subject );
 
-		// Test with non-ActivityPub comment
+		// Test with non-ActivityPub comment.
 		$regular_comment_id = wp_insert_comment(
 			array(
 				'comment_post_ID' => self::$post_id,
@@ -90,7 +90,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		$subject = Mailer::comment_notification_subject( 'Default Subject', $regular_comment_id );
 		$this->assertEquals( 'Default Subject', $subject );
 
-		// Clean up
+		// Clean up.
 		wp_delete_comment( $comment_id, true );
 		wp_delete_comment( $regular_comment_id, true );
 	}
@@ -120,7 +120,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'https://example.com/author', $text );
 		$this->assertStringContainsString( '127.0.0.1', $text );
 
-		// Test with non-ActivityPub comment
+		// Test with non-ActivityPub comment.
 		$regular_comment_id = wp_insert_comment(
 			array(
 				'comment_post_ID' => self::$post_id,
@@ -130,7 +130,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		$text = Mailer::comment_notification_text( 'Default Message', $regular_comment_id );
 		$this->assertEquals( 'Default Message', $text );
 
-		// Clean up
+		// Clean up.
 		wp_delete_comment( $comment_id, true );
 		wp_delete_comment( $regular_comment_id, true );
 	}
@@ -141,8 +141,6 @@ class Test_Mailer extends WP_UnitTestCase {
 	 * @covers ::new_follower
 	 */
 	public function test_new_follower() {
-		$user = get_user_by( 'id', self::$user_id );
-
 		$notification = new Notification(
 			'follow',
 			'https://example.com/author',
@@ -152,7 +150,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			self::$user_id
 		);
 
-		// Mock remote metadata
+		// Mock remote metadata.
 		add_filter(
 			'pre_get_remote_metadata_by_actor',
 			function () {
@@ -163,7 +161,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			}
 		);
 
-		// Capture email
+		// Capture email.
 		add_filter(
 			'wp_mail',
 			function ( $args ) {
@@ -176,7 +174,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		Mailer::new_follower( $notification );
 
-		// Clean up
+		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
 		remove_all_filters( 'wp_mail' );
 	}

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -67,9 +67,9 @@ class Test_Mailer extends WP_UnitTestCase {
 	public function test_comment_like_notification() {
 		$comment_id = wp_insert_comment(
 			array(
-				'comment_post_ID' => self::$post_id,
-				'comment_type'    => 'like',
-				'comment_author'  => 'Test Author',
+				'comment_post_ID'    => self::$post_id,
+				'comment_type'       => 'like',
+				'comment_author'     => 'Test Author',
 				'comment_author_url' => 'https://example.com/author',
 				'comment_author_IP'  => '127.0.0.1',
 			)
@@ -129,7 +129,6 @@ class Test_Mailer extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Repost', $subject );
 		$this->assertStringContainsString( 'Test Post', $subject );
 		$this->assertStringContainsString( get_option( 'blogname' ), $subject );
-
 
 		$text = Mailer::comment_notification_text( 'Default Message', $comment_id );
 

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Test Mailer Class.
+ *
+ * @package ActivityPub
+ */
+
+namespace Activitypub\Tests;
+
+use Activitypub\Mailer;
+use Activitypub\Notification;
+use WP_UnitTestCase;
+
+/**
+ * Test Mailer class.
+ *
+ * @coversDefaultClass \Activitypub\Mailer
+ */
+class Test_Mailer extends WP_UnitTestCase {
+	/**
+	 * A test post.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * A test user.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Create fake data before tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that creates fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		self::$post_id = $factory->post->create(
+			array(
+				'post_author' => self::$user_id,
+				'post_title'  => 'Test Post',
+			)
+		);
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$post_id, true );
+		wp_delete_user( self::$user_id );
+	}
+
+	/**
+	 * Test comment notification subject for ActivityPub comments.
+	 *
+	 * @covers ::comment_notification_subject
+	 */
+	public function test_comment_notification_subject() {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_type'    => 'like',
+			)
+		);
+
+		update_comment_meta( $comment_id, 'protocol', 'activitypub' );
+
+		$subject = Mailer::comment_notification_subject( 'Default Subject', $comment_id );
+
+		$this->assertStringContainsString( 'Like', $subject );
+		$this->assertStringContainsString( 'Test Post', $subject );
+		$this->assertStringContainsString( get_option( 'blogname' ), $subject );
+
+		// Test with non-ActivityPub comment
+		$regular_comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID' => self::$post_id,
+			)
+		);
+
+		$subject = Mailer::comment_notification_subject( 'Default Subject', $regular_comment_id );
+		$this->assertEquals( 'Default Subject', $subject );
+
+		// Clean up
+		wp_delete_comment( $comment_id, true );
+		wp_delete_comment( $regular_comment_id, true );
+	}
+
+	/**
+	 * Test comment notification text for ActivityPub comments.
+	 *
+	 * @covers ::comment_notification_text
+	 */
+	public function test_comment_notification_text() {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => self::$post_id,
+				'comment_type'         => 'like',
+				'comment_author'       => 'Test Author',
+				'comment_author_url'   => 'https://example.com/author',
+				'comment_author_IP'    => '127.0.0.1',
+			)
+		);
+
+		update_comment_meta( $comment_id, 'protocol', 'activitypub' );
+
+		$text = Mailer::comment_notification_text( 'Default Message', $comment_id );
+
+		$this->assertStringContainsString( 'Test Post', $text );
+		$this->assertStringContainsString( 'Test Author', $text );
+		$this->assertStringContainsString( 'https://example.com/author', $text );
+		$this->assertStringContainsString( '127.0.0.1', $text );
+
+		// Test with non-ActivityPub comment
+		$regular_comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID' => self::$post_id,
+			)
+		);
+
+		$text = Mailer::comment_notification_text( 'Default Message', $regular_comment_id );
+		$this->assertEquals( 'Default Message', $text );
+
+		// Clean up
+		wp_delete_comment( $comment_id, true );
+		wp_delete_comment( $regular_comment_id, true );
+	}
+
+	/**
+	 * Test new follower notification.
+	 *
+	 * @covers ::new_follower
+	 */
+	public function test_new_follower() {
+		$user = get_user_by( 'id', self::$user_id );
+
+		$notification = new Notification(
+			'follow',
+			'https://example.com/author',
+			array(
+				'object' => 'https://example.com/follow/1',
+			),
+			self::$user_id
+		);
+
+		// Mock remote metadata
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function() {
+				return array(
+					'name' => 'Test Follower',
+					'url'  => 'https://example.com/author',
+				);
+			}
+		);
+
+		// Capture email
+		add_filter(
+			'wp_mail',
+			function( $args ) {
+				$this->assertStringContainsString( 'Test Follower', $args['subject'] );
+				$this->assertStringContainsString( 'https://example.com/author', $args['message'] );
+				$this->assertEquals( get_user_by( 'id', self::$user_id )->user_email, $args['to'] );
+				return $args;
+			}
+		);
+
+		Mailer::new_follower( $notification );
+
+		// Clean up
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'wp_mail' );
+	}
+
+	/**
+	 * Test initialization of filters and actions.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init() {
+		Mailer::init();
+
+		$this->assertEquals( 10, has_filter( 'comment_notification_subject', array( Mailer::class, 'comment_notification_subject' ) ) );
+		$this->assertEquals( 10, has_filter( 'comment_notification_text', array( Mailer::class, 'comment_notification_text' ) ) );
+		$this->assertEquals( 10, has_action( 'activitypub_notification_follow', array( Mailer::class, 'new_follower' ) ) );
+	}
+}

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -103,11 +103,11 @@ class Test_Mailer extends WP_UnitTestCase {
 	public function test_comment_notification_text() {
 		$comment_id = wp_insert_comment(
 			array(
-				'comment_post_ID'      => self::$post_id,
-				'comment_type'         => 'like',
-				'comment_author'       => 'Test Author',
-				'comment_author_url'   => 'https://example.com/author',
-				'comment_author_IP'    => '127.0.0.1',
+				'comment_post_ID'    => self::$post_id,
+				'comment_type'       => 'like',
+				'comment_author'     => 'Test Author',
+				'comment_author_url' => 'https://example.com/author',
+				'comment_author_IP'  => '127.0.0.1',
 			)
 		);
 
@@ -155,7 +155,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		// Mock remote metadata
 		add_filter(
 			'pre_get_remote_metadata_by_actor',
-			function() {
+			function () {
 				return array(
 					'name' => 'Test Follower',
 					'url'  => 'https://example.com/author',
@@ -166,7 +166,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		// Capture email
 		add_filter(
 			'wp_mail',
-			function( $args ) {
+			function ( $args ) {
 				$this->assertStringContainsString( 'Test Follower', $args['subject'] );
 				$this->assertStringContainsString( 'https://example.com/author', $args['message'] );
 				$this->assertEquals( get_user_by( 'id', self::$user_id )->user_email, $args['to'] );

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -64,11 +64,14 @@ class Test_Mailer extends WP_UnitTestCase {
 	 *
 	 * @covers ::comment_notification_subject
 	 */
-	public function test_comment_notification_subject() {
+	public function test_comment_like_notification() {
 		$comment_id = wp_insert_comment(
 			array(
 				'comment_post_ID' => self::$post_id,
 				'comment_type'    => 'like',
+				'comment_author'  => 'Test Author',
+				'comment_author_url' => 'https://example.com/author',
+				'comment_author_IP'  => '127.0.0.1',
 			)
 		);
 
@@ -79,6 +82,14 @@ class Test_Mailer extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Like', $subject );
 		$this->assertStringContainsString( 'Test Post', $subject );
 		$this->assertStringContainsString( get_option( 'blogname' ), $subject );
+
+		$text = Mailer::comment_notification_text( 'Default Message', $comment_id );
+
+		$this->assertStringContainsString( 'Test Post', $text );
+		$this->assertStringContainsString( 'Test Author', $text );
+		$this->assertStringContainsString( 'Like', $text );
+		$this->assertStringContainsString( 'https://example.com/author', $text );
+		$this->assertStringContainsString( '127.0.0.1', $text );
 
 		// Test with non-ActivityPub comment.
 		$regular_comment_id = wp_insert_comment(
@@ -100,11 +111,11 @@ class Test_Mailer extends WP_UnitTestCase {
 	 *
 	 * @covers ::comment_notification_text
 	 */
-	public function test_comment_notification_text() {
+	public function test_comment_repost_notification() {
 		$comment_id = wp_insert_comment(
 			array(
 				'comment_post_ID'    => self::$post_id,
-				'comment_type'       => 'like',
+				'comment_type'       => 'repost',
 				'comment_author'     => 'Test Author',
 				'comment_author_url' => 'https://example.com/author',
 				'comment_author_IP'  => '127.0.0.1',
@@ -113,10 +124,18 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		update_comment_meta( $comment_id, 'protocol', 'activitypub' );
 
+		$subject = Mailer::comment_notification_subject( 'Default Subject', $comment_id );
+
+		$this->assertStringContainsString( 'Repost', $subject );
+		$this->assertStringContainsString( 'Test Post', $subject );
+		$this->assertStringContainsString( get_option( 'blogname' ), $subject );
+
+
 		$text = Mailer::comment_notification_text( 'Default Message', $comment_id );
 
 		$this->assertStringContainsString( 'Test Post', $text );
 		$this->assertStringContainsString( 'Test Author', $text );
+		$this->assertStringContainsString( 'Repost', $text );
 		$this->assertStringContainsString( 'https://example.com/author', $text );
 		$this->assertStringContainsString( '127.0.0.1', $text );
 


### PR DESCRIPTION
I tried to be as close to the classic emails as possible.

See #1058

Bonus: I added email support for receiving new followers.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed email templates for comment type: "like" and "repost"
* Send email when your user has a new follower

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout PR to your blog
* Comment to a blog-post on Mastodon
* Follow your blog user
* Check emails

