### PR TITLE
Outbox: Add settings for Outbox retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* Setting to adjust the number of days Outbox items are kept before being purged.
+
+### Fixed
+
+* The Outbox purging routine no longer is limited to deleting 5 items at a time.
+
 ## [5.2.0] - 2025-02-13
 
 ### Added

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -111,6 +111,7 @@ class Activitypub {
 		delete_option( 'activitypub_max_image_attachments' );
 		delete_option( 'activitypub_migration_lock' );
 		delete_option( 'activitypub_object_type' );
+		delete_option( 'activitypub_outbox_purge_days' );
 		delete_option( 'activitypub_support_post_types' );
 		delete_option( 'activitypub_use_hashtags' );
 		delete_option( 'activitypub_use_opengraph' );

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -228,6 +228,7 @@ class Scheduler {
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'any',
 				'fields'      => 'ids',
+				'numberposts' => -1,
 				'date_query'  => array(
 					array(
 						'before' => $date->format( 'Y-m-d' ),

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -31,12 +31,15 @@ class Scheduler {
 		\add_action( 'activitypub_update_followers', array( self::class, 'update_followers' ) );
 		\add_action( 'activitypub_cleanup_followers', array( self::class, 'cleanup_followers' ) );
 
+		// Event callbacks.
 		\add_action( 'activitypub_async_batch', array( self::class, 'async_batch' ), 10, 99 );
 		\add_action( 'activitypub_reprocess_outbox', array( self::class, 'reprocess_outbox' ) );
 		\add_action( 'activitypub_outbox_purge', array( self::class, 'purge_outbox' ) );
 
 		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'schedule_outbox_activity_for_federation' ) );
 		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'schedule_announce_activity' ), 10, 4 );
+
+		\add_action( 'update_option_activitypub_outbox_purge_days', array( self::class, 'handle_outbox_purge_days_update' ), 10, 2 );
 	}
 
 	/**
@@ -214,7 +217,7 @@ class Scheduler {
 			return;
 		}
 
-		$days     = 180; // TODO: Replace with a setting.
+		$days     = (int) get_option( 'activitypub_outbox_purge_days', 180 );
 		$timezone = new \DateTimeZone( 'UTC' );
 		$date     = new \DateTime( 'now', $timezone );
 
@@ -235,6 +238,20 @@ class Scheduler {
 
 		foreach ( $post_ids as $post_id ) {
 			\wp_delete_post( $post_id, true );
+		}
+	}
+
+	/**
+	 * Update schedules when outbox purge days settings change.
+	 *
+	 * @param int $old_value The old value.
+	 * @param int $value     The new value.
+	 */
+	public static function handle_outbox_purge_days_update( $old_value, $value ) {
+		if ( 0 === (int) $value ) {
+			wp_clear_scheduled_hook( 'activitypub_outbox_purge' );
+		} elseif ( ! wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
+			wp_schedule_event( time(), 'daily', 'activitypub_outbox_purge' );
 		}
 	}
 

--- a/includes/help.php
+++ b/includes/help.php
@@ -69,7 +69,9 @@
 			'<p>' . \__( 'For more information please visit <a href="https://webfinger.net/" target="_blank">webfinger.net</a>', 'activitypub' ) . '</p>' .
 			'<p><h2>' . \__( 'NodeInfo', 'activitypub' ) . '</h2></p>' .
 			'<p>' . \__( 'NodeInfo is an effort to create a standardized way of exposing metadata about a server running one of the distributed social networks. The two key goals are being able to get better insights into the user base of distributed social networking and the ability to build tools that allow users to choose the best fitting software and server for their needs.', 'activitypub' ) . '</p>' .
