### PR TITLE
Add rest controller for likes and shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Batch Outbox-Processing.
 * Outbox processed events get logged in Stream and show any errors returned from inboxes.
+* REST API endpoints for likes and shares.
 
 ### Changed
 

--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -471,6 +471,10 @@ class Base_Object {
 	protected $shares;
 
 	/**
+	 * Used to mark an object as containing sensitive content.
+	 * Mastodon displays a content warning, requiring users to click
+	 * through to view the content.
+	 *
 	 * @see https://docs.joinmastodon.org/spec/activitypub/#sensitive
 	 *
 	 * @var boolean

--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -451,10 +451,26 @@ class Base_Object {
 	protected $replies;
 
 	/**
-	 * Used to mark an object as containing sensitive content.
-	 * Mastodon displays a content warning, requiring users to click
-	 * through to view the content.
+	 * A Collection containing objects considered to be likes for
+	 * this object.
 	 *
+	 * @see https://www.w3.org/TR/activitypub/#likes
+	 *
+	 * @var array
+	 */
+	protected $likes;
+
+	/**
+	 * A Collection containing objects considered to be shares for
+	 * this object.
+	 *
+	 * @see https://www.w3.org/TR/activitypub/#shares
+	 *
+	 * @var array
+	 */
+	protected $shares;
+
+	/**
 	 * @see https://docs.joinmastodon.org/spec/activitypub/#sensitive
 	 *
 	 * @var boolean

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -713,11 +713,23 @@ class Comment {
 			return;
 		}
 
+		// Do not exclude likes and reposts on ActivityPub requests.
+		if ( defined( 'ACTIVITYPUB_REQUEST' ) && ACTIVITYPUB_REQUEST ) {
+			return;
+		}
+
+		// Do not exclude likes and reposts on REST requests.
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return;
+		}
+
+		// Do not exclude likes and reposts on admin pages or on non-singular pages.
 		if ( is_admin() || ! is_singular() ) {
 			return;
 		}
 
-		if ( ! empty( $query->query_vars['type__in'] ) ) {
+		// Do not exclude likes and reposts if the query is for comments.
+		if ( ! empty( $query->query_vars['type__in'] ) || ! empty( $query->query_vars['type'] ) ) {
 			return;
 		}
 

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -247,6 +247,7 @@ class Query {
 
 		// One can trigger an ActivityPub request by adding ?activitypub to the URL.
 		if ( isset( $wp_query->query_vars['activitypub'] ) ) {
+			defined( 'ACTIVITYPUB_REQUEST' ) || \define( 'ACTIVITYPUB_REQUEST', true );
 			$this->is_activitypub_request = true;
 
 			return true;
@@ -268,6 +269,7 @@ class Query {
 			 * - application/json
 			 */
 			if ( \preg_match( '/(application\/(ld\+json|activity\+json|json))/i', $accept ) ) {
+				defined( 'ACTIVITYPUB_REQUEST' ) || \define( 'ACTIVITYPUB_REQUEST', true );
 				$this->is_activitypub_request = true;
 
 				return true;

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -335,6 +335,7 @@ class Interactions {
 				'type'    => $type,
 				'count'   => true,
 				'paging'  => false,
+				'fields'  => 'ids',
 			)
 		);
 	}

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -318,4 +318,24 @@ class Interactions {
 			return $state; // Either WP_Comment, false, a WP_Error, 0, or 1!
 		}
 	}
+
+	/**
+	 * Get the total number of interactions by type for a given ID.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $type    The type of interaction to count.
+	 *
+	 * @return int The total number of interactions.
+	 */
+	public static function count_by_type( $post_id, $type ) {
+		return \get_comments(
+			array(
+				'post_id' => $post_id,
+				'status'  => 'approve',
+				'type'    => $type,
+				'count'   => true,
+				'paging'  => false,
+			)
+		);
+	}
 }

--- a/includes/collection/class-replies.php
+++ b/includes/collection/class-replies.php
@@ -80,7 +80,7 @@ class Replies {
 			'type' => 'Collection',
 		);
 
