### PR TITLE
PHPUnit: Fix slow tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,9 @@
 			<directory prefix="class-test-" suffix=".php">./tests</directory>
 		</testsuite>
 	</testsuites>
+	<!--
 	<listeners>
 		<listener class="Activitypub\Tests\Activitypub_Testcase_Timer" file="tests/class-activitypub-testcase-timer.php" />
 	</listeners>
+	-->
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,4 +11,7 @@
 			<directory prefix="class-test-" suffix=".php">./tests</directory>
 		</testsuite>
 	</testsuites>
+	<listeners>
+		<listener class="Activitypub\Tests\Activitpub_Testcase_Timer" file="tests/class-activitypub-testcase-timer.php" />
+	</listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,6 @@
 		</testsuite>
 	</testsuites>
 	<listeners>
-		<listener class="Activitypub\Tests\Activitpub_Testcase_Timer" file="tests/class-activitypub-testcase-timer.php" />
+		<listener class="Activitypub\Tests\Activitypub_Testcase_Timer" file="tests/class-activitypub-testcase-timer.php" />
 	</listeners>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,68 @@ function _manually_load_plugin() {
 }
 \tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
+/**
+ * Disable HTTP requests.
+ *
+ * @param mixed  $response The value to return instead of making a HTTP request.
+ * @param array  $args     Request arguments.
+ * @param string $url      The request URL.
+ * @return mixed|false|WP_Error
+ */
+function http_disable_request( $response, $args, $url ) {
+	if ( false !== $response ) {
+		// Another filter has already overridden this request.
+		return $response;
+	}
+
+	/**
+	 * Allow HTTP requests to be made.
+	 *
+	 * @param bool  $allow Whether to allow the HTTP request.
+	 * @param array $args  Request arguments.
+	 * @param string $url  The request URL.
+	 */
+	if ( apply_filters( 'tests_allow_http_request', false, $args, $url ) ) {
+		// This request has been specifically permitted.
+		return false;
+	}
+
+	$backtrace = array_reverse( debug_backtrace() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace,PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+	$trace_str = '';
+	foreach ( $backtrace as $frame ) {
+		if (
+			( isset( $frame['file'] ) && strpos( $frame['file'], 'phpunit.php' ) !== false ) ||
+			( isset( $frame['file'] ) && strpos( $frame['file'], 'wp-includes/http.php' ) !== false ) ||
+			( isset( $frame['file'] ) && strpos( $frame['file'], 'wp-includes/class-wp-hook.php' ) !== false ) ||
+			( isset( $frame['function'] ) && __FUNCTION__ === $frame['function'] ) ||
+			( isset( $frame['function'] ) && 'apply_filters' === $frame['function'] )
+		) {
+			continue;
+		}
+
+		if ( $trace_str ) {
+			$trace_str .= ', ';
+		}
+
+		if ( ! empty( $frame['file'] ) && ! empty( $frame['line'] ) ) {
+			$trace_str .= basename( $frame['file'] ) . ':' . $frame['line'];
+			if ( ! empty( $frame['function'] ) ) {
+				$trace_str .= ' ';
+			}
+		}
+
+		if ( ! empty( $frame['function'] ) ) {
+			if ( ! empty( $frame['class'] ) ) {
+				$trace_str .= $frame['class'] . '::';
+			}
+			$trace_str .= $frame['function'] . '()';
+		}
+	}
+
+	return new WP_Error( 'killed', 'Live HTTP Request Killed by Bootstrap Code' );
+}
+\tests_add_filter( 'pre_http_request', 'http_disable_request', 99, 3 );
+
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 require __DIR__ . '/class-activitypub-testcase-cache-http.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -96,7 +96,7 @@ function http_disable_request( $response, $args, $url ) {
 		}
 	}
 
-	return new WP_Error( 'killed', 'Live HTTP Request Killed by Bootstrap Code' );
+	return new WP_Error( 'cancelled', 'Live HTTP request cancelled by bootstrap.php' );
 }
 \tests_add_filter( 'pre_http_request', 'http_disable_request', 99, 3 );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,7 @@
 \define( 'WP_SITEURL', 'http://example.org' );
 \define( 'WP_HOME', 'http://example.org' );
 
