### PR TITLE
Outbox: Account for invalid json

### DIFF
--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -588,7 +588,7 @@ class Base_Object {
 	 *
 	 * @param string $json The JSON string.
 	 *
-	 * @return Base_Object An Object built from the JSON string.
+	 * @return Base_Object|WP_Error An Object built from the JSON string or WP_Error when it's not a JSON string.
 	 */
 	public static function init_from_json( $json ) {
 		$array = \json_decode( $json, true );

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -68,12 +68,6 @@ class Dispatcher {
 		$activity->set_object( \json_decode( $outbox_item->post_content, true ) );
 		$activity->set_actor( Actors::get_by_id( $outbox_item->post_author )->get_id() );
 
-		// Pre-fill the Activity with data (for example cc and to).
-		$activity_object = Activity::init_from_json( $outbox_item->post_content );
-		if ( ! is_wp_error( $activity_object ) ) {
-			$activity->set_object( $activity_object );
-		}
-
 		// Use simple Object (only ID-URI) for Like and Announce.
 		if ( in_array( $type, array( 'Like', 'Delete' ), true ) ) {
 			$activity->set_object( $activity->get_object()->get_id() );

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -68,6 +68,12 @@ class Dispatcher {
 		$activity->set_object( \json_decode( $outbox_item->post_content, true ) );
 		$activity->set_actor( Actors::get_by_id( $outbox_item->post_author )->get_id() );
 
+		// Pre-fill the Activity with data (for example cc and to).
+		$activity_object = Activity::init_from_json( $outbox_item->post_content );
+		if ( ! is_wp_error( $activity_object ) ) {
+			$activity->set_object( $activity_object );
+		}
+
 		// Use simple Object (only ID-URI) for Like and Announce.
 		if ( in_array( $type, array( 'Like', 'Delete' ), true ) ) {
 			$activity->set_object( $activity->get_object()->get_id() );

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -197,12 +197,8 @@ class Followers {
 		$args      = wp_parse_args( $args, $defaults );
 		$query     = new WP_Query( $args );
 		$total     = $query->found_posts;
-		$followers = array_map(
-			function ( $post ) {
-				return Follower::init_from_cpt( $post );
-			},
-			$query->get_posts()
-		);
+		$followers = array_map( array( Follower::class, 'init_from_cpt' ), $query->get_posts() );
+		$followers = array_filter( $followers );
 
 		return compact( 'followers', 'total' );
 	}
@@ -354,13 +350,9 @@ class Followers {
 		);
 
 		$posts = new WP_Query( $args );
-		$items = array();
+		$items = array_map( array( Follower::class, 'init_from_cpt' ), $posts->get_posts() );
 
-		foreach ( $posts->get_posts() as $follower ) {
-			$items[] = Follower::init_from_cpt( $follower );
-		}
-
-		return $items;
+		return array_filter( $items );
 	}
 
 	/**
@@ -403,13 +395,9 @@ class Followers {
 		);
 
 		$posts = new WP_Query( $args );
-		$items = array();
+		$items = array_map( array( Follower::class, 'init_from_cpt' ), $posts->get_posts() );
 
-		foreach ( $posts->get_posts() as $follower ) {
-			$items[] = Follower::init_from_cpt( $follower );
-		}
-
-		return $items;
+		return array_filter( $items );
 	}
 
 	/**

--- a/includes/model/class-follower.php
+++ b/includes/model/class-follower.php
@@ -331,11 +331,16 @@ class Follower extends Actor {
 	 * Convert a Custom-Post-Type input to an Activitypub\Model\Follower.
 	 *
 	 * @param \WP_Post $post The post object.
-	 * @return \Activitypub\Activity\Base_Object|WP_Error
+	 * @return \Activitypub\Activity\Base_Object|false The Follower object or false on failure.
 	 */
 	public static function init_from_cpt( $post ) {
 		$actor_json = get_post_meta( $post->ID, '_activitypub_actor_json', true );
 		$object     = self::init_from_json( $actor_json );
+
+		if ( is_wp_error( $object ) ) {
+			return false;
+		}
+
 		$object->set__id( $post->ID );
 		$object->set_id( $post->guid );
 		$object->set_name( $post->post_title );

--- a/tests/includes/activity/class-test-base-object.php
+++ b/tests/includes/activity/class-test-base-object.php
@@ -58,4 +58,16 @@ class Test_Base_Object extends \WP_UnitTestCase {
 			array( array( 'value', 'value' ), array( 'value' ) ),
 		);
 	}
+
+	/**
+	 * Test init_from_json method.
+	 *
+	 * @covers ::init_from_json
+	 */
+	public function test_init_from_json() {
+		$invalid_json = '{"@context":https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}';
+		$base_object  = Base_Object::init_from_json( $invalid_json );
+
+		$this->assertInstanceOf( 'WP_Error', $base_object );
+	}
 }

--- a/tests/includes/collection/class-test-followers.php
+++ b/tests/includes/collection/class-test-followers.php
@@ -115,6 +115,26 @@ class Test_Followers extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests get_followers with corrupted json.
+	 *
+	 * @covers ::get_followers
+	 */
+	public function test_get_followers_without_errors() {
+		$followers = array( 'https://example.com/author/jon', 'https://example.org/author/doe', 'https://sally.example.org' );
+
+		foreach ( $followers as $follower ) {
+			Followers::add_follower( 1, $follower );
+		}
+
+		$follower = Followers::get_follower( 1, 'https://example.org/author/doe' );
+		update_post_meta( $follower->get__id(), '_activitypub_actor_json', 'invalid json' );
+
+		$db_followers = Followers::get_followers( 1 );
+
+		$this->assertEquals( 2, \count( $db_followers ) );
+	}
+
+	/**
 	 * Tests add_follower.
 	 *
 	 * @covers ::add_follower

--- a/tests/includes/collection/class-test-followers.php
+++ b/tests/includes/collection/class-test-followers.php
@@ -120,7 +120,7 @@ class Test_Followers extends \WP_UnitTestCase {
 	 * @covers ::get_followers
 	 */
 	public function test_get_followers_without_errors() {
-		$followers = array( 'https://example.com/author/jon', 'https://example.org/author/doe', 'https://sally.example.org' );
+		$followers = array( 'https://example.com/author/jon', 'https://example.org/author/doe', 'http://sally.example.org' );
 
 		foreach ( $followers as $follower ) {
 			Followers::add_follower( 1, $follower );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Not quite sure this is the best way to go. I'd be fine with restoring `init_from_json()` to working with an empty array, too.

See p1738085487855409/1738079794.569609-slack-C04TJ8P900J

```
PHP Fatal error:  Uncaught Error: Call to undefined method WP_Error::set__id() in /wp-content/plugins/activitypub/includes/model/class-follower.php:339
Stack trace:
#0 /wp-content/plugins/activitypub/includes/collection/class-followers.php(202): Activitypub\Model\Follower::init_from_cpt(Object(WP_Post))
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds WP Error checks to all calls of `init_from_json()`.
* Adds test to cover the possibility of invalid json.

### Other information:

- [x] Have you written new tests for your changes, if applicable?