### PR TITLE
Reply Block: add broader text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.
+* Updated terminology to be client-neutral in the Federated Reply block.
 
 ## [5.1.0] - 2025-02-06
 

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Changed: Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.
+* Changed: Updated terminology to be client-neutral in the Federated Reply block.
 
 = 5.1.0 =
 

--- a/src/reply/edit.js
+++ b/src/reply/edit.js
@@ -7,7 +7,7 @@ import { useDispatch } from '@wordpress/data';
 export default function Edit( { attributes: attr, setAttributes, clientId, isSelected } ) {
 	const [ className, setClassName ] = useState( '' );
 	const { insertAfterBlock, removeBlock } = useDispatch( blockEditorStore );
-	const defaultHelpText = __( 'For example: Paste a URL from a Mastodon post or note into the field above to leave a comment.', 'activitypub' );
+	const defaultHelpText = __( 'For example: Paste a URL from a Fediverse/Mastodon post or note into the field above to leave a comment.', 'activitypub' );
 	const [ helpText, setHelpText ] = useState( defaultHelpText );
 	const reset = () => {
 		setClassName( '' );


### PR DESCRIPTION
When using this block, I paused to try to think through if this was restricted to only Mastodon APIs or any federated post.

Including both Fediverse and Mastodon that should help ease that wonder in others.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a federated reply block.
* See the new text under the URL field.
