### PR TITLE
Use a more explicit signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improve Interactions moderation
 * Compatibility with Akismet
 * Comment type mapping for `Like` and `Announce`
+* Signature verification for API endpoints
 
 ### Fixed
 

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -286,7 +286,7 @@ class Signature {
 			$signed_headers = array( 'date' );
 		}
 
-		$signed_data = self::get_signed_data( $signed_headers, $signature_block, $headers );
+ 		$signed_data = self::get_signed_data( $signed_headers, $signature_block, $headers );
 		if ( ! $signed_data ) {
 			return new WP_Error( 'activitypub_signature', __( 'Signed request date outside acceptable time window', 'activitypub' ), array( 'status' => 401 ) );
 		}
@@ -321,7 +321,6 @@ class Signature {
 		}
 
 		$verified = \openssl_verify( $signed_data, $signature_block['signature'], $public_key, $algorithm ) > 0;
-
 		if ( ! $verified ) {
 			return new WP_Error( 'activitypub_signature', __( 'Invalid signature', 'activitypub' ), array( 'status' => 401 ) );
 		}
@@ -403,7 +402,11 @@ class Signature {
 			$parsed_header['signature'] = \base64_decode( preg_replace( '/\s+/', '', trim( $matches[1] ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		}
 
-		if ( ( $parsed_header['signature'] ) && ( $parsed_header['algorithm'] ) && ( ! $parsed_header['headers'] ) ) {
+		if (
+			! empty( $parsed_header['signature'] ) &&
+			! empty( $parsed_header['algorithm'] ) &&
+			empty( $parsed_header['headers'] )
+		) {
 			$parsed_header['headers'] = array( 'date' );
 		}
 
@@ -461,6 +464,10 @@ class Signature {
 				}
 			}
 			if ( 'date' === $header ) {
+				if ( empty( $headers[ $header ][0] ) ) {
+					continue;
+				}
+
 				// Allow a bit of leeway for misconfigured clocks.
 				$d = new DateTime( $headers[ $header ][0] );
 				$d->setTimeZone( new DateTimeZone( 'UTC' ) );
@@ -474,7 +481,10 @@ class Signature {
 					return false;
 				}
 			}
-			$signed_data .= $header . ': ' . $headers[ $header ][0] . "\n";
+
+			if ( ! empty( $headers[ $header ][0] ) ) {
+				$signed_data .= $header . ': ' . $headers[ $header ][0] . "\n";
+			}
 		}
 		return \rtrim( $signed_data, "\n" );
 	}

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -286,7 +286,7 @@ class Signature {
 			$signed_headers = array( 'date' );
 		}
 
- 		$signed_data = self::get_signed_data( $signed_headers, $signature_block, $headers );
+		$signed_data = self::get_signed_data( $signed_headers, $signature_block, $headers );
 		if ( ! $signed_data ) {
 			return new WP_Error( 'activitypub_signature', __( 'Signed request date outside acceptable time window', 'activitypub' ), array( 'status' => 401 ) );
 		}

--- a/includes/handler/class-delete.php
+++ b/includes/handler/class-delete.php
@@ -27,8 +27,8 @@ class Delete {
 
 		// Defer signature verification for `Delete` requests.
 		\add_filter(
-			'activitypub_defer_signature_verification',
-			array( self::class, 'defer_signature_verification' ),
+			'activitypub_defer_verify_signature',
+			array( self::class, 'defer_verify_signature' ),
 			10,
 			2
 		);
@@ -183,7 +183,7 @@ class Delete {
 	 *
 	 * @return bool Whether to defer signature verification.
 	 */
-	public static function defer_signature_verification( $defer, $request ) {
+	public static function defer_verify_signature( $defer, $request ) {
 		$json = $request->get_json_params();
 
 		if ( isset( $json['type'] ) && 'Delete' === $json['type'] ) {

--- a/includes/handler/class-delete.php
+++ b/includes/handler/class-delete.php
@@ -27,8 +27,8 @@ class Delete {
 
 		// Defer signature verification for `Delete` requests.
 		\add_filter(
-			'activitypub_defer_verify_signature',
-			array( self::class, 'defer_verify_signature' ),
+			'activitypub_defer_signature_verification',
+			array( self::class, 'defer_signature_verification' ),
 			10,
 			2
 		);
@@ -183,7 +183,7 @@ class Delete {
 	 *
 	 * @return bool Whether to defer signature verification.
 	 */
-	public static function defer_verify_signature( $defer, $request ) {
+	public static function defer_signature_verification( $defer, $request ) {
 		$json = $request->get_json_params();
 
 		if ( isset( $json['type'] ) && 'Delete' === $json['type'] ) {

--- a/includes/rest/class-actors.php
+++ b/includes/rest/class-actors.php
@@ -41,7 +41,7 @@ class Actors {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'get' ),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'verify_signature' ),
 				),
 			)
 		);

--- a/includes/rest/class-actors.php
+++ b/includes/rest/class-actors.php
@@ -41,7 +41,7 @@ class Actors {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'get' ),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
 				),
 			)
 		);

--- a/includes/rest/class-followers.php
+++ b/includes/rest/class-followers.php
@@ -43,7 +43,7 @@ class Followers {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'verify_signature' ),
 				),
 			)
 		);

--- a/includes/rest/class-followers.php
+++ b/includes/rest/class-followers.php
@@ -43,7 +43,7 @@ class Followers {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
 				),
 			)
 		);

