### PR TITLE
Outbox: Fix broken HTML tags after decoding Outbox items

### DIFF
--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -41,7 +41,7 @@ class Outbox {
 		$outbox_item = array(
 			'post_type'    => self::POST_TYPE,
 			'post_title'   => $activity_object->get_id(),
-			'post_content' => $activity_object->to_json(),
+			'post_content' => wp_slash( $activity_object->to_json() ),
 			// ensure that user ID is not below 0.
 			'post_author'  => \max( $user_id, 0 ),
 			'post_status'  => 'pending',

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -36,6 +36,9 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_TestCase_Cache_HTTP {
 		$this->assertEquals( 'pending', $post->post_status );
 		$this->assertEquals( $json, $post->post_content );
 
+		$activity = json_decode( $post->post_content );
+		$this->assertSame( $data['content'], $activity->content );
+
 		$this->assertEquals( $type, get_post_meta( $id, '_activitypub_activity_type', true ) );
 		$this->assertEquals( 'user', get_post_meta( $id, '_activitypub_activity_actor', true ) );
 	}
@@ -52,22 +55,22 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_TestCase_Cache_HTTP {
 					'@context' => 'https://www.w3.org/ns/activitystreams',
 					'id'       => 'https://example.com/1',
 					'type'     => 'Note',
-					'content'  => 'This is a note',
+					'content'  => '<p>This is a note</p>',
 				),
 				'Create',
 				1,
-				'{"@context":["https://www.w3.org/ns/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https://example.com/1","type":"Note","content":"This is a note","contentMap":{"en":"This is a note"},"tag":[],"to":["https://www.w3.org/ns/activitystreams#Public"],"mediaType":"text/html","sensitive":false}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/1","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html","sensitive":false}',
 			),
 			array(
 				array(
 					'@context' => 'https://www.w3.org/ns/activitystreams',
 					'id'       => 'https://example.com/2',
 					'type'     => 'Note',
-					'content'  => 'This is another note',
+					'content'  => '<p>This is another note</p>',
 				),
 				'Create',
 				2,
-				'{"@context":["https://www.w3.org/ns/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https://example.com/2","type":"Note","content":"This is another note","contentMap":{"en":"This is another note"},"tag":[],"to":["https://www.w3.org/ns/activitystreams#Public"],"mediaType":"text/html","sensitive":false}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html","sensitive":false}',
 			),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes broken JSON after `wp_insert_post()` removed slashes needed to identified escaped entities.

See https://mastodon.social/@obenland@obietester.blog/113879625343031178

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Slashes Outbox json before inserting it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?


