### PR TITLE
Change priority of attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improve Interactions moderation
 * Compatibility with Akismet
 * Comment type mapping for `Like` and `Announce`
+* Changed priority of Attachments, to favor `Image` over `Audio` and `Video`
 
 ### Fixed
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -311,9 +311,9 @@ class Post extends Base {
 		);
 
 		$media = array(
+			'image' => array(),
 			'audio' => array(),
 			'video' => array(),
-			'image' => array(),
 		);
 		$id    = $this->wp_object->ID;
 

--- a/readme.txt
+++ b/readme.txt
@@ -142,6 +142,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Improved: Interactions moderation
 * Improved: Compatibility with Akismet
 * Improved: Comment type mapping for `Like` and `Announce`
+* Improved: Changed priority of Attachments, to favor `Image` over `Audio` and `Video`
 * Fixed: Empty `url` attributes in the Reply block no longer cause PHP warnings
 
 = 4.4.0 =


### PR DESCRIPTION
Use `image` as highest prio, followed by `audio` and `video`.

This should also improve the enclosure handling.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #790 and https://wordpress.org/support/topic/incorrect-image-attached-to-post/