-		$replies['first'] = self::get_collection_page( $wp_object, 0, $replies['id'] );
+		$replies['first'] = self::get_collection_page( $wp_object, 1, $replies['id'] );
 
 		return $replies;
 	}
@@ -116,7 +116,7 @@ class Replies {
 
 		// If set to zero, we get errors below. You need at least one comment per page, here.
 		$args['number'] = max( (int) \get_option( 'comments_per_page' ), 1 );
-		$args['offset'] = intval( $page ) * $args['number'];
+		$args['offset'] = intval( $page - 1 ) * $args['number'];
 
 		// Get the ActivityPub ID's of the comments, without local-only comments.
 		$comment_ids = self::get_reply_ids( \get_comments( $args ) );

--- a/includes/collection/class-replies.php
+++ b/includes/collection/class-replies.php
@@ -30,6 +30,7 @@ class Replies {
 			'status'  => 'approve',
 			'orderby' => 'comment_date_gmt',
 			'order'   => 'ASC',
+			'type'    => 'comment',
 		);
 
 		if ( $wp_object instanceof WP_Post ) {

--- a/includes/rest/class-replies-controller.php
+++ b/includes/rest/class-replies-controller.php
@@ -161,10 +161,10 @@ class Replies_Controller extends \WP_REST_Controller {
 	 * @return array Response collection of likes.
 	 */
 	public function get_likes( $request, $wp_object ) {
-		if ( ! $wp_object instanceof \WP_Post ) {
-			$likes = 0;
-		} else {
+		if ( $wp_object instanceof \WP_Post ) {
 			$likes = Interactions::count_by_type( $wp_object->ID, 'like' );
+		} else {
+			$likes = 0;
 		}
 
 		$response = array(
@@ -185,10 +185,10 @@ class Replies_Controller extends \WP_REST_Controller {
 	 * @return array Response collection of shares.
 	 */
 	public function get_shares( $request, $wp_object ) {
-		if ( ! $wp_object instanceof \WP_Post ) {
-			$shares = 0;
-		} else {
+		if ( $wp_object instanceof \WP_Post ) {
 			$shares = Interactions::count_by_type( $wp_object->ID, 'repost' );
+		} else {
+			$shares = 0;
 		}
 
 		$response = array(

--- a/includes/rest/class-replies-controller.php
+++ b/includes/rest/class-replies-controller.php
@@ -9,6 +9,7 @@ namespace Activitypub\Rest;
 
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Replies;
+use Activitypub\Collection\Interactions;
 
 use function Activitypub\get_rest_url_by_path;
 
@@ -163,15 +164,7 @@ class Replies_Controller extends \WP_REST_Controller {
 		if ( ! $wp_object instanceof \WP_Post ) {
 			$likes = 0;
 		} else {
-			$likes = \get_comments(
-				array(
-					'post_id' => $wp_object->ID,
-					'status'  => 'approve',
-					'type'    => 'like',
-					'count'   => true,
-					'fields'  => 'ids',
-				)
-			);
+			$likes = Interactions::count_by_type( $wp_object->ID, 'like' );
 		}
 
 		$response = array(
@@ -195,15 +188,7 @@ class Replies_Controller extends \WP_REST_Controller {
 		if ( ! $wp_object instanceof \WP_Post ) {
 			$shares = 0;
 		} else {
-			$shares = \get_comments(
-				array(
-					'post_id' => $wp_object->ID,
-					'status'  => 'approve',
-					'type'    => 'repost',
-					'count'   => true,
-					'fields'  => 'ids',
-				)
-			);
+			$shares = Interactions::count_by_type( $wp_object->ID, 'repost' );
 		}
 
 		$response = array(

--- a/includes/rest/class-replies-controller.php
+++ b/includes/rest/class-replies-controller.php
@@ -137,7 +137,7 @@ class Replies_Controller extends \WP_REST_Controller {
 	 * @param \WP_REST_Request     $request   The request object.
 	 * @param \WP_Post|\WP_Comment $wp_object The WordPress object.
 	 *
-	 * @return \WP_REST_Response|\WP_Error Response object or WP_Error object.
+	 * @return array Response collection of replies.
 	 */
 	public function get_replies( $request, $wp_object ) {
 		$page = $request->get_param( 'page' );
@@ -158,7 +158,7 @@ class Replies_Controller extends \WP_REST_Controller {
 	 * @param \WP_REST_Request     $request   The request object.
 	 * @param \WP_Post|\WP_Comment $wp_object The WordPress object.
 	 *
-	 * @return \WP_REST_Response|\WP_Error Response object or WP_Error object.
+	 * @return array Response collection of likes.
 	 */
 	public function get_likes( $request, $wp_object ) {
 		if ( ! $wp_object instanceof \WP_Post ) {
@@ -182,7 +182,7 @@ class Replies_Controller extends \WP_REST_Controller {
 	 * @param \WP_REST_Request     $request   The request object.
 	 * @param \WP_Post|\WP_Comment $wp_object The WordPress object.
 	 *
-	 * @return \WP_REST_Response|\WP_Error Response object or WP_Error object.
+	 * @return array Response collection of shares.
 	 */
 	public function get_shares( $request, $wp_object ) {
 		if ( ! $wp_object instanceof \WP_Post ) {

--- a/includes/rest/class-replies-controller.php
+++ b/includes/rest/class-replies-controller.php
@@ -10,6 +10,8 @@ namespace Activitypub\Rest;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Replies;
 
+use function Activitypub\get_rest_url_by_path;
+
 /**
  * ActivityPub Replies_Controller class.
  */
@@ -27,7 +29,7 @@ class Replies_Controller extends \WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = '(?P<type>[\w\-\.]+)s/(?P<id>[\w\-\.]+)/replies';
+	protected $rest_base = '(?P<object_type>[\w\-\.]+)s/(?P<id>[\w\-\.]+)/(?P<type>[\w\-\.]+)';
 
 	/**
 	 * Register routes.
@@ -38,15 +40,21 @@ class Replies_Controller extends \WP_REST_Controller {
 			'/' . $this->rest_base,
 			array(
 				'args'   => array(
-					'type' => array(
+					'object_type' => array(
 						'description' => 'The type of object to get replies for.',
 						'type'        => 'string',
 						'enum'        => array( 'post', 'comment' ),
 						'required'    => true,
 					),
-					'id'   => array(
+					'id'          => array(
 						'description' => 'The ID of the object.',
 						'type'        => 'string',
+						'required'    => true,
+					),
+					'type'        => array(
+						'description' => 'The type of collection to query.',
+						'type'        => 'string',
+						'enum'        => array( 'replies', 'likes', 'shares' ),
 						'required'    => true,
 					),
 				),
@@ -72,13 +80,14 @@ class Replies_Controller extends \WP_REST_Controller {
 	 * Retrieves a collection of replies.
 	 *
 	 * @param \WP_REST_Request $request The request object.
+	 *
 	 * @return \WP_REST_Response|\WP_Error Response object or WP_Error object.
 	 */
 	public function get_items( $request ) {
-		$type = $request->get_param( 'type' );
-		$id   = (int) $request->get_param( 'id' );
+		$object_type = $request->get_param( 'object_type' );
+		$id          = (int) $request->get_param( 'id' );
 
-		if ( 'comment' === $type ) {
+		if ( 'comment' === $object_type ) {
 			$wp_object = \get_comment( $id );
 		} else {
 			$wp_object = \get_post( $id );
@@ -90,29 +99,120 @@ class Replies_Controller extends \WP_REST_Controller {
 				\sprintf(
 					// translators: %s: The type (post, comment, etc.) for which no replies collection exists.
 					\__( 'No reply collection exists for the type %s.', 'activitypub' ),
-					$type
+					$object_type
 				),
 				array( 'status' => 404 )
 			);
 		}
 
-		$page = $request->get_param( 'page' );
+		switch ( $request->get_param( 'type' ) ) {
+			case 'replies':
+				$response = $this->get_replies( $request, $wp_object );
+				break;
 
-		// If the request parameter page is present get the CollectionPage otherwise the Replies collection.
-		if ( $page ) {
-			$response = Replies::get_collection_page( $wp_object, $page );
-		} else {
-			$response = Replies::get_collection( $wp_object );
-		}
+			case 'likes':
+				$response = $this->get_likes( $request, $wp_object );
+				break;
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
+			case 'shares':
+				$response = $this->get_shares( $request, $wp_object );
+				break;
+
+			default:
+				$response = new \WP_Error( 'rest_unknown_collection_type', 'Unknown collection type.', array( 'status' => 404 ) );
 		}
 
 		// Prepend ActivityPub Context.
 		$response = array_merge( array( '@context' => Base_Object::JSON_LD_CONTEXT ), $response );
+		$response = \rest_ensure_response( $response );
+		$response->header( 'Content-Type', 'application/activity+json; charset=' . \get_option( 'blog_charset' ) );
 
-		return \rest_ensure_response( $response );
+		return $response;
+	}
+
+	/**
+	 * Retrieves a collection of replies.
+	 *
+	 * @param \WP_REST_Request     $request   The request object.
+	 * @param \WP_Post|\WP_Comment $wp_object The WordPress object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error Response object or WP_Error object.
+	 */
+	public function get_replies( $request, $wp_object ) {
+		$page = $request->get_param( 'page' );
+
+		// If the request parameter page is present get the CollectionPage otherwise the Replies collection.
+		if ( $page <= 1 ) {
+			$response = Replies::get_collection( $wp_object );
+		} else {
+			$response = Replies::get_collection_page( $wp_object, $page );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Retrieves a collection of likes.
+	 *
+	 * @param \WP_REST_Request     $request   The request object.
+	 * @param \WP_Post|\WP_Comment $wp_object The WordPress object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error Response object or WP_Error object.
+	 */
+	public function get_likes( $request, $wp_object ) {
+		if ( ! $wp_object instanceof \WP_Post ) {
+			$likes = 0;
+		} else {
+			$likes = \get_comments(
+				array(
+					'post_id' => $wp_object->ID,
+					'status'  => 'approve',
+					'type'    => 'like',
+					'count'   => true,
+					'fields'  => 'ids',
+				)
+			);
+		}
+
+		$response = array(
+			'id'         => get_rest_url_by_path( sprintf( 'posts/%d/likes', $wp_object->ID ) ),
+			'type'       => 'Collection',
+			'totalItems' => $likes,
+		);
+
+		return $response;
+	}
+
+	/**
+	 * Retrieves a collection of shares.
+	 *
+	 * @param \WP_REST_Request     $request   The request object.
+	 * @param \WP_Post|\WP_Comment $wp_object The WordPress object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error Response object or WP_Error object.
+	 */
+	public function get_shares( $request, $wp_object ) {
+		if ( ! $wp_object instanceof \WP_Post ) {
+			$shares = 0;
+		} else {
+			$shares = \get_comments(
+				array(
+					'post_id' => $wp_object->ID,
+					'status'  => 'approve',
+					'type'    => 'repost',
+					'count'   => true,
+					'fields'  => 'ids',
+				)
+			);
+		}
+
+		$response = array(
+			'id'         => get_rest_url_by_path( sprintf( 'posts/%d/shares', $wp_object->ID ) ),
+			'type'       => 'Collection',
+			'totalItems' => $shares,
+		);
+
+		return $response;
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -1115,7 +1115,7 @@ class Post extends Base {
 	/**
 	 * Get the likes Collection.
 	 *
-	 * @return array|null The likes collection on success or null on failure.
+	 * @return array The likes collection.
 	 */
 	public function get_likes() {
 		return array(
@@ -1128,7 +1128,7 @@ class Post extends Base {
 	/**
 	 * Get the shares Collection.
 	 *
-	 * @return array|null The shares collection on success or null on failure.
+	 * @return array The shares collection.
 	 */
 	public function get_shares() {
 		return array(

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -12,6 +12,7 @@ use Activitypub\Shortcodes;
 use Activitypub\Model\Blog;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Replies;
+use Activitypub\Collection\Interactions;
 
 use function Activitypub\esc_hashtag;
 use function Activitypub\object_to_uri;
@@ -19,6 +20,7 @@ use function Activitypub\is_single_user;
 use function Activitypub\get_enclosures;
 use function Activitypub\get_upload_baseurl;
 use function Activitypub\get_content_warning;
+use function Activitypub\get_rest_url_by_path;
 use function Activitypub\site_supports_blocks;
 use function Activitypub\generate_post_summary;
 use function Activitypub\get_content_visibility;
@@ -1108,5 +1110,31 @@ class Post extends Base {
 	 */
 	public function get_replies() {
 		return Replies::get_collection( $this->item );
+	}
+
+	/**
+	 * Get the likes Collection.
+	 *
+	 * @return array|null The likes collection on success or null on failure.
+	 */
+	public function get_likes() {
+		return array(
+			'id'         => get_rest_url_by_path( sprintf( 'posts/%d/likes', $this->item->ID ) ),
+			'type'       => 'Collection',
+			'totalItems' => Interactions::count_by_type( $this->item->ID, 'like' ),
+		);
+	}
+
+	/**
+	 * Get the shares Collection.
+	 *
+	 * @return array|null The shares collection on success or null on failure.
+	 */
+	public function get_shares() {
+		return array(
+			'id'         => get_rest_url_by_path( sprintf( 'posts/%d/shares', $this->item->ID ) ),
+			'type'       => 'Collection',
+			'totalItems' => Interactions::count_by_type( $this->item->ID, 'repost' ),
+		);
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 * Added: Batch Outbox-Processing.
 * Added: Outbox processed events get logged in Stream and show any errors returned from inboxes.
+* Added: REST API endpoints for likes and shares.
 * Changed: Increased probability of Outbox items being processed with the correct author.
 * Changed: Enabled querying of Outbox posts through the REST API to improve troubleshooting and debugging.
 * Changed: Updated terminology to be client-neutral in the Federated Reply block.

--- a/tests/includes/rest/class-test-replies-controller.php
+++ b/tests/includes/rest/class-test-replies-controller.php
@@ -149,7 +149,7 @@ class Test_Replies_Controller extends \Activitypub\Tests\Test_REST_Controller_Te
 		$this->assertIsArray( $data );
 		$this->assertArrayHasKey( '@context', $data );
 		$this->assertArrayHasKey( 'type', $data );
-		$this->assertContains( $data['type'], array(  'Collection', 'CollectionPage', 'OrderedCollectionPage' ) );
+		$this->assertContains( $data['type'], array( 'Collection', 'CollectionPage', 'OrderedCollectionPage' ) );
 	}
 
 	/**
@@ -171,6 +171,96 @@ class Test_Replies_Controller extends \Activitypub\Tests\Test_REST_Controller_Te
 	 */
 	public function test_get_replies_non_existent_comment() {
 		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/comments/99999/replies' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'activitypub_replies_collection_does_not_exist', $response, 404 );
+	}
+
+	/**
+	 * Test getting likes for a post.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_post_likes() {
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/posts/' . self::$post_id . '/likes' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( '@context', $data );
+		$this->assertArrayHasKey( 'type', $data );
+		$this->assertContains( $data['type'], array( 'Collection', 'OrderedCollection', 'CollectionPage', 'OrderedCollectionPage' ) );
+		$this->assertArrayHasKey( 'totalItems', $data );
+	}
+
+	/**
+	 * Test getting shares for a post.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_post_shares() {
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/posts/' . self::$post_id . '/shares' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( '@context', $data );
+		$this->assertArrayHasKey( 'type', $data );
+		$this->assertContains( $data['type'], array( 'Collection', 'OrderedCollection', 'CollectionPage', 'OrderedCollectionPage' ) );
+		$this->assertArrayHasKey( 'totalItems', $data );
+	}
+
+	/**
+	 * Test getting shares for a comment.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_comment_shares() {
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/comments/' . self::$comment_ids[0] . '/shares' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( '@context', $data );
+		$this->assertArrayHasKey( 'type', $data );
+		$this->assertContains( $data['type'], array( 'Collection', 'OrderedCollection', 'CollectionPage', 'OrderedCollectionPage' ) );
+		$this->assertArrayHasKey( 'totalItems', $data );
+		$this->assertEquals( 0, $data['totalItems'] );
+	}
+
+	/**
+	 * Test getting likes for a comment.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_comment_likes() {
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/comments/' . self::$comment_ids[0] . '/likes' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( '@context', $data );
+		$this->assertArrayHasKey( 'type', $data );
+		$this->assertContains( $data['type'], array( 'Collection', 'OrderedCollection', 'CollectionPage', 'OrderedCollectionPage' ) );
+		$this->assertArrayHasKey( 'totalItems', $data );
+		$this->assertEquals( 0, $data['totalItems'] );
+	}
+
+	/**
+	 * Test getting shares for a non-existent post.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_post_shares_non_existent() {
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/posts/99999/shares' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'activitypub_replies_collection_does_not_exist', $response, 404 );

--- a/tests/includes/rest/class-test-replies-controller.php
+++ b/tests/includes/rest/class-test-replies-controller.php
@@ -92,7 +92,7 @@ class Test_Replies_Controller extends \Activitypub\Tests\Test_REST_Controller_Te
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( '/' . ACTIVITYPUB_REST_NAMESPACE . '/(?P<type>[\w\-\.]+)s/(?P<id>[\w\-\.]+)/replies', $routes );
+		$this->assertArrayHasKey( '/' . ACTIVITYPUB_REST_NAMESPACE . '/(?P<object_type>[\w\-\.]+)s/(?P<id>[\w\-\.]+)/(?P<type>[\w\-\.]+)', $routes );
 	}
 
 	/**
@@ -111,7 +111,7 @@ class Test_Replies_Controller extends \Activitypub\Tests\Test_REST_Controller_Te
 		$this->assertArrayHasKey( '@context', $data );
 		$this->assertArrayHasKey( 'type', $data );
 		$this->assertContains( $data['type'], array( 'Collection', 'OrderedCollection', 'CollectionPage', 'OrderedCollectionPage' ) );
-		$this->assertArrayHasKey( 'items', $data );
+		$this->assertArrayHasKey( 'first', $data );
 	}
 
 	/**
@@ -130,7 +130,7 @@ class Test_Replies_Controller extends \Activitypub\Tests\Test_REST_Controller_Te
 		$this->assertArrayHasKey( '@context', $data );
 		$this->assertArrayHasKey( 'type', $data );
 		$this->assertContains( $data['type'], array( 'Collection', 'OrderedCollection', 'CollectionPage', 'OrderedCollectionPage' ) );
-		$this->assertArrayHasKey( 'items', $data );
+		$this->assertArrayHasKey( 'first', $data );
 	}
 
 	/**
@@ -140,7 +140,7 @@ class Test_Replies_Controller extends \Activitypub\Tests\Test_REST_Controller_Te
 	 */
 	public function test_get_replies_pagination() {
 		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/posts/' . self::$post_id . '/replies' );
-		$request->set_param( 'page', 1 );
+		$request->set_param( 'page', 2 );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -149,7 +149,7 @@ class Test_Replies_Controller extends \Activitypub\Tests\Test_REST_Controller_Te
 		$this->assertIsArray( $data );
 		$this->assertArrayHasKey( '@context', $data );
 		$this->assertArrayHasKey( 'type', $data );
-		$this->assertContains( $data['type'], array( 'CollectionPage', 'OrderedCollectionPage' ) );
+		$this->assertContains( $data['type'], array(  'Collection', 'CollectionPage', 'OrderedCollectionPage' ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds endpoints for likes and shares and fixes some issues in the replies collection. The likes and shares endpoints list only the absolute number without any items.

A WordPress post on Mastodon (or any other Fediverse-Platform) does not properly show the likes and shares count, because of the missing endpoints. This PR should fix this issue.

Added:

* Shares endpoint, that lists a counter how much an entry was shared
* Likes endpoint, that lists a counter how much an entry was liked

Fixed issues:

* Properly nest collections page in Collection
* Set first page to "1" instead of "0"
* Fix unittests

<!--- Provide a general summary of your changes in the Title above -->

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load `/wp-json/activitypub/1.0/posts/<id>/likes` or `/wp-json/activitypub/1.0/posts/<id>/shares` on your test system

