### PR TITLE
Outbox: Fix attachment transitions

### DIFF
--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -49,15 +49,19 @@ class Post {
 	 * @param int $post_id Attachment ID.
 	 */
 	public static function transition_attachment_status( $post_id ) {
+		if ( ! \post_type_supports( 'attachment', 'activitypub' ) ) {
+			return;
+		}
+
 		switch ( current_action() ) {
 			case 'add_attachment':
-				self::schedule_post_activity( 'publish', '', $post_id );
+				self::schedule_post_activity( 'publish', '', get_post( $post_id ) );
 				break;
 			case 'edit_attachment':
-				self::schedule_post_activity( 'publish', 'publish', $post_id );
+				self::schedule_post_activity( 'publish', 'publish', get_post( $post_id ) );
 				break;
 			case 'delete_attachment':
-				self::schedule_post_activity( 'trash', '', $post_id );
+				self::schedule_post_activity( 'trash', '', get_post( $post_id ) );
 				break;
 		}
 	}

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -161,6 +161,10 @@ class Post {
 	/**
 	 * Filter the post data before it is inserted via the REST API.
 	 *
+	 * Posts being inserted via the REST API have a different order of operations than in wp_insert_post().
+	 * This filter updates post meta before the post is inserted into the database, so that the
+	 * information is available by the time @see Outbox::add() runs.
+	 *
 	 * @param \stdClass        $post     An object representing a single post prepared for inserting or updating the database.
 	 * @param \WP_REST_Request $request  The request object.
 	 *

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -69,9 +69,9 @@ class Post {
 	/**
 	 * Schedule Activities.
 	 *
-	 * @param string       $new_status New post status.
-	 * @param string       $old_status Old post status.
-	 * @param int|\WP_Post $post       Post ID or post object.
+	 * @param string   $new_status New post status.
+	 * @param string   $old_status Old post status.
+	 * @param \WP_Post $post       Post object.
 	 */
 	public static function schedule_post_activity( $new_status, $old_status, $post ) {
 		if ( is_post_disabled( $post ) ) {

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -15,6 +15,39 @@ namespace Activitypub\Tests\Scheduler;
 class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 	/**
+	 * Test post activity scheduling for attachments.
+	 *
+	 * @covers ::transition_attachment_status
+	 */
+	public function test_transition_attachment_status() {
+		add_post_type_support( 'attachment', 'activitypub' );
+		wp_set_current_user( self::$user_id );
+
+		// Create.
+		$post_id       = self::factory()->attachment->create_upload_object( dirname( __DIR__, 2 ) . '/assets/test.jpg' );
+		$activitpub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
+		$outbox_item   = $this->get_latest_outbox_item( $activitpub_id );
+
+		$this->assertNotNull( $outbox_item );
+		$this->assertSame( 'Create', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
+
+		// Update.
+		self::factory()->attachment->update_object( $post_id, array( 'post_title' => 'Updated title' ) );
+
+		$outbox_item = $this->get_latest_outbox_item( $activitpub_id );
+		$this->assertSame( 'Update', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
+
+		// Delete.
+		\wp_delete_attachment( $post_id, true );
+
+		// Not federated, should not send Delete activity.
+		$outbox_item = $this->get_latest_outbox_item( $activitpub_id );
+		$this->assertSame( 'Update', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
+
+		remove_post_type_support( 'attachment', 'activitypub' );
+	}
+
+	/**
 	 * Test post activity scheduling for regular posts.
 	 *
 	 * @covers ::schedule_post_activity


### PR DESCRIPTION
Passing Post ID only led to errors and Outbox items were not created for attachments.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Short-circuits attachment transition callbacks when the post type is not supported.
* Passes full post objects to `add_to_outbox()` instead of only post_ids (which caused errors)
* Adds unit tests for the fix.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

