### PR TITLE
Fix content-visibility in block editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Enforce 200 status header for valid ActivityPub requests.
+* Integration of content-visibility setup in the block editor.
 
 ## [5.1.0] - 2025-02-06
 

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -51,24 +51,26 @@ class Blocks {
 					},
 				)
 			);
+
 			\register_post_meta(
 				$post_type,
 				'activitypub_content_visibility',
 				array(
-					'show_in_rest'      => true,
-					'single'            => true,
 					'type'              => 'string',
-					'sanitize_callback' => function ( $visibility ) {
-						$options = array(
-							ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC,
-							ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL,
+					'single'            => true,
+					'show_in_rest'      => true,
+					'sanitize_callback' => function ( $value ) {
+						$schema = array(
+							'type'    => 'string',
+							'enum'    => array( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL ),
+							'default' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
 						);
 
-						if ( in_array( $visibility, $options, true ) ) {
-							return $visibility;
+						if ( is_wp_error( rest_validate_enum( $value, $schema, '' ) ) ) {
+							return $schema['default'];
 						}
 
-						return null;
+						return $value;
 					},
 				)
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Changed: Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.
 * Changed: Updated terminology to be client-neutral in the Federated Reply block.
 * Fixed: Enforce 200 status header for valid ActivityPub requests.
+* Fixed: Integration of content-visibility setup in the block editor.
 
 = 5.1.0 =
 

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -362,9 +362,16 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 		$visible_private_post_id = self::factory()->post->create();
 
 		add_post_meta( $visible_private_post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
-		$this->assertFalse( \Activitypub\is_post_disabled( $visible_private_post_id ) );
+		$this->assertTrue( \Activitypub\is_post_disabled( $visible_private_post_id ) );
 
 		wp_delete_post( $visible_private_post_id, true );
+
+		$visible_local_post_id = self::factory()->post->create();
+
+		add_post_meta( $visible_local_post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
+		$this->assertTrue( \Activitypub\is_post_disabled( $visible_local_post_id ) );
+
+		wp_delete_post( $visible_local_post_id, true );
 	}
 
 	/**


### PR DESCRIPTION
The current version throws an error if the user wants to switch from a different visibility to `public`

