### PR TITLE
Outbox: Skip most bulk editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
+* Post bulk edits no longer create Outbox items, unless author or post status change.
 
 ### Fixed
 

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -77,7 +77,7 @@ class Post {
 		}
 
 		// Bail on bulk edits, unless post author or post status changed.
-		if ( isset( $_REQUEST['bulk_edit'] ) && -1 === (int) $_REQUEST['post_author'] && -1 === (int) $_REQUEST['post_status'] ) { // phpcs:ignore WordPress
+		if ( isset( $_REQUEST['bulk_edit'] ) && -1 === (int) $_REQUEST['post_author'] && -1 === (int) $_REQUEST['_status'] ) { // phpcs:ignore WordPress
 			return;
 		}
 

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -7,7 +7,6 @@
 
 namespace Activitypub\Scheduler;
 
-use Activitypub\Scheduler;
 use Activitypub\Collection\Outbox;
 
 use function Activitypub\add_to_outbox;
@@ -77,6 +76,11 @@ class Post {
 			return;
 		}
 
+		// Bail on bulk edits, unless post author or post status changed.
+		if ( isset( $_REQUEST['bulk_edit'] ) && -1 === (int) $_REQUEST['post_author'] && -1 === (int) $_REQUEST['post_status'] ) { // phpcs:ignore WordPress
+			return;
+		}
+
 		switch ( $new_status ) {
 			case 'publish':
 				$type = ( 'publish' === $old_status ) ? 'Update' : 'Create';
@@ -110,8 +114,8 @@ class Post {
 	 * This filter updates post meta before the post is inserted into the database, so that the
 	 * information is available by the time @see Outbox::add() runs.
 	 *
-	 * @param \stdClass        $post     An object representing a single post prepared for inserting or updating the database.
-	 * @param \WP_REST_Request $request  The request object.
+	 * @param \stdClass        $post    An object representing a single post prepared for inserting or updating the database.
+	 * @param \WP_REST_Request $request The request object.
 	 *
 	 * @return \stdClass The prepared post.
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: Setting to adjust the number of days Outbox items are kept before being purged.
 * Added: Show metadata in the New Follower E-Mail.
 * Changed: Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
+* Changed: Post bulk edits no longer create Outbox items, unless author or post status change.
 * Fixed: The Outbox purging routine no longer is limited to deleting 5 items at a time.
 * Fixed an issue where the outbox could not send object types other than `Base_Object` (introduced in 5.0.0).
 * Fixed: Ellipses now display correctly in notification emails for Likes and Reposts.

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -63,6 +63,53 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test post activity scheduling during bulk edits.
+	 *
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_schedule_post_activity_bulk_edit() {
+		$post_id       = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$activitpub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
+
+		// Test bulk edit that should bail (no author or status change).
+		$_REQUEST['bulk_edit']   = 1;
+		$_REQUEST['post_author'] = -1;
+		$_REQUEST['post_status'] = -1;
+
+		self::factory()->post->update_object( $post_id, array( 'post_title' => 'Updated Title' ) );
+
+		$outbox_item = $this->get_latest_outbox_item( $activitpub_id );
+		$this->assertNotSame( 'Update', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
+
+		// Test bulk edit with author change (should not bail).
+		$new_user_id = self::factory()->user->create();
+		get_userdata( $new_user_id )->add_cap( 'activitypub' );
+		$_REQUEST['post_author'] = $new_user_id;
+		$_REQUEST['post_status'] = -1;
+
+		self::factory()->post->update_object( $post_id, array( 'post_author' => $new_user_id ) );
+
+		$outbox_item = $this->get_latest_outbox_item( $activitpub_id );
+		$this->assertNotNull( $outbox_item );
+
+		$this->assertSame( 'Update', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
+
+		// Test bulk edit with status change (should not bail).
+		$_REQUEST['post_author'] = -1;
+		$_REQUEST['post_status'] = 'draft';
+
+		self::factory()->post->update_object( $post_id, array( 'post_status' => 'trash' ) );
+
+		$outbox_item = $this->get_latest_outbox_item( $activitpub_id );
+		$this->assertNotNull( $outbox_item );
+		$this->assertSame( 'Delete', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
+
+		// Clean up.
+		unset( $_REQUEST['bulk_edit'], $_REQUEST['post_author'], $_REQUEST['post_status'] );
+		\wp_delete_post( $post_id, true );
+	}
+
+	/**
 	 * Data provider for no activity tests.
 	 *
 	 * @return array[] Test parameters.

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -74,7 +74,7 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Test bulk edit that should bail (no author or status change).
 		$_REQUEST['bulk_edit']   = 1;
 		$_REQUEST['post_author'] = -1;
-		$_REQUEST['post_status'] = -1;
+		$_REQUEST['_status']     = -1;
 
 		self::factory()->post->update_object( $post_id, array( 'post_title' => 'Updated Title' ) );
 
@@ -85,7 +85,7 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$new_user_id = self::factory()->user->create();
 		get_userdata( $new_user_id )->add_cap( 'activitypub' );
 		$_REQUEST['post_author'] = $new_user_id;
-		$_REQUEST['post_status'] = -1;
+		$_REQUEST['_status']     = -1;
 
 		self::factory()->post->update_object( $post_id, array( 'post_author' => $new_user_id ) );
 
@@ -96,7 +96,7 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Test bulk edit with status change (should not bail).
 		$_REQUEST['post_author'] = -1;
-		$_REQUEST['post_status'] = 'draft';
+		$_REQUEST['_status']     = 'draft';
 
 		self::factory()->post->update_object( $post_id, array( 'post_status' => 'trash' ) );
 

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -68,6 +68,7 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 * @covers ::schedule_post_activity
 	 */
 	public function test_schedule_post_activity_bulk_edit() {
+		wp_set_current_user( self::$user_id );
 		$post_id       = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
 		$activitpub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
 
@@ -75,19 +76,21 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$_REQUEST['bulk_edit']   = 1;
 		$_REQUEST['post_author'] = -1;
 		$_REQUEST['_status']     = -1;
+		$_REQUEST['post']        = array( $post_id );
 
-		self::factory()->post->update_object( $post_id, array( 'post_title' => 'Updated Title' ) );
+		bulk_edit_posts( $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		$outbox_item = $this->get_latest_outbox_item( $activitpub_id );
 		$this->assertNotSame( 'Update', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
 
 		// Test bulk edit with author change (should not bail).
-		$new_user_id = self::factory()->user->create();
+		$new_user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		get_userdata( $new_user_id )->add_cap( 'activitypub' );
-		$_REQUEST['post_author'] = $new_user_id;
-		$_REQUEST['_status']     = -1;
+		wp_set_current_user( $new_user_id );
 
-		self::factory()->post->update_object( $post_id, array( 'post_author' => $new_user_id ) );
+		$_REQUEST['post_author'] = $new_user_id;
+
+		bulk_edit_posts( $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		$outbox_item = $this->get_latest_outbox_item( $activitpub_id );
 		$this->assertNotNull( $outbox_item );
@@ -95,10 +98,9 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$this->assertSame( 'Update', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
 
 		// Test bulk edit with status change (should not bail).
-		$_REQUEST['post_author'] = -1;
-		$_REQUEST['_status']     = 'draft';
+		$_REQUEST['_status'] = 'trash';
 
-		self::factory()->post->update_object( $post_id, array( 'post_status' => 'trash' ) );
+		bulk_edit_posts( $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		$outbox_item = $this->get_latest_outbox_item( $activitpub_id );
 		$this->assertNotNull( $outbox_item );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bails on creating Outbox items for bulk edits unless author or post status change.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Bulk-edit multiple posts and change anything but author or post status.
* Make sure no Outbox items were created.
* Bulk-edit multiple posts and change the author and/or post status.
* Make sure no Outbox items are still created.


