### PR TITLE
Purge Outbox Items on Schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Batch Outbox-Processing.
 * Outbox processed events get logged in Stream and show any errors returned from inboxes.
+* Outbox items older than 6 months will be purged to avoid performance issues.
 * REST API endpoints for likes and shares.
 
 ### Changed

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -179,6 +179,9 @@ class Migration {
 			\wp_schedule_single_event( \time() + 15, 'activitypub_upgrade', array( 'create_comment_outbox_items' ) );
 			add_action( 'init', 'flush_rewrite_rules', 20 );
 		}
+		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
+			Scheduler::register_schedules();
+		}
 
 		/*
 		 * Add new update routines above this comment. ^

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -209,6 +209,11 @@ class Scheduler {
 	 * Purge outbox items based on a schedule.
 	 */
 	public static function purge_outbox() {
+		$total_posts = (int) wp_count_posts( Outbox::POST_TYPE )->publish;
+		if ( $total_posts <= 20 ) {
+			return;
+		}
+
 		$days     = 180; // TODO: Replace with a setting.
 		$timezone = new \DateTimeZone( 'UTC' );
 		$date     = new \DateTime( 'now', $timezone );

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -33,6 +33,7 @@ class Scheduler {
 
 		\add_action( 'activitypub_async_batch', array( self::class, 'async_batch' ), 10, 99 );
 		\add_action( 'activitypub_reprocess_outbox', array( self::class, 'reprocess_outbox' ) );
+		\add_action( 'activitypub_outbox_purge', array( self::class, 'purge_outbox' ) );
 
 		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'schedule_outbox_activity_for_federation' ) );
 		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'schedule_announce_activity' ), 10, 4 );
@@ -69,6 +70,10 @@ class Scheduler {
 		if ( ! \wp_next_scheduled( 'activitypub_reprocess_outbox' ) ) {
 			\wp_schedule_event( time(), 'hourly', 'activitypub_reprocess_outbox' );
 		}
+
+		if ( ! wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
+			wp_schedule_event( time(), 'daily', 'activitypub_outbox_purge' );
+		}
 	}
 
 	/**
@@ -80,6 +85,7 @@ class Scheduler {
 		wp_unschedule_hook( 'activitypub_update_followers' );
 		wp_unschedule_hook( 'activitypub_cleanup_followers' );
 		wp_unschedule_hook( 'activitypub_reprocess_outbox' );
+		wp_unschedule_hook( 'activitypub_outbox_purge' );
 	}
 
 	/**
@@ -196,6 +202,34 @@ class Scheduler {
 
 		foreach ( $ids as $id ) {
 			self::schedule_outbox_activity_for_federation( $id );
+		}
+	}
+
+	/**
+	 * Purge outbox items based on a schedule.
+	 */
+	public static function purge_outbox() {
+		$days     = 180; // TODO: Replace with a setting.
+		$timezone = new \DateTimeZone( 'UTC' );
+		$date     = new \DateTime( 'now', $timezone );
+
+		$date->sub( \DateInterval::createFromDateString( "$days days" ) );
+
+		$post_ids = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'any',
+				'fields'      => 'ids',
+				'date_query'  => array(
+					array(
+						'before' => $date->format( 'Y-m-d' ),
+					),
+				),
+			)
+		);
+
+		foreach ( $post_ids as $post_id ) {
+			\wp_delete_post( $post_id, true );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 * Added: Batch Outbox-Processing.
 * Added: Outbox processed events get logged in Stream and show any errors returned from inboxes.
+* Added: Outbox items older than 6 months will be purged to avoid performance issues.
 * Added: REST API endpoints for likes and shares.
 * Changed: Increased probability of Outbox items being processed with the correct author.
 * Changed: Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -194,4 +194,58 @@ class Test_Scheduler extends WP_UnitTestCase {
 		wp_delete_post( $pending_id, true );
 		remove_all_filters( 'schedule_event' );
 	}
+
+	/**
+	 * Test purge_outbox method with more than 20 posts.
+	 *
+	 * @covers ::purge_outbox
+	 */
+	public function test_purge_outbox_more_than_20_posts() {
+		// Create 25 posts, 5 older than 6 months.
+		self::factory()->post->create_many(
+			25,
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+			)
+		);
+		self::factory()->post->create_many(
+			5,
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+			)
+		);
+
+		Scheduler::purge_outbox();
+		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+
+		// Assert that 5 posts were deleted, leaving 25.
+		$this->assertEquals( 25, wp_count_posts( Outbox::POST_TYPE )->publish );
+	}
+
+	/**
+	 * Test purge_outbox method with 20 or fewer posts.
+	 *
+	 * @covers ::purge_outbox
+	 */
+	public function test_purge_outbox_20_or_fewer_posts() {
+		// Create 20 posts, all older than 6 months.
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+			)
+		);
+
+		Scheduler::purge_outbox();
+		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+
+		// Assert that no posts were deleted.
+		$this->assertEquals( 20, wp_count_posts( Outbox::POST_TYPE )->publish );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Helps preventing tons of Outbox items from polluting the wp_posts table. This should be followed up with a PR that makes the time offset customizable.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a recurring event to purge Outbox items.
* Adds a callback that purges outbox items when there's at least 20 items.
* Adds unit tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have a ton of Outbox items, at least 20.
* Maybe manually adjust the days threshold in `purge_outbox()` so it catches a few posts.
* Schedule the purging job: ` wp cron event schedule activitypub_outbox_purge`
* Run the job: `wp cron event run --due-now`

