### PR TITLE
Fix Announce Activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Metadata to New Follower E-Mail.
 * Allow Activities on URLs instead of requiring Activity-Objects. This is useful especially for sending Announces and Likes.
 * Labels to add context to visibility settings in the block editor.
+* WP CLI command to reschedule Outbox-Activities.
 
 ### Changed
 
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The Outbox purging routine no longer is limited to deleting 5 items at a time.
 * Ellipses now display correctly in notification emails for Likes and Reposts.
 * Send Update-Activity when "Actor-Mode" is changed.
+* Added delay to `Announce` Activity from the Blog-Actor, to not have race conditions.
 
 ## [5.2.0] - 2025-02-13
 

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -166,4 +166,37 @@ class Cli extends WP_CLI_Command {
 		}
 		WP_CLI::success( 'Undo activity scheduled.' );
 	}
+
+	/**
+	 * Re-Schedule an activity that was sent to the Fediverse before.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <outbox_item_id>
+	 *     The ID or URL of the outbox item to reschedule.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *    $ wp activitypub reschedule 123
+	 *    $ wp activitypub reschedule "https://example.com/?post_type=ap_outbox&p=123"
+	 *
+	 * @synopsis <outbox_item_id>
+	 *
+	 * @param array $args The arguments.
+	 */
+	public function reschedule( $args ) {
+		$outbox_item_id = $args[0];
+		if ( ! is_numeric( $outbox_item_id ) ) {
+			$outbox_item_id = url_to_postid( $outbox_item_id );
+		}
+
+		$outbox_item_id = get_post( $outbox_item_id );
+		if ( ! $outbox_item_id ) {
+			WP_CLI::error( 'Activity not found.' );
+		}
+
+		Outbox::reschedule( $outbox_item_id );
+
+		WP_CLI::success( 'Rescheduled activity.' );
+	}
 }

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -164,15 +164,16 @@ class Scheduler {
 	/**
 	 * Schedule the outbox item for federation.
 	 *
-	 * @param int $id The ID of the outbox item.
+	 * @param int $id     The ID of the outbox item.
+	 * @param int $offset The offset to add to the scheduled time.
 	 */
-	public static function schedule_outbox_activity_for_federation( $id ) {
+	public static function schedule_outbox_activity_for_federation( $id, $offset = 0 ) {
 		$hook = 'activitypub_process_outbox';
 		$args = array( $id );
 
 		if ( false === wp_next_scheduled( $hook, $args ) ) {
 			\wp_schedule_single_event(
-				\time() + 10,
+				\time() + $offset,
 				$hook,
 				$args
 			);
@@ -425,6 +426,6 @@ class Scheduler {
 		}
 
 		// Schedule the outbox item for federation.
-		self::schedule_outbox_activity_for_federation( $outbox_activity_id );
+		self::schedule_outbox_activity_for_federation( $outbox_activity_id, 30 );
 	}
 }

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -9,6 +9,7 @@ namespace Activitypub\Collection;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Dispatcher;
+use Activitypub\Scheduler;
 
 use function Activitypub\is_activity;
 use function Activitypub\add_to_outbox;
@@ -158,6 +159,7 @@ class Outbox {
 	 * Creates an Undo activity.
 	 *
 	 * @param int|\WP_Post $outbox_item The Outbox post or post ID.
+	 *
 	 * @return int|bool The ID of the outbox item or false on failure.
 	 */
 	public static function undo( $outbox_item ) {
@@ -172,6 +174,26 @@ class Outbox {
 		}
 
 		return add_to_outbox( $activity, $type, $outbox_item->post_author );
+	}
+
+	/**
+	 * Reschedule an activity.
+	 *
+	 * @param int|\WP_Post $outbox_item The Outbox post or post ID.
+	 *
+	 * @return bool True if the activity was rescheduled, false otherwise.
+	 */
+	public static function reschedule( $outbox_item ) {
+		$outbox_item = get_post( $outbox_item );
+
+		$outbox_item->post_status = 'pending';
+		$outbox_item->post_date   = current_time( 'mysql' );
+
+		wp_update_post( $outbox_item );
+
+		Scheduler::schedule_outbox_activity_for_federation( $outbox_item->ID );
+
+		return true;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Added: Setting to adjust the number of days Outbox items are kept before being purged.
 * Added: Show metadata in the New Follower E-Mail.
 * Added: Labels to add context to visibility settings in the block editor.
+* Added: WP CLI command to reschedule Outbox-Activities.
 * Changed: Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
 * Changed: Post bulk edits no longer create Outbox items, unless author or post status change.
 * Changed: Outbox processing accounts for shared inboxes again.
@@ -145,6 +146,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Fixed: An issue where the outbox could not send object types other than `Base_Object` (introduced in 5.0.0).
 * Fixed: Ellipses now display correctly in notification emails for Likes and Reposts.
 * Fixed: Send Update-Activity when "Actor-Mode" is changed.
+* Fixed: Added delay to `Announce` Activity from the Blog-Actor, to not have race conditions.
 
 = 5.2.0 =
 

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -187,7 +187,7 @@ class Test_Scheduler extends WP_UnitTestCase {
 		Scheduler::reprocess_outbox();
 
 		// Verify scheduling time.
-		$this->assertGreaterThan( 0, $scheduled_time, 'Event should be scheduled with a future timestamp' );
+		$this->assertSame( $scheduled_time, wp_next_scheduled( 'activitypub_process_outbox', array( $pending_id ) ) );
 
 		// Clean up.
 		wp_delete_post( $pending_id, true );

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -188,7 +188,6 @@ class Test_Scheduler extends WP_UnitTestCase {
 
 		// Verify scheduling time.
 		$this->assertGreaterThan( 0, $scheduled_time, 'Event should be scheduled with a future timestamp' );
-		$this->assertGreaterThanOrEqual( time() + 10, $scheduled_time, 'Event should be scheduled at least 10 seconds in the future' );
 
 		// Clean up.
 		wp_delete_post( $pending_id, true );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
It seems that the `Announce` Activities are sent to early or mixed in between of the original Activities, so they might not be handled properly.

This PR adds an offset of 30 sec for the `Announce`, to send them after the initial posts should be federated. Happy to postpone the `Announce`s even more.

To test it manually, I also added a CLI command to reschedule Outbox items.

Should Fix: https://wordpress.org/support/topic/no-boosts-and-likes-possible/


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add Cli Command to reschedule Outbox-Items
* Adds a delay to the `Announce` of the Group-Actor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Simply publish a post and check if the federated post will be Announced by the Blog-Author.

