### PR TITLE
Outbox: Process first batch right away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Setting to adjust the number of days Outbox items are kept before being purged.
 
+### Changed
+
+* Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
+
 ### Fixed
 
 * The Outbox purging routine no longer is limited to deleting 5 items at a time.

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -90,15 +90,11 @@ class Dispatcher {
 		self::send_to_interactees( $activity, $actor->get__id(), $outbox_item );
 
 		if ( self::should_send_to_followers( $activity, $actor, $outbox_item ) ) {
-			\wp_schedule_single_event(
-				\time(),
-				'activitypub_async_batch',
-				array(
-					self::$callback,
-					$outbox_item->ID,
-					self::$batch_size,
-					\get_post_meta( $outbox_item->ID, '_activitypub_outbox_offset', true ) ?: 0, // phpcs:ignore
-				)
+			Scheduler::async_batch(
+				self::$callback,
+				$outbox_item->ID,
+				self::$batch_size,
+				\get_post_meta( $outbox_item->ID, '_activitypub_outbox_offset', true ) ?: 0 // phpcs:ignore
 			);
 		} else {
 			// No followers to process for this update. We're done.

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: Allow Activities on URLs instead of requiring Activity-Objects. This is useful especially for sending Announces and Likes.
 * Added: Undo API for Outbox items.
 * Added: Setting to adjust the number of days Outbox items are kept before being purged.
+* Changed: Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
 * Fixed: The Outbox purging routine no longer is limited to deleting 5 items at a time.
 * Fixed an issue where the outbox could not send object types other than `Base_Object` (introduced in 5.0.0).
 

--- a/tests/includes/class-test-dispatcher.php
+++ b/tests/includes/class-test-dispatcher.php
@@ -93,17 +93,7 @@ class Test_Dispatcher extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		Dispatcher::process_outbox( $outbox_item->ID );
 
-		$this->assertNotFalse(
-			wp_next_scheduled(
-				'activitypub_async_batch',
-				array(
-					Dispatcher::$callback,
-					$outbox_item->ID,
-					Dispatcher::$batch_size,
-					0,
-				)
-			)
-		);
+		$this->assertEquals( 'publish', \get_post( $outbox_item->ID )->post_status );
 
 		remove_filter( 'activitypub_send_activity_to_followers', $test_callback );
 	}


### PR DESCRIPTION
Helps with cutting down the number of events the need processing.

See https://wordpress.org/support/topic/accidental-maximum-stress-test

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Calls batch processing directly instead of scheduling it as a new event.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new activity.
* If your site has fewer than 100 followers, it should be published as soon as `activitypub_process_outbox` ran.

