### PR TITLE
Add Undo functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Undo API for Outbox items.
+
 ## [5.2.0] - 2025-02-13
 
 ### Added
@@ -13,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Outbox processed events get logged in Stream and show any errors returned from inboxes.
 * Outbox items older than 6 months will be purged to avoid performance issues.
 * REST API endpoints for likes and shares.
-* Undo API for Outbox items.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Outbox processed events get logged in Stream and show any errors returned from inboxes.
 * Outbox items older than 6 months will be purged to avoid performance issues.
 * REST API endpoints for likes and shares.
+* Undo API for Outbox items.
 
 ### Changed
 

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -52,6 +52,7 @@ use function Activitypub\is_activity;
  * @method Activity set_attachment( array $attachment ) Sets the attachment property of the object.
  * @method Activity set_icon( array $icon )             Sets the icon property of the object.
  * @method Activity set_image( array $image )           Sets the image property of the object.
+ * @method Activity set_content( string $content )      Sets the content property of the object.
  */
 class Activity extends Base_Object {
 	const JSON_LD_CONTEXT = array(

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -237,4 +237,13 @@ class Activity extends Base_Object {
 
 		return static::JSON_LD_CONTEXT;
 	}
+
+	/**
+	 * Get the cc.
+	 *
+	 * @return array|string|null The cc.
+	 */
+	public function get_cc() {
+		return $this->cc ?? array();
+	}
 }

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -237,13 +237,4 @@ class Activity extends Base_Object {
 
 		return static::JSON_LD_CONTEXT;
 	}
-
-	/**
-	 * Get the cc.
-	 *
-	 * @return array|string|null The cc.
-	 */
-	public function get_cc() {
-		return $this->cc ?? array();
-	}
 }

--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -621,7 +621,7 @@ class Base_Object {
 			}
 
 			// If value is still empty, ignore it for the array and continue.
-			if ( isset( $value ) ) {
+			if ( ! empty( $value ) || false === $value ) {
 				$array[ snake_to_camel_case( $key ) ] = $value;
 			}
 		}

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -8,8 +8,8 @@
 namespace Activitypub;
 
 use Activitypub\Activity\Activity;
