### PR TITLE
Send Activity and not its object

### DIFF
--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -64,12 +64,9 @@ class Dispatcher {
 		$activity = new Activity();
 		$activity->set_type( $type );
 		$activity->set_id( $outbox_item->guid );
-		$activity->set_actor( Actors::get_by_id( $outbox_item->post_author )->get_id() );
-    
 		// Pre-fill the Activity with data (for example cc and to).
-		$activity_object = Activity::init_from_json( $outbox_item->post_content );
-		$activity->set_object( $activity_object );
-
+		$activity->set_object( Activity::init_from_json( $outbox_item->post_content ) );
+		$activity->set_actor( Actors::get_by_id( $outbox_item->post_author )->get_id() );
 
 		// Use simple Object (only ID-URI) for Like and Announce.
 		if ( 'Like' === $type ) {

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -10,7 +10,6 @@ namespace Activitypub;
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
-use Activitypub\Transformer\Factory as Transformer_Factory;
 
 /**
  * ActivityPub Dispatcher Class.
@@ -65,8 +64,10 @@ class Dispatcher {
 		$activity = new Activity();
 		$activity->set_type( $type );
 		$activity->set_id( $outbox_item->guid );
+
 		// Pre-fill the Activity with data (for example cc and to).
-		$activity->from_json( $outbox_item->post_content );
+		$activity_object = Activity::init_from_json( $outbox_item->post_content );
+		$activity->set_object( $activity_object );
 
 		// If the activity doesn't have an actor, set the actor to the post author.
 		if ( ! $activity->get_actor() ) {

--- a/tests/includes/class-test-dispatcher.php
+++ b/tests/includes/class-test-dispatcher.php
@@ -15,7 +15,7 @@ use Activitypub\Dispatcher;
  *
  * @coversDefaultClass Activitypub\Dispatcher
  */
-class Test_Dispatcher extends WP_UnitTestCase {
+class Test_Dispatcher extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	/**
 	 * Tear down the test case.
 	 */
@@ -89,5 +89,28 @@ class Test_Dispatcher extends WP_UnitTestCase {
 
 		$result = Dispatcher::maybe_add_inboxes_of_blog_user( $inboxes, 1, $activity );
 		$this->assertEquals( $inboxes, $result );
+	}
+
+	/**
+	 * Test process_outbox.
+	 *
+	 * @covers ::process_outbox
+	 */
+	public function test_process_outbox() {
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+
+		$test_callback = function ( $send, $activity ) {
+			$this->assertInstanceOf( Activity::class, $activity );
+			$this->assertEquals( 'Create', $activity->get_type() );
+
+			return $send;
+		};
+		add_filter( 'activitypub_send_activity_to_followers', $test_callback, 10, 2 );
+
+		$outbox_item = $this->get_latest_outbox_item( \add_query_arg( 'p', $post_id, \home_url( '/' ) ) );
+
+		Dispatcher::process_outbox( $outbox_item->ID );
+
+		remove_filter( 'activitypub_send_activity_to_followers', $test_callback );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a bug where we sent the activity object as an activity.