### PR TITLE
Fix missing migration for v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.7.1] - 2025-01-14
+
+### Fixed
+
+* Missing migration
+
 ## [4.7.0] - 2025-01-13
 
 ### Added
@@ -1200,8 +1206,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * initial
 
-[Unreleased]: https://github.com/Automattic/wordpress-activitypub/compare/4.7.0...trunk
+[Unreleased]: https://github.com/Automattic/wordpress-activitypub/compare/4.7.1...trunk
 <!-- Add new release below and update "Unreleased" link -->
+[4.7.1]: https://github.com/Automattic/wordpress-activitypub/compare/4.7.0...4.7.1
 [4.7.0]: https://github.com/Automattic/wordpress-activitypub/compare/4.6.0...4.7.0
 [4.6.0]: https://github.com/Automattic/wordpress-activitypub/compare/4.5.1...4.6.0
 [4.5.1]: https://github.com/Automattic/wordpress-activitypub/compare/4.5.0...4.5.1

--- a/activitypub.php
+++ b/activitypub.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActivityPub
  * Plugin URI: https://github.com/Automattic/wordpress-activitypub
  * Description: The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
- * Version: 4.7.0
+ * Version: 4.7.1
  * Author: Matthias Pfefferle & Automattic
  * Author URI: https://automattic.com/
  * License: MIT
@@ -19,7 +19,7 @@ namespace Activitypub;
 
 use WP_CLI;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '4.7.0' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '4.7.1' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -161,8 +161,8 @@ class Migration {
 		if ( \version_compare( $version_from_db, '4.5.0', '<' ) ) {
 			\wp_schedule_single_event( \time() + MINUTE_IN_SECONDS, 'activitypub_update_comment_counts' );
 		}
-		if ( \version_compare( $version_from_db, '4.6.0', '<' ) ) {
-			self::migrate_to_4_6_0();
+		if ( \version_compare( $version_from_db, '4.7.1', '<' ) ) {
+			self::migrate_to_4_7_1();
 		}
 
 		/**
@@ -393,7 +393,7 @@ class Migration {
 	/**
 	 * Updates post meta keys to be prefixed with an underscore.
 	 */
-	public static function migrate_to_4_6_0() {
+	public static function migrate_to_4_7_1() {
 		global $wpdb;
 
 		$meta_keys = array(

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaf
 Tags: OStatus, fediverse, activitypub, activitystream
 Requires at least: 5.5
 Tested up to: 6.7
-Stable tag: 4.7.0
+Stable tag: 4.7.1
 Requires PHP: 7.2
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -131,6 +131,10 @@ For reasons of data protection, it is not possible to see the followers of other
 5. A Blog-Profile on Mastodon
 
 == Changelog ==
+
+= 4.7.1 =
+
+* Fixed: Missing migration
 
 = 4.7.0 =
 

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -187,11 +187,11 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
-	 * Test migrate to 4.6.0.
+	 * Test migrate to 4.7.1.
 	 *
-	 * @covers ::migrate_to_4_6_0
+	 * @covers ::migrate_to_4_7_1
 	 */
-	public function test_migrate_to_4_6_0() {
+	public function test_migrate_to_4_7_1() {
 		$post1 = \wp_insert_post(
 			array(
 				'post_author'  => 1,
@@ -222,7 +222,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		}
 
 		// Run migration.
-		Migration::migrate_to_4_6_0();
+		Migration::migrate_to_4_7_1();
 
 		// Clean post cache to ensure fresh meta data.
 		\clean_post_cache( $post1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The renaming of the meta-tags #943 was planned for version 4.6.0, so the migration was set to this version, but we postponed the release to 4.7.0 without updating the migration, that is why it never ran. This results in empty follower lists.

This PR updates the version number for the migration, so that it will run after we release 4.7.1

Fixes https://wordpress.org/support/topic/did-4-7-0-break-things/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

