### PR TITLE
Tests: Specify port to make tests pass

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,6 +8,7 @@
 				"WP_SITEURL": "http://example.org",
 				"WP_HOME": "http://example.org"
 			},
+			"port": 80,
 			"mappings": {
 				"wp-content/plugins/activitypub": ".",
 				"wp-content/plugins/activitypub/tests": "./tests"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,11 +7,6 @@
 
 \define( 'ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS', false );
 
-// Defined here because setting them in .wp-env.json doesn't work for some reason.
-\define( 'WP_TESTS_DOMAIN', 'example.org' );
-\define( 'WP_SITEURL', 'http://example.org' );
-\define( 'WP_HOME', 'http://example.org' );
-
 \define( 'AP_TESTS_DIR', __DIR__ );
 $_tests_dir = \getenv( 'WP_TESTS_DIR' );
 


### PR DESCRIPTION
I seemed to have had a local conflict with wp-env, after setting the right port tests are passing.

See #1083.