-use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use Activitypub\Collection\Outbox;
 
 /**
  * ActivityPub Dispatcher Class.
@@ -77,14 +77,14 @@ class Dispatcher {
 			return;
 		}
 
-		$actor = self::get_actor( $outbox_item );
+		$actor = Outbox::get_actor( $outbox_item );
 		if ( \is_wp_error( $actor ) ) {
 			// If the actor is not found, publish the post and don't try again.
 			\wp_publish_post( $outbox_item );
 			return;
 		}
 
-		$activity = self::get_activity( $outbox_item );
+		$activity = Outbox::get_activity( $outbox_item );
 
 		// Send to mentioned and replied-to users. Everyone other than followers.
 		self::send_to_interactees( $activity, $actor->get__id(), $outbox_item );
@@ -117,8 +117,9 @@ class Dispatcher {
 	 * @return array|void The next batch of followers to process, or void if done.
 	 */
 	public static function send_to_followers( $outbox_item_id, $batch_size = 50, $offset = 0 ) {
-		$activity = self::get_activity( $outbox_item_id );
-		$actor    = self::get_actor( \get_post( $outbox_item_id ) );
+		$activity = Outbox::get_activity( $outbox_item_id );
+		$actor    = Outbox::get_actor( \get_post( $outbox_item_id ) );
+
 		$json     = $activity->to_json();
 		$inboxes  = Followers::get_inboxes_for_activity( $json, $actor->get__id(), $batch_size, $offset );
 
@@ -338,60 +339,5 @@ class Dispatcher {
 		 * @param \WP_Post $outbox_item                The WordPress object.
 		 */
 		return apply_filters( 'activitypub_send_activity_to_followers', $send, $activity, $actor->get__id(), $outbox_item );
-	}
-
-	/**
-	 * Get the Activity object from the Outbox item.
-	 *
-	 * @param int|\WP_Post $outbox_item The Outbox post or post ID.
-	 * @return Activity|\WP_Error The Activity object or WP_Error.
-	 */
-	private static function get_activity( $outbox_item ) {
-		$outbox_item = get_post( $outbox_item );
-		$actor       = self::get_actor( $outbox_item );
-		if ( is_wp_error( $actor ) ) {
-			return $actor;
-		}
-
-		$type     = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
-		$activity = new Activity();
-		$activity->set_type( $type );
-		$activity->set_id( $outbox_item->guid );
-		// Pre-fill the Activity with data (for example cc and to).
-		$activity->set_object( \json_decode( $outbox_item->post_content, true ) );
-		$activity->set_actor( $actor->get_id() );
-
-		// Use simple Object (only ID-URI) for Like and Announce.
-		if ( in_array( $type, array( 'Like', 'Delete' ), true ) ) {
-			$activity->set_object( $activity->get_object()->get_id() );
-		}
-
-		return $activity;
-	}
-
-	/**
-	 * Get the Actor object from the Outbox item.
-	 *
-	 * @param \WP_Post $outbox_item The Outbox post.
-	 *
-	 * @return \Activitypub\Model\User|\Activitypub\Model\Blog|\WP_Error The Actor object or WP_Error.
-	 */
-	private static function get_actor( $outbox_item ) {
-		$actor_type = \get_post_meta( $outbox_item->ID, '_activitypub_activity_actor', true );
-
-		switch ( $actor_type ) {
-			case 'blog':
-				$actor_id = Actors::BLOG_USER_ID;
-				break;
-			case 'application':
-				$actor_id = Actors::APPLICATION_USER_ID;
-				break;
-			case 'user':
-			default:
-				$actor_id = $outbox_item->post_author;
-				break;
-		}
-
-		return Actors::get_by_id( $actor_id );
 	}
 }

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -119,7 +119,6 @@ class Dispatcher {
 	public static function send_to_followers( $outbox_item_id, $batch_size = 50, $offset = 0 ) {
 		$activity = Outbox::get_activity( $outbox_item_id );
 		$actor    = Outbox::get_actor( \get_post( $outbox_item_id ) );
-
 		$json     = $activity->to_json();
 		$inboxes  = Followers::get_inboxes_for_activity( $json, $actor->get__id(), $batch_size, $offset );
 

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -90,7 +90,7 @@ abstract class Base {
 			if ( \method_exists( $this, $getter ) ) {
 				$value = \call_user_func( array( $this, $getter ) );
 
-				if ( isset( $value ) ) {
+				if ( ! empty( $value ) ) {
 					$setter = 'set_' . $var;
 
 					/**

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -171,7 +171,7 @@ abstract class Base {
 		$public = 'https://www.w3.org/ns/activitystreams#Public';
 		$actor  = Actors::get_by_resource( $this->get_attributed_to() );
 		if ( ! $actor || is_wp_error( $actor ) ) {
-			$followers = array();
+			$followers = null;
 		} else {
 			$followers = $actor->get_followers();
 		}

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -171,7 +171,7 @@ abstract class Base {
 		$public = 'https://www.w3.org/ns/activitystreams#Public';
 		$actor  = Actors::get_by_resource( $this->get_attributed_to() );
 		if ( ! $actor || is_wp_error( $actor ) ) {
-			$followers = null;
+			$followers = array();
 		} else {
 			$followers = $actor->get_followers();
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -129,13 +129,16 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Added: Undo API for Outbox items.
+
 = 5.2.0 =
 
 * Added: Batch Outbox-Processing.
 * Added: Outbox processed events get logged in Stream and show any errors returned from inboxes.
 * Added: Outbox items older than 6 months will be purged to avoid performance issues.
 * Added: REST API endpoints for likes and shares.
-* Added: Undo API for Outbox items.
 * Changed: Increased probability of Outbox items being processed with the correct author.
 * Changed: Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.
 * Changed: Updated terminology to be client-neutral in the Federated Reply block.

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: Outbox processed events get logged in Stream and show any errors returned from inboxes.
 * Added: Outbox items older than 6 months will be purged to avoid performance issues.
 * Added: REST API endpoints for likes and shares.
+* Added: Undo API for Outbox items.
 * Changed: Increased probability of Outbox items being processed with the correct author.
 * Changed: Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.
 * Changed: Updated terminology to be client-neutral in the Federated Reply block.

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -66,7 +66,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				1,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/' . self::$user_id . '","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/' . self::$user_id . '","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html","sensitive":false}',
 			),
 			array(
 				array(
@@ -77,7 +77,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				2,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html","sensitive":false}',
 			),
 		);
 	}

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -66,7 +66,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				1,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/' . self::$user_id . '","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/' . self::$user_id . '","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
 			),
 			array(
 				array(
@@ -77,7 +77,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				2,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"cc":[],"mediaType":"text\/html","sensitive":false}',
 			),
 		);
 	}

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -194,10 +194,10 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	/**
 	 * Helper method to create a dummy activity object for testing.
 	 *
-	 * @return \Activitypub\Activity\Base_Object
+	 * @return \Activitypub\Activity\Activity
 	 */
 	private function get_dummy_activity_object() {
-		$object = new \Activitypub\Activity\Base_Object();
+		$object = new \Activitypub\Activity\Activity();
 		$object->set_id( 'https://example.com/test-object' );
 		$object->set_type( 'Note' );
 		$object->set_content( 'Test content' );
@@ -229,7 +229,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Only ID for Deletes.
 		if ( 'Delete' === $expected ) {
-			$this->assertSame( get_post( $undo_id )->post_title, $activity->get_object() );
+			$this->assertSame( get_permalink( $id ), $activity->get_object() );
 		} else {
 			$this->assertEquals( json_decode( get_post( $undo_id )->post_content, true ), $activity->get_object()->to_array() );
 		}

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -7,6 +7,8 @@
 
 namespace Activitypub\Tests\Collection;
 
+use Activitypub\Collection\Outbox;
+
 /**
  * Test class for Outbox collection.
  *
@@ -199,6 +201,52 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$object->set_id( 'https://example.com/test-object' );
 		$object->set_type( 'Note' );
 		$object->set_content( 'Test content' );
+
 		return $object;
+	}
+
+	/**
+	 * Test undo.
+	 *
+	 * @covers ::undo
+	 * @dataProvider undo_object_provider
+	 *
+	 * @param string $type     Type of the activity to be undone.
+	 * @param string $expected Expected type.
+	 */
+	public function test_undo( $type, $expected ) {
+		$data = array(
+			'@context' => 'https://www.w3.org/ns/activitystreams',
+			'id'       => 'https://example.com/' . self::$user_id,
+			'type'     => 'Note',
+			'content'  => '<p>This is a note</p>',
+		);
+
+		$id = \Activitypub\add_to_outbox( $data, $type, self::$user_id );
+
+		$undo_id  = Outbox::undo( $id );
+		$activity = Outbox::get_activity( $undo_id );
+
+		// Only ID for Deletes.
+		if ( 'Delete' === $expected ) {
+			$this->assertSame( get_post( $undo_id )->post_title, $activity->get_object() );
+		} else {
+			$this->assertEquals( json_decode( get_post( $undo_id )->post_content, true ), $activity->get_object()->to_array() );
+		}
+
+		$this->assertSame( $expected, $activity->get_type() );
+	}
+
+	/**
+	 * Data provider for test_undo.
+	 *
+	 * @return array[]
+	 */
+	public function undo_object_provider() {
+		return array(
+			array( 'Create', 'Delete' ),
+			array( 'Update', 'Undo' ),
+			array( 'Add', 'Remove' ),
+		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1289

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves `get_activity()` and `get_author()` methods to `Outbox` class, where they feel more appropriate. These methods take an outbox id.
* Adds `undo()` method to `Outbox` class, that accepts an outbox item and creates an Undo activity based on it. It accounts for `Create` and `Add` activities requiring their own "undo" type.
* Updates `Base::transform_object_properties()` and `Base_Object::to_array()` to not only discard `null` values but also empty values unless they're `false`.
* Adds unit tests for the new functionality.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test by running it in CLI: `wp activitypub undo 123` where 123 is an Outbox post id.
* Test by running it in CLI: `wp activitypub undo "https://example.com/?post_type=ap_outbox&p=123"` where the URL is an Outbox post guid.
* The changes to `Base::transform_object_properties()` and `Base_Object::to_array()` are probably what has the highest potential for unintended consequences. Anything standing you there?
