### PR TITLE
Rewrite rules: be more specific in pattern to get author redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Post bulk edits no longer create Outbox items, unless author or post status change.
 * Properly process `Update` activities on profiles and ensure all properties of a followed person are updated accordingly.
 * Outbox processing accounts for shared inboxes again.
+* Rewrite rules: be more specific in author rewrite rules to avoid conflicts on sites that use the "@author" pattern in their permalinks.
 
 ### Fixed
 

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -413,7 +413,7 @@ class Activitypub {
 		}
 
 		\add_rewrite_rule(
-			'^@([\w\-\.]+)',
+			'^@([\w\-\.]+)$',
 			'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/$matches[1]',
 			'top'
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -145,7 +145,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Changed: Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
 * Changed: Post bulk edits no longer create Outbox items, unless author or post status change.
 * Changed: Outbox processing accounts for shared inboxes again.
-* Changed: * Rewrite rules: be more specific in author rewrite rules to avoid conflicts on sites that use the "@author" pattern in their permalinks.
+* Changed: Rewrite rules: be more specific in author rewrite rules to avoid conflicts on sites that use the "@author" pattern in their permalinks.
 * Fixed: The Outbox purging routine no longer is limited to deleting 5 items at a time.
 * Fixed: An issue where the outbox could not send object types other than `Base_Object` (introduced in 5.0.0).
 * Fixed: Ellipses now display correctly in notification emails for Likes and Reposts.

--- a/readme.txt
+++ b/readme.txt
@@ -145,6 +145,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Changed: Outbox now precesses the first batch of followers right away to avoid delays in processing new Activities.
 * Changed: Post bulk edits no longer create Outbox items, unless author or post status change.
 * Changed: Outbox processing accounts for shared inboxes again.
+* Changed: * Rewrite rules: be more specific in author rewrite rules to avoid conflicts on sites that use the "@author" pattern in their permalinks.
 * Fixed: The Outbox purging routine no longer is limited to deleting 5 items at a time.
 * Fixed: An issue where the outbox could not send object types other than `Base_Object` (introduced in 5.0.0).
 * Fixed: Ellipses now display correctly in notification emails for Likes and Reposts.


### PR DESCRIPTION
## Proposed changes:

Some site owners may want to use a "@author" pattern in their site permalinks, e.g. `/@%author%/%postname%/`, to get permalinks that look similar to other Fediverse tools like Mastodon.
ActivityPub's rewrite rules are currently a bit too loose to allow that, as they would force a redirect for those posts as well. I think we can affort to be a bit more strict.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Go to Settings > Permalinks
* Set your custom permalinks to `/@%author%/%postname%/`
* Save your changes.
* Load one of your posts.
    * It should load properly.
* Now load `yoursite.com/@authorslug`
    * It should redirect to the author page.
