### PR TITLE
Allow the Base Transformer to use WP_Term objects as item of transfor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Manually granting `activitypub` cap no longer requires the receiving user to have `publish_post`.
+* Changed: Allow Base Transformer to handle WP_Term objects for transformation.
 
 ### Fixed
 

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -7,8 +7,9 @@
 
 namespace Activitypub\Transformer;
 
-use WP_Post;
 use WP_Comment;
+use WP_Post;
+use WP_Term;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
@@ -27,7 +28,7 @@ abstract class Base {
 	 *
 	 * This is the source object of the transformer.
 	 *
-	 * @var WP_Post|WP_Comment|Base_Object|string|array
+	 * @var WP_Post|WP_Comment|Base_Object|string|array|WP_Term
 	 */
 	protected $item;
 
@@ -52,7 +53,7 @@ abstract class Base {
 	 *
 	 * This helps to chain the output of the Transformer.
 	 *
-	 * @param WP_Post|WP_Comment|Base_Object|string|array $item The item that should be transformed.
+	 * @param WP_Post|WP_Comment|Base_Object|string|array|WP_term $item The item that should be transformed.
 	 *
 	 * @return Base
 	 */
@@ -63,7 +64,7 @@ abstract class Base {
 	/**
 	 * Base constructor.
 	 *
-	 * @param WP_Post|WP_Comment|Base_Object|string|array $item The item that should be transformed.
+	 * @param WP_Post|WP_Comment|Base_Object|string|array|WP_Term $item The item that should be transformed.
 	 */
 	public function __construct( $item ) {
 		$this->item      = $item;

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Changed: Manually granting `activitypub` cap no longer requires the receiving user to have `publish_post`.
+* Changed: Allow Base Transformer to handle WP_Term objects for transformation.
 * Fixed: Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 
 = 5.0.0 =


### PR DESCRIPTION
I don't know if this is a good idea to put it here.  If it doesn’t make sense to merge, no worries at all—I can work around it by duplicating some functions from the base transformer in the meantime. 🙂

Background: Some Event plugin store locations/venues in terms rather than custom post types. With the new Query Singleton and Outbox it is easy to add support for those as ActivityPub `Place` objects!
