### PR TITLE
Fix race-condition on post creation/adding to outbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 * Avoid PHP warnings when using Debug mode and when the `actor` is not set.
 * No longer creates Outbox items when importing content/users.
+* Race-condition when adding a post to outbox directly at post creation or update.
 
 ## [5.0.0] - 2025-02-03
 

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Fixed: Negotiation of ActivityPub requests for custom post types when queried by the ActivityPub ID.
 * Fixed: Avoid PHP warnings when using Debug mode and when the `actor` is not set.
 * Fixed: No longer creates Outbox items when importing content/users.
+* Fixed: Race-condition when adding a post to outbox directly at post creation or update.
 
 = 5.0.0 =
 


### PR DESCRIPTION
This is a draft for a Hotfix for #1269.

Is there any better solution? This PR would change the behaviour a lot and many unit tests would have to be adopted.