### PR TITLE
Blocks: Avoid PHP warning in Reply block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improve Interactions moderation
 * Compatibility with Akismet
 
+### Fixed
+
+* Empty `url` attributes in the Reply block no longer cause PHP warnings
+
 ## [4.4.0] - 2024-12-09
 
 ### Added

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -305,23 +305,25 @@ class Blocks {
 	 * @return string The HTML to render.
 	 */
 	public static function render_reply_block( $attrs ) {
+		$html = '';
+
+		if ( ! empty( $attrs['url'] ) ) {
+			$html = sprintf(
+				'<p><a title="%2$s" aria-label="%2$s" href="%1$s" class="u-in-reply-to" target="_blank">%3$s</a></p>',
+				esc_url( $attrs['url'] ),
+				esc_attr__( 'This post is a response to the referenced content.', 'activitypub' ),
+				// translators: %s is the URL of the post being replied to.
+				sprintf( __( '&#8620;%s', 'activitypub' ), \str_replace( array( 'https://', 'http://' ), '', esc_url( $attrs['url'] ) ) )
+			);
+		}
+
 		/**
 		 * Filter the reply block.
 		 *
 		 * @param string $html  The HTML to render.
 		 * @param array  $attrs The block attributes.
 		 */
-		return apply_filters(
-			'activitypub_reply_block',
-			sprintf(
-				'<p><a title="%2$s" aria-label="%2$s" href="%1$s" class="u-in-reply-to" target="_blank">%3$s</a></p>',
-				esc_url( $attrs['url'] ),
-				esc_attr__( 'This post is a response to the referenced content.', 'activitypub' ),
-				// translators: %s is the URL of the post being replied to.
-				sprintf( __( '&#8620;%s', 'activitypub' ), \str_replace( array( 'https://', 'http://' ), '', $attrs['url'] ) )
-			),
-			$attrs
-		);
+		return apply_filters( 'activitypub_reply_block', $html, $attrs );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Improved: Email templates for Likes and Reposts
 * Improved: Interactions moderation
 * Improved: Compatibility with Akismet
+* Fixed: Empty `url` attributes in the Reply block no longer cause PHP warnings
 
 = 4.4.0 =
 

--- a/tests/includes/class-test-blocks.php
+++ b/tests/includes/class-test-blocks.php
@@ -14,39 +14,38 @@ namespace Activitypub\Tests;
  */
 class Test_Blocks extends \WP_UnitTestCase {
 
-    /**
-     * Test the render_reply_block() method with a valid URL attribute.
-     *
-     * @covers ::render_reply_block
-     */
-    public function test_render_reply_block_with_valid_url() {
-        $attrs = array( 'url' => 'https://example.com/post' );
-        $output = \Activitypub\Blocks::render_reply_block( $attrs );
-        $this->assertStringContainsString( 'u-in-reply-to', $output );
-        $this->assertStringContainsString( 'https://example.com/post', $output );
-        $this->assertStringContainsString( 'example.com/post', $output );
-    }
+	/**
+	 * Test the render_reply_block() method with a valid URL attribute.
+	 *
+	 * @covers ::render_reply_block
+	 */
+	public function test_render_reply_block_with_valid_url() {
+		$attrs  = array( 'url' => 'https://example.com/post' );
+		$output = \Activitypub\Blocks::render_reply_block( $attrs );
+		$this->assertStringContainsString( 'u-in-reply-to', $output );
+		$this->assertStringContainsString( 'https://example.com/post', $output );
+		$this->assertStringContainsString( 'example.com/post', $output );
+	}
 
-    /**
-     * Test the render_reply_block() method with a missing URL attribute.
-     *
-     * @covers ::render_reply_block
-     */
-    public function test_render_reply_block_with_missing_url() {
-        $attrs = array();
-        $output = \Activitypub\Blocks::render_reply_block( $attrs );
-        $this->assertEmpty( $output );
-    }
+	/**
+	 * Test the render_reply_block() method with a missing URL attribute.
+	 *
+	 * @covers ::render_reply_block
+	 */
+	public function test_render_reply_block_with_missing_url() {
+		$attrs  = array();
+		$output = \Activitypub\Blocks::render_reply_block( $attrs );
+		$this->assertEmpty( $output );
+	}
 
-    /**
-     * Test the render_reply_block() method with an empty URL attribute.
-     *
-     * @covers ::render_reply_block
-     */
-    public function test_render_reply_block_with_empty_url() {
-        $attrs = array( 'url' => '' );
-        $output = \Activitypub\Blocks::render_reply_block( $attrs );
-        $this->assertEmpty( $output );
-    }
-
-} 
+	/**
+	 * Test the render_reply_block() method with an empty URL attribute.
+	 *
+	 * @covers ::render_reply_block
+	 */
+	public function test_render_reply_block_with_empty_url() {
+		$attrs  = array( 'url' => '' );
+		$output = \Activitypub\Blocks::render_reply_block( $attrs );
+		$this->assertEmpty( $output );
+	}
+}

--- a/tests/includes/class-test-blocks.php
+++ b/tests/includes/class-test-blocks.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Test file for Blocks class.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+/**
+ * Test class for Blocks.
+ *
+ * @coversDefaultClass \Activitypub\Blocks
+ */
+class Test_Blocks extends \WP_UnitTestCase {
+
+    /**
+     * Test the render_reply_block() method with a valid URL attribute.
+     *
+     * @covers ::render_reply_block
+     */
+    public function test_render_reply_block_with_valid_url() {
+        $attrs = array( 'url' => 'https://example.com/post' );
+        $output = \Activitypub\Blocks::render_reply_block( $attrs );
+        $this->assertStringContainsString( 'u-in-reply-to', $output );
+        $this->assertStringContainsString( 'https://example.com/post', $output );
+        $this->assertStringContainsString( 'example.com/post', $output );
+    }
+
+    /**
+     * Test the render_reply_block() method with a missing URL attribute.
+     *
+     * @covers ::render_reply_block
+     */
+    public function test_render_reply_block_with_missing_url() {
+        $attrs = array();
+        $output = \Activitypub\Blocks::render_reply_block( $attrs );
+        $this->assertEmpty( $output );
+    }
+
+    /**
+     * Test the render_reply_block() method with an empty URL attribute.
+     *
+     * @covers ::render_reply_block
+     */
+    public function test_render_reply_block_with_empty_url() {
+        $attrs = array( 'url' => '' );
+        $output = \Activitypub\Blocks::render_reply_block( $attrs );
+        $this->assertEmpty( $output );
+    }
+
+} 


### PR DESCRIPTION
Avoids an "Undefined array key" warning when the Reply block gets saved without a URL set.

@mattwiebe Is this the best way to solve this? Or good enough? Or should it be solved in the block?

See p1734000287098329-slack-C04TJ8P900J.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets an empty string as default output if the URL is not specified.
* Adds unit tests for the new functionality

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post with the Reply block.
* Leave the URL field empty and publish the post.
* Checkout the post on the frontend and make sure there are no PHP warnings.

