### PR TITLE
Tests: Make it easier to run unit tests locally

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,17 @@
 {
 	"core": null,
-	"plugins": [ "." ]
+	"plugins": [ "." ],
+	"env": {
+		"tests": {
+			"config": {
+				"WP_TESTS_DOMAIN": "example.org",
+				"WP_SITEURL": "http://example.org",
+				"WP_HOME": "http://example.org"
+			},
+			"mappings": {
+				"wp-content/plugins/activitypub": ".",
+				"wp-content/plugins/activitypub/tests": "./tests"
+			}
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
             "bin/install-wp-tests.sh activitypub-test root activitypub-test test-db latest true",
             "vendor/bin/phpunit"
         ],
+        "test:wp-env": [
+            "wp-env run tests-cli --env-cwd=\"wp-content/plugins/activitypub\" vendor/bin/phpunit"
+        ],
         "lint": [
             "vendor/bin/phpcs"
         ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev": "wp-scripts start",
     "build": "wp-scripts build",
     "env-start": "wp-env start && wp-env run cli wp rewrite structure '/%year%/%monthnum%/%postname%/'",
-    "env-stop": "wp-env stop"
+    "env-stop": "wp-env stop",
+    "env-test": "wp-env run tests-cli --env-cwd=\"wp-content/plugins/activitypub\" vendor/bin/phpunit"
   },
   "license": "MIT",
   "bugs": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,11 @@
 \define( 'ACTIVITYPUB_DISABLE_REACTIONS', false );
 \define( 'ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS', false );
 
+// Defined here because setting them in .wp-env.json doesn't work for some reason.
+\define( 'WP_TESTS_DOMAIN', 'example.org' );
+\define( 'WP_SITEURL', 'http://example.org' );
+\define( 'WP_HOME', 'http://example.org' );
+
 $_tests_dir = \getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {


### PR DESCRIPTION
Running phpunit tests locally has been a bit cumbersome for me, frequently having to look up the right docker command (` docker compose -f docker-compose-test.yml up `). This PR adds and documents npm and composer scripts that run unit tests in wp-env. 

## Running Tests

You can now run the test suite using either npm or composer:

```bash
# Using npm
npm run env-start
npm run env-test

# Using composer
wp-env start
composer run test:wp-env
```

## PHPUnit Arguments

Both commands support additional PHPUnit arguments. Add them after `--`:

```bash
# Run a specific test
npm run env-test -- --filter=test_migrate_to_4_1_0

# Run tests in a specific file
npm run env-test -- tests/includes/class-test-migration.php

# Run tests with a specific group
npm run env-test -- --group=migration

# Run tests with verbose output
npm run env-test -- --verbose

# The same works with composer
composer run test:wp-env -- --filter=test_migrate_to_4_1_0
```

Common PHPUnit arguments:
- `--filter`: Run tests matching a pattern
- `--group`: Run tests with a specific @group annotation
- `--exclude-group`: Exclude tests with a specific @group annotation
- `--verbose`: Output more verbose information
- `--debug`: Display debugging information

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds tests specific config for wp-env.
* Adds scripts for npm and composer.

