### PR TITLE
Editor: Make Fediverse preview template filterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Add a filter to allow modifying the ActivityPub preview template
+
 ## [4.5.1] - 2024-12-18
 
 ### Improved

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -102,10 +102,15 @@ class Activitypub {
 		} elseif ( is_comment() ) {
 			$activitypub_template = ACTIVITYPUB_PLUGIN_DIR . '/templates/comment-json.php';
 		} elseif ( \is_singular() && ! is_post_disabled( \get_the_ID() ) ) {
-			$preview = \get_query_var( 'preview' );
-			if ( $preview ) {
+			if ( \get_query_var( 'preview' ) ) {
 				\define( 'ACTIVITYPUB_PREVIEW', true );
-				$activitypub_template = ACTIVITYPUB_PLUGIN_DIR . '/templates/post-preview.php';
+
+				/**
+				 * Filter the template used for the ActivityPub preview.
+				 *
+				 * @param string $activitypub_template Absolute path to the template file.
+				 */
+				$activitypub_template = apply_filters( 'activitypub_preview_template', ACTIVITYPUB_PLUGIN_DIR . '/templates/post-preview.php' );
 			} else {
 				$activitypub_template = ACTIVITYPUB_PLUGIN_DIR . '/templates/post-json.php';
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,10 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Added: A filter to allow modifying the ActivityPub preview template
+
 = 4.5.1 =
 
 * Improved: Reactions block: Remove the `wp-block-editor` dependency for frontend views

--- a/tests/includes/class-test-activitypub.php
+++ b/tests/includes/class-test-activitypub.php
@@ -26,4 +26,34 @@ class Test_Activitypub extends \WP_UnitTestCase {
 		$this->assertContains( 'post', \get_post_types_by_support( 'activitypub' ) );
 		$this->assertContains( 'page', \get_post_types_by_support( 'activitypub' ) );
 	}
+
+	/**
+	 * Test activitypub_preview_template filter.
+	 *
+	 * @covers ::render_activitypub_template
+	 */
+	public function test_preview_template_filter() {
+		// Create a test post.
+		$post_id = self::factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Simulate ActivityPub request and preview mode.
+		$_SERVER['HTTP_ACCEPT'] = 'application/activity+json';
+		\set_query_var( 'preview', true );
+
+		// Add filter before testing.
+		\add_filter(
+			'activitypub_preview_template',
+			function () {
+				return '/custom/template.php';
+			}
+		);
+
+		// Test that the filter is applied.
+		$template = \Activitypub\Activitypub::render_activitypub_template( 'original.php' );
+		$this->assertEquals( '/custom/template.php', $template, 'Custom preview template should be used when filter is applied.' );
+
+		// Clean up.
+		unset( $_SERVER['HTTP_ACCEPT'] );
+	}
 }


### PR DESCRIPTION
Fixes #967.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a filter for the preview template path.
* Adds unit tests for the filter.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Editor to create or edit a post.
* Click Preview > Fediverse Preview.
* Make sure the preview still works.