+\define( 'AP_TESTS_DIR', __DIR__ );
 $_tests_dir = \getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {

--- a/tests/class-activitypub-testcase-timer.php
+++ b/tests/class-activitypub-testcase-timer.php
@@ -2,7 +2,7 @@
 /**
  * Test Timer Listener for PHPUnit.
  *
- * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
  *
  * @package Activitypub
  */
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestSuite;
 /**
  * Activitypub Testcase Timer class.
  */
-class Activitpub_Testcase_Timer implements TestListener {
+class Activitypub_Testcase_Timer implements TestListener {
 	use TestListenerDefaultImplementation;
 
 	/**
@@ -56,7 +56,7 @@ class Activitpub_Testcase_Timer implements TestListener {
 	 * @param Test  $test The test case.
 	 * @param float $time Time taken.
 	 */
-	public function endTest( Test $test, float $time ): void {
+	public function endTest( Test $test, float $time ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$test_name = $test->getName();
 		if ( ! isset( $this->test_start_times[ $test_name ] ) ) {
 			return;

--- a/tests/class-activitypub-testcase-timer.php
+++ b/tests/class-activitypub-testcase-timer.php
@@ -56,7 +56,7 @@ class Activitypub_Testcase_Timer implements TestListener {
 	 * @param Test  $test The test case.
 	 * @param float $time Time taken.
 	 */
-	public function endTest( Test $test, float $time ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function endTest( Test $test, $time ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$test_name = $test->getName();
 		if ( ! isset( $this->test_start_times[ $test_name ] ) ) {
 			return;

--- a/tests/class-activitypub-testcase-timer.php
+++ b/tests/class-activitypub-testcase-timer.php
@@ -2,7 +2,7 @@
 /**
  * Test Timer Listener for PHPUnit.
  *
- * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped,PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
  *
  * @package Activitypub
  */

--- a/tests/class-activitypub-testcase-timer.php
+++ b/tests/class-activitypub-testcase-timer.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Test Timer Listener for PHPUnit.
+ *
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestSuite;
+
+/**
+ * Activitypub Testcase Timer class.
+ */
+class Activitpub_Testcase_Timer implements TestListener {
+	use TestListenerDefaultImplementation;
+
+	/**
+	 * Store test start times.
+	 *
+	 * @var array
+	 */
+	private $test_start_times = array();
+
+	/**
+	 * Store slow tests.
+	 *
+	 * @var array
+	 */
+	private $slow_tests = array();
+
+	/**
+	 * Threshold for slow tests in seconds.
+	 *
+	 * @var float
+	 */
+	private $slow_threshold = 0.2; // 200ms
+
+	/**
+	 * A test started.
+	 *
+	 * @param Test $test The test case.
+	 */
+	public function startTest( Test $test ): void {
+		$this->test_start_times[ $test->getName() ] = microtime( true );
+	}
+
+	/**
+	 * A test ended.
+	 *
+	 * @param Test  $test The test case.
+	 * @param float $time Time taken.
+	 */
+	public function endTest( Test $test, float $time ): void {
+		$test_name = $test->getName();
+		if ( ! isset( $this->test_start_times[ $test_name ] ) ) {
+			return;
+		}
+
+		$duration = microtime( true ) - $this->test_start_times[ $test_name ];
+		if ( $duration >= $this->slow_threshold ) {
+			$this->slow_tests[] = array(
+				'name'     => sprintf( '%s::%s', get_class( $test ), $test_name ),
+				'duration' => $duration,
+			);
+		}
+
+		unset( $this->test_start_times[ $test_name ] );
+	}
+
+	/**
+	 * A test suite ended.
+	 *
+	 * @param TestSuite $suite The test suite.
+	 */
+	public function endTestSuite( TestSuite $suite ): void {
+		if ( $suite->getName() === 'ActivityPub' && ! empty( $this->slow_tests ) ) {
+			usort(
+				$this->slow_tests,
+				function ( $a, $b ) {
+					return $b['duration'] <=> $a['duration'];
+				}
+			);
+
+			echo "\n\nSlow Tests (>= {$this->slow_threshold}s):\n";
+			foreach ( $this->slow_tests as $test ) {
+				printf(
+					"  \033[33m%.3fs\033[0m %s\n",
+					$test['duration'],
+					$test['name']
+				);
+			}
+			echo "\n";
+		}
+	}
+}

--- a/tests/includes/class-test-mention.php
+++ b/tests/includes/class-test-mention.php
@@ -30,6 +30,24 @@ class Test_Mention extends \WP_UnitTestCase {
 	);
 
 	/**
+	 * Set up the test case.
+	 */
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'pre_get_remote_metadata_by_actor' ), 10, 2 );
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request' ), 10, 3 );
+	}
+
+	/**
+	 * Tear down the test case.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'pre_get_remote_metadata_by_actor' ) );
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request' ) );
+		parent::tear_down();
+	}
+
+	/**
 	 * Test the content.
 	 *
 	 * @dataProvider the_content_provider
@@ -39,11 +57,7 @@ class Test_Mention extends \WP_UnitTestCase {
 	 * @param string $content_with_mention The content with mention.
 	 */
 	public function test_the_content( $content, $content_with_mention ) {
-		add_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'pre_get_remote_metadata_by_actor' ), 10, 2 );
-		$content = Mention::the_content( $content );
-		remove_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'pre_get_remote_metadata_by_actor' ) );
-
-		$this->assertEquals( $content_with_mention, $content );
+		$this->assertEquals( $content_with_mention, Mention::the_content( $content ) );
 	}
 
 	/**
@@ -77,17 +91,74 @@ ENDPRE;
 	}
 
 	/**
-	 * Filter for get_remote_metadata_by_actor.
+	 * Mock HTTP requests.
 	 *
-	 * @param string $pre The pre.
-	 * @param string $actor The actor.
-	 * @return array
+	 * @param false|array|\WP_Error $response    HTTP response.
+	 * @param array                 $parsed_args HTTP request arguments.
+	 * @param string                $url         The request URL.
+	 * @return array|false|\WP_Error
+	 */
+	public function pre_http_request( $response, $parsed_args, $url ) {
+		// Mock responses for remote users.
+		if ( false !== strpos( $url, 'notiz.blog' ) ) {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'id'   => 'https://notiz.blog/author/matthias-pfefferle/',
+						'url'  => 'https://notiz.blog/author/matthias-pfefferle/',
+						'name' => 'pfefferle',
+					)
+				),
+			);
+		}
+		if ( false !== strpos( $url, 'lemmy.ml' ) ) {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'id'   => 'https://lemmy.ml/u/pfefferle',
+						'url'  => 'https://lemmy.ml/u/pfefferle',
+						'name' => 'pfefferle',
+					)
+				),
+			);
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Filters remote metadata by actor.
+	 *
+	 * @param array|string $pre   The pre-filtered value.
+	 * @param string       $actor The actor.
+	 * @return array|string
 	 */
 	public static function pre_get_remote_metadata_by_actor( $pre, $actor ) {
 		$actor = ltrim( $actor, '@' );
+
 		if ( isset( self::$users[ $actor ] ) ) {
 			return self::$users[ $actor ];
 		}
+
+		// Handle remote users
+		if ( 'pfefferle@notiz.blog' === $actor ) {
+			return array(
+				'id'   => 'https://notiz.blog/author/matthias-pfefferle/',
+				'url'  => 'https://notiz.blog/author/matthias-pfefferle/',
+				'name' => 'pfefferle',
+			);
+		}
+
+		if ( 'pfefferle@lemmy.ml' === $actor ) {
+			return array(
+				'id'   => 'https://lemmy.ml/u/pfefferle',
+				'url'  => 'https://lemmy.ml/u/pfefferle',
+				'name' => 'pfefferle',
+			);
+		}
+
 		return $pre;
 	}
 }

