### PR TITLE
Outbox: Use actor type to determine actor id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* Increased probability of Outbox items being processed with the correct author.
+
 ## [5.1.0] - 2025-02-06
 
 ### Added

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,10 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Changed: Increased probability of Outbox items being processed with the correct author.
+
 = 5.1.0 =
 
 * Added: Cleanup of option values when the plugin is uninstalled.


### PR DESCRIPTION
We currently disregard the saved actor type for an Outbox item and just go with the post author in all cases.

This changes it to account for the actor type and bails if we still can't get a correct author object.

See https://wordpress.org/support/topic/fatal-error-uncaught-error-111/#post-18289000

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Dispatch outbox items with actor type-base authors.
* Bails when no author can be found.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not quite sure how to test this. I guess it would have to be an outbox item with a post author id that's different to the actor type meta it has associated with it. Which… should never happen?

