### PR TITLE
Outbox: Fall back to blog author for non-authorized authors

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1580,9 +1580,13 @@ function add_to_outbox( $data, $activity_type = 'Create', $user_id = 0, $content
 		return false;
 	}
 
-	// If the user is disabled, use the blog user.
-	if ( is_user_disabled( $user_id ) && ! is_user_disabled( Actors::BLOG_USER_ID ) ) {
-		$user_id = Actors::BLOG_USER_ID;
+	// If the user is disabled, fall back to the blog user when available.
+	if ( is_user_disabled( $user_id ) ) {
+		if ( is_user_disabled( Actors::BLOG_USER_ID ) ) {
+			return false;
+		} else {
+			$user_id = Actors::BLOG_USER_ID;
+		}
 	}
 
 	set_wp_object_state( $data, 'federate' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1580,6 +1580,11 @@ function add_to_outbox( $data, $activity_type = 'Create', $user_id = 0, $content
 		return false;
 	}
 
+	// If the user is disabled, use the blog user.
+	if ( is_user_disabled( $user_id ) && ! is_user_disabled( Actors::BLOG_USER_ID ) ) {
+		$user_id = Actors::BLOG_USER_ID;
+	}
+
 	set_wp_object_state( $data, 'federate' );
 
 	$outbox_activity_id = Outbox::add( $activity_object, $activity_type, $user_id, $content_visibility );

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -79,6 +79,11 @@ class Post {
 			return;
 		}
 
+		// Skip if the post author is not allowed to publish activities.
+		if ( $post->post_author > 0 && ! \user_can( $post->post_author, 'activitypub' ) ) {
+			return;
+		}
+
 		switch ( $new_status ) {
 			case 'publish':
 				$type = ( 'publish' === $old_status ) ? 'Update' : 'Create';

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -14,9 +14,8 @@ use Activitypub\Collection\Actors;
 use Activitypub\Transformer\Factory;
 
 use function Activitypub\add_to_outbox;
-use function Activitypub\get_wp_object_state;
 use function Activitypub\is_post_disabled;
-use function Activitypub\is_user_disabled;
+use function Activitypub\get_wp_object_state;
 
 /**
  * Post scheduler class.

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -80,11 +80,6 @@ class Post {
 			return;
 		}
 
-		// Skip if the post author is not allowed to publish activities.
-		if ( is_user_disabled( $post->post_author ) ) {
-			return;
-		}
-
 		switch ( $new_status ) {
 			case 'publish':
 				$type = ( 'publish' === $old_status ) ? 'Update' : 'Create';

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -14,8 +14,9 @@ use Activitypub\Collection\Actors;
 use Activitypub\Transformer\Factory;
 
 use function Activitypub\add_to_outbox;
-use function Activitypub\is_post_disabled;
 use function Activitypub\get_wp_object_state;
+use function Activitypub\is_post_disabled;
+use function Activitypub\is_user_disabled;
 
 /**
  * Post scheduler class.
@@ -80,7 +81,7 @@ class Post {
 		}
 
 		// Skip if the post author is not allowed to publish activities.
-		if ( $post->post_author > 0 && ! \user_can( $post->post_author, 'activitypub' ) ) {
+		if ( is_user_disabled( $post->post_author ) ) {
 			return;
 		}
 

--- a/tests/includes/class-test-signature.php
+++ b/tests/includes/class-test-signature.php
@@ -58,7 +58,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		$this->assertEquals( $key_pair['private_key'], $private_key );
 
 		// Check application user.
-		$user = Actors::get_by_id( -1 );
+		$user = Actors::get_by_id( Actors::APPLICATION_USER_ID );
 
 		$public_key  = 'public key ' . $user->get__id();
 		$private_key = 'private key ' . $user->get__id();
@@ -73,8 +73,9 @@ class Test_Signature extends \WP_UnitTestCase {
 		$this->assertEquals( $key_pair['private_key'], $private_key );
 
 		// Check blog user.
-		\define( 'ACTIVITYPUB_DISABLE_BLOG_USER', false );
-		$user = Actors::get_by_id( 0 );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		$user = Actors::get_by_id( Actors::BLOG_USER_ID );
+		\delete_option( 'activitypub_actor_mode' );
 
 		$public_key  = 'public key ' . $user->get__id();
 		$private_key = 'private key ' . $user->get__id();

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -12,7 +12,34 @@ namespace Activitypub\Tests\Collection;
  *
  * @coversDefaultClass \Activitypub\Collection\Outbox
  */
-class Test_Outbox extends \Activitypub\Tests\ActivityPub_TestCase_Cache_HTTP {
+class Test_Outbox extends \WP_UnitTestCase {
+	/**
+	 * User ID for testing.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Set up test resources.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		self::$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		// Add activitypub capability to the user.
+		\get_user_by( 'id', self::$user_id )->add_cap( 'activitypub' );
+
+		\add_filter( 'pre_schedule_event', '__return_false' );
+	}
+
+	/**
+	 * Clean up test resources.
+	 */
+	public static function tear_down_after_class() {
+		\wp_delete_user( self::$user_id );
+		\remove_filter( 'pre_schedule_event', '__return_false' );
+	}
 
 	/**
 	 * Test add an item to the outbox.
@@ -30,7 +57,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_TestCase_Cache_HTTP {
 
 		$this->assertIsInt( $id );
 
-		$post = get_post( $id );
+		$post = \get_post( $id );
 
 		$this->assertInstanceOf( 'WP_Post', $post );
 		$this->assertEquals( 'pending', $post->post_status );
@@ -39,8 +66,11 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_TestCase_Cache_HTTP {
 		$activity = json_decode( $post->post_content );
 		$this->assertSame( $data['content'], $activity->content );
 
-		$this->assertEquals( $type, get_post_meta( $id, '_activitypub_activity_type', true ) );
-		$this->assertEquals( 'user', get_post_meta( $id, '_activitypub_activity_actor', true ) );
+		$this->assertEquals( $type, \get_post_meta( $id, '_activitypub_activity_type', true ) );
+
+		// Fall back to blog if user does not have the activitypub capability.
+		$actor_type = \user_can( $user_id, 'activitypub' ) ? 'user' : 'blog';
+		$this->assertEquals( $actor_type, \get_post_meta( $id, '_activitypub_activity_actor', true ) );
 	}
 
 	/**
@@ -53,13 +83,13 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_TestCase_Cache_HTTP {
 			array(
 				array(
 					'@context' => 'https://www.w3.org/ns/activitystreams',
-					'id'       => 'https://example.com/1',
+					'id'       => 'https://example.com/' . self::$user_id,
 					'type'     => 'Note',
 					'content'  => '<p>This is a note</p>',
 				),
 				'Create',
 				1,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/1","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/' . self::$user_id . '","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
 			),
 			array(
 				array(

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -37,6 +37,7 @@ class Test_Outbox extends \WP_UnitTestCase {
 	 * Clean up test resources.
 	 */
 	public static function tear_down_after_class() {
+		\delete_option( 'activitypub_actor_mode' );
 		\wp_delete_user( self::$user_id );
 		\remove_filter( 'pre_schedule_event', '__return_false' );
 	}
@@ -53,6 +54,8 @@ class Test_Outbox extends \WP_UnitTestCase {
 	 * @param string $json    The JSON representation of the data.
 	 */
 	public function test_add( $data, $type, $user_id, $json ) {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
 		$id = \Activitypub\add_to_outbox( $data, $type, $user_id );
 
 		$this->assertIsInt( $id );
@@ -102,6 +105,45 @@ class Test_Outbox extends \WP_UnitTestCase {
 				2,
 				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
 			),
+		);
+	}
+
+	/**
+	 * Test add an item to the outbox with a user.
+	 *
+	 * @covers ::add
+	 * @dataProvider author_object_provider
+	 *
+	 * @param string $mode           The actor mode.
+	 * @param int    $user_id        The user ID.
+	 * @param string $expected_actor The expected actor.
+	 */
+	public function test_author_fallbacks( $mode, $user_id, $expected_actor ) {
+		\update_option( 'activitypub_actor_mode', $mode );
+
+		$user_id = $user_id ?? self::$user_id;
+		$data    = array(
+			'@context' => 'https://www.w3.org/ns/activitystreams',
+			'id'       => 'https://example.com/' . $user_id,
+			'type'     => 'Note',
+			'content'  => '<p>This is a note</p>',
+		);
+
+		$id = \Activitypub\add_to_outbox( $data, 'Create', $user_id );
+		$this->assertEquals( $expected_actor, \get_post_meta( $id, '_activitypub_activity_actor', true ) );
+	}
+
+	/**
+	 * Data provider for test_author_fallbacks.
+	 *
+	 * @return array[]
+	 */
+	public function author_object_provider() {
+		return array(
+			array( ACTIVITYPUB_ACTOR_AND_BLOG_MODE, self::$user_id, 'user' ), // Not sure why we can't access self::$user_id directly.
+			array( ACTIVITYPUB_ACTOR_AND_BLOG_MODE, 90210, 'blog' ),
+			array( ACTIVITYPUB_BLOG_MODE, 90210, 'blog' ),
+			array( ACTIVITYPUB_ACTOR_MODE, 90210, false ),
 		);
 	}
 }

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -88,6 +88,7 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 * @covers ::blog_user_update
 	 */
 	public function test_blog_user_update() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 		$test_value = 'test value';
 		$result     = \Activitypub\Scheduler\Actor::blog_user_update( $test_value );
 
@@ -160,7 +161,7 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 * @covers ::schedule_post_activity
 	 */
 	public function test_schedule_post_activity_extra_field_blog() {
-		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 		$blog_post_id  = self::factory()->post->create( array( 'post_type' => Extra_Fields::BLOG_POST_TYPE ) );
 		$activitpub_id = Actors::get_by_id( Actors::BLOG_USER_ID )->get_id();
 
@@ -169,6 +170,5 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Clean up.
 		\wp_delete_post( $blog_post_id, true );
-		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 	}
 }

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -20,7 +20,7 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 * @covers ::schedule_post_activity
 	 */
 	public function test_schedule_post_activity_regular_post() {
-		$post_id       = self::factory()->post->create();
+		$post_id       = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
 		$activitpub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
 
 		$post = $this->get_latest_outbox_item( $activitpub_id );

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -36,9 +36,6 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 */
 	public function no_activity_post_provider() {
 		return array(
-			'author_cannot_publish' => array(
-				array( 'post_author' => 90210 ),
-			),
 			'password_protected'    => array(
 				array( 'post_password' => 'test-password' ),
 			),

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -36,6 +36,9 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 */
 	public function no_activity_post_provider() {
 		return array(
+			'author_cannot_publish' => array(
+				array( 'post_author' => 90210 ),
+			),
 			'password_protected'    => array(
 				array( 'post_password' => 'test-password' ),
 			),


### PR DESCRIPTION
I noticed Outbox items being created when I imported content, including from authors that were not part of the site, and did not have the `activtipub` cap.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Skip adding Outbox items for post authors that don't have the cap.
* Adds unit test to cover that case.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

