### PR TITLE
Comments: Account for custom comment types when calculating comment counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `icon` support for `Audio` and `Video` attachments
 * Send "new follower" emails
 * Send "direct message" emails
+* Account for custom comment types when calculating comment counts
 
 ### Improved
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -671,10 +671,6 @@ class Comment {
 			return;
 		}
 
-		if ( isset( $query->query_vars['count'] ) && true === $query->query_vars['count'] ) {
-			return;
-		}
-
 		// Exclude likes and reposts by the ActivityPub plugin.
 		$query->query_vars['type__not_in'] = self::get_comment_type_names();
 	}

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -30,6 +30,7 @@ class Comment {
 		\add_action( 'pre_get_comments', array( static::class, 'comment_query' ) );
 		\add_filter( 'pre_comment_approved', array( static::class, 'pre_comment_approved' ), 10, 2 );
 		\add_filter( 'get_avatar_comment_types', array( static::class, 'get_avatar_comment_types' ), 99 );
+		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
 	}
 
 	/**
@@ -714,5 +715,28 @@ class Comment {
 		}
 
 		return $approved;
+	}
+
+	/**
+	 * Filters the comment count to exclude ActivityPub comment types.
+	 *
+	 * @param int|null $new_count The new comment count. Default null.
+	 * @param int      $old_count The old comment count.
+	 * @param int      $post_id   Post ID.
+	 *
+	 * @return int|null The updated comment count, or null to use the default query.
+	 */
+	public static function pre_wp_update_comment_count_now( $new_count, $old_count, $post_id ) {
+		if ( null === $new_count ) {
+			global $wpdb;
+
+			$excluded_types = self::get_comment_type_names();
+
+			// phpcs:ignore WordPress.DB
+			$new_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type NOT IN ('" . implode( "','", $excluded_types ) . "')", $post_id ) );
+
+		}
+
+		return $new_count;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: `icon` support for `Audio` and `Video` attachments
 * Added: Send "new follower" emails
 * Added: Send "direct message" emails
+* Added: Account for custom comment types when calculating comment counts
 * Improved: Email templates for Likes and Reposts
 * Improved: Interactions moderation
 * Improved: Compatibility with Akismet


### PR DESCRIPTION
Fixes #1069.

The benefit of this approach is that it doesn't add a DB query to front end requests.
The downsides are that if another plugin uses the same filter, there's a potential for conflict, and comment counts won't change until WordPress finds a reason to update the count, like approving/unapproving a comment.

One more consideration:
We might want to add an upgrade routine so we can grab all posts with a like or reblog and update their counts, after the plugin was upgraded ([example](https://github.com/WordPress/wordpress-develop/commit/d5a7a3a45dc18ad1554e185c6611ec54ced9b40c)).

There is almost certainly more work needed to make this work correctly.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds callback that queries comment counts without Activitypub custom comment types.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the diff.
* Go to the comments list on your development site.
* Approve/unapprove a like or repost.
* Make sure the new comment count reflects that number of actual comments (and pings).

