### PR TITLE
Debugging: avoid PHP warning when actor is not set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
+* Avoid PHP warnings when using Debug mode and when the `actor` is not set.
 
 ## [5.0.0] - 2025-02-03
 

--- a/includes/class-debug.php
+++ b/includes/class-debug.php
@@ -48,7 +48,8 @@ class Debug {
 		$type = strtolower( $type );
 
 		if ( 'delete' !== $type ) {
-			$url = object_to_uri( $data['actor'] );
+			$actor = $data['actor'] ?? '';
+			$url   = object_to_uri( $actor );
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
 			\error_log( "[INBOX] Request From: {$url} with Activity: " . \print_r( $data, true ) );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 * Changed: Manually granting `activitypub` cap no longer requires the receiving user to have `publish_post`.
 * Fixed: Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
+* Fixed: Avoid PHP warnings when using Debug mode and when the `actor` is not set.
 
 = 5.0.0 =
 


### PR DESCRIPTION
## Proposed changes:

This addresses the following PHP warning I saw in my logs.

```
PHP Warning:  Undefined array key "actor" in /srv/htdocs/wp-content/plugins/activitypub/includes/class-debug.php on line 51
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Not much to test on this one ; I assume you would need a wrongly formatted followers for this warning to appear.
