### PR TITLE
Improve: Always send `Vary` header

### DIFF
--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -177,11 +177,6 @@ class Activitypub {
 			if ( ! \headers_sent() ) {
 				// Send 200 status header.
 				\status_header( 200 );
-
-				if ( ACTIVITYPUB_SEND_VARY_HEADER ) {
-					// Send Vary header for Accept header.
-					\header( 'Vary: Accept' );
-				}
 			}
 
 			return $activitypub_template;
@@ -201,7 +196,12 @@ class Activitypub {
 		}
 
 		if ( ! headers_sent() ) {
-			header( 'Link: <' . esc_url( $id ) . '>; title="ActivityPub (JSON)"; rel="alternate"; type="application/activity+json"', false );
+			\header( 'Link: <' . esc_url( $id ) . '>; title="ActivityPub (JSON)"; rel="alternate"; type="application/activity+json"', false );
+
+			if ( ACTIVITYPUB_SEND_VARY_HEADER ) {
+				// Send Vary header for Accept header.
+				\header( 'Vary: Accept', false );
+			}
 		}
 
 		add_action(


### PR DESCRIPTION
Send Vary header also for HTML requests. This helps with content negotiation and (external) caches.

If we only send it for `application/activity+json` it might add the HTML to the wrong bucket.

Context: https://chat.indieweb.org/dev/2025-02-24#t1740415054664400

/cc @snarfed