### PR TITLE
Remove link to firefish

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -33,7 +33,6 @@ The plugin works with the following tested federated platforms, but there may be
 * [Pixelfed](https://pixelfed.org/)
 * [Socialhome](https://socialhome.network/)
 * [Misskey](https://join.misskey.page/)
-* [Firefish](https://joinfirefish.org/) (rebrand of Calckey)
 
 Some things to note:
 


### PR DESCRIPTION
Firefish seems no longer maintained: https://joinfediverse.wiki/Firefish_(discontinued)

Fixes https://wordpress.org/support/topic/firefish-link-on-home-re-directs-to-advertising-net/

