### PR TITLE
Migration: flush post caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * More robust handling of `_activityPubOptions` in scripts, using a `useOptions()` helper.
+* Flush post caches after Followers migration.
 
 ### Added
 

--- a/activitypub.php
+++ b/activitypub.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActivityPub
  * Plugin URI: https://github.com/Automattic/wordpress-activitypub
  * Description: The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
- * Version: 4.7.1
+ * Version: 4.7.2
  * Author: Matthias Pfefferle & Automattic
  * Author URI: https://automattic.com/
  * License: MIT
@@ -19,7 +19,7 @@ namespace Activitypub;
 
 use WP_CLI;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '4.7.1' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '4.7.2' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -418,6 +418,7 @@ class Migration {
 	 */
 	public static function migrate_to_4_7_2() {
 		global $wpdb;
+		// phpcs:ignore WordPress.DB
 		$followers = $wpdb->get_col(
 			$wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type = %s", Followers::POST_TYPE )
 		);

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -164,6 +164,9 @@ class Migration {
 		if ( \version_compare( $version_from_db, '4.7.1', '<' ) ) {
 			self::migrate_to_4_7_1();
 		}
+		if ( \version_compare( $version_from_db, '4.7.2', '<' ) ) {
+			self::migrate_to_4_7_2();
+		}
 
 		/**
 		 * Fires when the system has to be migrated.
@@ -407,6 +410,19 @@ class Migration {
 		foreach ( $meta_keys as $meta_key ) {
 			// phpcs:ignore WordPress.DB
 			$wpdb->update( $wpdb->postmeta, array( 'meta_key' => '_' . $meta_key ), array( 'meta_key' => $meta_key ) );
+		}
+	}
+
+	/**
+	 * Clears the post cache for Followers, we should have done this in 4.7.1 when we renamed those keys.
+	 */
+	public static function migrate_to_4_7_2() {
+		global $wpdb;
+		$followers = $wpdb->get_col(
+			$wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type = %s", Followers::POST_TYPE )
+		);
+		foreach ( $followers as $id ) {
+			clean_post_cache( $id );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: Support for WPML post locale
 * Removed: Built-in support for nodeinfo2. Use the [NodeInfo plugin](https://wordpress.org/plugins/nodeinfo/) instead.
 * Fixed: More robust handling of `_activityPubOptions` in scripts, using a `useOptions()` helper.
+* Fixed: Flush post caches after Followers migration.
 
 = 4.7.1 =
 


### PR DESCRIPTION
The migrations from #1161 did not flush post caches, which can lead to problems on sites with a persistent object cache.

Aka `get_post_meta( ID, '_activitypub_actor_json' )` would return empty even though the data was in the DB.


## Proposed changes:
* Add a migration to flush caches

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
On a site with a persistent object cache:
* Start a site on ActivityPub 4.6.0. 
* Receive a follower
* Upgrade to this version

Everything should work normally. Without this we were seeing Followers not display correctly, eg in the Followers block or in wp-admin Followers screen

