### PR TITLE
Ensure that direct messages are only sent when the user is the recipient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+* Direct Messages: Test for the user being in the to field
 * Direct Messages: Improve HTML to e-mail text conversion
 
 ## [4.5.1] - 2024-12-18

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -152,13 +152,13 @@ class Mailer {
 
 		if (
 			is_activity_public( $activity ) ||
-			! in_array( \get_author_posts_url( $user_id ), $recipients )
+			! in_array( \get_author_posts_url( $user_id ), $recipients, true )
 		) {
 			return;
 		}
 
 		// Only accept messages that have the user in the "to" field.
-		if ( ! in_array( \get_author_posts_url( $user_id ), $activity['to'] ) ) {
+		if ( ! in_array( \get_author_posts_url( $user_id ), $activity['to'], true ) ) {
 			return;
 		}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -157,6 +157,11 @@ class Mailer {
 			return;
 		}
 
+		// Only accept messages that have the user in the "to" field.
+		if ( ! in_array( \get_author_posts_url( $user_id ), $activity['to'] ) ) {
+			return;
+		}
+
 		$actor = get_remote_metadata_by_actor( $activity['actor'] );
 
 		if ( ! $actor || \is_wp_error( $actor ) || empty( $activity['object']['content'] ) ) {

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -148,8 +148,12 @@ class Mailer {
 	 * @param int   $user_id  The id of the local blog-user.
 	 */
 	public static function direct_message( $activity, $user_id ) {
-		// Check if Activity is public or not.
-		if ( is_activity_public( $activity ) ) {
+		$recipients = extract_recipients_from_activity( $activity );
+
+		if (
+			is_activity_public( $activity ) ||
+			! in_array( \get_author_posts_url( $user_id ), $recipients )
+		) {
 			return;
 		}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -153,7 +153,7 @@ class Mailer {
 			is_activity_public( $activity ) ||
 			// Only accept messages that have the user in the "to" field.
 			empty( $activity['to'] ) ||
-			! in_array( ( new User( $user_id ) )->get_id(), (array) $activity['to'], true )
+			! in_array( Actors::get_by_id( $user_id )->get_id(), (array) $activity['to'], true )
 		) {
 			return;
 		}

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -8,6 +8,7 @@
 namespace Activitypub;
 
 use Activitypub\Collection\Actors;
+use Activitypub\Model\User;
 
 /**
  * Mailer Class.
@@ -152,7 +153,7 @@ class Mailer {
 			is_activity_public( $activity ) ||
 			// Only accept messages that have the user in the "to" field.
 			empty( $activity['to'] ) ||
-			! in_array( \get_author_posts_url( $user_id ), (array) $activity['to'], true )
+			! in_array( ( new User( $user_id ) )->get_id(), (array) $activity['to'], true )
 		) {
 			return;
 		}

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -148,17 +148,12 @@ class Mailer {
 	 * @param int   $user_id  The id of the local blog-user.
 	 */
 	public static function direct_message( $activity, $user_id ) {
-		$recipients = extract_recipients_from_activity( $activity );
-
 		if (
 			is_activity_public( $activity ) ||
-			! in_array( \get_author_posts_url( $user_id ), $recipients, true )
+			// Only accept messages that have the user in the "to" field.
+			empty( $activity['to'] ) ||
+			! in_array( \get_author_posts_url( $user_id ), (array) $activity['to'], true )
 		) {
-			return;
-		}
-
-		// Only accept messages that have the user in the "to" field.
-		if ( ! in_array( \get_author_posts_url( $user_id ), $activity['to'], true ) ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 = Unreleased =
 
+* Direct Messages: Test for the user being in the to field
 * Improved: HTML to e-mail text conversion
 
 = 4.5.1 =

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Tests;
 
 use Activitypub\Mailer;
+use Activitypub\Model\User;
 use Activitypub\Notification;
 use WP_UnitTestCase;
 
@@ -312,7 +313,8 @@ class Test_Mailer extends WP_UnitTestCase {
 		// We need to replace back in the user URL because the user_id is not available in the data provider.
 		$replace = function ( $url ) use ( $user_id ) {
 			if ( 'user_url' === $url ) {
-				return get_author_posts_url( $user_id );
+				return ( new User( $user_id ) )->get_id();
+
 			}
 			return $url;
 		};
@@ -406,7 +408,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			'object' => array(
 				'content' => $text,
 			),
-			'to'     => array( get_author_posts_url( $user_id ) ),
+			'to'     => array( ( new User( $user_id ) )->get_id() ),
 		);
 
 		// Mock remote metadata.

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -282,6 +282,18 @@ class Test_Mailer extends WP_UnitTestCase {
 					'to'     => array( 'https://example.com/followers' ),
 				),
 			),
+			'reply+cc'        => array(
+				false,
+				array(
+					'actor'  => 'https://example.com/author',
+					'object' => array(
+						'content'   => 'Reply activity to me and to followers',
+						'inReplyTo' => 'https://example.com/post/1',
+					),
+					'to'     => array( 'https://example.com/followers' ),
+					'cc'     => array( 'user_url' ),
+				),
+			),
 		);
 	}
 

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -8,7 +8,7 @@
 namespace Activitypub\Tests;
 
 use Activitypub\Mailer;
-use Activitypub\Model\User;
+use Activitypub\Collection\Actors;
 use Activitypub\Notification;
 use WP_UnitTestCase;
 
@@ -313,7 +313,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		// We need to replace back in the user URL because the user_id is not available in the data provider.
 		$replace = function ( $url ) use ( $user_id ) {
 			if ( 'user_url' === $url ) {
-				return ( new User( $user_id ) )->get_id();
+				return Actors::get_by_id( $user_id )->get_id();
 
 			}
 			return $url;
@@ -408,7 +408,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			'object' => array(
 				'content' => $text,
 			),
-			'to'     => array( ( new User( $user_id ) )->get_id() ),
+			'to'     => array( Actors::get_by_id( $user_id )->get_id() ),
 		);
 
 		// Mock remote metadata.

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -282,7 +282,7 @@ class Test_Mailer extends WP_UnitTestCase {
 					'to'     => array( 'https://example.com/followers' ),
 				),
 			),
-			'reply+cc'        => array(
+			'reply+cc'         => array(
 				false,
 				array(
 					'actor'  => 'https://example.com/author',
@@ -311,7 +311,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		// We need to replace back in the user URL because the user_id is not available in the data provider.
 		$replace = function ( $url ) use ( $user_id ) {
-			if ( $url === 'user_url' ) {
+			if ( 'user_url' === $url ) {
 				return get_author_posts_url( $user_id );
 			}
 			return $url;
@@ -406,7 +406,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			'object' => array(
 				'content' => $text,
 			),
-			'to' => array( get_author_posts_url( $user_id ) ),
+			'to'     => array( get_author_posts_url( $user_id ) ),
 		);
 
 		// Mock remote metadata.

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -211,20 +211,107 @@ class Test_Mailer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for direct message notification.
+	 *
+	 * @return array
+	 */
+	public function direct_message_provider() {
+		return array(
+			'to'               => array(
+				true,
+				array(
+					'actor'  => 'https://example.com/author',
+					'object' => array(
+						'content' => 'Test direct message',
+					),
+					'to'     => array( 'user_url' ),
+				),
+			),
+			'none'             => array(
+				false,
+				array(
+					'actor'  => 'https://example.com/author',
+					'object' => array(
+						'content' => 'Test direct message',
+					),
+				),
+			),
+			'public+reply'     => array(
+				false,
+				array(
+					'actor'  => 'https://example.com/author',
+					'object' => array(
+						'content'   => 'Test public reply',
+						'inReplyTo' => 'https://example.com/post/1',
+					),
+					'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+				),
+			),
+			'public+reply+cc'  => array(
+				false,
+				array(
+					'actor'  => 'https://example.com/author',
+					'object' => array(
+						'content'   => 'Test public reply',
+						'inReplyTo' => 'https://example.com/post/1',
+					),
+					'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+					'cc'     => array( 'user_url' ),
+				),
+			),
+			'public+followers' => array(
+				false,
+				array(
+					'actor'  => 'https://example.com/author',
+					'object' => array(
+						'content'   => 'Test public activity',
+						'inReplyTo' => null,
+					),
+					'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+					'cc'     => array( 'https://example.com/followers' ),
+				),
+			),
+			'followers'        => array(
+				false,
+				array(
+					'actor'  => 'https://example.com/author',
+					'object' => array(
+						'content'   => 'Test activity just to followers',
+						'inReplyTo' => null,
+					),
+					'to'     => array( 'https://example.com/followers' ),
+				),
+			),
+		);
+	}
+
+	/**
 	 * Test direct message notification.
 	 *
+	 * @param bool  $send_email Whether email should be sent.
+	 * @param array $activity   Activity object.
+	 * @dataProvider direct_message_provider
 	 * @covers ::direct_message
 	 */
-	public function test_direct_message() {
+	public function test_direct_message( $send_email, $activity ) {
 		$user_id = self::$user_id;
 		$mock    = new \MockAction();
 
-		$activity = array(
-			'actor'  => 'https://example.com/author',
-			'object' => array(
-				'content' => 'Test direct message',
-			),
-		);
+		// We need to replace back in the user URL because the user_id is not available in the data provider.
+		$replace = function ( $url ) use ( $user_id ) {
+			if ( $url === 'user_url' ) {
+				return get_author_posts_url( $user_id );
+			}
+			return $url;
+		};
+
+		foreach ( $activity as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$activity[ $key ] = array_map( $replace, $value );
+			} else {
+				$activity[ $key ] = $replace( $value );
+			}
+		}
 
 		// Mock remote metadata.
 		add_filter(
@@ -238,69 +325,33 @@ class Test_Mailer extends WP_UnitTestCase {
 		);
 		add_filter( 'wp_mail', array( $mock, 'filter' ), 1 );
 
-		// Capture email.
-		add_filter(
-			'wp_mail',
-			function ( $args ) use ( $user_id ) {
-				$this->assertStringContainsString( 'Direct Message', $args['subject'] );
-				$this->assertStringContainsString( 'Test Sender', $args['subject'] );
-				$this->assertStringContainsString( 'Test direct message', $args['message'] );
-				$this->assertStringContainsString( 'https://example.com/author', $args['message'] );
-				$this->assertEquals( get_user_by( 'id', $user_id )->user_email, $args['to'] );
-				return $args;
-			}
-		);
+		if ( $send_email ) {
+			// Capture email.
+			add_filter(
+				'wp_mail',
+				function ( $args ) use ( $user_id, $activity ) {
+					$this->assertStringContainsString( 'Direct Message', $args['subject'] );
+					$this->assertStringContainsString( 'Test Sender', $args['subject'] );
+					$this->assertStringContainsString( $activity['object']['content'], $args['message'] );
+					$this->assertStringContainsString( 'https://example.com/author', $args['message'] );
+					$this->assertEquals( get_user_by( 'id', $user_id )->user_email, $args['to'] );
+					return $args;
+				}
+			);
+		} else {
+			add_filter(
+				'wp_mail',
+				function ( $args ) {
+					$this->fail( 'Email should not be sent for public activity' );
+					return $args;
+				}
+			);
+
+		}
 
 		Mailer::direct_message( $activity, $user_id );
 
-		// Test public activity (should not send email).
-		$public_activity = array(
-			'actor'  => 'https://example.com/author',
-			'object' => array(
-				'content'   => 'Test public reply',
-				'inReplyTo' => 'https://example.com/post/1',
-			),
-			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
-		);
-
-		// Reset email capture.
-		remove_all_filters( 'wp_mail' );
-		add_filter( 'wp_mail', array( $mock, 'filter' ), 1 );
-		add_filter(
-			'wp_mail',
-			function ( $args ) {
-				$this->fail( 'Email should not be sent for public activity' );
-				return $args;
-			}
-		);
-
-		Mailer::direct_message( $public_activity, $user_id );
-
-		// Test public activity (should not send email).
-		$public_activity = array(
-			'actor'  => 'https://example.com/author',
-			'object' => array(
-				'content'   => 'Test public activity',
-				'inReplyTo' => null,
-			),
-			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
-			'cc'     => array( 'https://example.com/followers' ),
-		);
-
-		// Reset email capture.
-		remove_all_filters( 'wp_mail' );
-		add_filter( 'wp_mail', array( $mock, 'filter' ), 1 );
-		add_filter(
-			'wp_mail',
-			function ( $args ) {
-				$this->fail( 'Email should not be sent for public activity' );
-				return $args;
-			}
-		);
-
-		Mailer::direct_message( $public_activity, $user_id );
-
-		$this->assertEquals( 1, $mock->get_call_count() );
+		$this->assertEquals( $send_email ? 1 : 0, $mock->get_call_count() );
 
 		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
@@ -343,6 +394,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			'object' => array(
 				'content' => $text,
 			),
+			'to' => array( get_author_posts_url( $user_id ) ),
 		);
 
 		// Mock remote metadata.


### PR DESCRIPTION
I was still receiving e-mails when someone's message was a reply to only followers. This adds a check to see if the user is a direct recipient.