--- a/tests/includes/class-test-mention.php
+++ b/tests/includes/class-test-mention.php
@@ -142,7 +142,7 @@ ENDPRE;
 			return self::$users[ $actor ];
 		}
 
-		// Handle remote users
+		// Handle remote users.
 		if ( 'pfefferle@notiz.blog' === $actor ) {
 			return array(
 				'id'   => 'https://notiz.blog/author/matthias-pfefferle/',

--- a/tests/includes/class-test-mention.php
+++ b/tests/includes/class-test-mention.php
@@ -100,14 +100,215 @@ ENDPRE;
 	 */
 	public function pre_http_request( $response, $parsed_args, $url ) {
 		// Mock responses for remote users.
+		if ( 'https://notiz.blog/.well-known/webfinger?resource=acct%3Apfefferle%40notiz.blog' === $url ) {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'subject' => 'acct:pfefferle@notiz.blog',
+						'aliases' => array(
+							'acct:pfefferle@notiz.blog',
+							'https://notiz.blog/author/matthias-pfefferle/',
+							'https://notiz.blog/@pfefferle',
+						),
+						'links'   => array(
+							array(
+								'rel'  => 'http://webfinger.net/rel/profile-page',
+								'type' => 'text/html',
+								'href' => 'https://notiz.blog/author/matthias-pfefferle/',
+							),
+							array(
+								'rel'  => 'http://webfinger.net/rel/avatar',
+								'href' => 'https://notiz.blog/wp-content/uploads/avatar-privacy/cache/user/1/9/19d7da2fb5b6409265f7c51eb992c3aca83b854ddb371bec96ab05d6f40a45eb-96.jpg',
+							),
+							array(
+								'rel'  => 'http://webfinger.net/rel/profile-page',
+								'type' => 'text/html',
+								'href' => 'https://pfefferle.org/',
+							),
+							array(
+								'rel'  => 'self',
+								'type' => 'application/activity+json',
+								'href' => 'https://notiz.blog/author/matthias-pfefferle/',
+							),
+							array(
+								'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+								'template' => 'https://notiz.blog/wp-api/activitypub/1.0/interactions?uri={uri}',
+							),
+							array(
+								'rel'  => 'payment',
+								'href' => 'https://www.paypal.me/matthiaspfefferle',
+							),
+							array(
+								'rel'  => 'payment',
+								'href' => 'https://liberapay.com/pfefferle/',
+							),
+							array(
+								'rel'  => 'payment',
+								'href' => 'https://notiz.blog/donate/',
+							),
+							array(
+								'rel'  => 'payment',
+								'href' => 'https://flattr.com/@pfefferle',
+							),
+							array(
+								'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/2.1',
+								'href' => 'https://notiz.blog/wp-api/nodeinfo/2.1',
+							),
+							array(
+								'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+								'href' => 'https://notiz.blog/wp-api/nodeinfo/2.0',
+							),
+							array(
+								'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/1.1',
+								'href' => 'https://notiz.blog/wp-api/nodeinfo/1.1',
+							),
+							array(
+								'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/1.0',
+								'href' => 'https://notiz.blog/wp-api/nodeinfo/1.0',
+							),
+							array(
+								'rel'  => 'http://a9.com/-/spec/opensearch/1.1/',
+								'type' => 'application/opensearchdescription+xml',
+								'href' => 'https://notiz.blog/wp-api/opensearch/1.1/document',
+							),
+							array(
+								'rel'  => 'webmention',
+								'href' => 'https://notiz.blog/wp-api/webmention/1.0/endpoint',
+							),
+							array(
+								'rel'  => 'http://webmention.org/',
+								'href' => 'https://notiz.blog/wp-api/webmention/1.0/endpoint',
+							),
+						),
+					)
+				),
+			);
+		}
+
+		if ( 'https://lemmy.ml/.well-known/webfinger?resource=acct%3Apfefferle%40lemmy.ml' === $url ) {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'subject' => 'acct:pfefferle@lemmy.ml',
+						'links'   => array(
+							array(
+								'rel'  => 'http://webfinger.net/rel/profile-page',
+								'type' => 'text/html',
+								'href' => 'https://lemmy.ml/u/pfefferle',
+							),
+							array(
+								'rel'        => 'self',
+								'type'       => 'application/activity+json',
+								'href'       => 'https://lemmy.ml/u/pfefferle',
+								'properties' => array(
+									'https://www.w3.org/ns/activitystreams#type' => 'Person',
+								),
+							),
+							array(
+								'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+								'template' => 'https://lemmy.ml/activitypub/externalInteraction?uri={uri}',
+							),
+						),
+					)
+				),
+			);
+		}
+
 		if ( false !== strpos( $url, 'notiz.blog' ) ) {
 			return array(
 				'response' => array( 'code' => 200 ),
 				'body'     => wp_json_encode(
 					array(
-						'id'   => 'https://notiz.blog/author/matthias-pfefferle/',
-						'url'  => 'https://notiz.blog/author/matthias-pfefferle/',
-						'name' => 'pfefferle',
+						'@context'                  => array(
+							'https://www.w3.org/ns/activitystreams',
+							'https://w3id.org/security/v1',
+							'https://purl.archive.org/socialweb/webfinger',
+							array(
+								'schema'                  => 'http://schema.org#',
+								'toot'                    => 'http://joinmastodon.org/ns#',
+								'lemmy'                   => 'https://join-lemmy.org/ns#',
+								'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
+								'PropertyValue'           => 'schema:PropertyValue',
+								'value'                   => 'schema:value',
+								'Hashtag'                 => 'as:Hashtag',
+								'featured'                => array(
+									'@id'   => 'toot:featured',
+									'@type' => '@id',
+								),
+								'featuredTags'            => array(
+									'@id'   => 'toot:featuredTags',
+									'@type' => '@id',
+								),
+								'moderators'              => array(
+									'@id'   => 'lemmy:moderators',
+									'@type' => '@id',
+								),
+								'attributionDomains'      => array(
+									'@id'   => 'toot:attributionDomains',
+									'@type' => '@id',
+								),
+								'postingRestrictedToMods' => 'lemmy:postingRestrictedToMods',
+								'discoverable'            => 'toot:discoverable',
+								'indexable'               => 'toot:indexable',
+							),
+						),
+						'id'                        => 'https://notiz.blog/author/matthias-pfefferle/',
+						'type'                      => 'Person',
+						'attachment'                => array(
+							array(
+								'type'  => 'PropertyValue',
+								'name'  => 'Blog',
+								'value' => '<p><a rel="me noopener" title="https://notiz.blog/" target="_blank" href="https://notiz.blog/">notiz.blog</a></p>',
+							),
+							array(
+								'type' => 'Link',
+								'name' => 'Blog',
+								'href' => 'https://notiz.blog/',
+								'rel'  => array( 'me', 'noopener' ),
+							),
+							array(
+								'type'  => 'PropertyValue',
+								'name'  => 'Podcasts',
+								'value' => '<p><a href="https://notiz.blog/podcasts" rel="me">notiz.blog/podcasts</a></p>',
+							),
+							array(
+								'type' => 'Link',
+								'name' => 'Podcasts',
+								'href' => 'https://notiz.blog/podcasts',
+								'rel'  => array( 'me' ),
+							),
+						),
+						'name'                      => 'Matthias Pfefferle',
+						'icon'                      => array(
+							'type' => 'Image',
+							'url'  => 'https://notiz.blog/wp-content/uploads/avatar-privacy/cache/user/1/9/19d7da2fb5b6409265f7c51eb992c3aca83b854ddb371bec96ab05d6f40a45eb-120.jpg',
+						),
+						'image'                     => array(
+							'type' => 'Image',
+							'url'  => 'https://notiz.blog/wp-content/uploads/2024/07/cropped-pixel-pfefferle.jpg',
+						),
+						'published'                 => '2005-11-25T11:41:56Z',
+						'summary'                   => '',
+						'tag'                       => array(),
+						'url'                       => 'https://notiz.blog/author/matthias-pfefferle/',
+						'inbox'                     => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/inbox',
+						'outbox'                    => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/outbox',
+						'following'                 => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/following',
+						'followers'                 => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/followers',
+						'preferredUsername'         => 'pfefferle',
+						'publicKey'                 => array(
+							'id'           => 'https://notiz.blog/author/matthias-pfefferle/#main-key',
+							'owner'        => 'https://notiz.blog/author/matthias-pfefferle/',
+							'publicKeyPem' => '',
+						),
+						'manuallyApprovesFollowers' => false,
+						'attributionDomains'        => array( 'notiz.blog' ),
+						'featured'                  => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/collections/featured',
+						'discoverable'              => true,
+						'indexable'                 => true,
+						'webfinger'                 => 'pfefferle@notiz.blog',
 					)
 				),
 			);
@@ -117,15 +318,33 @@ ENDPRE;
 				'response' => array( 'code' => 200 ),
 				'body'     => wp_json_encode(
 					array(
-						'id'   => 'https://lemmy.ml/u/pfefferle',
-						'url'  => 'https://lemmy.ml/u/pfefferle',
-						'name' => 'pfefferle',
+						'@context'          => array(
+							'https://join-lemmy.org/context.json',
+							'https://www.w3.org/ns/activitystreams',
+						),
+						'type'              => 'Person',
+						'id'                => 'https://lemmy.ml/u/pfefferle',
+						'preferredUsername' => 'pfefferle',
+						'inbox'             => 'https://lemmy.ml/u/pfefferle/inbox',
+						'outbox'            => 'https://lemmy.ml/u/pfefferle/outbox',
+						'publicKey'         => array(
+							'id'           => 'https://lemmy.ml/u/pfefferle#main-key',
+							'owner'        => 'https://lemmy.ml/u/pfefferle',
+							'publicKeyPem' => '',
+						),
+						'endpoints'         => array(
+							'sharedInbox' => 'https://lemmy.ml/inbox',
+						),
+						'published'         => '2020-01-07T08:09:09.600169Z',
 					)
 				),
 			);
 		}
 
