### PR TITLE
Extra Fields: Fix rel me count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Handle deletes from remote servers that leave behind an accessible Tombstone object.
 * No longer parses tags for post types that don't support Activitypub.
+* rel attribute will now contain no more than one "me" value.
 
 ## [4.7.3] - 2025-01-21
 

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -93,14 +93,7 @@ class Extra_Fields {
 	 */
 	public static function fields_to_attachments( $fields ) {
 		$attachments = array();
-		\add_filter(
-			'activitypub_link_rel',
-			function ( $rel ) {
-				$rel .= ' me';
-
-				return $rel;
-			}
-		);
+		\add_filter( 'activitypub_link_rel', array( self::class, 'add_rel_me' ) );
 
 		foreach ( $fields as $post ) {
 			$content       = self::get_formatted_content( $post );
@@ -114,7 +107,7 @@ class Extra_Fields {
 				),
 			);
 
-			$link_added = false;
+			$attachment = false;
 
 			// Add support for FEP-fb2a, for more information see FEDERATION.md.
 			$link_content = \trim( \strip_tags( $content, '<a>' ) );
@@ -139,12 +132,10 @@ class Extra_Fields {
 					if ( $rel && \is_string( $rel ) ) {
 						$attachment['rel'] = \explode( ' ', $rel );
 					}
-
-					$link_added = true;
 				}
 			}
 
-			if ( ! $link_added ) {
+			if ( ! $attachment ) {
 				$attachment = array(
 					'type'    => 'Note',
 					'name'    => \get_the_title( $post ),
@@ -158,6 +149,8 @@ class Extra_Fields {
 
 			$attachments[] = $attachment;
 		}
+
+		\remove_filter( 'activitypub_link_rel', array( self::class, 'add_rel_me' ) );
 
 		return $attachments;
 	}
@@ -283,6 +276,16 @@ class Extra_Fields {
 			return $content;
 		}
 		return '<!-- wp:paragraph --><p>' . $content . '</p><!-- /wp:paragraph -->';
+	}
+
+	/**
+	 * Add the 'me' rel to the link.
+	 *
+	 * @param string $rel The rel attribute.
+	 * @return string The modified rel attribute.
+	 */
+	public static function add_rel_me( $rel ) {
+		return $rel . ' me';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Changed: Improved content negotiation and AUTHORIZED_FETCH support for third-party plugins
 * Fixed: Handle deletes from remote servers that leave behind an accessible Tombstone object.
 * Fixed: No longer parses tags for post types that don't support Activitypub.
+* Fixed: rel attribute will now contain no more than one "me" value.
 
 = 4.7.3 =
 

--- a/tests/includes/collection/class-test-extra-fields.php
+++ b/tests/includes/collection/class-test-extra-fields.php
@@ -22,6 +22,10 @@ class Test_Extra_Fields extends \WP_UnitTestCase {
 	 * @covers ::get_attachment
 	 */
 	public function test_get_attachment() {
+		if ( ! class_exists( '\WP_HTML_Tag_Processor' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Tag_Processor not available' );
+		}
+
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => Extra_Fields::BLOG_POST_TYPE,

--- a/tests/includes/collection/class-test-extra-fields.php
+++ b/tests/includes/collection/class-test-extra-fields.php
@@ -1,21 +1,20 @@
 <?php
 /**
- * Test file for Activitypub Blog.
+ * Test file for Extra Fields.
  *
  * @package Activitypub
  */
 
-namespace Activitypub\Tests\Model;
+namespace Activitypub\Tests\Collection;
 
 use Activitypub\Collection\Extra_Fields;
-use Activitypub\Model\Blog;
 
 /**
- * Test class for Activitypub Blog.
+ * Test class for Extra Fields.
  *
- * @coversDefaultClass \Activitypub\Model\Blog
+ * @coversDefaultClass \Activitypub\Collection\Extra_Fields
  */
-class Test_Blog extends \WP_UnitTestCase {
+class Test_Extra_Fields extends \WP_UnitTestCase {
 
 	/**
 	 * Test the get_attachment.
@@ -23,7 +22,7 @@ class Test_Blog extends \WP_UnitTestCase {
 	 * @covers ::get_attachment
 	 */
 	public function test_get_attachment() {
-		self::factory()->post->create(
+		$post = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => Extra_Fields::BLOG_POST_TYPE,
 				'post_content' => 'https://wordpress.org/plugins/activitypub/',
@@ -32,10 +31,9 @@ class Test_Blog extends \WP_UnitTestCase {
 		);
 
 		// Multiple calls should not result in multiple "me" values in rel attribute.
-		$user = new Blog();
-		$user->get_attachment();
-		$user->get_attachment();
-		$attachments = $user->get_attachment();
+		Extra_Fields::fields_to_attachments( array( $post ) );
+		Extra_Fields::fields_to_attachments( array( $post ) );
+		$attachments = Extra_Fields::fields_to_attachments( array( $post ) );
 		$value_count = array_count_values( $attachments[1]['rel'] );
 
 		$this->assertEquals( 1, $value_count['me'] );

--- a/tests/includes/model/class-test-blog.php
+++ b/tests/includes/model/class-test-blog.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Test file for Activitypub Blog.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Model;
+
+use Activitypub\Collection\Extra_Fields;
+use Activitypub\Model\Blog;
+
+/**
+ * Test class for Activitypub Blog.
+ *
+ * @coversDefaultClass \Activitypub\Model\Blog
+ */
+class Test_Blog extends \WP_UnitTestCase {
+
+	/**
+	 * Test the get_attachment.
+	 *
+	 * @covers ::get_attachment
+	 */
+	public function test_get_attachment() {
+		self::factory()->post->create(
+			array(
+				'post_type'    => Extra_Fields::BLOG_POST_TYPE,
+				'post_content' => 'https://wordpress.org/plugins/activitypub/',
+				'post_title'   => 'ActivityPub',
+			)
+		);
+
+		// Multiple calls should not result in multiple "me" values in rel attribute.
+		$user = new Blog();
+		$user->get_attachment();
+		$user->get_attachment();
+		$attachments = $user->get_attachment();
+		$value_count = array_count_values( $attachments[1]['rel'] );
+
+		$this->assertEquals( 1, $value_count['me'] );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Multiple calls to `ActivityPub\Model\Blog::get_attachment()` result in multiple `me` values getting added to the `rel` attribute. No more!

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes rel me filter after adding it so they don't get stacked.
* Fixes a possible undefined variable warning.
* Adds unit test.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

