### PR TITLE
Outbox: Allow querying of outbox posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.
+
 ## [5.1.0] - 2025-02-06
 
 ### Added

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -558,8 +558,11 @@ class Activitypub {
 					'create_posts' => false,
 				),
 				'map_meta_cap'        => true,
+				'public'              => false,
+				'show_in_rest'        => true,
 				'rewrite'             => false,
 				'query_var'           => false,
+				'supports'            => array( 'title', 'editor', 'author', 'custom-fields' ),
 				'delete_with_user'    => true,
 				'can_export'          => true,
 				'exclude_from_search' => true,
@@ -578,6 +581,7 @@ class Activitypub {
 				'type'              => 'string',
 				'description'       => 'The type of the activity',
 				'single'            => true,
+				'show_in_rest'      => true,
 				'sanitize_callback' => function ( $value ) {
 					$value  = ucfirst( strtolower( $value ) );
 					$schema = array(
@@ -601,6 +605,7 @@ class Activitypub {
 			array(
 				'type'              => 'string',
 				'single'            => true,
+				'show_in_rest'      => true,
 				'sanitize_callback' => function ( $value ) {
 					$schema = array(
 						'type'    => 'string',
@@ -621,9 +626,9 @@ class Activitypub {
 			Outbox::POST_TYPE,
 			'activitypub_content_visibility',
 			array(
-				'show_in_rest'      => true,
-				'single'            => true,
 				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => true,
 				'sanitize_callback' => function ( $value ) {
 					$schema = array(
 						'type'    => 'string',

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,10 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Changed: Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.
+
 = 5.1.0 =
 
 * Added: Cleanup of option values when the plugin is uninstalled.


### PR DESCRIPTION
Keeps UI and front-end querying disabled, but allows REST API requests for the post type.

Useful for debugging.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin and make sure the admin UI for Outbox items doesn't show up.
* Query the rest api with `/wp-json/wp/v2/ap_outbox` and make sure it works and has author and meta information.
* Pick a `guid` and try to access it from the front-end (it should fail)

