### PR TITLE
Add: Preview support for Articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Undo API for Outbox items.
 * Allow Activities on URLs instead of requiring Activity-Objects. This is useful especially for sending Announces and Likes.
 
-
 ## [5.2.0] - 2025-02-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* A `preview` property to the `Article` object.
+* A fallback `Note` for `Article` objects to improve previews on services that don't support Articles yet.
 * Undo API for Outbox items.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* A `preview` property to the `Article` object.
+
 ## [5.2.0] - 2025-02-13
 
 ### Added

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -1137,4 +1137,20 @@ class Post extends Base {
 			'totalItems' => Interactions::count_by_type( $this->item->ID, 'repost' ),
 		);
 	}
+
+	/**
+	 * Get the preview of the post.
+	 *
+	 * @return array|null The preview of the post or null if the post is not an Article.
+	 */
+	public function get_preview() {
+		if ( 'Article' !== $this->get_type() ) {
+			return null;
+		}
+
+		return array(
+			'type'    => 'Note',
+			'content' => $this->get_summary(),
+		);
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -131,7 +131,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 = Unreleased =
 
-* Added: A `preview` property to the `Article` object.
+* Added: A fallback `Note` for `Article` objects to improve previews on services that don't support Articles yet.
 * Added: Undo API for Outbox items.
 
 = 5.2.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,10 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+= Unreleased =
+
+* Added: A `preview` property to the `Article` object.
+
 = 5.2.0 =
 
 * Added: Batch Outbox-Processing.

--- a/tests/includes/transformer/class-test-post.php
+++ b/tests/includes/transformer/class-test-post.php
@@ -624,4 +624,44 @@ class Test_Post extends \WP_UnitTestCase {
 
 		return $id;
 	}
+
+	/**
+	 * Test preview property generation.
+	 *
+	 * @covers ::get_preview
+	 */
+	public function test_preview_property() {
+		// Create a test post of type "Article".
+		$post = $this->factory->post->create_and_get(
+			array(
+				'post_title'   => 'Test Article',
+				'post_content' => str_repeat( 'Long content. ', 100 ),
+				'post_status'  => 'publish',
+			)
+		);
+
+		$transformer = new Post( $post );
+		$preview     = $transformer->get_preview();
+
+		// Check if the preview for an Article is correctly generated.
+		$this->assertIsArray( $preview );
+		$this->assertEquals( 'Note', $preview['type'] );
+		$this->assertArrayHasKey( 'content', $preview );
+		$this->assertNotEmpty( $preview['content'] );
+
+		// Create a test post of type "Note" (short content).
+		$note_post = $this->factory->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => 'Short note content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$note_transformer = new Post( $note_post );
+		$note_preview     = $note_transformer->get_preview();
+
+		// Check if the preview for a Note is null.
+		$this->assertNull( $note_preview );
+	}
 }


### PR DESCRIPTION
Mastodon does not support `Articles` yet, so we need a way to provide subsets of the `Article`, so that Microblogging services can show a summary.

The `summary` filed of an `Article` is not reliable enough, because it is (mis)used for the content warning.

This PR adds a `Note` as `preview`, so that Microblogging services have something to fall back when they do not support `Article`s

Some context:

* https://codeberg.org/fediverse/fep/src/branch/main/fep/b2b8/fep-b2b8.md#preview
* https://codeberg.org/evanp/fep/issues/21

props @Menrath 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check if Object-Type is `Article` and add summary as preview `Note` object

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an Article
* Load the permalink
* Add `?activitypub`
* Check JSON

