### PR TITLE
Outbox: Don't federate Updates to unfederated posts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
+* Updates to unfederated posts no longer trigger a new Activity.
 
 ### Fixed
 

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -99,6 +99,11 @@ class Post {
 			return;
 		}
 
+		// If the post is not federated, do not send Updates.
+		if ( 'Update' === $type && 'federated' !== get_wp_object_state( $post ) ) {
+			return;
+		}
+
 		// Add the post to the outbox.
 		add_to_outbox( $post, $type, $post->post_author );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: Setting to adjust the number of days Outbox items are kept before being purged.
 * Added: Show metadata in the New Follower E-Mail.
 * Changed: Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
+* Changed: Updates to unfederated posts no longer trigger a new Activity.
 * Fixed: The Outbox purging routine no longer is limited to deleting 5 items at a time.
 * Fixed an issue where the outbox could not send object types other than `Base_Object` (introduced in 5.0.0).
 

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -7,6 +7,8 @@
 
 namespace Activitypub\Tests\Scheduler;
 
+use Activitypub\Scheduler\Post;
+
 /**
  * Test Post scheduler class.
  *
@@ -58,6 +60,25 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$post = $this->get_latest_outbox_item( $activitpub_id );
 		$id   = \get_post_meta( $post->ID, '_activitypub_object_id', true );
 		$this->assertSame( $activitpub_id, $id );
+
+		\wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test post activity scheduling for regular posts.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_not_schedule_post_activity_unfederated_post() {
+		\remove_action( 'transition_post_status', array( Post::class, 'schedule_post_activity' ), 33 );
+		$post_id       = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$activitpub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
+		\add_action( 'transition_post_status', array( Post::class, 'schedule_post_activity' ), 33, 3 );
+
+		// Update the post.
+		self::factory()->post->update_object( $post_id, array( 'ping_status' => false ) );
+
+		$this->assertNull( $this->get_latest_outbox_item( $activitpub_id ) );
 
 		\wp_delete_post( $post_id, true );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This will require some scrutiny. For example, this ignores changing content visibility in the Editor for old posts.
Not quite sure how to account for that in the callback, since post meta gets updated before `transition_post_status` runs and it's impossible to differentiate between a post with public visibility and one that doesn't have the post meta.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bail before creating an Outbox item for update activities of unfederated posts.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Import posts into your test site (they won't get Outbox items created for them or marked as federated).
* Make an update to one of the imported posts.
* Check the Outbox and make sure no Update activity was created.