--- a/includes/rest/class-followers.php
+++ b/includes/rest/class-followers.php
@@ -43,7 +43,7 @@ class Followers {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
 				),
 			)
 		);

--- a/includes/rest/class-following.php
+++ b/includes/rest/class-following.php
@@ -43,7 +43,7 @@ class Following {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
 				),
 			)
 		);

--- a/includes/rest/class-following.php
+++ b/includes/rest/class-following.php
@@ -43,7 +43,7 @@ class Following {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
 				),
 			)
 		);

--- a/includes/rest/class-following.php
+++ b/includes/rest/class-following.php
@@ -43,7 +43,7 @@ class Following {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'verify_signature' ),
 				),
 			)
 		);

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -45,7 +45,7 @@ class Inbox {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( self::class, 'shared_inbox_post' ),
 					'args'                => self::shared_inbox_post_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
 				),
 			)
 		);
@@ -58,13 +58,13 @@ class Inbox {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( self::class, 'user_inbox_post' ),
 					'args'                => self::user_inbox_post_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'user_inbox_get' ),
 					'args'                => self::user_inbox_get_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
 				),
 			)
 		);

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -45,7 +45,7 @@ class Inbox {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( self::class, 'shared_inbox_post' ),
 					'args'                => self::shared_inbox_post_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'verify_signature' ),
 				),
 			)
 		);
@@ -58,13 +58,13 @@ class Inbox {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( self::class, 'user_inbox_post' ),
 					'args'                => self::user_inbox_post_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'verify_signature' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'user_inbox_get' ),
 					'args'                => self::user_inbox_get_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'verify_signature' ),
 				),
 			)
 		);

--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -45,7 +45,7 @@ class Inbox {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( self::class, 'shared_inbox_post' ),
 					'args'                => self::shared_inbox_post_parameters(),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
 				),
 			)
 		);
@@ -58,13 +58,13 @@ class Inbox {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( self::class, 'user_inbox_post' ),
 					'args'                => self::user_inbox_post_parameters(),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'user_inbox_get' ),
 					'args'                => self::user_inbox_get_parameters(),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
 				),
 			)
 		);

--- a/includes/rest/class-outbox.php
+++ b/includes/rest/class-outbox.php
@@ -45,7 +45,7 @@ class Outbox {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'user_outbox_get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
 				),
 			)
 		);

--- a/includes/rest/class-outbox.php
+++ b/includes/rest/class-outbox.php
@@ -45,7 +45,7 @@ class Outbox {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'user_outbox_get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'authorize_activitypub_permissions' ),
 				),
 			)
 		);

--- a/includes/rest/class-outbox.php
+++ b/includes/rest/class-outbox.php
@@ -45,7 +45,7 @@ class Outbox {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'user_outbox_get' ),
 					'args'                => self::request_parameters(),
