### PR TITLE
Fix: Do not add an audience to the Actor-Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Enforce 200 status header for valid ActivityPub requests.
 * Integration of content-visibility setup in the block editor.
 * Update CLI commands to the new scheduler refactorings.
+* Do not add an audience to the Actor-Profiles.
 
 ## [5.1.0] - 2025-02-06
 

--- a/includes/transformer/class-user.php
+++ b/includes/transformer/class-user.php
@@ -27,8 +27,6 @@ class User extends Base {
 			return $activity_object;
 		}
 
-		$activity_object = $this->set_audience( $activity_object );
-
 		return $activity_object;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Fixed: Enforce 200 status header for valid ActivityPub requests.
 * Fixed: Integration of content-visibility setup in the block editor.
 * Fixed: Update CLI commands to the new scheduler refactorings.
+* Fixed: Do not add an audience to the Actor-Profiles.
 
 = 5.1.0 =
 


### PR DESCRIPTION
Fixes: Do not add `cc` and `to` to the Actor-Profiles.

## Testing instructions:

* Load a user profile with `Accept` header `application/activity+json`
* Before the PR, the JSON included `cc` and `to` attrubutes
* The PR removes them

