### PR TITLE
Outbox: Use post meta instead of taxonomies

### DIFF
--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -554,35 +554,59 @@ class Activitypub {
 				'delete_with_user' => true,
 				'can_export'       => true,
 				'supports'         => array(),
-				'taxonomies'       => array( 'ap_actor', 'ap_activity_type' ),
 			)
 		);
 
-		\register_taxonomy(
-			'ap_actor',
+		/**
+		 * Register Activity Type meta for Outbox items.
+		 *
+		 * @see https://www.w3.org/TR/activitystreams-vocabulary/#activity-types
+		 */
+		\register_post_meta(
 			Outbox::POST_TYPE,
+			'_activitypub_activity_type',
 			array(
-				'labels'       => array(
-					'name' => _x( 'Actor', 'post_type plural name', 'activitypub' ),
-				),
-				'hierarchical' => true,
-				'public'       => false,
-			)
-		);
-		\register_taxonomy_for_object_type( 'ap_actor', Outbox::POST_TYPE );
+				'type'              => 'string',
+				'description'       => 'The type of the activity',
+				'single'            => true,
+				'sanitize_callback' => function ( $value ) {
+					$value  = ucfirst( strtolower( $value ) );
+					$schema = array(
+						'type'    => 'string',
+						'enum'    => array( 'Accept', 'Add', 'Announce', 'Arrive', 'Block', 'Create', 'Delete', 'Dislike', 'Flag', 'Follow', 'Ignore', 'Invite', 'Join', 'Leave', 'Like', 'Listen', 'Move', 'Offer', 'Question', 'Reject', 'Read', 'Remove', 'TentativeReject', 'TentativeAccept', 'Travel', 'Undo', 'Update', 'View' ),
+						'default' => 'Announce',
+					);
 
-		\register_taxonomy(
-			'ap_activity_type',
-			Outbox::POST_TYPE,
-			array(
-				'labels'       => array(
-					'name' => _x( 'Activity Type', 'post_type plural name', 'activitypub' ),
-				),
-				'hierarchical' => true,
-				'public'       => false,
+					if ( is_wp_error( rest_validate_enum( $value, $schema, '' ) ) ) {
+						return $schema['default'];
+					}
+
+					return $value;
+				},
 			)
 		);
-		\register_taxonomy_for_object_type( 'ap_activity_type', Outbox::POST_TYPE );
+
+		\register_post_meta(
+			Outbox::POST_TYPE,
+			'_activitypub_activity_actor',
+			array(
+				'type'              => 'integer',
+				'single'            => true,
+				'sanitize_callback' => function ( $value ) {
+					$schema = array(
+						'type'    => 'string',
+						'enum'    => array( 'application', 'blog', 'user' ),
+						'default' => 'user',
+					);
+
+					if ( is_wp_error( rest_validate_enum( $value, $schema, '' ) ) ) {
+						return $schema['default'];
+					}
+
+					return $value;
+				},
+			)
+		);
 
 		// Both User and Blog Extra Fields types have the same args.
 		$args = array(

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -43,6 +43,10 @@ class Outbox {
 			// ensure that user ID is not below 0.
 			'post_author'  => \max( $user_id, 0 ),
 			'post_status'  => 'draft',
+			'meta_input'   => array(
+				'_activitypub_activity_type'  => $activity_type,
+				'_activitypub_activity_actor' => $actor,
+			),
 		);
 
 		$has_kses = false !== \has_filter( 'content_save_pre', 'wp_filter_post_kses' );
@@ -60,12 +64,6 @@ class Outbox {
 		if ( ! $id || \is_wp_error( $id ) ) {
 			return false;
 		}
-
-		// Set the actor type.
-		\wp_set_object_terms( $id, array( $actor ), 'ap_actor' );
-
-		// Set the activity type.
-		\wp_set_object_terms( $id, array( strtolower( $activity_type ) ), 'ap_activity_type' );
 
 		return $id;
 	}

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -46,7 +46,7 @@ class Outbox {
 			'meta_input'   => array(
 				'_activitypub_activity_type'     => $activity_type,
 				'_activitypub_activity_actor'    => $actor,
-        'activitypub_content_visibility' => $content_visibility,
+				'activitypub_content_visibility' => $content_visibility,
 			),
 		);
 

--- a/tests/includes/class-test-activitypub.php
+++ b/tests/includes/class-test-activitypub.php
@@ -7,12 +7,22 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Collection\Outbox;
+
 /**
  * Test class for Activitypub.
  *
  * @coversDefaultClass \Activitypub\Activitypub
  */
 class Test_Activitypub extends \WP_UnitTestCase {
+
+	/**
+	 * Set up test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		\Activitypub\Activitypub::init();
+	}
 
 	/**
 	 * Test post type support.
@@ -55,5 +65,50 @@ class Test_Activitypub extends \WP_UnitTestCase {
 
 		// Clean up.
 		unset( $_SERVER['HTTP_ACCEPT'] );
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test activity type meta sanitization.
+	 *
+	 * @dataProvider activity_meta_sanitization_provider
+	 * @covers ::register_post_types
+	 *
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 * @param mixed  $expected   Expected value for invalid meta value.
+	 */
+	public function test_activity_meta_sanitization( $meta_key, $meta_value, $expected ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'  => Outbox::POST_TYPE,
+				'meta_input' => array( $meta_key => $meta_value ),
+			)
+		);
+
+		$this->assertEquals( $meta_value, \get_post_meta( $post_id, $meta_key, true ) );
+
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'meta_input' => array( $meta_key => 'InvalidType' ),
+			)
+		);
+		$this->assertEquals( $expected, \get_post_meta( $post_id, $meta_key, true ) );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Data provider for test_activity_meta_sanitization.
+	 *
+	 * @return array
+	 */
+	public function activity_meta_sanitization_provider() {
+		return array(
+			array( '_activitypub_activity_type', 'Create', 'Announce' ),
+			array( '_activitypub_activity_actor', 'user', 'user' ),
+			array( '_activitypub_activity_actor', 'blog', 'user' ),
+		);
 	}
 }

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -35,6 +35,9 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_TestCase_Cache_HTTP {
 		$this->assertInstanceOf( 'WP_Post', $post );
 		$this->assertEquals( 'draft', $post->post_status );
 		$this->assertEquals( $json, $post->post_content );
+
+		$this->assertEquals( $type, get_post_meta( $id, '_activitypub_activity_type', true ) );
+		$this->assertEquals( 'user', get_post_meta( $id, '_activitypub_activity_actor', true ) );
 	}
 
 	/**


### PR DESCRIPTION
Actor and Activity Type have a 1:1 relationship with Activities, whereas taxonomies can have multiple or no terms associated with a post. Switching to post meta also allows for value sanitization and a bit more control over what's accepted there.

### Other information:

- [x] Have you written new tests for your changes, if applicable?


