### PR TITLE
Fix: Uncaught Error: Call to undefined method Json::get_id

### DIFF
--- a/includes/transformer/class-activity-object.php
+++ b/includes/transformer/class-activity-object.php
@@ -29,6 +29,15 @@ class Activity_Object extends Base {
 	}
 
 	/**
+	 * Get the ID of the object.
+	 *
+	 * @return string The ID of the object.
+	 */
+	public function get_id() {
+		return $this->item->get_id();
+	}
+
+	/**
 	 * Get the attributed to.
 	 *
 	 * @return string The attributed to.


### PR DESCRIPTION
Fixes an `Uncaught Error: Call to undefined method Activitypub\Transformer\Json::get_id()` error