-		return $response;
+		return array(
+			'response' => array( 'code' => 200 ),
+			'body'     => wp_json_encode( array() ),
+		);
 	}
 
 	/**
@@ -140,23 +359,6 @@ ENDPRE;
 
 		if ( isset( self::$users[ $actor ] ) ) {
 			return self::$users[ $actor ];
-		}
-
-		// Handle remote users.
-		if ( 'pfefferle@notiz.blog' === $actor ) {
-			return array(
-				'id'   => 'https://notiz.blog/author/matthias-pfefferle/',
-				'url'  => 'https://notiz.blog/author/matthias-pfefferle/',
-				'name' => 'pfefferle',
-			);
-		}
-
-		if ( 'pfefferle@lemmy.ml' === $actor ) {
-			return array(
-				'id'   => 'https://lemmy.ml/u/pfefferle',
-				'url'  => 'https://lemmy.ml/u/pfefferle',
-				'name' => 'pfefferle',
-			);
 		}
 
 		return $pre;

--- a/tests/includes/class-test-mention.php
+++ b/tests/includes/class-test-mention.php
@@ -101,250 +101,26 @@ ENDPRE;
 	public function pre_http_request( $response, $parsed_args, $url ) {
 		// Mock responses for remote users.
 		if ( 'https://notiz.blog/.well-known/webfinger?resource=acct%3Apfefferle%40notiz.blog' === $url ) {
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => wp_json_encode(
-					array(
-						'subject' => 'acct:pfefferle@notiz.blog',
-						'aliases' => array(
-							'acct:pfefferle@notiz.blog',
-							'https://notiz.blog/author/matthias-pfefferle/',
-							'https://notiz.blog/@pfefferle',
-						),
-						'links'   => array(
-							array(
-								'rel'  => 'http://webfinger.net/rel/profile-page',
-								'type' => 'text/html',
-								'href' => 'https://notiz.blog/author/matthias-pfefferle/',
-							),
-							array(
-								'rel'  => 'http://webfinger.net/rel/avatar',
-								'href' => 'https://notiz.blog/wp-content/uploads/avatar-privacy/cache/user/1/9/19d7da2fb5b6409265f7c51eb992c3aca83b854ddb371bec96ab05d6f40a45eb-96.jpg',
-							),
-							array(
-								'rel'  => 'http://webfinger.net/rel/profile-page',
-								'type' => 'text/html',
-								'href' => 'https://pfefferle.org/',
-							),
-							array(
-								'rel'  => 'self',
-								'type' => 'application/activity+json',
-								'href' => 'https://notiz.blog/author/matthias-pfefferle/',
-							),
-							array(
-								'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
-								'template' => 'https://notiz.blog/wp-api/activitypub/1.0/interactions?uri={uri}',
-							),
-							array(
-								'rel'  => 'payment',
-								'href' => 'https://www.paypal.me/matthiaspfefferle',
-							),
-							array(
-								'rel'  => 'payment',
-								'href' => 'https://liberapay.com/pfefferle/',
-							),
-							array(
-								'rel'  => 'payment',
-								'href' => 'https://notiz.blog/donate/',
-							),
-							array(
-								'rel'  => 'payment',
-								'href' => 'https://flattr.com/@pfefferle',
-							),
-							array(
-								'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/2.1',
-								'href' => 'https://notiz.blog/wp-api/nodeinfo/2.1',
-							),
-							array(
-								'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/2.0',
-								'href' => 'https://notiz.blog/wp-api/nodeinfo/2.0',
-							),
-							array(
-								'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/1.1',
-								'href' => 'https://notiz.blog/wp-api/nodeinfo/1.1',
-							),
-							array(
-								'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/1.0',
-								'href' => 'https://notiz.blog/wp-api/nodeinfo/1.0',
-							),
-							array(
-								'rel'  => 'http://a9.com/-/spec/opensearch/1.1/',
-								'type' => 'application/opensearchdescription+xml',
-								'href' => 'https://notiz.blog/wp-api/opensearch/1.1/document',
-							),
-							array(
-								'rel'  => 'webmention',
-								'href' => 'https://notiz.blog/wp-api/webmention/1.0/endpoint',
-							),
-							array(
-								'rel'  => 'http://webmention.org/',
-								'href' => 'https://notiz.blog/wp-api/webmention/1.0/endpoint',
-							),
-						),
-					)
-				),
-			);
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			return json_decode( file_get_contents( AP_TESTS_DIR . '/fixtures/notiz-blog-well-known-webfinger.json' ), true );
 		}
 
 		if ( 'https://lemmy.ml/.well-known/webfinger?resource=acct%3Apfefferle%40lemmy.ml' === $url ) {
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => wp_json_encode(
-					array(
-						'subject' => 'acct:pfefferle@lemmy.ml',
-						'links'   => array(
-							array(
-								'rel'  => 'http://webfinger.net/rel/profile-page',
-								'type' => 'text/html',
-								'href' => 'https://lemmy.ml/u/pfefferle',
-							),
-							array(
-								'rel'        => 'self',
-								'type'       => 'application/activity+json',
-								'href'       => 'https://lemmy.ml/u/pfefferle',
-								'properties' => array(
-									'https://www.w3.org/ns/activitystreams#type' => 'Person',
-								),
-							),
-							array(
-								'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
-								'template' => 'https://lemmy.ml/activitypub/externalInteraction?uri={uri}',
-							),
-						),
-					)
-				),
-			);
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			return json_decode( file_get_contents( AP_TESTS_DIR . '/fixtures/lemmy-ml-well-known-webfinger.json' ), true );
 		}
 
-		if ( false !== strpos( $url, 'notiz.blog' ) ) {
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => wp_json_encode(
-					array(
-						'@context'                  => array(
-							'https://www.w3.org/ns/activitystreams',
-							'https://w3id.org/security/v1',
-							'https://purl.archive.org/socialweb/webfinger',
-							array(
-								'schema'                  => 'http://schema.org#',
-								'toot'                    => 'http://joinmastodon.org/ns#',
-								'lemmy'                   => 'https://join-lemmy.org/ns#',
-								'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
-								'PropertyValue'           => 'schema:PropertyValue',
-								'value'                   => 'schema:value',
-								'Hashtag'                 => 'as:Hashtag',
-								'featured'                => array(
-									'@id'   => 'toot:featured',
-									'@type' => '@id',
-								),
-								'featuredTags'            => array(
-									'@id'   => 'toot:featuredTags',
-									'@type' => '@id',
-								),
-								'moderators'              => array(
-									'@id'   => 'lemmy:moderators',
-									'@type' => '@id',
-								),
-								'attributionDomains'      => array(
-									'@id'   => 'toot:attributionDomains',
-									'@type' => '@id',
-								),
-								'postingRestrictedToMods' => 'lemmy:postingRestrictedToMods',
-								'discoverable'            => 'toot:discoverable',
-								'indexable'               => 'toot:indexable',
-							),
-						),
-						'id'                        => 'https://notiz.blog/author/matthias-pfefferle/',
-						'type'                      => 'Person',
-						'attachment'                => array(
-							array(
-								'type'  => 'PropertyValue',
-								'name'  => 'Blog',
-								'value' => '<p><a rel="me noopener" title="https://notiz.blog/" target="_blank" href="https://notiz.blog/">notiz.blog</a></p>',
-							),
-							array(
-								'type' => 'Link',
-								'name' => 'Blog',
-								'href' => 'https://notiz.blog/',
-								'rel'  => array( 'me', 'noopener' ),
-							),
-							array(
-								'type'  => 'PropertyValue',
-								'name'  => 'Podcasts',
-								'value' => '<p><a href="https://notiz.blog/podcasts" rel="me">notiz.blog/podcasts</a></p>',
-							),
-							array(
-								'type' => 'Link',
-								'name' => 'Podcasts',
-								'href' => 'https://notiz.blog/podcasts',
-								'rel'  => array( 'me' ),
-							),
-						),
-						'name'                      => 'Matthias Pfefferle',
-						'icon'                      => array(
-							'type' => 'Image',
-							'url'  => 'https://notiz.blog/wp-content/uploads/avatar-privacy/cache/user/1/9/19d7da2fb5b6409265f7c51eb992c3aca83b854ddb371bec96ab05d6f40a45eb-120.jpg',
-						),
-						'image'                     => array(
-							'type' => 'Image',
-							'url'  => 'https://notiz.blog/wp-content/uploads/2024/07/cropped-pixel-pfefferle.jpg',
-						),
-						'published'                 => '2005-11-25T11:41:56Z',
-						'summary'                   => '',
-						'tag'                       => array(),
-						'url'                       => 'https://notiz.blog/author/matthias-pfefferle/',
-						'inbox'                     => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/inbox',
-						'outbox'                    => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/outbox',
-						'following'                 => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/following',
-						'followers'                 => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/followers',
-						'preferredUsername'         => 'pfefferle',
-						'publicKey'                 => array(
-							'id'           => 'https://notiz.blog/author/matthias-pfefferle/#main-key',
-							'owner'        => 'https://notiz.blog/author/matthias-pfefferle/',
-							'publicKeyPem' => '',
-						),
-						'manuallyApprovesFollowers' => false,
-						'attributionDomains'        => array( 'notiz.blog' ),
-						'featured'                  => 'https://notiz.blog/wp-api/activitypub/1.0/actors/1/collections/featured',
-						'discoverable'              => true,
-						'indexable'                 => true,
-						'webfinger'                 => 'pfefferle@notiz.blog',
-					)
-				),
-			);
-		}
-		if ( false !== strpos( $url, 'lemmy.ml' ) ) {
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => wp_json_encode(
-					array(
-						'@context'          => array(
-							'https://join-lemmy.org/context.json',
-							'https://www.w3.org/ns/activitystreams',
-						),
-						'type'              => 'Person',
-						'id'                => 'https://lemmy.ml/u/pfefferle',
-						'preferredUsername' => 'pfefferle',
-						'inbox'             => 'https://lemmy.ml/u/pfefferle/inbox',
-						'outbox'            => 'https://lemmy.ml/u/pfefferle/outbox',
-						'publicKey'         => array(
-							'id'           => 'https://lemmy.ml/u/pfefferle#main-key',
-							'owner'        => 'https://lemmy.ml/u/pfefferle',
-							'publicKeyPem' => '',
-						),
-						'endpoints'         => array(
-							'sharedInbox' => 'https://lemmy.ml/inbox',
-						),
-						'published'         => '2020-01-07T08:09:09.600169Z',
-					)
-				),
-			);
+		if ( 'https://notiz.blog/author/matthias-pfefferle/' === $url ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			return json_decode( file_get_contents( AP_TESTS_DIR . '/fixtures/notiz-blog-author-matthias-pfefferle.json' ), true );
 		}
 
-		return array(
-			'response' => array( 'code' => 200 ),
-			'body'     => wp_json_encode( array() ),
-		);
+		if ( 'https://lemmy.ml/u/pfefferle' === $url ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			return json_decode( file_get_contents( AP_TESTS_DIR . '/fixtures/lemmy-ml-u-pfefferle.json' ), true );
+		}
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
Takes test execution from 7.8s to ~3s.

[`class-test-followers.php`](https://github.com/Automattic/wordpress-activitypub/compare/fix/slow-tests?expand=1#diff-f4a1cd985da53a0d11e13f79cd35f252fcdce604e0d61148cd3ba68a7daeef05) needs a keen eye to see if the AI has inadvertently removed an implicit test that we should keep.

Once we drop support for PHP 7.0, the listener can be enabled by default.
 
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a timing listener to tests
* Adds http request mocks and breaks up tests to make them faster.

### Other information:

- [x] Have you written new tests for your changes, if applicable?


