### PR TITLE
Settings: Make tabs filterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Cleanup of option values when the plugin is uninstalled
-
-### Added
-
 * Third-party plugins can filter settings tabs to add their own settings pages for ActivityPub.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Cleanup of option values when the plugin is uninstalled
 
+### Added
+
+* Third-party plugins can filter settings tabs to add their own settings pages for ActivityPub.
+
 ### Changed
 
 * Manually granting `activitypub` cap no longer requires the receiving user to have `publish_post`.

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -45,11 +45,10 @@
 }
 
 .activitypub-settings-tabs-wrapper {
-	display: -ms-inline-grid;
-	-ms-grid-columns: auto auto auto auto;
+	display: inline-flex;
 	vertical-align: top;
-	display: inline-grid;
-	grid-template-columns: auto auto auto auto;
+	flex-wrap: nowrap;
+	gap: 0;
 }
 
 .activitypub-settings-tab.active {

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -1,0 +1,61 @@
+# ActivityPub Plugin Developer Documentation
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Extending the Settings Interface](#extending-the-settings-interface)
+
+## Introduction
+This documentation provides information for developers who want to extend and build upon the ActivityPub plugin. Whether you're developing a complementary plugin or integrating ActivityPub features into your existing WordPress plugin, this guide will help you understand the available hooks and customization options.
+
+## Extending the Settings Interface
+
+### Adding Custom Settings Tabs
+The ActivityPub plugin provides a flexible settings interface that can be extended with custom tabs. This allows you to seamlessly integrate your plugin's settings within the ActivityPub settings page.
+
+#### Using the `activitypub_admin_settings_tabs` Filter
+The `activitypub_admin_settings_tabs` filter allows you to add new tabs to the settings interface. Each tab consists of a label and a template file path.
+
+##### Example Usage:
+```php
+/**
+ * Adds a custom tab to the ActivityPub settings.
+ *
+ * @param array $tabs The existing tabs array.
+ * @return array The modified tabs array.
+ */
+function my_custom_settings_tab( $tabs ) {
+    $tabs['my-custom-tab'] = array(
+        'label'    => __( 'My Custom Tab', 'my-plugin-textdomain' ),
+        'template' => MY_PLUGIN_DIR . 'templates/custom-settings.php',
+    );
+
+    return $tabs;
+}
+add_filter( 'activitypub_admin_settings_tabs', 'my_custom_settings_tab' );
+```
+
+##### Parameters:
+The tab configuration array requires two keys:
+- `label`: (string) The displayed name of the tab (should be translatable).
+- `template`: (string) Absolute path to the template file that will be loaded when the tab is active.
+
+#### Best Practices
+1. **Namespace Your Tab Keys**: Use unique identifiers for your tab keys to avoid conflicts with other plugins.
+2. **Template Location**: Store your template files in your plugin's directory structure.
+3. **Security**: Always implement proper security checks in your template files.
+4. **Internationalization**: Make your labels and template content translatable.
+5. **Asset Loading**: If your tab requires specific CSS or JavaScript, enqueue them conditionally:
+```php
+add_action( 'admin_enqueue_scripts', function( $hook ) {
+    if ( 'settings_page_activitypub' !== $hook ) {
+        return;
+    }
+    
+    // Check if we're on your custom tab.
+    $current_tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'welcome';
+    if ( 'my-custom-tab' === $current_tab ) {
+        wp_enqueue_script( 'my-custom-tab-script' );
+        wp_enqueue_style( 'my-custom-tab-style' );
+    }
+} );
+```

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -148,12 +148,7 @@ class Admin {
 	 */
 	public static function settings_page() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( empty( $_GET['tab'] ) ) {
-			$tab = 'welcome';
-		} else {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$tab = sanitize_key( $_GET['tab'] );
-		}
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'welcome';
 
 		$settings_tabs = array(
 			'welcome'  => array(
@@ -196,13 +191,13 @@ class Admin {
 				break;
 		}
 
-		\load_template(
-			$settings_tabs[ $tab ]['template'],
-			true,
-			array(
-				'settings_tabs' => wp_list_pluck( $settings_tabs, 'label' ),
-			)
-		);
+		$labels       = wp_list_pluck( $settings_tabs, 'label' );
+		$args         = array_fill_keys( array_keys( $labels ), '' );
+		$args[ $tab ] = 'active';
+		$args['tabs'] = $labels;
+
+		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/admin-header.php', true, $args );
+		\load_template( $settings_tabs[ $tab ]['template'] );
 	}
 
 	/**

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -155,28 +155,54 @@ class Admin {
 			$tab = sanitize_key( $_GET['tab'] );
 		}
 
+		$settings_tabs = array(
+			'welcome'  => array(
+				'label'    => __( 'Welcome', 'activitypub' ),
+				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/welcome.php',
+			),
+			'settings' => array(
+				'label'    => __( 'Settings', 'activitypub' ),
+				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php',
+			),
+		);
+		if ( ! is_user_disabled( Actors::BLOG_USER_ID ) ) {
+			$settings_tabs['blog-profile'] = array(
+				'label'    => __( 'Blog Profile', 'activitypub' ),
+				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-settings.php',
+			);
+			$settings_tabs['followers']    = array(
+				'label'    => __( 'Followers', 'activitypub' ),
+				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-followers-list.php',
+			);
+		}
+
+		/**
+		 * Filters the tabs displayed in the ActivityPub settings.
+		 *
+		 * @param array $settings_tabs The tabs to display.
+		 */
+		$custom_tabs   = \apply_filters( 'activitypub_admin_settings_tabs', array() );
+		$settings_tabs = \array_merge( $settings_tabs, $custom_tabs );
+
 		switch ( $tab ) {
-			case 'settings':
-				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php' );
-				break;
 			case 'blog-profile':
 				wp_enqueue_media();
 				wp_enqueue_script( 'activitypub-header-image' );
-
-				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-settings.php' );
-				break;
-			case 'followers':
-				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-followers-list.php' );
 				break;
 			case 'welcome':
-			default:
 				wp_enqueue_script( 'plugin-install' );
 				add_thickbox();
 				wp_enqueue_script( 'updates' );
-
-				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/welcome.php' );
 				break;
 		}
+
+		\load_template(
+			$settings_tabs[ $tab ]['template'],
+			true,
+			array(
+				'settings_tabs' => wp_list_pluck( $settings_tabs, 'label' ),
+			)
+		);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Added: Cleanup of option values when the plugin is uninstalled
+* Added: Third-party plugins can filter settings tabs to add their own settings pages for ActivityPub.
 * Changed: Manually granting `activitypub` cap no longer requires the receiving user to have `publish_post`.
 * Changed: Allow Base Transformer to handle WP_Term objects for transformation.
 * Fixed: Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -5,16 +5,10 @@
  * @package Activitypub
  */
 
+global $settings_tabs;
+
 /* @var array $args Template arguments. */
-$args = wp_parse_args(
-	$args,
-	array(
-		'welcome'      => '',
-		'settings'     => '',
-		'blog-profile' => '',
-		'followers'    => '',
-	)
-);
+$args = wp_parse_args( $args, array_fill_keys( array_keys( $settings_tabs ), '' ) );
 ?>
 <div class="activitypub-settings-header">
 	<div class="activitypub-settings-title-section">
@@ -22,25 +16,21 @@ $args = wp_parse_args(
 	</div>
 
 	<nav class="activitypub-settings-tabs-wrapper" aria-label="<?php \esc_attr_e( 'Secondary menu', 'activitypub' ); ?>">
-		<a href="<?php echo \esc_url( admin_url( 'options-general.php?page=activitypub' ) ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args['welcome'] ); ?>">
-			<?php \esc_html_e( 'Welcome', 'activitypub' ); ?>
-		</a>
+		<?php
+		foreach ( $settings_tabs as $slug => $label ) :
+			$url = add_query_arg(
+				array( 'tab' => 'welcome' !== $slug ? $slug : false ),
+				\admin_url( 'options-general.php?page=activitypub' )
+			);
+			?>
 
-		<a href="<?php echo \esc_url( admin_url( 'options-general.php?page=activitypub&tab=settings' ) ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args['settings'] ); ?>">
-			<?php \esc_html_e( 'Settings', 'activitypub' ); ?>
-		</a>
+			<a href="<?php echo \esc_url( $url ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args[ $slug ] ); ?>">
+				<?php echo \esc_html( $label ); ?>
+			</a>
 
-		<?php if ( ! \Activitypub\is_user_disabled( \Activitypub\Collection\Actors::BLOG_USER_ID ) ) : ?>
-
-		<a href="<?php echo \esc_url( admin_url( 'options-general.php?page=activitypub&tab=blog-profile' ) ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args['blog-profile'] ); ?>">
-			<?php \esc_html_e( 'Blog-Profile', 'activitypub' ); ?>
-		</a>
-
-		<a href="<?php echo \esc_url( admin_url( 'options-general.php?page=activitypub&tab=followers' ) ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args['followers'] ); ?>">
-			<?php \esc_html_e( 'Followers', 'activitypub' ); ?>
-		</a>
-
-		<?php endif; ?>
+			<?php
+		endforeach;
+		?>
 	</nav>
 </div>
 <hr class="wp-header-end">

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -5,10 +5,8 @@
  * @package Activitypub
  */
 
-global $settings_tabs;
-
 /* @var array $args Template arguments. */
-$args = wp_parse_args( $args, array_fill_keys( array_keys( $settings_tabs ), '' ) );
+$args = wp_parse_args( $args );
 ?>
 <div class="activitypub-settings-header">
 	<div class="activitypub-settings-title-section">
@@ -17,7 +15,7 @@ $args = wp_parse_args( $args, array_fill_keys( array_keys( $settings_tabs ), '' 
 
 	<nav class="activitypub-settings-tabs-wrapper" aria-label="<?php \esc_attr_e( 'Secondary menu', 'activitypub' ); ?>">
 		<?php
-		foreach ( $settings_tabs as $slug => $label ) :
+		foreach ( $args['tabs'] as $slug => $label ) :
 			$url = add_query_arg(
 				array( 'tab' => 'welcome' !== $slug ? $slug : false ),
 				\admin_url( 'options-general.php?page=activitypub' )

--- a/templates/blog-followers-list.php
+++ b/templates/blog-followers-list.php
@@ -5,14 +5,6 @@
  * @package Activitypub
  */
 
-\load_template(
-	__DIR__ . '/admin-header.php',
-	true,
-	array(
-		'followers' => 'active',
-	)
-);
-
 $table          = new \Activitypub\Table\Followers();
 $follower_count = $table->get_user_count();
 // translators: The follower count.

--- a/templates/blog-settings.php
+++ b/templates/blog-settings.php
@@ -5,13 +5,6 @@
  * @package Activitypub
  */
 
-\load_template(
-	__DIR__ . '/admin-header.php',
-	true,
-	array(
-		'blog-profile' => 'active',
-	)
-);
 ?>
 
 <div class="activitypub-settings activitypub-settings-page hide-if-no-js">

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -5,13 +5,6 @@
  * @package Activitypub
  */
 
-\load_template(
-	__DIR__ . '/admin-header.php',
-	true,
-	array(
-		'settings' => 'active',
-	)
-);
 ?>
 
 <div class="activitypub-settings activitypub-settings-page hide-if-no-js">

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -5,13 +5,6 @@
  * @package Activitypub
  */
 
-\load_template(
-	__DIR__ . '/admin-header.php',
-	true,
-	array(
-		'welcome' => 'active',
-	)
-);
 ?>
 
 <div class="activitypub-settings activitypub-welcome-page hide-if-no-js">


### PR DESCRIPTION
Fixes #1250.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a filter to add custom settings tabs.
* Updates template loader and tabs template to account for custom tabs.
* Adds developer docs.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the settings page under Settings > ActivityPub and make sure it still works as expected.
* Switching between tabs should show the correct active status.
* Try extending the tabs and see that it works.
