### PR TITLE
Fix: consistent use of `site_supports_blocks`

### DIFF
--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -176,14 +176,16 @@ class Shortcodes {
 			/** This filter is documented in wp-includes/post-template.php */
 			$content = \apply_filters( 'the_content', $content );
 		} else {
-			$content = do_blocks( $content );
-			$content = wptexturize( $content );
-			$content = wp_filter_content_tags( $content );
+			if ( site_supports_blocks() ) {
+				$content = \do_blocks( $content );
+			}
+			$content = \wptexturize( $content );
+			$content = \wp_filter_content_tags( $content );
 		}
 
 		// Replace script and style elements.
 		$content = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $content );
-		$content = strip_shortcodes( $content );
+		$content = \strip_shortcodes( $content );
 		$content = \trim( \preg_replace( '/[\n\r\t]/', '', $content ) );
 
 		add_shortcode( 'ap_content', array( 'Activitypub\Shortcodes', 'content' ) );

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -544,6 +544,10 @@ class Post extends Base {
 	 * @return string|null The in-reply-to URL of the post.
 	 */
 	protected function get_in_reply_to() {
+		if ( ! site_supports_blocks() ) {
+			return null;
+		}
+
 		$blocks = \parse_blocks( $this->item->post_content );
 
 		foreach ( $blocks as $block ) {


### PR DESCRIPTION
This PR puts the block methods behind the `site_supports_blocks` check. This way it is possible to deactivate the usage of blocks through the filter.

Fixes #1306 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

