### PR TITLE
Add test for HTML in direct messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 * Reactions block: Remove the `wp-block-editor` dependency for frontend views 
+* Direct Messages: HTML to e-mail text conversion
 
 ### Fixed
 * Direct Messages: Don't send notification for received public activities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 * Reactions block: Remove the `wp-block-editor` dependency for frontend views 
-* Direct Messages: HTML to e-mail text conversion
+* Direct Messages: Improve HTML to e-mail text conversion
 
 ### Fixed
 * Direct Messages: Don't send notification for received public activities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Improved
+
+* Direct Messages: Improve HTML to e-mail text conversion
+
 ## [4.5.1] - 2024-12-18
 
 ### Improved
 
-* Reactions block: Remove the `wp-block-editor` dependency for frontend views 
-* Direct Messages: Improve HTML to e-mail text conversion
 * Reactions block: Remove the `wp-block-editor` dependency for frontend views
-
 
 ### Fixed
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -171,10 +171,17 @@ class Mailer {
 			$email = $user->user_email;
 		}
 
+		$content = \html_entity_decode(
+			\wp_strip_all_tags(
+				str_replace( '</p>', PHP_EOL . PHP_EOL, $activity['object']['content'] )
+			),
+			ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+		);
+
 		/* translators: 1: Blog name, 2 Actor name */
 		$subject = \sprintf( \esc_html__( '[%1$s] Direct Message from: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \esc_html( $actor['name'] ) );
 		/* translators: 1: Blog name, 2: Actor name */
-		$message = \sprintf( \esc_html__( 'New Direct Message: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \html_entity_decode( \wp_strip_all_tags( str_replace( '</p>', PHP_EOL . PHP_EOL, $activity['object']['content'] ) ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) ) . "\r\n\r\n";
+		$message = \sprintf( \esc_html__( 'New Direct Message: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), $content ) . "\r\n\r\n";
 		/* translators: Actor name */
 		$message .= \sprintf( \esc_html__( 'From: %s', 'activitypub' ), \esc_html( $actor['name'] ) ) . "\r\n";
 		/* translators: Actor URL */

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -174,7 +174,7 @@ class Mailer {
 		/* translators: 1: Blog name, 2 Actor name */
 		$subject = \sprintf( \esc_html__( '[%1$s] Direct Message from: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \esc_html( $actor['name'] ) );
 		/* translators: 1: Blog name, 2: Actor name */
-		$message = \sprintf( \esc_html__( 'New Direct Message: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \wp_strip_all_tags( $activity['object']['content'] ) ) . "\r\n\r\n";
+		$message = \sprintf( \esc_html__( 'New Direct Message: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \html_entity_decode( \wp_strip_all_tags( str_replace( '</p>', PHP_EOL . PHP_EOL, $activity['object']['content'] ) ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) ) . "\r\n\r\n";
 		/* translators: Actor name */
 		$message .= \sprintf( \esc_html__( 'From: %s', 'activitypub' ), \esc_html( $actor['name'] ) ) . "\r\n";
 		/* translators: Actor URL */

--- a/readme.txt
+++ b/readme.txt
@@ -132,10 +132,13 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Improved: HTML to e-mail text conversion
+
 = 4.5.1 =
 
 * Improved: Reactions block: Remove the `wp-block-editor` dependency for frontend views
-* Improved: HTML to e-mail text conversion
 * Fixed: Direct Messages: Don't send notification for received public activities
 
 = 4.5.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Improved: Reactions block: Remove the `wp-block-editor` dependency for frontend views
+* Improved: HTML to e-mail text conversion
 * Fixed: Direct Messages: Don't send notification for received public activities
 
 = 4.5.0 =

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -308,6 +308,11 @@ class Test_Mailer extends WP_UnitTestCase {
 		wp_delete_user( $user_id );
 	}
 
+	/**
+	 * Data provider for direct message notification text.
+	 *
+	 * @return array
+	 */
 	public function direct_message_text_provider() {
 		return array(
 			'HTML entities' => array(
@@ -323,6 +328,9 @@ class Test_Mailer extends WP_UnitTestCase {
 
 	/**
 	 * Test direct message notification text.
+	 *
+	 * @param string $text     Text to test.
+	 * @param string $expected Expected result.
 	 *
 	 * @covers ::direct_message
 	 * @dataProvider direct_message_text_provider

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -307,4 +307,62 @@ class Test_Mailer extends WP_UnitTestCase {
 		remove_all_filters( 'wp_mail' );
 		wp_delete_user( $user_id );
 	}
+
+	public function direct_message_text_provider() {
+		return array(
+			'HTML entities' => array(
+				json_decode( '"<p>Interesting story from <span class=\"h-card\" translate=\"no\"><a href=\"https:\/\/example.com\/@test\" class=\"u-url mention\">@<span>test<\/span><\/a><\/span> about people who don&#39;t own their own domain.<\/p><p>&quot;This is not a new issue, of course, but Service\u2019s implementation shows limitations.&quot;<\/p>"' ),
+				'Interesting story from @test about people who don\'t own their own domain.' . PHP_EOL . PHP_EOL . '"This is not a new issue, of course, but Service’s implementation shows limitations."'
+			),
+			'invalid HTML' => array(
+				json_decode( '"<ptest"' ),
+				''
+			),
+		);
+	}
+
+	/**
+	 * Test direct message notification text.
+	 *
+	 * @covers ::direct_message
+	 * @dataProvider direct_message_text_provider
+	 */
+	public function test_direct_message_text( $text, $expected ) {
+		$user_id = self::$user_id;
+
+		$activity = array(
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'content' => $text,
+			),
+		);
+
+		// Mock remote metadata.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function () {
+				return array(
+					'name' => 'Test Sender',
+					'url'  => 'https://example.com/author',
+				);
+			}
+		);
+
+		// Capture email.
+		add_filter(
+			'wp_mail',
+			function ( $args ) use ( $expected, $user_id ) {
+				$this->assertStringContainsString( $expected, $args['message'] );
+				$this->assertEquals( get_user_by( 'id', $user_id )->user_email, $args['to'] );
+				return $args;
+			}
+		);
+
+		Mailer::direct_message( $activity, $user_id );
+
+		// Clean up.
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'wp_mail' );
+		wp_delete_user( $user_id );
+	}
 }

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -312,11 +312,11 @@ class Test_Mailer extends WP_UnitTestCase {
 		return array(
 			'HTML entities' => array(
 				json_decode( '"<p>Interesting story from <span class=\"h-card\" translate=\"no\"><a href=\"https:\/\/example.com\/@test\" class=\"u-url mention\">@<span>test<\/span><\/a><\/span> about people who don&#39;t own their own domain.<\/p><p>&quot;This is not a new issue, of course, but Service\u2019s implementation shows limitations.&quot;<\/p>"' ),
-				'Interesting story from @test about people who don\'t own their own domain.' . PHP_EOL . PHP_EOL . '"This is not a new issue, of course, but Service’s implementation shows limitations."'
+				'Interesting story from @test about people who don\'t own their own domain.' . PHP_EOL . PHP_EOL . '"This is not a new issue, of course, but Service’s implementation shows limitations."',
 			),
-			'invalid HTML' => array(
+			'invalid HTML'  => array(
 				json_decode( '"<ptest"' ),
-				''
+				'',
 			),
 		);
 	}


### PR DESCRIPTION
This improves the e-mail text when the original HTML contains entities.