### PR TITLE
Outbox: Fix Query

### DIFF
--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -26,13 +26,13 @@ class Outbox {
 	public static function add( $activity_object, $activity_type, $user_id, $content_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) { // phpcs:ignore
 		switch ( $user_id ) {
 			case -1:
-				$actor = 'application';
+				$actor_type = 'application';
 				break;
 			case 0:
-				$actor = 'blog';
+				$actor_type = 'blog';
 				break;
 			default:
-				$actor = 'user';
+				$actor_type = 'user';
 				break;
 		}
 
@@ -45,7 +45,7 @@ class Outbox {
 			'post_status'  => 'draft',
 			'meta_input'   => array(
 				'_activitypub_activity_type'     => $activity_type,
-				'_activitypub_activity_actor'    => $actor,
+				'_activitypub_activity_actor'    => $actor_type,
 				'activitypub_content_visibility' => $content_visibility,
 			),
 		);

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -25,10 +25,10 @@ class Outbox {
 	 */
 	public static function add( $activity_object, $activity_type, $user_id, $content_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) { // phpcs:ignore
 		switch ( $user_id ) {
-			case -1:
+			case Actors::APPLICATION_USER_ID:
 				$actor_type = 'application';
 				break;
-			case 0:
+			case Actors::BLOG_USER_ID:
 				$actor_type = 'blog';
 				break;
 			default:

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -137,8 +137,8 @@ class Outbox_Controller extends \WP_REST_Controller {
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'     => array(
 				array(
-					'key'     => '_activitypub_activity_actor',
-					'value'   => $actor_type,
+					'key'   => '_activitypub_activity_actor',
+					'value' => $actor_type,
 				),
 			),
 		);

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -115,15 +115,32 @@ class Outbox_Controller extends \WP_REST_Controller {
 		 */
 		$activity_types = apply_filters( 'rest_activitypub_outbox_activity_types', array( 'Announce', 'Create', 'Like', 'Update' ) );
 
+		switch ( $user_id ) {
+			case -1:
+				$actor_type = 'application';
+				break;
+			case 0:
+				$actor_type = 'blog';
+				break;
+			default:
+				$actor_type = 'user';
+				break;
+		}
+
 		$args = array(
 			'posts_per_page' => $request->get_param( 'per_page' ),
 			'author'         => $user_id > 0 ? $user_id : null,
 			'paged'          => $page,
 			'post_type'      => Outbox::POST_TYPE,
-			'post_status'    => 'draft',
+			'post_status'    => 'any',
 
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'     => array(
+				array(
+					'key'     => '_activitypub_activity_actor',
+					'value'   => $actor_type,
+					'compare' => '=',
+				),
 				array(
 					'key'     => '_activitypub_activity_type',
 					'value'   => $activity_types,

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -116,10 +116,10 @@ class Outbox_Controller extends \WP_REST_Controller {
 		$activity_types = apply_filters( 'rest_activitypub_outbox_activity_types', array( 'Announce', 'Create', 'Like', 'Update' ) );
 
 		switch ( $user_id ) {
-			case -1:
+			case Actors::APPLICATION_USER_ID:
 				$actor_type = 'application';
 				break;
-			case 0:
+			case Actors::BLOG_USER_ID:
 				$actor_type = 'blog';
 				break;
 			default:

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -140,27 +140,27 @@ class Outbox_Controller extends \WP_REST_Controller {
 					'key'     => '_activitypub_activity_actor',
 					'value'   => $actor_type,
 				),
-				array(
-					'key'     => '_activitypub_activity_type',
-					'value'   => $activity_types,
-					'compare' => 'IN',
-				),
-				array(
-					'relation' => 'OR',
-					array(
-						'key'     => 'activitypub_content_visibility',
-						'compare' => 'NOT EXISTS',
-					),
-					array(
-						'key'   => 'activitypub_content_visibility',
-						'value' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
-					),
-				),
 			),
 		);
 
-		if ( current_user_can( 'activitypub' ) ) {
-			unset( $args['meta_query'] );
+		if ( get_current_user_id() !== $user_id && ! current_user_can( 'activitypub' ) ) {
+			$args['meta_query'][] = array(
+				'key'     => '_activitypub_activity_type',
+				'value'   => $activity_types,
+				'compare' => 'IN',
+			);
+
+			$args['meta_query'][] = array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'activitypub_content_visibility',
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key'   => 'activitypub_content_visibility',
+					'value' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
+				),
+			);
 		}
 
 		/**

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -139,7 +139,6 @@ class Outbox_Controller extends \WP_REST_Controller {
 				array(
 					'key'     => '_activitypub_activity_actor',
 					'value'   => $actor_type,
-					'compare' => '=',
 				),
 				array(
 					'key'     => '_activitypub_activity_type',

--- a/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/includes/rest/class-test-outbox-controller.php
@@ -541,7 +541,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 		// Create a post with blog actor type.
 		$blog_post_id = self::factory()->post->create(
 			array(
-				'post_author'  => $user_id,
+				'post_author'  => 0,
 				'post_type'    => Outbox::POST_TYPE,
 				'post_status'  => 'draft',
 				'post_title'   => 'https://example.org/activity/2',

--- a/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/includes/rest/class-test-outbox-controller.php
@@ -16,6 +16,14 @@ use Activitypub\Rest\Outbox_Controller;
  * @coversDefaultClass \Activitypub\Rest\Outbox_Controller
  */
 class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	public static $user_id;
+
 	/**
 	 * Test post IDs.
 	 *
@@ -25,17 +33,20 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 
 	/**
 	 * Set up class test fixtures.
-	 *
-	 * @param \WP_UnitTest_Factory $factory WordPress unit test factory.
 	 */
-	public static function wpSetUpBeforeClass( $factory ) {
-		self::$post_ids = $factory->post->create_many( 10 );
+	public static function set_up_before_class() {
+		self::$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'ID', self::$user_id )->add_cap( 'activitypub' );
+
+		self::$post_ids = self::factory()->post->create_many( 10, array( 'post_author' => self::$user_id ) );
 	}
 
 	/**
 	 * Clean up test fixtures.
 	 */
 	public static function wpTearDownAfterClass() {
+		\wp_delete_user( self::$user_id );
+
 		foreach ( self::$post_ids as $post_id ) {
 			\wp_delete_post( $post_id, true );
 		}
@@ -79,7 +90,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 	 * @covers ::get_items
 	 */
 	public function test_get_items() {
-		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request  = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
 		$response = \rest_get_server()->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -91,7 +102,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 	 * @covers ::get_collection_schema
 	 */
 	public function test_get_collection_schema() {
-		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request  = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$schema   = ( new Outbox_Controller() )->get_collection_schema();
@@ -106,7 +117,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 	 * @covers ::get_items
 	 */
 	public function test_get_items_pagination() {
-		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
 		$request->set_param( 'page', 2 );
 		$request->set_param( 'per_page', 3 );
 		$response = \rest_get_server()->dispatch( $request );
@@ -125,7 +136,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 	 * @covers ::get_items
 	 */
 	public function test_get_items_response_structure() {
-		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request  = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
 		$response = \rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -151,7 +162,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 		$post_id = self::factory()->post->create(
 			array(
 				'post_author'  => $user_id,
-				'post_type'    => 'ap_outbox',
+				'post_type'    => Outbox::POST_TYPE,
 				'post_status'  => 'draft',
 				'post_title'   => 'https://example.org/activity/1',
 				'post_content' => wp_json_encode(
@@ -219,7 +230,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 			}
 		);
 
-		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
 		\rest_get_server()->dispatch( $request );
 
 		$this->assertTrue( $filter_called, 'activitypub_rest_outbox_array filter was not called.' );
@@ -237,7 +248,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 	 * @covers ::get_items
 	 */
 	public function test_get_items_minimum_per_page() {
-		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
 		$request->set_param( 'per_page', 1 );
 		$response = \rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -252,7 +263,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 	 * @covers ::get_items
 	 */
 	public function test_get_items_maximum_per_page() {
-		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
 		$request->set_param( 'per_page', 100 );
 		$response = \rest_get_server()->dispatch( $request );
 
@@ -489,6 +500,183 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 
 		\wp_delete_post( $post_id, true );
 		\wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test getting items with correct actor type filtering.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_actor_type_filtering() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		// Create a post with user actor type.
+		$user_post_id = self::factory()->post->create(
+			array(
+				'post_author'  => $user_id,
+				'post_type'    => Outbox::POST_TYPE,
+				'post_status'  => 'draft',
+				'post_title'   => 'https://example.org/activity/1',
+				'post_content' => wp_json_encode(
+					array(
+						'@context' => array( 'https://www.w3.org/ns/activitystreams' ),
+						'id'       => 'https://example.org/activity/1',
+						'type'     => 'Create',
+						'actor'    => 'https://example.org/user/' . $user_id,
+						'object'   => array(
+							'id'      => 'https://example.org/note/1',
+							'type'    => 'Note',
+							'content' => 'Test content',
+						),
+					)
+				),
+				'meta_input'   => array(
+					'_activitypub_activity_type'     => 'Create',
+					'_activitypub_activity_actor'    => 'user',
+					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
+				),
+			)
+		);
+
+		// Create a post with blog actor type.
+		$blog_post_id = self::factory()->post->create(
+			array(
+				'post_author'  => $user_id,
+				'post_type'    => Outbox::POST_TYPE,
+				'post_status'  => 'draft',
+				'post_title'   => 'https://example.org/activity/2',
+				'post_content' => wp_json_encode(
+					array(
+						'@context' => array( 'https://www.w3.org/ns/activitystreams' ),
+						'id'       => 'https://example.org/activity/2',
+						'type'     => 'Create',
+						'actor'    => 'https://example.org/blog',
+						'object'   => array(
+							'id'      => 'https://example.org/note/2',
+							'type'    => 'Note',
+							'content' => 'Test content',
+						),
+					)
+				),
+				'meta_input'   => array(
+					'_activitypub_activity_type'     => 'Create',
+					'_activitypub_activity_actor'    => 'blog',
+					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
+				),
+			)
+		);
+
+		// Test user outbox only returns user actor type.
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/outbox' );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 1, (int) $data['totalItems'] );
+		$this->assertCount( 1, $data['orderedItems'] );
+		$this->assertSame( 'https://example.org/activity/1', $data['orderedItems'][0]['object']['id'] );
+
+		// Test blog outbox only returns blog actor type.
+		$request  = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/0/outbox', ACTIVITYPUB_REST_NAMESPACE ) );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 1, (int) $data['totalItems'] );
+
+		\wp_delete_post( $user_post_id, true );
+		\wp_delete_post( $blog_post_id, true );
+		\wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test meta query behavior for non-privileged users.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_meta_query_for_non_privileged_users() {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$viewer_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		// Create a public post.
+		$public_post_id = self::factory()->post->create(
+			array(
+				'post_author'  => $author_id,
+				'post_type'    => Outbox::POST_TYPE,
+				'post_status'  => 'draft',
+				'post_title'   => 'https://example.org/activity/1',
+				'post_content' => wp_json_encode(
+					array(
+						'@context' => array( 'https://www.w3.org/ns/activitystreams' ),
+						'id'       => 'https://example.org/activity/1',
+						'type'     => 'Create',
+						'actor'    => 'https://example.org/user/' . $author_id,
+						'object'   => array(
+							'id'      => 'https://example.org/note/1',
+							'type'    => 'Note',
+							'content' => 'Public content',
+						),
+					)
+				),
+				'meta_input'   => array(
+					'_activitypub_activity_type'     => 'Create',
+					'_activitypub_activity_actor'    => 'user',
+					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
+				),
+			)
+		);
+
+		// Create a private post.
+		$private_post_id = self::factory()->post->create(
+			array(
+				'post_author'  => $author_id,
+				'post_type'    => Outbox::POST_TYPE,
+				'post_status'  => 'draft',
+				'post_title'   => 'https://example.org/activity/2',
+				'post_content' => wp_json_encode(
+					array(
+						'@context' => array( 'https://www.w3.org/ns/activitystreams' ),
+						'id'       => 'https://example.org/activity/2',
+						'type'     => 'Follow',
+						'actor'    => 'https://example.org/user/' . $author_id,
+						'object'   => 'https://example.org/user/123',
+					)
+				),
+				'meta_input'   => array(
+					'_activitypub_activity_type'     => 'Follow',
+					'_activitypub_activity_actor'    => 'user',
+					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL,
+				),
+			)
+		);
+
+		// Test as non-privileged user.
+		wp_set_current_user( $viewer_id );
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $author_id . '/outbox' );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 1, (int) $data['totalItems'] );
+		$this->assertCount( 1, $data['orderedItems'] );
+		$this->assertSame( 'https://example.org/activity/1', $data['orderedItems'][0]['object']['id'] );
+
+		// Test as privileged user.
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $author_id . '/outbox' );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 2, (int) $data['totalItems'] );
+		$this->assertCount( 2, $data['orderedItems'] );
+
+		\wp_delete_post( $public_post_id, true );
+		\wp_delete_post( $private_post_id, true );
+		\wp_delete_user( $author_id );
+		\wp_delete_user( $viewer_id );
+		\wp_delete_user( $admin_id );
 	}
 
 	/**


### PR DESCRIPTION
If the `author` field is null, the `WP_Query` will return every activity regardless of the Actor.

To have a proper result for the blog and application Actor, we have to also add the `_activitypub_activity_actor` to the query.