-					'permission_callback' => array( 'Activitypub\Rest\Server', 'signature_verification' ),
+					'permission_callback' => array( 'Activitypub\Rest\Server', 'verify_signature' ),
 				),
 			)
 		);

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -36,7 +36,7 @@ class Server {
 	 */
 	public static function add_hooks() {
 		\add_filter( 'rest_request_before_callbacks', array( self::class, 'validate_activitypub_requests' ), 9, 3 );
-		//\add_filter( 'rest_request_before_callbacks', array( self::class, 'authorize_activitypub_requests' ), 10, 3 );
+		// \add_filter( 'rest_request_before_callbacks', array( self::class, 'authorize_activitypub_requests' ), 10, 3 );
 		\add_filter( 'rest_request_parameter_order', array( self::class, 'request_parameter_order' ), 10, 2 );
 	}
 

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -35,7 +35,7 @@ class Server {
 	 * Add sever hooks.
 	 */
 	public static function add_hooks() {
-		\add_filter( 'rest_request_before_callbacks', array( self::class, 'validate_activitypub_requests' ), 9, 3 );
+		\add_filter( 'rest_request_before_callbacks', array( self::class, 'validate_requests' ), 9, 3 );
 		\add_filter( 'rest_request_parameter_order', array( self::class, 'request_parameter_order' ), 10, 2 );
 	}
 
@@ -139,7 +139,7 @@ class Server {
 	 *
 	 * @return mixed|WP_Error The response, error, or modified response.
 	 */
-	public static function validate_activitypub_requests( $response, $handler, $request ) {
+	public static function validate_requests( $response, $handler, $request ) {
 		if ( 'HEAD' === $request->get_method() ) {
 			return $response;
 		}

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -78,7 +78,7 @@ class Server {
 	 * The function is meant to be used as a permission callback for the rest api.
 	 *
 	 * It verifies the signature of POST, PUT, PATCH and DELETE requests and also the GET requests in secure mode.
-	 * You can use the filter 'activitypub_defer_signature_verification' to defer the signature verification.
+	 * You can use the filter 'activitypub_defer_verify_signature' to defer the signature verification.
 	 * The HEAD request is always bypassed.
 	 *
 	 * @see https://www.w3.org/wiki/SocialCG/ActivityPub/Primer/Authentication_Authorization#Authorized_fetch
@@ -88,7 +88,7 @@ class Server {
 	 *
 	 * @return bool|\WP_Error True if the request is authorized, WP_Error if not.
 	 */
-	public static function signature_verification( $request ) {
+	public static function verify_signature( $request ) {
 		if ( 'HEAD' === $request->get_method() ) {
 			return true;
 		}
@@ -104,7 +104,7 @@ class Server {
 		 *
 		 * @return bool Whether to defer signature verification.
 		 */
-		$defer = \apply_filters( 'activitypub_defer_signature_verification', false, $request );
+		$defer = \apply_filters( 'activitypub_defer_verify_signature', false, $request );
 
 		if ( $defer ) {
 			return true;
@@ -119,7 +119,7 @@ class Server {
 			$verified_request = Signature::verify_http_signature( $request );
 			if ( \is_wp_error( $verified_request ) ) {
 				return new WP_Error(
-					'activitypub_signature_verification',
+					'activitypub_verify_signature',
 					$verified_request->get_error_message(),
 					array( 'status' => 401 )
 				);

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -75,11 +75,11 @@ class Server {
 	/**
 	 * Callback function to authorize an api request.
 	 *
-	 * The function is meant to be used as a permission callback for the rest api.
+	 * The function is meant to be used as part of permission callbacks for rest api endpoints.
 	 *
-	 * It verifies the signature of POST, PUT, PATCH and DELETE requests and also the GET requests in secure mode.
+	 * It verifies the signature of POST, PUT, PATCH, and DELETE requests, as well as GET requests in secure mode.
 	 * You can use the filter 'activitypub_defer_verify_signature' to defer the signature verification.
-	 * The HEAD request is always bypassed.
+	 * HEAD requests are always bypassed.
 	 *
 	 * @see https://www.w3.org/wiki/SocialCG/ActivityPub/Primer/Authentication_Authorization#Authorized_fetch
 	 * @see https://swicg.github.io/activitypub-http-signature/#authorized-fetch

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -36,6 +36,7 @@ class Server {
 	 */
 	public static function add_hooks() {
 		\add_filter( 'rest_request_before_callbacks', array( self::class, 'validate_activitypub_requests' ), 9, 3 );
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		// \add_filter( 'rest_request_before_callbacks', array( self::class, 'authorize_activitypub_requests' ), 10, 3 );
 		\add_filter( 'rest_request_parameter_order', array( self::class, 'request_parameter_order' ), 10, 2 );
 	}

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -111,7 +111,7 @@ class Server {
 		}
 
 		if (
-			// POST-Requests have to be always signed.
+			// POST-Requests always have to be signed.
 			'GET' !== $request->get_method() ||
 			// GET-Requests only require a signature in secure mode.
 			( 'GET' === $request->get_method() && use_authorized_fetch() )

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -73,16 +73,20 @@ class Server {
 	}
 
 	/**
-	 * Callback function to authorize each api requests
+	 * Callback function to authorize an api request.
 	 *
-	 * @see WP_REST_Request
+	 * The function is meant to be used as a permission callback for the rest api.
+	 *
+	 * It verifies the signature of POST, PUT, PATCH and DELETE requests and also the GET requests in secure mode.
+	 * You can use the filter 'activitypub_defer_signature_verification' to defer the signature verification.
+	 * The HEAD request is always bypassed.
 	 *
 	 * @see https://www.w3.org/wiki/SocialCG/ActivityPub/Primer/Authentication_Authorization#Authorized_fetch
 	 * @see https://swicg.github.io/activitypub-http-signature/#authorized-fetch
 	 *
-	 * @param \WP_REST_Request $request  Request used to generate the response.
+	 * @param \WP_REST_Request $request The request object.
 	 *
-	 * @return bool Whether the request is authorized.
+	 * @return bool|\WP_Error True if the request is authorized, WP_Error if not.
 	 */
 	public static function signature_verification( $request ) {
 		if ( 'HEAD' === $request->get_method() ) {
@@ -98,7 +102,7 @@ class Server {
 		 * @param bool             $defer   Whether to defer signature verification.
 		 * @param \WP_REST_Request $request The request used to generate the response.
 		 *
-		 * @return bool|WP_Error True if the request is authorized, WP_Error if not.
+		 * @return bool Whether to defer signature verification.
 		 */
 		$defer = \apply_filters( 'activitypub_defer_signature_verification', false, $request );
 

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -78,7 +78,7 @@ class Server {
 	 * The function is meant to be used as part of permission callbacks for rest api endpoints.
 	 *
 	 * It verifies the signature of POST, PUT, PATCH, and DELETE requests, as well as GET requests in secure mode.
-	 * You can use the filter 'activitypub_defer_verify_signature' to defer the signature verification.
+	 * You can use the filter 'activitypub_defer_signature_verification' to defer the signature verification.
 	 * HEAD requests are always bypassed.
 	 *
 	 * @see https://www.w3.org/wiki/SocialCG/ActivityPub/Primer/Authentication_Authorization#Authorized_fetch
@@ -104,7 +104,7 @@ class Server {
 		 *
 		 * @return bool Whether to defer signature verification.
 		 */
-		$defer = \apply_filters( 'activitypub_defer_verify_signature', false, $request );
+		$defer = \apply_filters( 'activitypub_defer_signature_verification', false, $request );
 
 		if ( $defer ) {
 			return true;

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -36,7 +36,7 @@ class Server {
 	 */
 	public static function add_hooks() {
 		\add_filter( 'rest_request_before_callbacks', array( self::class, 'validate_activitypub_requests' ), 9, 3 );
-		\add_filter( 'rest_request_before_callbacks', array( self::class, 'authorize_activitypub_requests' ), 10, 3 );
+		//\add_filter( 'rest_request_before_callbacks', array( self::class, 'authorize_activitypub_requests' ), 10, 3 );
 		\add_filter( 'rest_request_parameter_order', array( self::class, 'request_parameter_order' ), 10, 2 );
 	}
 
@@ -143,6 +143,55 @@ class Server {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Callback function to authorize each api requests
+	 *
+	 * @see WP_REST_Request
+	 *
+	 * @see https://www.w3.org/wiki/SocialCG/ActivityPub/Primer/Authentication_Authorization#Authorized_fetch
+	 * @see https://swicg.github.io/activitypub-http-signature/#authorized-fetch
+	 *
+	 * @param \WP_REST_Request $request  Request used to generate the response.
+	 *
+	 * @return bool Whether the request is authorized.
+	 */
+	public static function authorize_activitypub_permissions( $request ) {
+		if ( 'HEAD' === $request->get_method() ) {
+			return true;
+		}
+
+		/**
+		 * Filter to defer signature verification.
+		 *
+		 * Skip signature verification for debugging purposes or to reduce load for
+		 * certain Activity-Types, like "Delete".
+		 *
+		 * @param bool             $defer   Whether to defer signature verification.
+		 * @param \WP_REST_Request $request The request used to generate the response.
+		 *
+		 * @return bool Whether to defer signature verification.
+		 */
+		$defer = \apply_filters( 'activitypub_defer_signature_verification', false, $request );
+
+		if ( $defer ) {
+			return true;
+		}
+
+		if (
+			// POST-Requests are always signed.
+			'GET' !== $request->get_method() ||
+			// GET-Requests only require a signature in secure mode.
+			( 'GET' === $request->get_method() && use_authorized_fetch() )
+		) {
+			$verified_request = Signature::verify_http_signature( $request );
+			if ( \is_wp_error( $verified_request ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -36,8 +36,6 @@ class Server {
 	 */
 	public static function add_hooks() {
 		\add_filter( 'rest_request_before_callbacks', array( self::class, 'validate_activitypub_requests' ), 9, 3 );
-		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		// \add_filter( 'rest_request_before_callbacks', array( self::class, 'authorize_activitypub_requests' ), 10, 3 );
 		\add_filter( 'rest_request_parameter_order', array( self::class, 'request_parameter_order' ), 10, 2 );
 	}
 
@@ -72,78 +70,6 @@ class Server {
 		$rest_response->header( 'Content-Type', 'application/activity+json; charset=' . get_option( 'blog_charset' ) );
 
 		return $rest_response;
-	}
-
-	/**
-	 * Callback function to authorize each api requests
-	 *
-	 * @see WP_REST_Request
-	 *
-	 * @see https://www.w3.org/wiki/SocialCG/ActivityPub/Primer/Authentication_Authorization#Authorized_fetch
-	 * @see https://swicg.github.io/activitypub-http-signature/#authorized-fetch
-	 *
-	 * @param WP_REST_Response|\WP_HTTP_Response|WP_Error|mixed $response Result to send to the client.
-	 *                                                                    Usually a WP_REST_Response or WP_Error.
-	 * @param array                                             $handler  Route handler used for the request.
-	 * @param \WP_REST_Request                                  $request  Request used to generate the response.
-	 *
-	 * @return mixed|WP_Error The response, error, or modified response.
-	 */
-	public static function authorize_activitypub_requests( $response, $handler, $request ) {
-		if ( 'HEAD' === $request->get_method() ) {
-			return $response;
-		}
-
-		if ( \is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$route = $request->get_route();
-
-		// Check if it is an activitypub request and exclude webfinger and nodeinfo endpoints.
-		if (
-			! \str_starts_with( $route, '/' . ACTIVITYPUB_REST_NAMESPACE ) ||
-			\str_starts_with( $route, '/' . \trailingslashit( ACTIVITYPUB_REST_NAMESPACE ) . 'webfinger' ) ||
-			\str_starts_with( $route, '/' . \trailingslashit( ACTIVITYPUB_REST_NAMESPACE ) . 'nodeinfo' ) ||
-			\str_starts_with( $route, '/' . \trailingslashit( ACTIVITYPUB_REST_NAMESPACE ) . 'application' )
-		) {
-			return $response;
-		}
-
-		/**
-		 * Filter to defer signature verification.
-		 *
-		 * Skip signature verification for debugging purposes or to reduce load for
-		 * certain Activity-Types, like "Delete".
-		 *
-		 * @param bool             $defer   Whether to defer signature verification.
-		 * @param \WP_REST_Request $request The request used to generate the response.
-		 *
-		 * @return bool Whether to defer signature verification.
-		 */
-		$defer = \apply_filters( 'activitypub_defer_signature_verification', false, $request );
-
-		if ( $defer ) {
-			return $response;
-		}
-
-		if (
-			// POST-Requests are always signed.
-			'GET' !== $request->get_method() ||
-			// GET-Requests only require a signature in secure mode.
-			( 'GET' === $request->get_method() && use_authorized_fetch() )
-		) {
-			$verified_request = Signature::verify_http_signature( $request );
-			if ( \is_wp_error( $verified_request ) ) {
-				return new WP_Error(
-					'activitypub_signature_verification',
-					$verified_request->get_error_message(),
-					array( 'status' => 401 )
-				);
-			}
-		}
-
-		return $response;
 	}
 
 	/**

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -84,7 +84,7 @@ class Server {
 	 *
 	 * @return bool Whether the request is authorized.
 	 */
-	public static function authorize_activitypub_permissions( $request ) {
+	public static function signature_verification( $request ) {
 		if ( 'HEAD' === $request->get_method() ) {
 			return true;
 		}
@@ -98,7 +98,7 @@ class Server {
 		 * @param bool             $defer   Whether to defer signature verification.
 		 * @param \WP_REST_Request $request The request used to generate the response.
 		 *
-		 * @return bool Whether to defer signature verification.
+		 * @return bool|WP_Error True if the request is authorized, WP_Error if not.
 		 */
 		$defer = \apply_filters( 'activitypub_defer_signature_verification', false, $request );
 
@@ -107,14 +107,18 @@ class Server {
 		}
 
 		if (
-			// POST-Requests are always signed.
+			// POST-Requests have to be always signed.
 			'GET' !== $request->get_method() ||
 			// GET-Requests only require a signature in secure mode.
 			( 'GET' === $request->get_method() && use_authorized_fetch() )
 		) {
 			$verified_request = Signature::verify_http_signature( $request );
 			if ( \is_wp_error( $verified_request ) ) {
-				return false;
+				return new WP_Error(
+					'activitypub_signature_verification',
+					$verified_request->get_error_message(),
+					array( 'status' => 401 )
+				);
 			}
 		}
 

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -119,7 +119,7 @@ class Server {
 			$verified_request = Signature::verify_http_signature( $request );
 			if ( \is_wp_error( $verified_request ) ) {
 				return new WP_Error(
-					'activitypub_verify_signature',
+					'activitypub_signature_verification',
 					$verified_request->get_error_message(),
 					array( 'status' => 401 )
 				);

--- a/readme.txt
+++ b/readme.txt
@@ -142,6 +142,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Improved: Interactions moderation
 * Improved: Compatibility with Akismet
 * Improved: Comment type mapping for `Like` and `Announce`
+* Improved: Signature verification for API endpoints
 * Fixed: Empty `url` attributes in the Reply block no longer cause PHP warnings
 
 = 4.4.0 =

--- a/tests/includes/rest/class-test-inbox.php
+++ b/tests/includes/rest/class-test-inbox.php
@@ -51,7 +51,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$response = \rest_do_request( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
-		$this->assertEquals( 'activitypub_signature_verification', $response->get_data()['code'] );
+		$this->assertEquals( 'rest_forbidden', $response->get_data()['code'] );
 	}
 
 	/**

--- a/tests/includes/rest/class-test-inbox.php
+++ b/tests/includes/rest/class-test-inbox.php
@@ -13,6 +13,48 @@ namespace Activitypub\Tests\Rest;
  * @coversDefaultClass \Activitypub\Rest\Inbox
  */
 class Test_Inbox extends \WP_UnitTestCase {
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Post ID.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Create fake data before tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that creates fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		self::$post_id = $factory->post->create(
+			array(
+				'post_author'  => self::$user_id,
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test Content',
+				'post_status'  => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public static function wpTearDownAfterClass() {
+		wp_delete_user( self::$user_id );
+	}
 
 	/**
 	 * Set up the test.
@@ -28,7 +70,6 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		\delete_option( 'permalink_structure' );
-		\add_filter( 'activitypub_defer_signature_verification', '__return_false' );
 	}
 
 	/**
@@ -75,6 +116,8 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'rest_missing_callback_param', $response->get_data()['code'] );
 		$this->assertEquals( 'object', $response->get_data()['data']['params'][0] );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 	}
 
 	/**
@@ -97,6 +140,8 @@ class Test_Inbox extends \WP_UnitTestCase {
 		// Dispatch the request.
 		$response = \rest_do_request( $request );
 		$this->assertEquals( 202, $response->get_status() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 	}
 
 	/**
@@ -119,6 +164,8 @@ class Test_Inbox extends \WP_UnitTestCase {
 		// Dispatch the request.
 		$response = \rest_do_request( $request );
 		$this->assertEquals( 202, $response->get_status() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 	}
 
 	/**
@@ -159,6 +206,8 @@ class Test_Inbox extends \WP_UnitTestCase {
 		// Dispatch the request.
 		$response = \rest_do_request( $request );
 		$this->assertEquals( 202, $response->get_status() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 	}
 
 	/**
@@ -199,6 +248,8 @@ class Test_Inbox extends \WP_UnitTestCase {
 		// Dispatch the request.
 		$response = \rest_do_request( $request );
 		$this->assertEquals( 202, $response->get_status() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 	}
 
 	/**
@@ -227,6 +278,8 @@ class Test_Inbox extends \WP_UnitTestCase {
 		// Dispatch the request.
 		$response = \rest_do_request( $request );
 		$this->assertEquals( 202, $response->get_status() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 	}
 
 	/**
@@ -249,6 +302,8 @@ class Test_Inbox extends \WP_UnitTestCase {
 		// Dispatch the request.
 		$response = \rest_do_request( $request );
 		$this->assertEquals( 202, $response->get_status() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 	}
 
 	/**
@@ -271,6 +326,8 @@ class Test_Inbox extends \WP_UnitTestCase {
 		// Dispatch the request.
 		$response = \rest_do_request( $request );
 		$this->assertEquals( 202, $response->get_status() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 	}
 
 	/**
@@ -353,5 +410,79 @@ class Test_Inbox extends \WP_UnitTestCase {
 				true,
 			),
 		);
+	}
+
+	/**
+	 * Test user_inbox_post verification.
+	 *
+	 * @covers ::user_inbox_post
+	 */
+	public function test_user_inbox_post_verification() {
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function ( $json, $actor ) {
+				$user       = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
+				$public_key = \Activitypub\Signature::get_public_key_for( $user->get__id() );
+
+				// Return ActivityPub Profile with signature.
+				return array(
+					'id'        => $actor,
+					'type'      => 'Person',
+					'publicKey' => array(
+						'id'           => $actor . '#main-key',
+						'owner'        => $actor,
+						'publicKeyPem' => $public_key,
+					),
+				);
+			},
+			10,
+			2
+		);
+
+		// Get the post object
+		$post = get_post( self::$post_id );
+
+		// Test valid request.
+		$actor    = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
+		$object   = \Activitypub\Transformer\Post::transform( $post )->to_object();
+		$activity = new \Activitypub\Activity\Activity( 'Like' );
+		$activity->from_array( array(
+			'id'     => 'https://example.com/activity/1',
+			'type'   => 'Like',
+			'actor'  => 'https://example.com/actor',
+			'object' => $object->get_id(),
+		) );
+
+		// Mock remote actor URL
+		$activity->add_cc( $actor->get_id() );
+		$activity = $activity->to_json();
+
+		// Generate_digest & generate_signature.
+		$digest    = \Activitypub\Signature::generate_digest( $activity );
+		$date      = gmdate( 'D, d M Y H:i:s T' );
+		$signature = \Activitypub\Signature::generate_signature( self::$user_id, 'POST', $actor->get_inbox(), $date, $digest );
+
+		$this->assertMatchesRegularExpression(
+			'/keyId="' . preg_quote( $actor->get_id(), '/' ) . '#main-key",algorithm="rsa-sha256",headers="\(request-target\) host date digest",signature="[^"]*"/',
+			$signature
+		);
+
+		// Signed headers.
+		$url_parts = wp_parse_url( $actor->get_inbox() );
+		$route     = $url_parts['path'];
+		$host      = $url_parts['host'];
+
+		$request = new \WP_REST_Request( 'POST', str_replace( '/wp-json', '', $route ) );
+		$request->set_header( 'content-type', 'application/activity+json' );
+		$request->set_header( 'digest', $digest );
+		$request->set_header( 'signature', $signature );
+		$request->set_header( 'date', $date );
+		$request->set_header( 'host', $host );
+		$request->set_body( $activity );
+
+		$response = \rest_do_request( $request );
+		$this->assertEquals( 202, $response->get_status() );
+
+		remove_filter( 'pre_get_remote_metadata_by_actor', '__return_true' );
 	}
 }

--- a/tests/includes/rest/class-test-inbox.php
+++ b/tests/includes/rest/class-test-inbox.php
@@ -439,21 +439,23 @@ class Test_Inbox extends \WP_UnitTestCase {
 			2
 		);
 
-		// Get the post object
+		// Get the post object.
 		$post = get_post( self::$post_id );
 
 		// Test valid request.
 		$actor    = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
 		$object   = \Activitypub\Transformer\Post::transform( $post )->to_object();
 		$activity = new \Activitypub\Activity\Activity( 'Like' );
-		$activity->from_array( array(
-			'id'     => 'https://example.com/activity/1',
-			'type'   => 'Like',
-			'actor'  => 'https://example.com/actor',
-			'object' => $object->get_id(),
-		) );
+		$activity->from_array(
+			array(
+				'id'     => 'https://example.com/activity/1',
+				'type'   => 'Like',
+				'actor'  => 'https://example.com/actor',
+				'object' => $object->get_id(),
+			)
+		);
 
-		// Mock remote actor URL
+		// Mock remote actor URL.
 		$activity->add_cc( $actor->get_id() );
 		$activity = $activity->to_json();
 

--- a/tests/includes/rest/class-test-inbox.php
+++ b/tests/includes/rest/class-test-inbox.php
@@ -28,14 +28,14 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		\delete_option( 'permalink_structure' );
-		\add_filter( 'activitypub_defer_signature_verification', '__return_false' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_false' );
 	}
 
 	/**
 	 * Test the inbox signature issue.
 	 */
 	public function test_inbox_signature_issue() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_false' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_false' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -51,14 +51,14 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$response = \rest_do_request( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
-		$this->assertEquals( 'activitypub_signature_verification', $response->get_data()['code'] );
+		$this->assertEquals( 'activitypub_verify_signature', $response->get_data()['code'] );
 	}
 
 	/**
 	 * Test missing attribute.
 	 */
 	public function test_missing_attribute() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
 
 		$json = array(
 			'id'    => 'https://remote.example/@id',
@@ -81,7 +81,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test follow request.
 	 */
 	public function test_follow_request() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -103,7 +103,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test follow request global inbox.
 	 */
 	public function test_follow_request_global_inbox() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -125,7 +125,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test create request with a remote actor.
 	 */
 	public function test_create_request() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
 
 		// Invalid request, because of an invalid object.
 		$json = array(
@@ -165,7 +165,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test create request global inbox.
 	 */
 	public function test_create_request_global_inbox() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
 
 		// Invalid request, because of an invalid object.
 		$json = array(
@@ -205,7 +205,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test update request.
 	 */
 	public function test_update_request() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -233,7 +233,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test like request.
 	 */
 	public function test_like_request() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -255,7 +255,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test announce request.
 	 */
 	public function test_announce_request() {
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',

--- a/tests/includes/rest/class-test-inbox.php
+++ b/tests/includes/rest/class-test-inbox.php
@@ -51,7 +51,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$response = \rest_do_request( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
-		$this->assertEquals( 'activitypub_verify_signature', $response->get_data()['code'] );
+		$this->assertEquals( 'activitypub_signature_verification', $response->get_data()['code'] );
 	}
 
 	/**

--- a/tests/includes/rest/class-test-inbox.php
+++ b/tests/includes/rest/class-test-inbox.php
@@ -51,7 +51,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$response = \rest_do_request( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
-		$this->assertEquals( 'rest_forbidden', $response->get_data()['code'] );
+		$this->assertEquals( 'activitypub_signature_verification', $response->get_data()['code'] );
 	}
 
 	/**

--- a/tests/includes/rest/class-test-inbox.php
+++ b/tests/includes/rest/class-test-inbox.php
@@ -28,14 +28,14 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		\delete_option( 'permalink_structure' );
-		\add_filter( 'activitypub_defer_verify_signature', '__return_false' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_false' );
 	}
 
 	/**
 	 * Test the inbox signature issue.
 	 */
 	public function test_inbox_signature_issue() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_false' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_false' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -58,7 +58,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test missing attribute.
 	 */
 	public function test_missing_attribute() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
 		$json = array(
 			'id'    => 'https://remote.example/@id',
@@ -81,7 +81,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test follow request.
 	 */
 	public function test_follow_request() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -103,7 +103,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test follow request global inbox.
 	 */
 	public function test_follow_request_global_inbox() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -125,7 +125,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test create request with a remote actor.
 	 */
 	public function test_create_request() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
 		// Invalid request, because of an invalid object.
 		$json = array(
@@ -165,7 +165,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test create request global inbox.
 	 */
 	public function test_create_request_global_inbox() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
 		// Invalid request, because of an invalid object.
 		$json = array(
@@ -205,7 +205,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test update request.
 	 */
 	public function test_update_request() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -233,7 +233,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test like request.
 	 */
 	public function test_like_request() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',
@@ -255,7 +255,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * Test announce request.
 	 */
 	public function test_announce_request() {
-		\add_filter( 'activitypub_defer_verify_signature', '__return_true' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
 		$json = array(
 			'id'     => 'https://remote.example/@id',


### PR DESCRIPTION
This is a proposal to use the `permission_callback`, instead of a general hook, to verify signatures.

The advantage is, that it is easier to enable/disable verification for specific endpoints this way.

See #1077

