### PR TITLE
Fix negotiation of ActivityPub requests for custom post types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Handle deletes from remote servers that leave behind an accessible Tombstone object.
 * No longer parses tags for post types that don't support Activitypub.
+* Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 
 ## [4.7.3] - 2025-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Changed
 
 * Manually granting `activitypub` cap no longer requires the receiving user to have `publish_post`.
+
+### Fixed
+
+* Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 
 ## [5.0.0] - 2025-02-03
 
@@ -22,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Handle deletes from remote servers that leave behind an accessible Tombstone object.
 * No longer parses tags for post types that don't support Activitypub.
-* Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 * rel attribute will now contain no more than one "me" value.
 
 ## [4.7.3] - 2025-01-21

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -154,6 +154,12 @@ class Query {
 			return \get_comment( $comment_id );
 		}
 
+		// Check Post by ID (works for custom post types).
+		$post_id = \get_query_var( 'p' );
+		if ( $post_id ) {
+			return \get_post( $post_id );
+		}
+
 		// Try to get Author by ID.
 		$url       = $this->get_request_url();
 		$author_id = url_to_authorid( $url );

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Changed: Improved content negotiation and AUTHORIZED_FETCH support for third-party plugins
 * Fixed: Handle deletes from remote servers that leave behind an accessible Tombstone object.
 * Fixed: No longer parses tags for post types that don't support Activitypub.
+* Fixed: Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 
 = 4.7.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Changed: Manually granting `activitypub` cap no longer requires the receiving user to have `publish_post`.
+* Fixed: Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 
 = 5.0.0 =
 
@@ -143,7 +144,6 @@ For reasons of data protection, it is not possible to see the followers of other
 * Changed: Moved password check to `is_post_disabled` function.
 * Fixed: Handle deletes from remote servers that leave behind an accessible Tombstone object.
 * Fixed: No longer parses tags for post types that don't support Activitypub.
-* Fixed: Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 * Fixed: rel attribute will now contain no more than one "me" value.
 
 = 4.7.3 =


### PR DESCRIPTION
Please try to reproduce this first. It seems the WordPress function `\get_queried_object() `used in the `\ActivityPub\Query->get_queried_object()` does not work with custom post types, when pretty permalinks are used and the query URL is `?p=<post_id>`.
