### PR TITLE
Fix: `set_object` falsely overwrites the Activity-ID with a default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Enforce 200 status header for valid ActivityPub requests.
 * Integration of content-visibility setup in the block editor.
 * Update CLI commands to the new scheduler refactorings.
+* `Activity::set_object` falsely overwrites the Activity-ID with a default.
 
 ## [5.1.0] - 2025-02-06
 

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -171,7 +171,7 @@ class Activity extends Base_Object {
 		$this->set( 'object', $data );
 
 		// Check if `$data` is a URL and use it to generate an ID then.
-		if ( is_string( $data ) && filter_var( $data, FILTER_VALIDATE_URL ) ) {
+		if ( is_string( $data ) && filter_var( $data, FILTER_VALIDATE_URL ) && ! $this->get_id() ) {
 			$this->set( 'id', $data . '#activity-' . strtolower( $this->get_type() ) . '-' . time() );
 
 			return;

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Fixed: Enforce 200 status header for valid ActivityPub requests.
 * Fixed: Integration of content-visibility setup in the block editor.
 * Fixed: Update CLI commands to the new scheduler refactorings.
+* Fixed: `Activity::set_object` falsely overwrites the Activity-ID with a default.
 
 = 5.1.0 =
 

--- a/tests/includes/activity/class-test-activity.php
+++ b/tests/includes/activity/class-test-activity.php
@@ -72,6 +72,8 @@ class Test_Activity extends \WP_UnitTestCase {
 
 	/**
 	 * Test activity object.
+	 *
+	 * @covers ::init_from_array
 	 */
 	public function test_activity_object() {
 		$test_array = array(
@@ -92,8 +94,34 @@ class Test_Activity extends \WP_UnitTestCase {
 
 	/**
 	 * Test activity object.
+	 *
+	 * @covers ::init_from_array
 	 */
 	public function test_activity_object_url() {
+		$test_array = array(
+			'id'     => 'https://example.com/id/123',
+			'type'   => 'Follow',
+			'object' => 'https://example.com/post/123',
+		);
+
+		$activity = Activity::init_from_array( $test_array );
+
+		$this->assertEquals( 'https://example.com/id/123', $activity->get_id() );
+
+		$test_array2 = array(
+			'type'   => 'Follow',
+			'object' => 'https://example.com/post/123',
+		);
+
+		$activity2 = Activity::init_from_array( $test_array2 );
+
+		$this->assertTrue( str_starts_with( $activity2->get_id(), 'https://example.com/post/123#activity-follow-' ) );
+	}
+
+	/**
+	 * Test activity object.
+	 */
+	public function test_activity_object_id() {
 		$id = 'https://example.com/author/123';
 
 		// Build the update.


### PR DESCRIPTION
The `Activity::set_object` falsely assumes that a URL as string means that there is no Activity-ID available and sets it to a default.

This PR adds a check, if there is already an ID, to not overwrite an existing one any more.

Fixes #1314

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only set a default, when the ID is empty

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Bypass Signature verification
* Send a Follow request
* Check the Outbox `Accept` item
* The old code show the default ID
* With the PR you will see the ID, you have sent with the Follow request

