### PR TITLE
Group admin-related classes

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -69,16 +69,20 @@ function plugin_init() {
 	\add_action( 'init', array( __NAMESPACE__ . '\Activitypub', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Dispatcher', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Handler', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Admin', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Hashtag', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Mention', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Health_Check', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Comment', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Link', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Mailer', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Settings_Fields', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Blog_Settings_Fields', 'init' ) );
+
+	// Menus are registered before `admin_init`, because of course they are.
+	\add_action( 'admin_menu', array( __NAMESPACE__ . '\WP_Admin\Menu', 'admin_menu' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Admin', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Health_Check', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Settings', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Settings_Fields', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Blog_Settings_Fields', 'init' ) );
 
 	if ( site_supports_blocks() ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\Blocks', 'init' ) );

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -5,12 +5,19 @@
  * @package Activitypub
  */
 
-namespace Activitypub;
+namespace Activitypub\WP_Admin;
 
+use Activitypub\Comment;
 use WP_User_Query;
 use Activitypub\Model\Blog;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
+use function Activitypub\count_followers;
+use function Activitypub\get_content_visibility;
+use function Activitypub\is_user_disabled;
+use function Activitypub\is_user_type_disabled;
+use function Activitypub\site_supports_blocks;
+use function Activitypub\was_comment_received;
 
 /**
  * ActivityPub Admin Class.
@@ -22,8 +29,6 @@ class Admin {
 	 * Initialize the class, registering WordPress hooks,
 	 */
 	public static function init() {
-		\add_action( 'admin_menu', array( self::class, 'admin_menu' ) );
-		\add_action( 'admin_init', array( self::class, 'register_settings' ) );
 		\add_action( 'load-comment.php', array( self::class, 'edit_comment' ) );
 		\add_action( 'load-post.php', array( self::class, 'edit_post' ) );
 		\add_action( 'load-edit.php', array( self::class, 'list_posts' ) );
@@ -52,50 +57,6 @@ class Admin {
 
 		\add_filter( 'dashboard_glance_items', array( self::class, 'dashboard_glance_items' ) );
 		\add_filter( 'plugin_action_links_' . ACTIVITYPUB_PLUGIN_BASENAME, array( self::class, 'add_plugin_settings_link' ) );
-	}
-
-	/**
-	 * Add admin menu entry.
-	 */
-	public static function admin_menu() {
-		$settings_page = \add_options_page(
-			'Welcome',
-			'ActivityPub',
-			'manage_options',
-			'activitypub',
-			array( self::class, 'settings_page' )
-		);
-
-		\add_action(
-			'load-' . $settings_page,
-			array( self::class, 'add_settings_help_tab' )
-		);
-
-		// User has to be able to publish posts.
-		if ( ! is_user_disabled( get_current_user_id() ) ) {
-			$followers_list_page = \add_users_page(
-				\__( 'Followers ⁂', 'activitypub' ),
-				\__( 'Followers ⁂', 'activitypub' ),
-				'activitypub',
-				'activitypub-followers-list',
-				array(
-					self::class,
-					'followers_list_page',
-				)
-			);
-
-			\add_action(
-				'load-' . $followers_list_page,
-				array( self::class, 'add_followers_list_help_tab' )
-			);
-
-			\add_users_page(
-				\__( 'Extra Fields ⁂', 'activitypub' ),
-				\__( 'Extra Fields ⁂', 'activitypub' ),
-				'activitypub',
-				\esc_url( \admin_url( '/edit.php?post_type=ap_extrafield' ) )
-			);
-		}
 	}
 
 	/**
@@ -144,63 +105,6 @@ class Admin {
 	}
 
 	/**
-	 * Load settings page.
-	 */
-	public static function settings_page() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'welcome';
-
-		$settings_tabs = array(
-			'welcome'  => array(
-				'label'    => __( 'Welcome', 'activitypub' ),
-				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/welcome.php',
-			),
-			'settings' => array(
-				'label'    => __( 'Settings', 'activitypub' ),
-				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php',
-			),
-		);
-		if ( ! is_user_disabled( Actors::BLOG_USER_ID ) ) {
-			$settings_tabs['blog-profile'] = array(
-				'label'    => __( 'Blog Profile', 'activitypub' ),
-				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-settings.php',
-			);
-			$settings_tabs['followers']    = array(
-				'label'    => __( 'Followers', 'activitypub' ),
-				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-followers-list.php',
-			);
-		}
-
-		/**
-		 * Filters the tabs displayed in the ActivityPub settings.
-		 *
-		 * @param array $settings_tabs The tabs to display.
-		 */
-		$custom_tabs   = \apply_filters( 'activitypub_admin_settings_tabs', array() );
-		$settings_tabs = \array_merge( $settings_tabs, $custom_tabs );
-
-		switch ( $tab ) {
-			case 'blog-profile':
-				wp_enqueue_media();
-				wp_enqueue_script( 'activitypub-header-image' );
-				break;
-			case 'welcome':
-				wp_enqueue_script( 'plugin-install' );
-				add_thickbox();
-				wp_enqueue_script( 'updates' );
-				break;
-		}
-
-		$labels       = wp_list_pluck( $settings_tabs, 'label' );
-		$args         = array_fill_keys( array_keys( $labels ), '' );
-		$args[ $tab ] = 'active';
-		$args['tabs'] = $labels;
-
-		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/admin-header.php', true, $args );
-		\load_template( $settings_tabs[ $tab ]['template'] );
-	}
-
-	/**
 	 * Load user settings page
 	 */
 	public static function followers_list_page() {
@@ -208,223 +112,6 @@ class Admin {
 		if ( ! is_user_disabled( get_current_user_id() ) ) {
 			\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/user-followers-list.php' );
 		}
-	}
-
-	/**
-	 * Register ActivityPub settings
-	 */
-	public static function register_settings() {
-		\register_setting(
-			'activitypub',
-			'activitypub_post_content_type',
-			array(
-				'type'         => 'string',
-				'description'  => \__( 'Use title and link, summary, full or custom content', 'activitypub' ),
-				'show_in_rest' => array(
-					'schema' => array(
-						'enum' => array(
-							'title',
-							'excerpt',
-							'content',
-						),
-					),
-				),
-				'default'      => 'content',
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_custom_post_content',
-			array(
-				'type'         => 'string',
-				'description'  => \__( 'Define your own custom post template', 'activitypub' ),
-				'show_in_rest' => true,
-				'default'      => ACTIVITYPUB_CUSTOM_POST_CONTENT,
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_max_image_attachments',
-			array(
-				'type'        => 'integer',
-				'description' => \__( 'Number of images to attach to posts.', 'activitypub' ),
-				'default'     => ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS,
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_object_type',
-			array(
-				'type'         => 'string',
-				'description'  => \__( 'The Activity-Object-Type', 'activitypub' ),
-				'show_in_rest' => array(
-					'schema' => array(
-						'enum' => array(
-							'note',
-							'wordpress-post-format',
-						),
-					),
-				),
-				'default'      => ACTIVITYPUB_DEFAULT_OBJECT_TYPE,
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_use_hashtags',
-			array(
-				'type'        => 'boolean',
-				'description' => \__( 'Add hashtags in the content as native tags and replace the #tag with the tag-link', 'activitypub' ),
-				'default'     => '0',
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_use_opengraph',
-			array(
-				'type'        => 'boolean',
-				'description' => \__( 'Automatically add "fediverse:creator" OpenGraph tags for Authors and the Blog-User.', 'activitypub' ),
-				'default'     => '1',
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_support_post_types',
-			array(
-				'type'         => 'string',
-				'description'  => \esc_html__( 'Enable ActivityPub support for post types', 'activitypub' ),
-				'show_in_rest' => true,
-				'default'      => array( 'post' ),
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_actor_mode',
-			array(
-				'type'        => 'integer',
-				'description' => \__( 'Choose your preferred Actor-Mode.', 'activitypub' ),
-				'default'     => ACTIVITYPUB_ACTOR_MODE,
-			)
-		);
-
-		\register_setting(
-			'activitypub',
-			'activitypub_attribution_domains',
-			array(
-				'type'              => 'string',
-				'description'       => \__( 'Websites allowed to credit you.', 'activitypub' ),
-				'default'           => home_host(),
-				'sanitize_callback' => function ( $value ) {
-					$value = explode( PHP_EOL, $value );
-					$value = array_filter( array_map( 'trim', $value ) );
-					$value = array_filter( array_map( 'esc_attr', $value ) );
-					$value = implode( PHP_EOL, $value );
-
-					return $value;
-				},
-			)
-		);
-
-		\register_setting(
-			'activitypub',
-			'activitypub_authorized_fetch',
-			array(
-				'type'        => 'boolean',
-				'description' => \__( 'Require HTTP signature authentication.', 'activitypub' ),
-				'default'     => false,
-			)
-		);
-
-		\register_setting(
-			'activitypub',
-			'activitypub_mailer_new_follower',
-			array(
-				'type'        => 'boolean',
-				'description' => \__( 'Send notifications via e-mail when a new follower is added.', 'activitypub' ),
-				'default'     => '0',
-			)
-		);
-		\register_setting(
-			'activitypub',
-			'activitypub_mailer_new_dm',
-			array(
-				'type'        => 'boolean',
-				'description' => \__( 'Send notifications via e-mail when a direct message is received.', 'activitypub' ),
-				'default'     => '0',
-			)
-		);
-
-		// Blog-User Settings.
-		\register_setting(
-			'activitypub_blog',
-			'activitypub_blog_description',
-			array(
-				'type'         => 'string',
-				'description'  => \esc_html__( 'The Description of the Blog-User', 'activitypub' ),
-				'show_in_rest' => true,
-				'default'      => '',
-			)
-		);
-		\register_setting(
-			'activitypub_blog',
-			'activitypub_blog_identifier',
-			array(
-				'type'              => 'string',
-				'description'       => \esc_html__( 'The Identifier of the Blog-User', 'activitypub' ),
-				'show_in_rest'      => true,
-				'default'           => Blog::get_default_username(),
-				'sanitize_callback' => function ( $value ) {
-					// Hack to allow dots in the username.
-					$parts     = explode( '.', $value );
-					$sanitized = array();
-
-					foreach ( $parts as $part ) {
-						$sanitized[] = \sanitize_title( $part );
-					}
-
-					$sanitized = implode( '.', $sanitized );
-
-					// Check for login or nicename.
-					$user = new WP_User_Query(
-						array(
-							'search'         => $sanitized,
-							'search_columns' => array( 'user_login', 'user_nicename' ),
-							'number'         => 1,
-							'hide_empty'     => true,
-							'fields'         => 'ID',
-						)
-					);
-
-					if ( $user->results ) {
-						add_settings_error(
-							'activitypub_blog_identifier',
-							'activitypub_blog_identifier',
-							\esc_html__( 'You cannot use an existing author\'s name for the blog profile ID.', 'activitypub' ),
-							'error'
-						);
-
-						return Blog::get_default_username();
-					}
-
-					return $sanitized;
-				},
-			)
-		);
-		\register_setting(
-			'activitypub_blog',
-			'activitypub_header_image',
-			array(
-				'type'        => 'integer',
-				'description' => \__( 'The Attachment-ID of the Sites Header-Image', 'activitypub' ),
-				'default'     => null,
-			)
-		);
-	}
-
-	/**
-	 * Adds the ActivityPub settings to the Help tab.
-	 */
-	public static function add_settings_help_tab() {
-		require_once ACTIVITYPUB_PLUGIN_DIR . 'includes/help.php';
 	}
 
 	/**

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -5,7 +5,7 @@
  * @package ActivityPub
  */
 
-namespace Activitypub;
+namespace Activitypub\WP_Admin;
 
 /**
  * Class to handle all blog settings fields and callbacks.
@@ -15,7 +15,7 @@ class Blog_Settings_Fields {
 	 * Initialize the settings fields.
 	 */
 	public static function init() {
-		add_action( 'settings_page_activitypub', array( self::class, 'register_settings' ) );
+		add_action( 'load-settings_page_activitypub', array( self::class, 'register_settings' ) );
 	}
 
 	/**
@@ -143,7 +143,7 @@ class Blog_Settings_Fields {
 	public static function profile_id_callback() {
 		?>
 		<label for="activitypub_blog_identifier">
-			<input id="activitypub_blog_identifier" class="blog-user-identifier" name="activitypub_blog_identifier" type="text" value="<?php echo esc_attr( get_option( 'activitypub_blog_identifier', Model\Blog::get_default_username() ) ); ?>" />
+			<input id="activitypub_blog_identifier" class="blog-user-identifier" name="activitypub_blog_identifier" type="text" value="<?php echo esc_attr( get_option( 'activitypub_blog_identifier', \Activitypub\Model\Blog::get_default_username() ) ); ?>" />
 			@<?php echo esc_html( wp_parse_url( home_url(), PHP_URL_HOST ) ); ?>
 		</label>
 		<p class="description">
@@ -188,7 +188,7 @@ class Blog_Settings_Fields {
 
 		<table class="widefat striped activitypub-extra-fields" role="presentation" style="margin: 15px 0;">
 		<?php
-		$extra_fields = Collection\Extra_Fields::get_actor_fields( Collection\Actors::BLOG_USER_ID );
+		$extra_fields = \Activitypub\Collection\Extra_Fields::get_actor_fields( \Activitypub\Collection\Actors::BLOG_USER_ID );
 
 		if ( empty( $extra_fields ) ) :
 			?>

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -5,10 +5,12 @@
  * @package Activitypub
  */
 
-namespace Activitypub;
+namespace Activitypub\WP_Admin;
 
+use Activitypub\Webfinger;
 use WP_Error;
 use Activitypub\Collection\Actors;
+use function Activitypub\is_user_disabled;
 
 /**
  * ActivityPub Health_Check Class.

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Menu file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\WP_Admin;
+
+use function Activitypub\is_user_disabled;
+
+/**
+ * ActivityPub Menu Class.
+ */
+class Menu {
+
+	/**
+	 * Add admin menu entry.
+	 */
+	public static function admin_menu() {
+		$settings_page = \add_options_page(
+			'Welcome',
+			'ActivityPub',
+			'manage_options',
+			'activitypub',
+			array( Settings::class, 'settings_page' )
+		);
+
+		\add_action( 'load-' . $settings_page, array( Settings::class, 'add_settings_help_tab' ) );
+
+		// User has to be able to publish posts.
+		if ( ! is_user_disabled( get_current_user_id() ) ) {
+			$followers_list_page = \add_users_page(
+				\__( 'Followers ⁂', 'activitypub' ),
+				\__( 'Followers ⁂', 'activitypub' ),
+				'activitypub',
+				'activitypub-followers-list',
+				array( Admin::class, 'followers_list_page' )
+			);
+
+			\add_action( 'load-' . $followers_list_page, array( Admin::class, 'add_followers_list_help_tab' ) );
+
+			\add_users_page(
+				\__( 'Extra Fields ⁂', 'activitypub' ),
+				\__( 'Extra Fields ⁂', 'activitypub' ),
+				'activitypub',
+				\esc_url( \admin_url( '/edit.php?post_type=ap_extrafield' ) )
+			);
+		}
+	}
+}

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -5,7 +5,7 @@
  * @package Activitypub
  */
 
-namespace Activitypub;
+namespace Activitypub\WP_Admin;
 
 /**
  * Class Settings_Fields.
@@ -15,7 +15,7 @@ class Settings_Fields {
 	 * Initialize the settings fields.
 	 */
 	public static function init() {
-		add_action( 'settings_page_activitypub', array( self::class, 'register_settings_fields' ) );
+		add_action( 'load-settings_page_activitypub', array( self::class, 'register_settings_fields' ) );
 	}
 
 	/**
@@ -291,7 +291,7 @@ class Settings_Fields {
 					<input type="checkbox" id="activitypub_support_post_type_<?php echo esc_attr( $post_type->name ); ?>" name="activitypub_support_post_types[]" value="<?php echo esc_attr( $post_type->name ); ?>" <?php checked( in_array( $post_type->name, $supported_post_types, true ) ); ?> />
 					<label for="activitypub_support_post_type_<?php echo esc_attr( $post_type->name ); ?>"><?php echo esc_html( $post_type->label ); ?></label>
 					<span class="description">
-						<?php echo esc_html( get_post_type_description( $post_type ) ); ?>
+						<?php echo esc_html( \Activitypub\get_post_type_description( $post_type ) ); ?>
 					</span>
 				</li>
 			<?php endforeach; ?>
@@ -334,9 +334,9 @@ class Settings_Fields {
 	 * Render attribution domains field.
 	 */
 	public static function render_attribution_domains_field() {
-		$value = get_option( 'activitypub_attribution_domains', home_host() );
+		$value = get_option( 'activitypub_attribution_domains', \Activitypub\home_host() );
 		?>
-		<textarea id="activitypub_attribution_domains" name="activitypub_attribution_domains" class="large-text" cols="50" rows="5" placeholder="<?php echo esc_attr( home_host() ); ?>"><?php echo esc_textarea( $value ); ?></textarea>
+		<textarea id="activitypub_attribution_domains" name="activitypub_attribution_domains" class="large-text" cols="50" rows="5" placeholder="<?php echo esc_attr( \Activitypub\home_host() ); ?>"><?php echo esc_textarea( $value ); ?></textarea>
 		<p class="description"><?php esc_html_e( 'Websites allowed to credit you, one per line. Protects from false attributions.', 'activitypub' ); ?></p>
 		<?php
 	}

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Settings file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\WP_Admin;
+
+use Activitypub\Collection\Actors;
+use Activitypub\Model\Blog;
+use function Activitypub\is_user_disabled;
+
+/**
+ * ActivityPub Settings Class.
+ */
+class Settings {
+	/**
+	 * Initialize the class, registering WordPress hooks,
+	 */
+	public static function init() {
+		\add_action( 'admin_init', array( self::class, 'register_settings' ), 11 );
+		\add_action( 'admin_menu', array( self::class, 'add_settings_page' ) );
+	}
+
+	/**
+	 * Register ActivityPub settings
+	 */
+	public static function register_settings() {
+		\register_setting(
+			'activitypub',
+			'activitypub_post_content_type',
+			array(
+				'type'         => 'string',
+				'description'  => \__( 'Use title and link, summary, full or custom content', 'activitypub' ),
+				'show_in_rest' => array(
+					'schema' => array(
+						'enum' => array( 'title', 'excerpt', 'content' ),
+					),
+				),
+				'default'      => 'content',
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_custom_post_content',
+			array(
+				'type'         => 'string',
+				'description'  => \__( 'Define your own custom post template', 'activitypub' ),
+				'show_in_rest' => true,
+				'default'      => ACTIVITYPUB_CUSTOM_POST_CONTENT,
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_max_image_attachments',
+			array(
+				'type'        => 'integer',
+				'description' => \__( 'Number of images to attach to posts.', 'activitypub' ),
+				'default'     => ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS,
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_object_type',
+			array(
+				'type'         => 'string',
+				'description'  => \__( 'The Activity-Object-Type', 'activitypub' ),
+				'show_in_rest' => array(
+					'schema' => array(
+						'enum' => array( 'note', 'wordpress-post-format' ),
+					),
+				),
+				'default'      => ACTIVITYPUB_DEFAULT_OBJECT_TYPE,
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_use_hashtags',
+			array(
+				'type'        => 'boolean',
+				'description' => \__( 'Add hashtags in the content as native tags and replace the #tag with the tag-link', 'activitypub' ),
+				'default'     => '0',
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_use_opengraph',
+			array(
+				'type'        => 'boolean',
+				'description' => \__( 'Automatically add "fediverse:creator" OpenGraph tags for Authors and the Blog-User.', 'activitypub' ),
+				'default'     => '1',
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_support_post_types',
+			array(
+				'type'         => 'string',
+				'description'  => \esc_html__( 'Enable ActivityPub support for post types', 'activitypub' ),
+				'show_in_rest' => true,
+				'default'      => array( 'post' ),
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_actor_mode',
+			array(
+				'type'        => 'integer',
+				'description' => \__( 'Choose your preferred Actor-Mode.', 'activitypub' ),
+				'default'     => ACTIVITYPUB_ACTOR_MODE,
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_attribution_domains',
+			array(
+				'type'              => 'string',
+				'description'       => \__( 'Websites allowed to credit you.', 'activitypub' ),
+				'default'           => \Activitypub\home_host(),
+				'sanitize_callback' => function ( $value ) {
+					$value = explode( PHP_EOL, $value );
+					$value = array_filter( array_map( 'trim', $value ) );
+					$value = array_filter( array_map( 'esc_attr', $value ) );
+					$value = implode( PHP_EOL, $value );
+
+					return $value;
+				},
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_authorized_fetch',
+			array(
+				'type'        => 'boolean',
+				'description' => \__( 'Require HTTP signature authentication.', 'activitypub' ),
+				'default'     => false,
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_mailer_new_follower',
+			array(
+				'type'        => 'boolean',
+				'description' => \__( 'Send notifications via e-mail when a new follower is added.', 'activitypub' ),
+				'default'     => '0',
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_mailer_new_dm',
+			array(
+				'type'        => 'boolean',
+				'description' => \__( 'Send notifications via e-mail when a direct message is received.', 'activitypub' ),
+				'default'     => '0',
+			)
+		);
+
+		// Blog-User Settings.
+		\register_setting(
+			'activitypub_blog',
+			'activitypub_blog_description',
+			array(
+				'type'         => 'string',
+				'description'  => \esc_html__( 'The Description of the Blog-User', 'activitypub' ),
+				'show_in_rest' => true,
+				'default'      => '',
+			)
+		);
+
+		\register_setting(
+			'activitypub_blog',
+			'activitypub_blog_identifier',
+			array(
+				'type'              => 'string',
+				'description'       => \esc_html__( 'The Identifier of the Blog-User', 'activitypub' ),
+				'show_in_rest'      => true,
+				'default'           => Blog::get_default_username(),
+				'sanitize_callback' => function ( $value ) {
+					// Hack to allow dots in the username.
+					$parts     = explode( '.', $value );
+					$sanitized = array();
+
+					foreach ( $parts as $part ) {
+						$sanitized[] = \sanitize_title( $part );
+					}
+
+					$sanitized = implode( '.', $sanitized );
+
+					// Check for login or nicename.
+					$user = new WP_User_Query(
+						array(
+							'search'         => $sanitized,
+							'search_columns' => array( 'user_login', 'user_nicename' ),
+							'number'         => 1,
+							'hide_empty'     => true,
+							'fields'         => 'ID',
+						)
+					);
+
+					if ( $user->results ) {
+						add_settings_error(
+							'activitypub_blog_identifier',
+							'activitypub_blog_identifier',
+							\esc_html__( 'You cannot use an existing author\'s name for the blog profile ID.', 'activitypub' ),
+							'error'
+						);
+
+						return Blog::get_default_username();
+					}
+
+					return $sanitized;
+				},
+			)
+		);
+
+		\register_setting(
+			'activitypub_blog',
+			'activitypub_header_image',
+			array(
+				'type'        => 'integer',
+				'description' => \__( 'The Attachment-ID of the Sites Header-Image', 'activitypub' ),
+				'default'     => null,
+			)
+		);
+	}
+
+	/**
+	 * Load settings page.
+	 */
+	public static function settings_page() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'welcome';
+
+		$settings_tabs = array(
+			'welcome'  => array(
+				'label'    => __( 'Welcome', 'activitypub' ),
+				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/welcome.php',
+			),
+			'settings' => array(
+				'label'    => __( 'Settings', 'activitypub' ),
+				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php',
+			),
+		);
+		if ( ! is_user_disabled( Actors::BLOG_USER_ID ) ) {
+			$settings_tabs['blog-profile'] = array(
+				'label'    => __( 'Blog Profile', 'activitypub' ),
+				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-settings.php',
+			);
+			$settings_tabs['followers']    = array(
+				'label'    => __( 'Followers', 'activitypub' ),
+				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-followers-list.php',
+			);
+		}
+
+		/**
+		 * Filters the tabs displayed in the ActivityPub settings.
+		 *
+		 * @param array $settings_tabs The tabs to display.
+		 */
+		$custom_tabs   = \apply_filters( 'activitypub_admin_settings_tabs', array() );
+		$settings_tabs = \array_merge( $settings_tabs, $custom_tabs );
+
+		switch ( $tab ) {
+			case 'blog-profile':
+				wp_enqueue_media();
+				wp_enqueue_script( 'activitypub-header-image' );
+				break;
+			case 'welcome':
+				wp_enqueue_script( 'plugin-install' );
+				add_thickbox();
+				wp_enqueue_script( 'updates' );
+				break;
+		}
+
+		$labels       = wp_list_pluck( $settings_tabs, 'label' );
+		$args         = array_fill_keys( array_keys( $labels ), '' );
+		$args[ $tab ] = 'active';
+		$args['tabs'] = $labels;
+
+		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/admin-header.php', true, $args );
+		\load_template( $settings_tabs[ $tab ]['template'] );
+	}
+
+	/**
+	 * Adds the ActivityPub settings to the Help tab.
+	 */
+	public static function add_settings_help_tab() {
+		require_once ACTIVITYPUB_PLUGIN_DIR . 'includes/help.php';
+	}
+}

--- a/tests/includes/wp-admin/class-test-admin.php
+++ b/tests/includes/wp-admin/class-test-admin.php
@@ -5,14 +5,21 @@
  * @package Activitypub
  */
 
-namespace Activitypub\Tests;
+namespace Activitypub\Tests\WP_Admin;
 
 /**
  * Test class for Admin.
  *
- * @coversDefaultClass \Activitypub\Admin
+ * @coversDefaultClass \Activitypub\WP_Admin\Admin
  */
 class Test_Admin extends \WP_UnitTestCase {
+
+	/**
+	 * Set up before class.
+	 */
+	public static function set_up_before_class() {
+		\Activitypub\WP_Admin\Admin::init();
+	}
 
 	/**
 	 * Test the admin notice for missing permalink structure.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves Admin, Health_Check, and settings fields classes into a new `wp-admin` folder.
* Creates separate Menu class to be hooked in `admin_menu`.
* Creates Settings class to contain all settings-related methods.
* Updates unit tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Everything should continue to work as expected.
* Navigate to Health Check page and make sure ActivityPub checks still show up.
* Navigate to Dashboard and see that At a Glance still contains follower count.
* Navigate to settings and make sure they still work as expected.

