### PR TITLE
Settings: Bring back notifications

### DIFF
--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -38,6 +38,13 @@ class Settings_Fields {
 		);
 
 		add_settings_section(
+			'activitypub_notifications',
+			__( 'Notifications', 'activitypub' ),
+			array( self::class, 'render_notifications_section' ),
+			'activitypub_settings'
+		);
+
+		add_settings_section(
 			'activitypub_general',
 			__( 'General', 'activitypub' ),
 			'__return_empty_string',
@@ -151,6 +158,49 @@ class Settings_Fields {
 				array( 'label_for' => 'activitypub_authorized_fetch' )
 			);
 		}
+	}
+
+	/**
+	 * Render notifications section.
+	 */
+	public static function render_notifications_section() {
+		?>
+		<p>
+			<?php \esc_html_e( 'Choose which notifications you want to receive. The plugin currently only supports e-mail notifications, but we will add more options in the future.', 'activitypub' ); ?>
+		</p>
+		<table class="form-table">
+			<tbody>
+			<tr>
+				<th scope="col">
+					<?php \esc_html_e( 'Type', 'activitypub' ); ?>
+				</th>
+				<th scope="col">
+					<?php \esc_html_e( 'E-Mail', 'activitypub' ); ?>
+				</th>
+			</tr>
+			<tr>
+				<td>
+					<?php \esc_html_e( 'New followers', 'activitypub' ); ?>
+				</td>
+				<td>
+					<label>
+						<input type="checkbox" name="activitypub_mailer_new_follower" id="activitypub_mailer_new_follower" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_follower', '0' ) ); ?> />
+					</label>
+				</td>
+			</tr>
+			<tr>
+				<td>
+					<?php \esc_html_e( 'Direct Messages', 'activitypub' ); ?>
+				</td>
+				<td>
+					<label>
+						<input type="checkbox" name="activitypub_mailer_new_dm" id="activitypub_mailer_new_dm" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_dm', '0' ) ); ?> />
+					</label>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

See #1109, #1311.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds notifications setting section.
* Renders the settings table as part of the section description as the lesser of the bad choices to display these settings.

### After
![image](https://github.com/user-attachments/assets/baeb77ae-b5f0-4c6f-aa73-37e3e0d04a4f)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > ActivityPub and make sure the settings work.

