### PR TITLE
Account for pre-existing image when adding alt text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Undefined array key warnings in various places
+* Image captions not being included in the ActivityPub representation when the image is attached to the post
 
 ## [4.6.0] - 2024-12-20
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -454,10 +454,21 @@ class Post extends Base {
 							$alt = $match[2];
 						}
 
-						$media['image'][] = array(
-							'id'  => $block['attrs']['id'],
-							'alt' => $alt,
-						);
+						$found = false;
+						foreach ( $media['image'] as $i => $image ) {
+							if ( $image['id'] === $block['attrs']['id'] ) {
+								$media['image'][ $i ]['alt'] = $alt;
+								$found                       = true;
+								break;
+							}
+						}
+
+						if ( ! $found ) {
+							$media['image'][] = array(
+								'id'  => $block['attrs']['id'],
+								'alt' => $alt,
+							);
+						}
 					}
 					break;
 				case 'core/audio':

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Fixed: Undefined array key warnings in various places
+* Fixed: Image captions not being included in the ActivityPub representation when the image is attached to the post
 
 = 4.6.0 =
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1121.

I'm not quite sure if it's a bug yet, as I'm uncertain on how to recreate the scenario @jeherve is experiencing in #1121, but this PR should fix it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds image alt text to existing images if they match with the image ID in the image block.
* Adds unit tests to cover the new functionality.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post.
* Insert an image block and upload a new image to the post.
* Set this new image as the post thumbnail.
* Add a caption to the image in its block settings.
* Publish the post and view it in the front end with `?activitypub` appended to the URL.
* Make sure the caption shows up in the ActivityPub representation of the post.