-			'<p>' . \__( 'For more information please visit <a href="http://nodeinfo.diaspora.software/" target="_blank">nodeinfo.diaspora.software</a>', 'activitypub' ) . '</p>',
+			'<p>' . \__( 'For more information please visit <a href="http://nodeinfo.diaspora.software/" target="_blank">nodeinfo.diaspora.software</a>', 'activitypub' ) . '</p>' .
+			'<p><h2>' . \__( 'Outbox', 'activitypub' ) . '</h2></p>' .
+			'<p>' . \__( 'An "Outbox" is a virtual location on a user&#8217;s profile where all the activities (posts, likes, replies) they publish are stored, acting as a feed that other users can access to see their publicly shared content; it&#8217;s essentially how a user "sends" information to others on a decentralized social network following the ActivityPub standard.', 'activitypub' ) . '</p>',
 	)
 );
 

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -376,7 +376,18 @@ class Settings_Fields {
 	public static function render_outbox_purge_days_field() {
 		$value = get_option( 'activitypub_outbox_purge_days', 180 );
 		echo '<input type="number" id="activitypub_outbox_purge_days" name="activitypub_outbox_purge_days" value="' . esc_attr( $value ) . '" class="small-text" min="0" max="365" />';
-		echo '<p class="description">' . esc_html__( 'Maximum number of days to keep items in the Outbox. A lower value might be better for sites with lots of activity to maintain site performance.', 'activitypub' ) . '</p>';
+		echo '<p class="description">' . wp_kses(
+			sprintf(
+				// translators: 1: Definition of Outbox; 2: Default value (180).
+				__( 'Maximum number of days to keep items in the <abbr title="%1$s">Outbox</abbr>. A lower value might be better for sites with lots of activity to maintain site performance. Default: <code>%2$s</code>', 'activitypub' ),
+				esc_attr__( 'A virtual location on a user&#8217;s profile where all the activities (posts, likes, replies) they publish are stored, acting as a feed that other users can access to see their publicly shared content', 'activitypub' ),
+				esc_html( 180 )
+			),
+			array(
+				'abbr' => array( 'title' => array() ),
+				'code' => array(),
+			)
+		) . '</p>';
 	}
 
 	/**

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -125,6 +125,15 @@ class Settings_Fields {
 			'activitypub_general'
 		);
 
+		add_settings_field(
+			'activitypub_outbox_purge_days',
+			__( 'Outbox Retention Period', 'activitypub' ),
+			array( self::class, 'render_outbox_purge_days_field' ),
+			'activitypub_settings',
+			'activitypub_general',
+			array( 'label_for' => 'activitypub_outbox_purge_days' )
+		);
+
 		if ( ! defined( 'ACTIVITYPUB_AUTHORIZED_FETCH' ) ) {
 			add_settings_section(
 				'activitypub_security',
@@ -255,7 +264,7 @@ class Settings_Fields {
 	public static function render_max_image_attachments_field() {
 		$value = get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
 		?>
-		<input id="activitypub_max_image_attachments" value="<?php echo esc_attr( $value ); ?>" name="activitypub_max_image_attachments" type="number" min="0" />
+		<input id="activitypub_max_image_attachments" value="<?php echo esc_attr( $value ); ?>" name="activitypub_max_image_attachments" type="number" min="0" class="small-text" />
 		<p class="description">
 			<?php
 			echo wp_kses(
@@ -359,6 +368,15 @@ class Settings_Fields {
 			?>
 		</p>
 		<?php
+	}
+
+	/**
+	 * Render outbox purge days field.
+	 */
+	public static function render_outbox_purge_days_field() {
+		$value = get_option( 'activitypub_outbox_purge_days', 180 );
+		echo '<input type="number" id="activitypub_outbox_purge_days" name="activitypub_outbox_purge_days" value="' . esc_attr( $value ) . '" class="small-text" min="0" max="365" />';
+		echo '<p class="description">' . esc_html__( 'Maximum number of days to keep items in the Outbox. A lower value might be better for sites with lots of activity to maintain site performance.', 'activitypub' ) . '</p>';
 	}
 
 	/**

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -65,6 +65,16 @@ class Settings {
 
 		\register_setting(
 			'activitypub',
+			'activitypub_outbox_purge_days',
+			array(
+				'type'        => 'integer',
+				'description' => \__( 'Number of days to keep items in the Outbox.', 'activitypub' ),
+				'default'     => 180,
+			)
+		);
+
+		\register_setting(
+			'activitypub',
 			'activitypub_object_type',
 			array(
 				'type'         => 'string',

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,11 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Added: Setting to adjust the number of days Outbox items are kept before being purged.
+* Fixed: The Outbox purging routine no longer is limited to deleting 5 items at a time.
+
 = 5.2.0 =
 
 * Added: Batch Outbox-Processing.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Follow-up to #1288.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a setting to change the amount of days Outbox items are kept.
* Updates purging logic to purge all posts, not just the default 5.
* Adds a Glossary entry for `Outbox`.
* Adds a callback to disable purging when retention days are set to 0.
* Adds unit tests for the new setting.

## After
<img width="871" alt="image" src="https://github.com/user-attachments/assets/c3c92eae-465c-4071-9f64-9002f6f9e64e" />


### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unit tests should be enough, I think.
* Go to Settings > Activitypub > Settings
* Change the retention days to `0` and save changes.
* Run `wp cron event list` and make sure the daily activitypub_outbox_purge job is no longer there.
* Change the setting back to a number greater than 0
* Run `wp cron event list` and make sure the daily activitypub_outbox_purge job is there.

