### PR TITLE
Add metadata to New Follower E-Mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The Outbox purging routine no longer is limited to deleting 5 items at a time.
 * Undo API for Outbox items.
+* Metadata to New Follower E-Mail.
 
 ## [5.2.0] - 2025-02-13
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -135,15 +135,15 @@ class Mailer {
 		}
 
 		/* translators: 1: Blog name, 2: Follower name */
-		$subject = \sprintf( \__( '[%1$s] Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
+		$subject = \sprintf( \__( '[%1$s] New Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
 
 		\ob_start();
 		require ACTIVITYPUB_PLUGIN_DIR . '/templates/new-follower-email.php';
 		$html_message = \ob_get_clean();
 
 		$alt_function = function ( $mailer ) use ( $actor, $admin_url ) {
-			/* translators: 1: Blog name, 2: Follower name */
-			$message = \sprintf( \__( 'New Follower: %2$s.', 'activitypub' ), \get_option( 'blogname' ), $actor['name'] ) . "\r\n\r\n";
+			/* translators: 1: Follower name */
+			$message = \sprintf( \__( 'New Follower: %1$s.', 'activitypub' ), $actor['name'] ) . "\r\n\r\n";
 			/* translators: Follower URL */
 			$message            .= \sprintf( \__( 'URL: %s', 'activitypub' ), \esc_url( $actor['url'] ) ) . "\r\n\r\n";
 			$message            .= \__( 'You can see all followers here:', 'activitypub' ) . "\r\n";

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -146,7 +146,7 @@ class Mailer {
 			$message = \sprintf( \__( 'New Follower: %2$s.', 'activitypub' ), \get_option( 'blogname' ), $actor['name'] ) . "\r\n\r\n";
 			/* translators: Follower URL */
 			$message            .= \sprintf( \__( 'URL: %s', 'activitypub' ), \esc_url( $actor['url'] ) ) . "\r\n\r\n";
-			$message            .= \esc_html__( 'You can see all followers here:', 'activitypub' ) . "\r\n";
+			$message            .= \__( 'You can see all followers here:', 'activitypub' ) . "\r\n";
 			$message            .= \esc_url( \admin_url( $admin_url ) ) . "\r\n\r\n";
 			$mailer->{'AltBody'} = $message;
 		};

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -143,11 +143,11 @@ class Mailer {
 
 		$alt_function = function ( $mailer ) use ( $actor, $admin_url ) {
 			/* translators: 1: Blog name, 2: Follower name */
-			$message = \sprintf( \__( 'New Follower: %2$s.', 'activitypub' ), \get_option( 'blogname' ), $actor['name'] ). "\r\n\r\n";
+			$message = \sprintf( \__( 'New Follower: %2$s.', 'activitypub' ), \get_option( 'blogname' ), $actor['name'] ) . "\r\n\r\n";
 			/* translators: Follower URL */
-			$message .= \sprintf( \__( 'URL: %s', 'activitypub' ), \esc_url( $actor['url'] ) ) . "\r\n\r\n";
-			$message .= \esc_html__( 'You can see all followers here:', 'activitypub' ) . "\r\n";
-			$message .= \esc_url( \admin_url( $admin_url ) ) . "\r\n\r\n";
+			$message            .= \sprintf( \__( 'URL: %s', 'activitypub' ), \esc_url( $actor['url'] ) ) . "\r\n\r\n";
+			$message            .= \esc_html__( 'You can see all followers here:', 'activitypub' ) . "\r\n";
+			$message            .= \esc_url( \admin_url( $admin_url ) ) . "\r\n\r\n";
 			$mailer->{'AltBody'} = $message;
 		};
 		\add_action( 'phpmailer_init', $alt_function );
@@ -155,7 +155,6 @@ class Mailer {
 		\wp_mail( $email, $subject, $html_message, array( 'Content-type: text/html' ) );
 
 		\remove_action( 'phpmailer_init', $alt_function );
-
 	}
 
 	/**

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -134,7 +134,13 @@ class Mailer {
 			$admin_url = '/users.php?page=activitypub-followers-list';
 		}
 
-		$template_args = array_merge( $actor, array( 'admin_url' => $admin_url ) );
+		$template_args = array_merge(
+			$actor,
+			array(
+				'admin_url' => $admin_url,
+				'target'    => $notification->target,
+			)
+		);
 
 		/* translators: 1: Blog name, 2: Follower name */
 		$subject = \sprintf( \__( '[%1$s] New Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -135,19 +135,19 @@ class Mailer {
 		}
 
 		/* translators: 1: Blog name, 2: Follower name */
-		$subject = \sprintf( \esc_html__( '[%1$s] Follower: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \esc_html( $actor['name'] ) );
-		/* translators: 1: Blog name, 2: Follower name */
-		$message = \sprintf( \esc_html__( 'New Follower: %2$s.', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \esc_html( $actor['name'] ) ) . "\r\n\r\n";
-		/* translators: Follower URL */
-		$message .= \sprintf( \esc_html__( 'URL: %s', 'activitypub' ), \esc_url( $actor['url'] ) ) . "\r\n\r\n";
-		$message .= \esc_html__( 'You can see all followers here:', 'activitypub' ) . "\r\n";
-		$message .= \esc_url( \admin_url( $admin_url ) ) . "\r\n\r\n";
+		$subject = \sprintf( \__( '[%1$s] Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
 
 		\ob_start();
 		require ACTIVITYPUB_PLUGIN_DIR . '/templates/new-follower-email.php';
 		$html_message = \ob_get_clean();
 
-		$alt_function = function ( $mailer ) use ( $message ) {
+		$alt_function = function ( $mailer ) use ( $actor, $admin_url ) {
+			/* translators: 1: Blog name, 2: Follower name */
+			$message = \sprintf( \__( 'New Follower: %2$s.', 'activitypub' ), \get_option( 'blogname' ), $actor['name'] ). "\r\n\r\n";
+			/* translators: Follower URL */
+			$message .= \sprintf( \__( 'URL: %s', 'activitypub' ), \esc_url( $actor['url'] ) ) . "\r\n\r\n";
+			$message .= \esc_html__( 'You can see all followers here:', 'activitypub' ) . "\r\n";
+			$message .= \esc_url( \admin_url( $admin_url ) ) . "\r\n\r\n";
 			$mailer->{'AltBody'} = $message;
 		};
 		\add_action( 'phpmailer_init', $alt_function );

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -134,11 +134,13 @@ class Mailer {
 			$admin_url = '/users.php?page=activitypub-followers-list';
 		}
 
+		$template_args = array_merge( $actor, array( 'admin_url' => $admin_url ) );
+
 		/* translators: 1: Blog name, 2: Follower name */
 		$subject = \sprintf( \__( '[%1$s] New Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
 
 		\ob_start();
-		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/new-follower-email.php', false, $actor );
+		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/new-follower-email.php', false, $template_args );
 		$html_message = \ob_get_clean();
 
 		$alt_function = function ( $mailer ) use ( $actor, $admin_url ) {

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -138,7 +138,7 @@ class Mailer {
 		$subject = \sprintf( \__( '[%1$s] New Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
 
 		\ob_start();
-		require ACTIVITYPUB_PLUGIN_DIR . '/templates/new-follower-email.php';
+		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/new-follower-email.php', false, $actor );
 		$html_message = \ob_get_clean();
 
 		$alt_function = function ( $mailer ) use ( $actor, $admin_url ) {

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -143,7 +143,19 @@ class Mailer {
 		$message .= \esc_html__( 'You can see all followers here:', 'activitypub' ) . "\r\n";
 		$message .= \esc_url( \admin_url( $admin_url ) ) . "\r\n\r\n";
 
-		\wp_mail( $email, $subject, $message );
+		\ob_start();
+		require ACTIVITYPUB_PLUGIN_DIR . '/templates/new-follower-email.php';
+		$html_message = \ob_get_clean();
+
+		$alt_function = function ( $mailer ) use ( $message ) {
+			$mailer->{'AltBody'} = $message;
+		};
+		\add_action( 'phpmailer_init', $alt_function );
+
+		\wp_mail( $email, $subject, $html_message, array( 'Content-type: text/html' ) );
+
+		\remove_action( 'phpmailer_init', $alt_function );
+
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 * Added: Undo API for Outbox items.
 * Added: Setting to adjust the number of days Outbox items are kept before being purged.
+* Added: Show metadata in the New Follower E-Mail.
 * Fixed: The Outbox purging routine no longer is limited to deleting 5 items at a time.
 
 = 5.2.0 =

--- a/templates/new-follower-email.php
+++ b/templates/new-follower-email.php
@@ -19,7 +19,7 @@ $args = wp_parse_args( $args );
 		<td style="vertical-align: top">
 			<a href="<?php echo esc_url( $args['url'] ); ?>" style="float: left; margin-right: 1em;">
 				<?php if ( ! empty( $args['icon']['url'] ) ) : ?>
-				<img src="<?php echo esc_url( $args['icon']['url'] ); ?>" alt="<?php echo esc_attr( $args['name'] ); ?>" width="64" height="64">
+					<img src="<?php echo esc_url( $args['icon']['url'] ); ?>" alt="<?php echo esc_attr( $args['name'] ); ?>" width="64" height="64">
 				<?php endif; ?>
 			</a>
 		</td>
@@ -35,18 +35,17 @@ $args = wp_parse_args( $args );
 			?>
 		</td>
 	</tr>
-	<tr>
-		<td colspan="2">
-			<?php
-			printf(
-				/* translators: %s: URL to followers list. */
-				wp_kses( __( 'Visit the <a href="%s">followers list</a> to see all followers.', 'activitypub' ), array( 'a' => array( 'href' => array() ) ) ),
-				esc_url( admin_url( $args['admin_url'] ) )
-			);
-			?>
-		</td>
-	</tr>
 </table>
+
+<p>
+	<?php
+	printf(
+		/* translators: %s: URL to followers list. */
+		wp_kses( __( 'Visit the <a href="%s">followers list</a> to see all followers.', 'activitypub' ), array( 'a' => array( 'href' => array() ) ) ),
+		esc_url( admin_url( $args['admin_url'] ) )
+	);
+	?>
+</p>
 
 <?php
 

--- a/templates/new-follower-email.php
+++ b/templates/new-follower-email.php
@@ -35,6 +35,17 @@ $args = wp_parse_args( $args );
 			?>
 		</td>
 	</tr>
+	<tr>
+		<td colspan="2">
+			<?php
+			printf(
+				/* translators: %s: URL to followers list. */
+				wp_kses( __( 'Visit the <a href="%s">followers list</a> to see all followers.', 'activitypub' ), array( 'a' => array( 'href' => array() ) ) ),
+				esc_url( admin_url( $args['admin_url'] ) )
+			);
+			?>
+		</td>
+	</tr>
 </table>
 
 <?php

--- a/templates/new-follower-email.php
+++ b/templates/new-follower-email.php
@@ -5,11 +5,8 @@
  * @package Activitypub
  */
 
-if ( ! isset( $actor ) ) {
-	$actor = array();
-	return;
-}
-
+/* @var array $args Template arguments. */
+$args = wp_parse_args( $args );
 ?>
 <p>
 	<?php
@@ -20,20 +17,20 @@ if ( ! isset( $actor ) ) {
 <table>
 	<tr>
 		<td style="vertical-align: top">
-			<a href="<?php echo esc_url( $actor['url'] ); ?>" style="float: left; margin-right: 1em;">
-				<?php if ( ! empty( $actor['icon']['url'] ) ) : ?>
-				<img src="<?php echo esc_url( $actor['icon']['url'] ); ?>" alt="<?php echo esc_attr( $actor['name'] ); ?>" width="64" height="64">
+			<a href="<?php echo esc_url( $args['url'] ); ?>" style="float: left; margin-right: 1em;">
+				<?php if ( ! empty( $args['icon']['url'] ) ) : ?>
+				<img src="<?php echo esc_url( $args['icon']['url'] ); ?>" alt="<?php echo esc_attr( $args['name'] ); ?>" width="64" height="64">
 				<?php endif; ?>
 			</a>
 		</td>
 		<td>
-			<a href="<?php echo esc_url( $actor['url'] ); ?>">
-				<strong><?php echo esc_html( $actor['name'] ); ?></strong> (<?php echo esc_html( $actor['url'] ); ?>)
+			<a href="<?php echo esc_url( $args['url'] ); ?>">
+				<strong><?php echo esc_html( $args['name'] ); ?></strong> (<?php echo esc_html( $args['url'] ); ?>)
 			</a>
 			<br>
 			<?php
-			if ( ! empty( $actor['summary'] ) ) :
-				echo wp_kses_post( nl2br( $actor['summary'] ) );
+			if ( ! empty( $args['summary'] ) ) :
+				echo wp_kses_post( nl2br( $args['summary'] ) );
 			endif;
 			?>
 		</td>
@@ -45,6 +42,6 @@ if ( ! isset( $actor ) ) {
 /**
  * Fires at the bottom of the new follower email.
  *
- * @param array $actor The actor that followed the blog.
+ * @param array $args The actor that followed the blog.
  */
-do_action( 'activitypub_new_follower_email', $actor );
+do_action( 'activitypub_new_follower_email', $args );

--- a/templates/new-follower-email.php
+++ b/templates/new-follower-email.php
@@ -1,0 +1,36 @@
+<p>
+	<?php
+	echo __( 'You have a new follower:', 'friends' );
+	?>
+</p>
+
+<table>
+	<tr>
+		<td style="vertical-align: top">
+			<a href="<?php echo esc_url( $actor['url'] ); ?>" style="float: left; margin-right: 1em;">
+				<?php if ( ! empty( $actor['icon']['url'] ) ) : ?>
+				<img src="<?php echo esc_url( $actor['icon']['url'] ); ?>" alt="<?php echo esc_attr( $actor['name'] ); ?>" width="64" height="64">
+				<?php endif; ?>
+			</a>
+		</td>
+		<td>
+
+			<a href="<?php echo esc_url( $actor['url'] ); ?>">
+				<strong><?php echo esc_html( $actor['name'] ); ?></strong> (<?php echo esc_html( $actor['url'] ); ?>)
+			</a>
+			<br>
+			<?php
+			if ( ! empty( $actor['summary'] ) ) {
+				echo wp_kses_post( nl2br( $actor['summary'] ) );
+			}
+			?>
+		</td>
+	</tr>
+</table>
+
+<?php
+
+/**
+ * { item_description }
+ */
+do_action( 'activitypub_new_follower_email', $actor );

--- a/templates/new-follower-email.php
+++ b/templates/new-follower-email.php
@@ -27,15 +27,14 @@ if ( ! isset( $actor ) ) {
 			</a>
 		</td>
 		<td>
-
 			<a href="<?php echo esc_url( $actor['url'] ); ?>">
 				<strong><?php echo esc_html( $actor['name'] ); ?></strong> (<?php echo esc_html( $actor['url'] ); ?>)
 			</a>
 			<br>
 			<?php
-			if ( ! empty( $actor['summary'] ) ) {
+			if ( ! empty( $actor['summary'] ) ) :
 				echo wp_kses_post( nl2br( $actor['summary'] ) );
-			}
+			endif;
 			?>
 		</td>
 	</tr>
@@ -45,5 +44,7 @@ if ( ! isset( $actor ) ) {
 
 /**
  * Fires at the bottom of the new follower email.
+ *
+ * @param array $actor The actor that followed the blog.
  */
 do_action( 'activitypub_new_follower_email', $actor );

--- a/templates/new-follower-email.php
+++ b/templates/new-follower-email.php
@@ -5,12 +5,18 @@
  * @package Activitypub
  */
 
+use Activitypub\Collection\Actors;
+
 /* @var array $args Template arguments. */
 $args = wp_parse_args( $args );
 ?>
 <p>
 	<?php
-	esc_html_e( 'You have a new follower:', 'activitypub' );
+	if ( Actors::BLOG_USER_ID === $args['target'] ) :
+		esc_html_e( 'Your blog has a new follower:', 'activitypub' );
+	else :
+		esc_html_e( 'You have a new follower:', 'activitypub' );
+	endif;
 	?>
 </p>
 

--- a/templates/new-follower-email.php
+++ b/templates/new-follower-email.php
@@ -1,6 +1,19 @@
+<?php
+/**
+ * ActivityPub New Follower E-Mail template.
+ *
+ * @package Activitypub
+ */
+
+if ( ! isset( $actor ) ) {
+	$actor = array();
+	return;
+}
+
+?>
 <p>
 	<?php
-	echo __( 'You have a new follower:', 'friends' );
+	esc_html_e( 'You have a new follower:', 'activitypub' );
 	?>
 </p>
 

--- a/templates/new-follower-email.php
+++ b/templates/new-follower-email.php
@@ -44,6 +44,6 @@ if ( ! isset( $actor ) ) {
 <?php
 
 /**
- * { item_description }
+ * Fires at the bottom of the new follower email.
  */
 do_action( 'activitypub_new_follower_email', $actor );


### PR DESCRIPTION
This adds some metadata like the user icon and the user summary to the new follower e-mail and adds an action for other plugins to include their data (for example, a Follow Back link). See https://github.com/akirk/friends/issues/428

![Screenshot 2025-01-16 at 14 46 08](https://github.com/user-attachments/assets/616777c6-2fc8-4678-95af-cfb309889e98)
