### PR TITLE
Outbox: Add upgrade script to populate outbox items

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -19,7 +19,7 @@ namespace Activitypub;
 
 use WP_CLI;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '4.7.4' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '4.7.3' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/activitypub.php
+++ b/activitypub.php
@@ -19,7 +19,7 @@ namespace Activitypub;
 
 use WP_CLI;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '4.7.3' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '4.7.4' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -523,21 +523,23 @@ class Activitypub {
 		register_post_type(
 			Outbox::POST_TYPE,
 			array(
-				'labels'           => array(
+				'labels'              => array(
 					'name'          => _x( 'Outbox', 'post_type plural name', 'activitypub' ),
 					'singular_name' => _x( 'Outbox Item', 'post_type single name', 'activitypub' ),
 				),
-				'capabilities'     => array(
+				'capabilities'        => array(
 					'create_posts' => false,
 				),
-				'map_meta_cap'     => true,
-				'public'           => true,
-				'hierarchical'     => true,
-				'rewrite'          => false,
-				'query_var'        => false,
-				'delete_with_user' => true,
-				'can_export'       => true,
-				'supports'         => array(),
+				'map_meta_cap'        => true,
+				'public'              => true,
+				'hierarchical'        => true,
+				'rewrite'             => false,
+				'query_var'           => false,
+				'delete_with_user'    => true,
+				'can_export'          => true,
+				'supports'            => array(),
+				'exclude_from_search' => true,
+				'menu_icon'           => 'dashicons-networking',
 			)
 		);
 

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -7,8 +7,10 @@
 
 namespace Activitypub;
 
+use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use Activitypub\Transformer\Factory;
 
 /**
  * ActivityPub Migration Class
@@ -22,6 +24,7 @@ class Migration {
 	public static function init() {
 		\add_action( 'activitypub_migrate', array( self::class, 'async_migration' ) );
 		\add_action( 'activitypub_update_comment_counts', array( self::class, 'update_comment_counts' ), 10, 2 );
+		\add_action( 'activitypub_create_outbox_items', array( self::class, 'create_outbox_items' ), 10, 2 );
 
 		self::maybe_migrate();
 	}
@@ -169,6 +172,9 @@ class Migration {
 		}
 		if ( \version_compare( $version_from_db, '4.7.3', '<' ) ) {
 			add_action( 'init', 'flush_rewrite_rules', 20 );
+		}
+		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
+			\wp_schedule_single_event( \time() + MINUTE_IN_SECONDS, 'activitypub_create_outbox_items' );
 		}
 
 		/*
@@ -486,6 +492,98 @@ class Migration {
 		}
 
 		if ( count( $post_ids ) === $batch_size ) {
+			// Schedule next batch.
+			\wp_schedule_single_event(
+				time() + MINUTE_IN_SECONDS,
+				'activitypub_update_comment_counts',
+				array(
+					'batch_size' => $batch_size,
+					'offset'     => $offset + $batch_size,
+				)
+			);
+		}
+
+		self::unlock();
+	}
+
+	/**
+	 * Create outbox items for posts in batches.
+	 *
+	 * @param int $batch_size Optional. Number of posts to process per batch. Default 100.
+	 * @param int $offset     Optional. Number of posts to skip. Default 0.
+	 */
+	public static function create_outbox_items( $batch_size = 100, $offset = 0 ) {
+
+		// Bail if the existing lock is still valid.
+		if ( self::is_locked() ) {
+			\wp_schedule_single_event(
+				time() + ( 5 * MINUTE_IN_SECONDS ),
+				'activitypub_update_comment_counts',
+				array(
+					'batch_size' => $batch_size,
+					'offset'     => $offset,
+				)
+			);
+			return;
+		}
+
+		self::lock();
+
+		$post_types = \get_option( 'activitypub_support_post_types', array( 'post' ) );
+		$posts      = \get_posts(
+			array(
+				'posts_per_page' => $batch_size,
+				'offset'         => $offset,
+				'post_type'      => $post_types,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'     => array(
+					'relation' => 'OR',
+					array(
+						'key'     => 'activitypub_content_visibility',
+						'compare' => 'NOT EXISTS',
+					),
+					array(
+						'key'     => 'activitypub_content_visibility',
+						'value'   => ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL,
+						'compare' => '!=',
+					),
+				),
+			)
+		);
+
+		// Avoid multiple queries for post meta.
+		update_postmeta_cache( \wp_list_pluck( $posts, 'ID' ) );
+
+		// Don't schedule federation events while processing.
+		add_filter( 'pre_schedule_event', '__return_false' );
+
+		foreach ( $posts as $post ) {
+			$content_visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
+
+			add_to_outbox( $post, 'Create', $post->post_author, $content_visibility );
+
+			// Add Update activity when the post has been modified.
+			if ( $post->post_modified_gmt !== $post->post_date_gmt ) {
+				add_to_outbox( $post, 'Update', $post->post_author, $content_visibility );
+			}
+		}
+
+		$comments = get_comments(
+			array(
+				'author__not_in' => array( 0 ), // Limit to comments by registered users.
+				'number'         => $batch_size,
+				'offset'         => $offset,
+			)
+		);
+
+		foreach ( $comments as $comment ) {
+			add_to_outbox( $comment, 'Create', $comment->user_id );
+		}
+
+		// Allow new events to be scheduled again.
+		remove_filter( 'pre_schedule_event', '__return_false' );
+
+		if ( count( $posts ) === $batch_size || count( $comments ) === $batch_size ) {
 			// Schedule next batch.
 			\wp_schedule_single_event(
 				time() + MINUTE_IN_SECONDS,

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -23,7 +23,7 @@ class Migration {
 	 */
 	public static function init() {
 		\add_action( 'activitypub_migrate', array( self::class, 'async_migration' ) );
-		\add_action( 'activitypub_upgrade', array( self::class, 'async_upgrade' ) );
+		\add_action( 'activitypub_upgrade', array( self::class, 'async_upgrade' ), 10, 99 );
 		\add_action( 'activitypub_update_comment_counts', array( self::class, 'update_comment_counts' ), 10, 2 );
 
 		self::maybe_migrate();
@@ -221,22 +221,29 @@ class Migration {
 	 * @param mixed  ...$args  The arguments to pass to the callback.
 	 */
 	public static function async_upgrade( $callback, ...$args ) {
+		$args = \func_get_args();
+
 		// Bail if the existing lock is still valid.
 		if ( self::is_locked() ) {
-			\wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'activitypub_upgrade', \array_merge( array( $callback ), $args ) );
+			\wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'activitypub_upgrade', $args );
 			return;
 		}
 
 		self::lock();
 
-		$next = \call_user_func_array( array( self::class, $callback ), $args );
+		$callback = array_shift( $args );  // Remove $callback from arguments.
+		$next     = \call_user_func_array( array( self::class, $callback ), $args );
+
+		self::unlock();
 
 		if ( ! empty( $next ) ) {
 			// Schedule the next run, adding the result to the arguments.
-			\wp_schedule_single_event( \time() + 30, 'activitypub_upgrade', \array_merge( array( $callback ), $next ) );
+			\wp_schedule_single_event(
+				\time() + 30,
+				'activitypub_upgrade',
+				\array_merge( array( $callback ), \array_values( $next ) )
+			);
 		}
-
-		self::unlock();
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -535,11 +535,11 @@ class Migration {
 	/**
 	 * Create outbox items for posts in batches.
 	 *
-	 * @param int $batch_size Optional. Number of posts to process per batch. Default 100.
+	 * @param int $batch_size Optional. Number of posts to process per batch. Default 50.
 	 * @param int $offset     Optional. Number of posts to skip. Default 0.
 	 * @return array|null Array with batch size and offset if there are more posts to process, null otherwise.
 	 */
-	public static function create_post_outbox_items( $batch_size = 100, $offset = 0 ) {
+	public static function create_post_outbox_items( $batch_size = 50, $offset = 0 ) {
 		$post_types = \get_option( 'activitypub_support_post_types', array( 'post' ) );
 		$posts      = \get_posts(
 			array(
@@ -589,11 +589,11 @@ class Migration {
 	/**
 	 * Create outbox items for comments in batches.
 	 *
-	 * @param int $batch_size Optional. Number of posts to process per batch. Default 100.
+	 * @param int $batch_size Optional. Number of posts to process per batch. Default 50.
 	 * @param int $offset     Optional. Number of posts to skip. Default 0.
 	 * @return array|null Array with batch size and offset if there are more posts to process, null otherwise.
 	 */
-	public static function create_comment_outbox_items( $batch_size = 100, $offset = 0 ) {
+	public static function create_comment_outbox_items( $batch_size = 50, $offset = 0 ) {
 		$comments = \get_comments(
 			array(
 				'author__not_in' => array( 0 ), // Limit to comments by registered users.
@@ -645,7 +645,10 @@ class Migration {
 			return;
 		}
 
-		Outbox::add( $activity, $activity_type, $user_id, $visibility );
+		$post_id = Outbox::add( $activity, $activity_type, $user_id, $visibility );
+
+		// Immediately set to publish, no federation needed.
+		\wp_publish_post( $post_id );
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -173,7 +173,7 @@ class Migration {
 		if ( \version_compare( $version_from_db, '4.7.3', '<' ) ) {
 			add_action( 'init', 'flush_rewrite_rules', 20 );
 		}
-		if ( \version_compare( $version_from_db, '4.7.4', '<' ) ) {
+		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'create_post_outbox_items' ) );
 			\wp_schedule_single_event( \time() + 15, 'activitypub_upgrade', array( 'create_comment_outbox_items' ) );
 		}
@@ -549,6 +549,7 @@ class Migration {
 	public static function create_post_outbox_items( $batch_size = 50, $offset = 0 ) {
 		$posts = \get_posts(
 			array(
+				// our own `ap_outbox` will be excluded from `any` by virtue of its `exclude_from_search` arg.
 				'post_type'      => 'any',
 				'posts_per_page' => $batch_size,
 				'offset'         => $offset,

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -173,7 +173,7 @@ class Migration {
 		if ( \version_compare( $version_from_db, '4.7.3', '<' ) ) {
 			add_action( 'init', 'flush_rewrite_rules', 20 );
 		}
-		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
+		if ( \version_compare( $version_from_db, '4.7.4', '<' ) ) {
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'create_post_outbox_items' ) );
 			\wp_schedule_single_event( \time() + 15, 'activitypub_upgrade', array( 'create_comment_outbox_items' ) );
 		}
@@ -540,23 +540,15 @@ class Migration {
 	 * @return array|null Array with batch size and offset if there are more posts to process, null otherwise.
 	 */
 	public static function create_post_outbox_items( $batch_size = 50, $offset = 0 ) {
-		$post_types = \get_option( 'activitypub_support_post_types', array( 'post' ) );
 		$posts      = \get_posts(
 			array(
 				'posts_per_page' => $batch_size,
 				'offset'         => $offset,
-				'post_type'      => $post_types,
-
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query'     => array(
-					'relation' => 'OR',
 					array(
-						'key'     => 'activitypub_content_visibility',
-						'compare' => 'NOT EXISTS',
-					),
-					array(
-						'key'   => 'activitypub_content_visibility',
-						'value' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
+						'key'   => 'activitypub_status',
+						'value' => 'federated',
 					),
 				),
 			)
@@ -603,6 +595,13 @@ class Migration {
 				'author__not_in' => array( 0 ), // Limit to comments by registered users.
 				'number'         => $batch_size,
 				'offset'         => $offset,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'     => array(
+					array(
+						'key'   => 'activitypub_status',
+						'value' => 'federated',
+					),
+				),
 			)
 		);
 

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -7,9 +7,9 @@
 
 namespace Activitypub;
 
-use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use Activitypub\Collection\Outbox;
 use Activitypub\Transformer\Factory;
 
 /**
@@ -552,23 +552,35 @@ class Migration {
 		);
 
 		// Avoid multiple queries for post meta.
-		update_postmeta_cache( \wp_list_pluck( $posts, 'ID' ) );
+		\update_postmeta_cache( \wp_list_pluck( $posts, 'ID' ) );
 
-		// Don't schedule federation events while processing.
-		add_filter( 'pre_schedule_event', '__return_false' );
+		// Local function to add an activity to the outbox.
+		$add_to_outbox = function ( $comment, $activity_type, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
+			$transformer = Factory::get_transformer( $comment );
+			if ( ! $transformer || \is_wp_error( $transformer ) ) {
+				return;
+			}
+
+			$activity = $transformer->to_object();
+			if ( ! $activity || \is_wp_error( $activity ) ) {
+				return;
+			}
+
+			Outbox::add( $activity, $activity_type, $user_id, $visibility );
+		};
 
 		foreach ( $posts as $post ) {
-			$content_visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
+			$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
 
-			add_to_outbox( $post, 'Create', $post->post_author, $content_visibility );
+			$add_to_outbox( $post, 'Create', $post->post_author, $visibility );
 
 			// Add Update activity when the post has been modified.
 			if ( $post->post_modified_gmt !== $post->post_date_gmt ) {
-				add_to_outbox( $post, 'Update', $post->post_author, $content_visibility );
+				$add_to_outbox( $post, 'Update', $post->post_author, $visibility );
 			}
 		}
 
-		$comments = get_comments(
+		$comments = \get_comments(
 			array(
 				'author__not_in' => array( 0 ), // Limit to comments by registered users.
 				'number'         => $batch_size,
@@ -577,11 +589,8 @@ class Migration {
 		);
 
 		foreach ( $comments as $comment ) {
-			add_to_outbox( $comment, 'Create', $comment->user_id );
+			$add_to_outbox( $comment, 'Create', $comment->user_id );
 		}
-
-		// Allow new events to be scheduled again.
-		remove_filter( 'pre_schedule_event', '__return_false' );
 
 		if ( count( $posts ) === $batch_size || count( $comments ) === $batch_size ) {
 			// Schedule next batch.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -535,6 +535,7 @@ class Migration {
 				'posts_per_page' => $batch_size,
 				'offset'         => $offset,
 				'post_type'      => $post_types,
+
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query'     => array(
 					'relation' => 'OR',
@@ -543,9 +544,8 @@ class Migration {
 						'compare' => 'NOT EXISTS',
 					),
 					array(
-						'key'     => 'activitypub_content_visibility',
-						'value'   => ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL,
-						'compare' => '!=',
+						'key'   => 'activitypub_content_visibility',
+						'value' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
 					),
 				),
 			)
@@ -575,7 +575,7 @@ class Migration {
 			$add_to_outbox( $post, 'Create', $post->post_author, $visibility );
 
 			// Add Update activity when the post has been modified.
-			if ( $post->post_modified_gmt !== $post->post_date_gmt ) {
+			if ( $post->post_modified !== $post->post_date ) {
 				$add_to_outbox( $post, 'Update', $post->post_author, $visibility );
 			}
 		}

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -566,6 +566,10 @@ class Migration {
 		\update_postmeta_cache( \wp_list_pluck( $posts, 'ID' ) );
 
 		foreach ( $posts as $post ) {
+			if ( is_user_disabled( $post->post_author ) ) {
+				continue;
+			}
+
 			$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
 
 			self::add_to_outbox( $post, 'Create', $post->post_author, $visibility );

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -567,10 +567,6 @@ class Migration {
 		\update_postmeta_cache( \wp_list_pluck( $posts, 'ID' ) );
 
 		foreach ( $posts as $post ) {
-			if ( is_user_disabled( $post->post_author ) ) {
-				continue;
-			}
-
 			$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
 
 			self::add_to_outbox( $post, 'Create', $post->post_author, $visibility );
@@ -655,6 +651,15 @@ class Migration {
 		$activity = $transformer->to_object();
 		if ( ! $activity || \is_wp_error( $activity ) ) {
 			return;
+		}
+
+		// If the user is disabled, fall back to the blog user when available.
+		if ( is_user_disabled( $user_id ) ) {
+			if ( is_user_disabled( Actors::BLOG_USER_ID ) ) {
+				return;
+			} else {
+				$user_id = Actors::BLOG_USER_ID;
+			}
 		}
 
 		$post_id = Outbox::add( $activity, $activity_type, $user_id, $visibility );

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -542,6 +542,7 @@ class Migration {
 	public static function create_post_outbox_items( $batch_size = 50, $offset = 0 ) {
 		$posts = \get_posts(
 			array(
+				'post_type'      => 'any',
 				'posts_per_page' => $batch_size,
 				'offset'         => $offset,
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -518,7 +518,7 @@ class Migration {
 		if ( self::is_locked() ) {
 			\wp_schedule_single_event(
 				time() + ( 5 * MINUTE_IN_SECONDS ),
-				'activitypub_update_comment_counts',
+				'activitypub_create_outbox_items',
 				array(
 					'batch_size' => $batch_size,
 					'offset'     => $offset,
@@ -554,29 +554,14 @@ class Migration {
 		// Avoid multiple queries for post meta.
 		\update_postmeta_cache( \wp_list_pluck( $posts, 'ID' ) );
 
-		// Local function to add an activity to the outbox.
-		$add_to_outbox = function ( $comment, $activity_type, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
-			$transformer = Factory::get_transformer( $comment );
-			if ( ! $transformer || \is_wp_error( $transformer ) ) {
-				return;
-			}
-
-			$activity = $transformer->to_object();
-			if ( ! $activity || \is_wp_error( $activity ) ) {
-				return;
-			}
-
-			Outbox::add( $activity, $activity_type, $user_id, $visibility );
-		};
-
 		foreach ( $posts as $post ) {
 			$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
 
-			$add_to_outbox( $post, 'Create', $post->post_author, $visibility );
+			self::add_to_outbox( $post, 'Create', $post->post_author, $visibility );
 
 			// Add Update activity when the post has been modified.
 			if ( $post->post_modified !== $post->post_date ) {
-				$add_to_outbox( $post, 'Update', $post->post_author, $visibility );
+				self::add_to_outbox( $post, 'Update', $post->post_author, $visibility );
 			}
 		}
 
@@ -589,14 +574,14 @@ class Migration {
 		);
 
 		foreach ( $comments as $comment ) {
-			$add_to_outbox( $comment, 'Create', $comment->user_id );
+			self::add_to_outbox( $comment, 'Create', $comment->user_id );
 		}
 
 		if ( count( $posts ) === $batch_size || count( $comments ) === $batch_size ) {
 			// Schedule next batch.
 			\wp_schedule_single_event(
 				time() + MINUTE_IN_SECONDS,
-				'activitypub_update_comment_counts',
+				'activitypub_create_outbox_items',
 				array(
 					'batch_size' => $batch_size,
 					'offset'     => $offset + $batch_size,
@@ -615,6 +600,28 @@ class Migration {
 	public static function add_default_settings() {
 		self::add_activitypub_capability();
 		self::add_notification_defaults();
+	}
+
+	/**
+	 * Add an activity to the outbox without federating it.
+	 *
+	 * @param \WP_Post|\WP_Comment $comment       The comment or post object.
+	 * @param string               $activity_type The type of activity.
+	 * @param int                  $user_id       The user ID.
+	 * @param string               $visibility    Optional. The visibility of the content. Default 'public'.
+	 */
+	private static function add_to_outbox( $comment, $activity_type, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
+		$transformer = Factory::get_transformer( $comment );
+		if ( ! $transformer || \is_wp_error( $transformer ) ) {
+			return;
+		}
+
+		$activity = $transformer->to_object();
+		if ( ! $activity || \is_wp_error( $activity ) ) {
+			return;
+		}
+
+		Outbox::add( $activity, $activity_type, $user_id, $visibility );
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -217,10 +217,10 @@ class Migration {
 	/**
 	 * Asynchronously runs upgrade routines.
 	 *
-	 * @param string $callback The callback to run.
-	 * @param mixed  ...$args  The arguments to pass to the callback.
+	 * @param callable $callback Callable upgrade routine. Must be a method of this class.
+	 * @params mixed   ...$args  Optional. Parameters that get passed to the callback.
 	 */
-	public static function async_upgrade( $callback, ...$args ) {
+	public static function async_upgrade( $callback ) {
 		$args = \func_get_args();
 
 		// Bail if the existing lock is still valid.
@@ -231,7 +231,7 @@ class Migration {
 
 		self::lock();
 
-		$callback = array_shift( $args );  // Remove $callback from arguments.
+		$callback = array_shift( $args ); // Remove $callback from arguments.
 		$next     = \call_user_func_array( array( self::class, $callback ), $args );
 
 		self::unlock();

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -540,7 +540,7 @@ class Migration {
 	 * @return array|null Array with batch size and offset if there are more posts to process, null otherwise.
 	 */
 	public static function create_post_outbox_items( $batch_size = 50, $offset = 0 ) {
-		$posts      = \get_posts(
+		$posts = \get_posts(
 			array(
 				'posts_per_page' => $batch_size,
 				'offset'         => $offset,

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -23,8 +23,8 @@ class Migration {
 	 */
 	public static function init() {
 		\add_action( 'activitypub_migrate', array( self::class, 'async_migration' ) );
+		\add_action( 'activitypub_upgrade', array( self::class, 'async_upgrade' ) );
 		\add_action( 'activitypub_update_comment_counts', array( self::class, 'update_comment_counts' ), 10, 2 );
-		\add_action( 'activitypub_create_outbox_items', array( self::class, 'create_outbox_items' ), 10, 2 );
 
 		self::maybe_migrate();
 	}
@@ -174,7 +174,8 @@ class Migration {
 			add_action( 'init', 'flush_rewrite_rules', 20 );
 		}
 		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
-			\wp_schedule_single_event( \time() + MINUTE_IN_SECONDS, 'activitypub_create_outbox_items' );
+			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'create_post_outbox_items' ) );
+			\wp_schedule_single_event( \time() + 15, 'activitypub_upgrade', array( 'create_comment_outbox_items' ) );
 		}
 
 		/*
@@ -211,6 +212,31 @@ class Migration {
 		if ( \version_compare( $version_from_db, '1.0.0', '<' ) ) {
 			self::migrate_from_0_17();
 		}
+	}
+
+	/**
+	 * Asynchronously runs upgrade routines.
+	 *
+	 * @param string $callback The callback to run.
+	 * @param mixed  ...$args  The arguments to pass to the callback.
+	 */
+	public static function async_upgrade( $callback, ...$args ) {
+		// Bail if the existing lock is still valid.
+		if ( self::is_locked() ) {
+			\wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'activitypub_upgrade', \array_merge( array( $callback ), $args ) );
+			return;
+		}
+
+		self::lock();
+
+		$next = \call_user_func_array( array( self::class, $callback ), $args );
+
+		if ( ! empty( $next ) ) {
+			// Schedule the next run, adding the result to the arguments.
+			\wp_schedule_single_event( \time() + 30, 'activitypub_upgrade', \array_merge( array( $callback ), $next ) );
+		}
+
+		self::unlock();
 	}
 
 	/**
@@ -511,24 +537,9 @@ class Migration {
 	 *
 	 * @param int $batch_size Optional. Number of posts to process per batch. Default 100.
 	 * @param int $offset     Optional. Number of posts to skip. Default 0.
+	 * @return array|null Array with batch size and offset if there are more posts to process, null otherwise.
 	 */
-	public static function create_outbox_items( $batch_size = 100, $offset = 0 ) {
-
-		// Bail if the existing lock is still valid.
-		if ( self::is_locked() ) {
-			\wp_schedule_single_event(
-				time() + ( 5 * MINUTE_IN_SECONDS ),
-				'activitypub_create_outbox_items',
-				array(
-					'batch_size' => $batch_size,
-					'offset'     => $offset,
-				)
-			);
-			return;
-		}
-
-		self::lock();
-
+	public static function create_post_outbox_items( $batch_size = 100, $offset = 0 ) {
 		$post_types = \get_option( 'activitypub_support_post_types', array( 'post' ) );
 		$posts      = \get_posts(
 			array(
@@ -565,6 +576,24 @@ class Migration {
 			}
 		}
 
+		if ( count( $posts ) === $batch_size ) {
+			return array(
+				'batch_size' => $batch_size,
+				'offset'     => $offset + $batch_size,
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create outbox items for comments in batches.
+	 *
+	 * @param int $batch_size Optional. Number of posts to process per batch. Default 100.
+	 * @param int $offset     Optional. Number of posts to skip. Default 0.
+	 * @return array|null Array with batch size and offset if there are more posts to process, null otherwise.
+	 */
+	public static function create_comment_outbox_items( $batch_size = 100, $offset = 0 ) {
 		$comments = \get_comments(
 			array(
 				'author__not_in' => array( 0 ), // Limit to comments by registered users.
@@ -577,19 +606,14 @@ class Migration {
 			self::add_to_outbox( $comment, 'Create', $comment->user_id );
 		}
 
-		if ( count( $posts ) === $batch_size || count( $comments ) === $batch_size ) {
-			// Schedule next batch.
-			\wp_schedule_single_event(
-				time() + MINUTE_IN_SECONDS,
-				'activitypub_create_outbox_items',
-				array(
-					'batch_size' => $batch_size,
-					'offset'     => $offset + $batch_size,
-				)
+		if ( count( $comments ) === $batch_size ) {
+			return array(
+				'batch_size' => $batch_size,
+				'offset'     => $offset + $batch_size,
 			);
 		}
 
-		self::unlock();
+		return null;
 	}
 
 	/**

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -534,27 +534,13 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 
 		// Test scheduling next batch when callback returns more work.
 		Migration::async_upgrade( 'create_post_outbox_items', 1, 0 ); // Small batch size to force multiple batches.
-		$scheduled = \wp_next_scheduled(
-			'activitypub_upgrade',
-			array(
-				'create_post_outbox_items',
-				'batch_size' => 1,
-				'offset'     => 1,
-			)
-		);
+		$scheduled = \wp_next_scheduled( 'activitypub_upgrade', array( 'create_post_outbox_items', 1, 1 ) );
 		$this->assertNotFalse( $scheduled );
 
 		// Test no scheduling when callback returns null (no more work).
 		Migration::async_upgrade( 'create_post_outbox_items', 100, 1000 ); // Large offset to ensure no posts found.
 		$this->assertFalse(
-			\wp_next_scheduled(
-				'activitypub_upgrade',
-				array(
-					'create_post_outbox_items',
-					'batch_size' => 100,
-					'offset'     => 1100,
-				)
-			)
+			\wp_next_scheduled( 'activitypub_upgrade', array( 'create_post_outbox_items', 100, 1100 ) )
 		);
 	}
 
@@ -566,16 +552,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	public function test_async_upgrade_multiple_args() {
 		// Test that multiple arguments are passed correctly.
 		Migration::async_upgrade( 'update_comment_counts', 50, 100 );
-		$scheduled = \wp_next_scheduled(
-			'activitypub_upgrade',
-			array(
-				'update_comment_counts',
-				array(
-					'batch_size' => 50,
-					'offset'     => 150,
-				),
-			)
-		);
+		$scheduled = \wp_next_scheduled( 'activitypub_upgrade', array( 'update_comment_counts', 50, 150 ) );
 		$this->assertFalse( $scheduled, 'Should not schedule next batch when no comments found' );
 	}
 

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -34,7 +34,13 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		\remove_action( 'wp_insert_comment', array( \Activitypub\Scheduler\Comment::class, 'schedule_comment_activity_on_insert' ) );
 
 		// Create test posts.
-		self::$fixtures['posts'] = self::factory()->post->create_many( 3, array( 'post_author' => 1 ) );
+		self::$fixtures['posts'] = self::factory()->post->create_many(
+			3,
+			array(
+				'post_author' => 1,
+				'meta_input'  => array( 'activitypub_status' => 'federated' ),
+			)
+		);
 
 		$modified_post_id = self::factory()->post->create(
 			array(
@@ -43,6 +49,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 				'post_status'  => 'publish',
 				'post_type'    => 'post',
 				'post_date'    => '2020-01-01 00:00:00',
+				'meta_input'   => array( 'activitypub_status' => 'federated' ),
 			)
 		);
 		self::factory()->post->update_object( $modified_post_id, array( 'post_content' => 'Test post 2 updated' ) );
@@ -77,6 +84,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 				'comment_approved' => '1',
 			)
 		);
+		\add_comment_meta( self::$fixtures['comment'], 'activitypub_status', 'federated' );
 	}
 
 	/**

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -437,14 +437,14 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
-	 * Test create outbox items.
+	 * Test create post outbox items.
 	 *
-	 * @covers ::create_outbox_items
+	 * @covers ::create_post_outbox_items
 	 */
 	public function test_create_outbox_items() {
 		// Run migration.
 		add_filter( 'pre_schedule_event', '__return_false' );
-		Migration::create_outbox_items( 10, 0 );
+		Migration::create_post_outbox_items( 10, 0 );
 		remove_filter( 'pre_schedule_event', '__return_false' );
 
 		// Get outbox items.
@@ -456,36 +456,26 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 			)
 		);
 
-		// Should now have 6 outbox items total, 4 post Create, 1 post Update, and 1 comment Create.
-		$this->assertEquals( 6, count( $outbox_items ) );
-
-		// Verify first post create activity.
-		$this->assertEquals( 'Create', \get_post_meta( $outbox_items[0]->ID, '_activitypub_activity_type', true ) );
-		$this->assertEquals( '', \get_post_meta( $outbox_items[0]->ID, 'activitypub_content_visibility', true ) );
-
-		// Verify second post update activity.
-		$this->assertEquals( 'Update', \get_post_meta( $outbox_items[1]->ID, '_activitypub_activity_type', true ) );
-		$this->assertEquals( '', \get_post_meta( $outbox_items[1]->ID, 'activitypub_content_visibility', true ) );
-
-		// Verify second post create activity.
-		$this->assertEquals( 'Create', \get_post_meta( $outbox_items[2]->ID, '_activitypub_activity_type', true ) );
-		$this->assertEquals( '', \get_post_meta( $outbox_items[2]->ID, 'activitypub_content_visibility', true ) );
-
-		// Verify comment create activity.
-		$this->assertEquals( 'Create', \get_post_meta( $outbox_items[3]->ID, '_activitypub_activity_type', true ) );
-		$this->assertEquals( '', \get_post_meta( $outbox_items[3]->ID, 'activitypub_content_visibility', true ) );
+		// Should now have 5 outbox items total, 4 post Create, 1 post Update.
+		$this->assertEquals( 5, count( $outbox_items ) );
 	}
 
 	/**
-	 * Test create outbox items with batching.
+	 * Test create post outbox items with batching.
 	 *
-	 * @covers ::create_outbox_items
+	 * @covers ::create_post_outbox_items
 	 */
 	public function test_create_outbox_items_batching() {
-		add_filter( 'pre_schedule_event', '__return_false' );
-
 		// Run migration with batch size of 2.
-		Migration::create_outbox_items( 2, 0 );
+		$next = Migration::create_post_outbox_items( 2, 0 );
+
+		$this->assertSame(
+			array(
+				'batch_size' => 2,
+				'offset'     => 2,
+			),
+			$next
+		);
 
 		// Get outbox items.
 		$outbox_items = \get_posts(
@@ -496,11 +486,11 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 			)
 		);
 
-		// Should have 3 outbox items, 2 post Create and 1 comment Create.
-		$this->assertEquals( 3, count( $outbox_items ) );
+		// Should have 2 outbox items.
+		$this->assertEquals( 2, count( $outbox_items ) );
 
 		// Run migration with next batch.
-		Migration::create_outbox_items( 2, 2 );
+		Migration::create_post_outbox_items( 2, 2 );
 
 		// Get outbox items again.
 		$outbox_items = \get_posts(
@@ -511,9 +501,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 			)
 		);
 
-		// Should now have 6 outbox items total, 4 post Create, 1 post Update, and 1 comment Create.
-		$this->assertEquals( 6, count( $outbox_items ) );
-
-		remove_filter( 'pre_schedule_event', '__return_false' );
+		// Should now have 5 outbox items total, 4 post Create, 1 post Update.
+		$this->assertEquals( 5, count( $outbox_items ) );
 	}
 }

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -18,6 +18,14 @@ use Activitypub\Comment;
 class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 
 	/**
+	 * Set up the test.
+	 */
+	public static function set_up_before_class() {
+		\remove_action( 'transition_post_status', array( \Activitypub\Scheduler\Post::class, 'schedule_post_activity' ), 33 );
+		\remove_action( 'transition_comment_status', array( \Activitypub\Scheduler\Comment::class, 'schedule_comment_activity' ), 20 );
+		\remove_action( 'wp_insert_comment', array( \Activitypub\Scheduler\Comment::class, 'schedule_comment_activity_on_insert' ) );
+	}
+	/**
 	 * Tear down the test.
 	 */
 	public function tear_down() {
@@ -184,6 +192,9 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 
 		$this->assertEquals( $custom, $template );
 		$this->assertFalse( $content_type );
+
+		\wp_delete_post( $post1, true );
+		\wp_delete_post( $post2, true );
 	}
 
 	/**
@@ -257,6 +268,9 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		// Verify unrelated meta is unchanged.
 		$this->assertEquals( 'should not change', \get_post_meta( $post1, 'unrelated_meta', true ), 'Unrelated meta should not change' );
 		$this->assertEquals( 'should not change-2', \get_post_meta( $post2, 'unrelated_meta', true ), 'Unrelated meta should not change' );
+
+		\wp_delete_post( $post1, true );
+		\wp_delete_post( $post2, true );
 	}
 
 	/**
@@ -274,7 +288,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
-	 * Tests retrieving the timestamp of an existing lock.
+	 * Test retrieving the timestamp of an existing lock.
 	 *
 	 * @covers ::lock
 	 */
@@ -291,7 +305,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
-	 * Tests update_comment_counts() properly cleans up the lock.
+	 * Test update_comment_counts() properly cleans up the lock.
 	 *
 	 * @covers ::update_comment_counts
 	 */
@@ -320,7 +334,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
-	 * Tests update_comment_counts() with existing valid lock.
+	 * Test update_comment_counts() with existing valid lock.
 	 *
 	 * @covers ::update_comment_counts
 	 */
@@ -352,5 +366,200 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 				'offset'     => 0,
 			)
 		);
+	}
+
+	/**
+	 * Test create outbox items.
+	 *
+	 * @covers ::create_outbox_items
+	 */
+	public function test_create_outbox_items() {
+		// Create test posts.
+		$post1 = self::factory()->post->create(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Test post 1',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+
+		$post2 = self::factory()->post->create(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Test post 2',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_date'    => '2020-01-01 00:00:00',
+			)
+		);
+		self::factory()->post->update_object( $post2, array( 'post_content' => 'Test post 2 updated' ) );
+
+		$post3 = self::factory()->post->create(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Test post 3',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+			)
+		);
+
+		$post4 = self::factory()->post->create(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Test post 4',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'meta_input'   => array(
+					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL,
+				),
+			)
+		);
+
+		// Create test comment.
+		$comment = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post1,
+				'user_id'          => 1,
+				'comment_content'  => 'Test comment',
+				'comment_approved' => '1',
+			)
+		);
+
+		// Run migration.
+		add_filter( 'pre_schedule_event', '__return_false' );
+		Migration::create_outbox_items( 10, 0 );
+		remove_filter( 'pre_schedule_event', '__return_false' );
+
+		// Get outbox items.
+		$outbox_items = \get_posts(
+			array(
+				'post_type'      => 'ap_outbox',
+				'posts_per_page' => -1,
+				'post_status'    => 'draft',
+			)
+		);
+
+		// Should have 4 outbox items: 1 for post1 (create), 2 for post2 (create + update), none for post3 (wrong type), none for post4 (private), and 1 for comment.
+		$this->assertEquals( 4, count( $outbox_items ) );
+
+		// Verify first post create activity.
+		$this->assertEquals( 'Create', \get_post_meta( $outbox_items[0]->ID, '_activitypub_activity_type', true ) );
+		$this->assertEquals( '', \get_post_meta( $outbox_items[0]->ID, 'activitypub_content_visibility', true ) );
+
+		// Verify second post update activity.
+		$this->assertEquals( 'Update', \get_post_meta( $outbox_items[1]->ID, '_activitypub_activity_type', true ) );
+		$this->assertEquals( '', \get_post_meta( $outbox_items[1]->ID, 'activitypub_content_visibility', true ) );
+
+		// Verify second post create activity.
+		$this->assertEquals( 'Create', \get_post_meta( $outbox_items[2]->ID, '_activitypub_activity_type', true ) );
+		$this->assertEquals( '', \get_post_meta( $outbox_items[2]->ID, 'activitypub_content_visibility', true ) );
+
+		// Verify comment create activity.
+		$this->assertEquals( 'Create', \get_post_meta( $outbox_items[3]->ID, '_activitypub_activity_type', true ) );
+		$this->assertEquals( '', \get_post_meta( $outbox_items[3]->ID, 'activitypub_content_visibility', true ) );
+
+		// Clean up.
+		\wp_delete_post( $post1, true );
+		\wp_delete_post( $post2, true );
+		\wp_delete_post( $post3, true );
+		\wp_delete_post( $post4, true );
+		\wp_delete_comment( $comment, true );
+		foreach ( $outbox_items as $item ) {
+			\wp_delete_post( $item->ID, true );
+		}
+	}
+
+	/**
+	 * Test create outbox items with batching.
+	 *
+	 * @covers ::create_outbox_items
+	 */
+	public function test_create_outbox_items_batching() {
+		// Create 3 test posts.
+		$posts = self::factory()->post->create_many(
+			3,
+			array(
+				'post_author' => 1,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		// Run migration with batch size of 2.
+		Migration::create_outbox_items( 2, 0 );
+
+		// Get outbox items.
+		$outbox_items = \get_posts(
+			array(
+				'post_type'      => 'ap_outbox',
+				'posts_per_page' => -1,
+				'post_status'    => 'draft',
+			)
+		);
+
+		// Should have 2 outbox items (batch size).
+		$this->assertEquals( 2, count( $outbox_items ) );
+
+		// Run migration with next batch.
+		Migration::create_outbox_items( 2, 2 );
+
+		// Get outbox items again.
+		$outbox_items = \get_posts(
+			array(
+				'post_type'      => 'ap_outbox',
+				'posts_per_page' => -1,
+				'post_status'    => 'draft',
+			)
+		);
+
+		// Should now have 3 outbox items total.
+		$this->assertEquals( 3, count( $outbox_items ) );
+
+		// Clean up.
+		foreach ( $posts as $post ) {
+			\wp_delete_post( $post, true );
+		}
+		foreach ( $outbox_items as $item ) {
+			\wp_delete_post( $item->ID, true );
+		}
+	}
+
+	/**
+	 * Test create outbox items with locking.
+	 *
+	 * @covers ::create_outbox_items
+	 */
+	public function test_create_outbox_items_locking() {
+		// Create a lock.
+		Migration::lock();
+
+		// Create test post.
+		$post = self::factory()->post->create(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Test post',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+
+		// Run migration.
+		Migration::create_outbox_items();
+
+		// Get outbox items.
+		$outbox_items = \get_posts(
+			array(
+				'post_type'      => 'ap_outbox',
+				'posts_per_page' => -1,
+			)
+		);
+
+		// Should have no outbox items due to lock.
+		$this->assertEquals( 0, count( $outbox_items ) );
+
+		// Clean up.
+		Migration::unlock();
+		\wp_delete_post( $post, true );
 	}
 }

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -18,13 +18,81 @@ use Activitypub\Comment;
 class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 
 	/**
+	 * Test fixture.
+	 *
+	 * @var array
+	 */
+	public static $fixtures = array();
+
+	/**
 	 * Set up the test.
 	 */
 	public static function set_up_before_class() {
 		\remove_action( 'transition_post_status', array( \Activitypub\Scheduler\Post::class, 'schedule_post_activity' ), 33 );
 		\remove_action( 'transition_comment_status', array( \Activitypub\Scheduler\Comment::class, 'schedule_comment_activity' ), 20 );
 		\remove_action( 'wp_insert_comment', array( \Activitypub\Scheduler\Comment::class, 'schedule_comment_activity_on_insert' ) );
+
+		// Create test posts.
+		self::$fixtures['posts'] = self::factory()->post->create_many( 3, array( 'post_author' => 1 ) );
+
+		$modified_post_id = self::factory()->post->create(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Test post 2',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_date'    => '2020-01-01 00:00:00',
+			)
+		);
+		self::factory()->post->update_object( $modified_post_id, array( 'post_content' => 'Test post 2 updated' ) );
+
+		self::$fixtures['posts'][] = $modified_post_id;
+		self::$fixtures['posts'][] = self::factory()->post->create(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Test post 3',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+			)
+		);
+		self::$fixtures['posts'][] = self::factory()->post->create(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Test post 4',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'meta_input'   => array(
+					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL,
+				),
+			)
+		);
+
+		// Create test comment.
+		self::$fixtures['comment'] = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$fixtures['posts'][0],
+				'user_id'          => 1,
+				'comment_content'  => 'Test comment',
+				'comment_approved' => '1',
+			)
+		);
 	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public static function tear_down_after_class() {
+		// Clean up posts.
+		foreach ( self::$fixtures['posts'] as $post_id ) {
+			\wp_delete_post( $post_id, true );
+		}
+
+		// Clean up comment.
+		if ( isset( self::$fixtures['comment'] ) ) {
+			\wp_delete_comment( self::$fixtures['comment'], true );
+		}
+	}
+
 	/**
 	 * Tear down the test.
 	 */
@@ -32,6 +100,20 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		\delete_option( 'activitypub_object_type' );
 		\delete_option( 'activitypub_custom_post_content' );
 		\delete_option( 'activitypub_post_content_type' );
+
+		// Clean up outbox items.
+		$outbox_items = \get_posts(
+			array(
+				'post_type'      => 'ap_outbox',
+				'posts_per_page' => -1,
+				'post_status'    => 'draft',
+				'fields'         => 'ids',
+			)
+		);
+
+		foreach ( $outbox_items as $item_id ) {
+			\wp_delete_post( $item_id, true );
+		}
 	}
 
 	/**
@@ -203,19 +285,8 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	 * @covers ::migrate_to_4_7_1
 	 */
 	public function test_migrate_to_4_7_1() {
-		$post1 = \wp_insert_post(
-			array(
-				'post_author'  => 1,
-				'post_content' => 'Test post 1',
-			)
-		);
-
-		$post2 = \wp_insert_post(
-			array(
-				'post_author'  => 1,
-				'post_content' => 'Test post 2',
-			)
-		);
+		$post1 = self::$fixtures['posts'][0];
+		$post2 = self::$fixtures['posts'][1];
 
 		// Set up test meta data.
 		$meta_data = array(
@@ -268,9 +339,6 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		// Verify unrelated meta is unchanged.
 		$this->assertEquals( 'should not change', \get_post_meta( $post1, 'unrelated_meta', true ), 'Unrelated meta should not change' );
 		$this->assertEquals( 'should not change-2', \get_post_meta( $post2, 'unrelated_meta', true ), 'Unrelated meta should not change' );
-
-		\wp_delete_post( $post1, true );
-		\wp_delete_post( $post2, true );
 	}
 
 	/**
@@ -374,58 +442,6 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	 * @covers ::create_outbox_items
 	 */
 	public function test_create_outbox_items() {
-		// Create test posts.
-		$post1 = self::factory()->post->create(
-			array(
-				'post_author'  => 1,
-				'post_content' => 'Test post 1',
-				'post_status'  => 'publish',
-				'post_type'    => 'post',
-			)
-		);
-
-		$post2 = self::factory()->post->create(
-			array(
-				'post_author'  => 1,
-				'post_content' => 'Test post 2',
-				'post_status'  => 'publish',
-				'post_type'    => 'post',
-				'post_date'    => '2020-01-01 00:00:00',
-			)
-		);
-		self::factory()->post->update_object( $post2, array( 'post_content' => 'Test post 2 updated' ) );
-
-		$post3 = self::factory()->post->create(
-			array(
-				'post_author'  => 1,
-				'post_content' => 'Test post 3',
-				'post_status'  => 'publish',
-				'post_type'    => 'page',
-			)
-		);
-
-		$post4 = self::factory()->post->create(
-			array(
-				'post_author'  => 1,
-				'post_content' => 'Test post 4',
-				'post_status'  => 'publish',
-				'post_type'    => 'post',
-				'meta_input'   => array(
-					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL,
-				),
-			)
-		);
-
-		// Create test comment.
-		$comment = self::factory()->comment->create(
-			array(
-				'comment_post_ID'  => $post1,
-				'user_id'          => 1,
-				'comment_content'  => 'Test comment',
-				'comment_approved' => '1',
-			)
-		);
-
 		// Run migration.
 		add_filter( 'pre_schedule_event', '__return_false' );
 		Migration::create_outbox_items( 10, 0 );
@@ -440,8 +456,8 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 			)
 		);
 
-		// Should have 4 outbox items: 1 for post1 (create), 2 for post2 (create + update), none for post3 (wrong type), none for post4 (private), and 1 for comment.
-		$this->assertEquals( 4, count( $outbox_items ) );
+		// Should now have 6 outbox items total, 4 post Create, 1 post Update, and 1 comment Create.
+		$this->assertEquals( 6, count( $outbox_items ) );
 
 		// Verify first post create activity.
 		$this->assertEquals( 'Create', \get_post_meta( $outbox_items[0]->ID, '_activitypub_activity_type', true ) );
@@ -458,16 +474,6 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		// Verify comment create activity.
 		$this->assertEquals( 'Create', \get_post_meta( $outbox_items[3]->ID, '_activitypub_activity_type', true ) );
 		$this->assertEquals( '', \get_post_meta( $outbox_items[3]->ID, 'activitypub_content_visibility', true ) );
-
-		// Clean up.
-		\wp_delete_post( $post1, true );
-		\wp_delete_post( $post2, true );
-		\wp_delete_post( $post3, true );
-		\wp_delete_post( $post4, true );
-		\wp_delete_comment( $comment, true );
-		foreach ( $outbox_items as $item ) {
-			\wp_delete_post( $item->ID, true );
-		}
 	}
 
 	/**
@@ -476,15 +482,7 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	 * @covers ::create_outbox_items
 	 */
 	public function test_create_outbox_items_batching() {
-		// Create 3 test posts.
-		$posts = self::factory()->post->create_many(
-			3,
-			array(
-				'post_author' => 1,
-				'post_status' => 'publish',
-				'post_type'   => 'post',
-			)
-		);
+		add_filter( 'pre_schedule_event', '__return_false' );
 
 		// Run migration with batch size of 2.
 		Migration::create_outbox_items( 2, 0 );
@@ -498,8 +496,8 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 			)
 		);
 
-		// Should have 2 outbox items (batch size).
-		$this->assertEquals( 2, count( $outbox_items ) );
+		// Should have 3 outbox items, 2 post Create and 1 comment Create.
+		$this->assertEquals( 3, count( $outbox_items ) );
 
 		// Run migration with next batch.
 		Migration::create_outbox_items( 2, 2 );
@@ -513,53 +511,9 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 			)
 		);
 
-		// Should now have 3 outbox items total.
-		$this->assertEquals( 3, count( $outbox_items ) );
+		// Should now have 6 outbox items total, 4 post Create, 1 post Update, and 1 comment Create.
+		$this->assertEquals( 6, count( $outbox_items ) );
 
-		// Clean up.
-		foreach ( $posts as $post ) {
-			\wp_delete_post( $post, true );
-		}
-		foreach ( $outbox_items as $item ) {
-			\wp_delete_post( $item->ID, true );
-		}
-	}
-
-	/**
-	 * Test create outbox items with locking.
-	 *
-	 * @covers ::create_outbox_items
-	 */
-	public function test_create_outbox_items_locking() {
-		// Create a lock.
-		Migration::lock();
-
-		// Create test post.
-		$post = self::factory()->post->create(
-			array(
-				'post_author'  => 1,
-				'post_content' => 'Test post',
-				'post_status'  => 'publish',
-				'post_type'    => 'post',
-			)
-		);
-
-		// Run migration.
-		Migration::create_outbox_items();
-
-		// Get outbox items.
-		$outbox_items = \get_posts(
-			array(
-				'post_type'      => 'ap_outbox',
-				'posts_per_page' => -1,
-			)
-		);
-
-		// Should have no outbox items due to lock.
-		$this->assertEquals( 0, count( $outbox_items ) );
-
-		// Clean up.
-		Migration::unlock();
-		\wp_delete_post( $post, true );
+		remove_filter( 'pre_schedule_event', '__return_false' );
 	}
 }

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -451,9 +451,8 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		// Get outbox items.
 		$outbox_items = \get_posts(
 			array(
-				'post_type'      => 'ap_outbox',
+				'post_type'      => Outbox::POST_TYPE,
 				'posts_per_page' => -1,
-				'post_status'    => 'draft',
 			)
 		);
 
@@ -481,9 +480,8 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		// Get outbox items.
 		$outbox_items = \get_posts(
 			array(
-				'post_type'      => 'ap_outbox',
+				'post_type'      => Outbox::POST_TYPE,
 				'posts_per_page' => -1,
-				'post_status'    => 'draft',
 			)
 		);
 
@@ -496,9 +494,8 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		// Get outbox items again.
 		$outbox_items = \get_posts(
 			array(
-				'post_type'      => 'ap_outbox',
+				'post_type'      => Outbox::POST_TYPE,
 				'posts_per_page' => -1,
-				'post_status'    => 'draft',
 			)
 		);
 

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -443,6 +443,9 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 	 * @covers ::create_post_outbox_items
 	 */
 	public function test_create_outbox_items() {
+		// Create additional post that should not be included in outbox.
+		$post_id = self::factory()->post->create( array( 'post_author' => 90210 ) );
+
 		// Run migration.
 		add_filter( 'pre_schedule_event', '__return_false' );
 		Migration::create_post_outbox_items( 10, 0 );
@@ -458,6 +461,8 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 
 		// Should now have 5 outbox items total, 4 post Create, 1 post Update.
 		$this->assertEquals( 5, count( $outbox_items ) );
+
+		\wp_delete_post( $post_id, true );
 	}
 
 	/**

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Collection\Outbox;
 use Activitypub\Migration;
 use Activitypub\Comment;
 
@@ -104,9 +105,9 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		// Clean up outbox items.
 		$outbox_items = \get_posts(
 			array(
-				'post_type'      => 'ap_outbox',
+				'post_type'      => Outbox::POST_TYPE,
 				'posts_per_page' => -1,
-				'post_status'    => 'draft',
+				'post_status'    => 'any',
 				'fields'         => 'ids',
 			)
 		);

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -504,4 +504,89 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		// Should now have 5 outbox items total, 4 post Create, 1 post Update.
 		$this->assertEquals( 5, count( $outbox_items ) );
 	}
+
+	/**
+	 * Test async upgrade functionality.
+	 *
+	 * @covers ::async_upgrade
+	 * @covers ::lock
+	 * @covers ::unlock
+	 * @covers ::create_post_outbox_items
+	 */
+	public function test_async_upgrade() {
+		// Test that lock prevents simultaneous upgrades.
+		Migration::lock();
+		Migration::async_upgrade( 'create_post_outbox_items' );
+		$scheduled = \wp_next_scheduled( 'activitypub_upgrade', array( 'create_post_outbox_items' ) );
+		$this->assertNotFalse( $scheduled );
+		Migration::unlock();
+
+		// Test scheduling next batch when callback returns more work.
+		Migration::async_upgrade( 'create_post_outbox_items', 1, 0 ); // Small batch size to force multiple batches.
+		$scheduled = \wp_next_scheduled(
+			'activitypub_upgrade',
+			array(
+				'create_post_outbox_items',
+				'batch_size' => 1,
+				'offset'     => 1,
+			)
+		);
+		$this->assertNotFalse( $scheduled );
+
+		// Test no scheduling when callback returns null (no more work).
+		Migration::async_upgrade( 'create_post_outbox_items', 100, 1000 ); // Large offset to ensure no posts found.
+		$this->assertFalse(
+			\wp_next_scheduled(
+				'activitypub_upgrade',
+				array(
+					'create_post_outbox_items',
+					'batch_size' => 100,
+					'offset'     => 1100,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Test async upgrade with multiple arguments.
+	 *
+	 * @covers ::async_upgrade
+	 */
+	public function test_async_upgrade_multiple_args() {
+		// Test that multiple arguments are passed correctly.
+		Migration::async_upgrade( 'update_comment_counts', 50, 100 );
+		$scheduled = \wp_next_scheduled(
+			'activitypub_upgrade',
+			array(
+				'update_comment_counts',
+				array(
+					'batch_size' => 50,
+					'offset'     => 150,
+				),
+			)
+		);
+		$this->assertFalse( $scheduled, 'Should not schedule next batch when no comments found' );
+	}
+
+	/**
+	 * Test create_comment_outbox_items batch processing.
+	 *
+	 * @covers ::create_comment_outbox_items
+	 */
+	public function test_create_comment_outbox_items_batching() {
+		// Test with small batch size.
+		$result = Migration::create_comment_outbox_items( 1, 0 );
+		$this->assertIsArray( $result );
+		$this->assertEquals(
+			array(
+				'batch_size' => 1,
+				'offset'     => 1,
+			),
+			$result
+		);
+
+		// Test with large offset (no more comments).
+		$result = Migration::create_comment_outbox_items( 1, 1000 );
+		$this->assertNull( $result );
+	}
 }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `activitypub_upgrade` event for async upgrades with locking.
* Adds upgrade callbacks to create outbox items for posts and comments.
* Adds custom `add_to_outbox` function that skips any federation considerations.
* Adds tests for the async upgrade event, and outbox generation callbacks.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install [the zip file of this branch](https://github.com/Automattic/wordpress-activitypub/archive/refs/heads/add/outbox-migration.zip) on a test site and activate it.
* Manually update the version compare in `/includes/class-migration.php` to a version of your choice (e.g. `4.7.3.1`).
* Manually update the plugin version in `activitypub.php` to the same version.
* Go to `/wp-admin/edit.php?post_type=ap_outbox` on your test site to see the results.
