### PR TITLE
Janitorial: Fix PHP Warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Undefined array key warnings in various places
+
 ## [4.6.0] - 2024-12-20
 
 ### Added

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -246,10 +246,10 @@ class Interactions {
 			return false;
 		}
 
-		$url = object_to_uri( $actor['url'] );
+		$url = object_to_uri( $actor['url'] ?? $actor['id'] );
 
 		if ( ! $url ) {
-			object_to_uri( $actor['id'] );
+			$url = object_to_uri( $actor['id'] );
 		}
 
 		if ( isset( $activity['object']['content'] ) ) {

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -1114,7 +1114,7 @@ class Post extends Base {
 		$blocks = \parse_blocks( $this->wp_object->post_content );
 
 		foreach ( $blocks as $block ) {
-			if ( 'activitypub/reply' === $block['blockName'] ) {
+			if ( 'activitypub/reply' === $block['blockName'] && isset( $block['attrs']['url'] ) ) {
 				// We only support one reply block per post for now.
 				return $block['attrs']['url'];
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,10 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Fixed: Undefined array key warnings in various places
+
 = 4.6.0 =
 
 * Added: A filter to allow modifying the ActivityPub preview template

--- a/templates/post-preview.php
+++ b/templates/post-preview.php
@@ -179,7 +179,7 @@ $user   = $transformer->get_actor_object();
 	<body>
 		<div class="columns">
 			<aside class="sidebar">
-				<input type="search" disabled="disabled" placeholder="<?php echo esc_html_e( 'Search', 'activitypub' ); ?>" disabled="disabled" />
+				<input type="search" disabled="disabled" placeholder="<?php esc_html_e( 'Search', 'activitypub' ); ?>" />
 				<div>
 					<div class="fake-image"></div>
 					<div>
@@ -218,7 +218,7 @@ $user   = $transformer->get_actor_object();
 					<div class="attachments">
 						<?php foreach ( $object->get_attachment() as $attachment ) : ?>
 							<?php if ( 'Image' === $attachment['type'] ) : ?>
-								<img src="<?php echo esc_url( $attachment['url'] ); ?>" alt="<?php echo esc_attr( $attachment['name'] ); ?>" />
+								<img src="<?php echo esc_url( $attachment['url'] ); ?>" alt="<?php echo esc_attr( $attachment['name'] ?? '' ); ?>" />
 							<?php endif; ?>
 						<?php endforeach; ?>
 					</div>


### PR DESCRIPTION
See p1734826115516029-slack-C04TJ8P900J

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds fallbacks and checks to avoid PHP warnings we've seen triggered on WordPress.com.