### PR TITLE
Fix: Importing tags from the Fediverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Handle deletes from remote servers that leave behind an accessible Tombstone object.
+* No longer parses tags for post types that don't support Activitypub.
 
 ## [4.7.3] - 2025-01-21
 

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -53,6 +53,11 @@ class Hashtag {
 	 * @param \WP_Post $post    Post object.
 	 */
 	public static function insert_post( $post_id, $post ) {
+		// Check if the post supports ActivityPub.
+		if ( ! \post_type_supports( \get_post_type( $post ), 'activitypub' ) ) {
+			return;
+		}
+
 		$tags = array();
 
 		// Skip hashtags in HTML attributes, like hex colors.

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -58,6 +58,12 @@ class Hashtag {
 			return;
 		}
 
+		// Check if the (custom) post supports tags.
+		$taxonomies = \get_object_taxonomies( $post );
+		if ( ! in_array( 'post_tag', $taxonomies, true ) ) {
+			return;
+		}
+
 		$tags = array();
 
 		// Skip hashtags in HTML attributes, like hex colors.

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 * Changed: Improved content negotiation and AUTHORIZED_FETCH support for third-party plugins
 * Fixed: Handle deletes from remote servers that leave behind an accessible Tombstone object.
+* Fixed: No longer parses tags for post types that don't support Activitypub.
 
 = 4.7.3 =
 

--- a/tests/includes/class-test-hashtag.php
+++ b/tests/includes/class-test-hashtag.php
@@ -7,6 +7,8 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Collection\Followers;
+
 /**
  * Test class for Activitypub Hashtag.
  *
@@ -89,7 +91,7 @@ ENDPRE;
 	 * @param string   $message       The error message.
 	 */
 	public function test_hashtag_conversion( $content, $excerpt, $expected_tags, $message ) {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => $content,
 				'post_excerpt' => $excerpt,
@@ -102,6 +104,25 @@ ENDPRE;
 		foreach ( $expected_tags as $tag ) {
 			$this->assertContains( $tag, $tags, $message );
 		}
+	}
+
+	/**
+	 * Test no hashtags for unsupported post types.
+	 *
+	 * @covers ::insert_post
+	 */
+	public function test_no_hashtags_for_unsupported_post_types() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => 'Testing #php and #programming',
+				'post_type'    => Followers::POST_TYPE,
+			)
+		);
+
+		\Activitypub\Hashtag::insert_post( $post_id, get_post( $post_id ) );
+		$tags = wp_get_post_tags( $post_id, array( 'fields' => 'names' ) );
+
+		$this->assertEmpty( $tags, 'Should not add hashtags to unsupported post types' );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a check, so that only supported posts will be parsed for tags. This will prevent, that followers and other custom post types will be parsed for Hashtags.

Fixes #1167