### PR TITLE
Followers: Fix backslash breaking actor json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
 
+### Fixed
+
+* Followers with backslashes in their descriptions no longer break their actor representation.
+
 ## [5.3.0] - 2025-02-25
 
 ### Added

--- a/includes/model/class-follower.php
+++ b/includes/model/class-follower.php
@@ -230,7 +230,7 @@ class Follower extends Actor {
 	protected function get_post_meta_input() {
 		$meta_input                            = array();
 		$meta_input['_activitypub_inbox']      = $this->get_shared_inbox();
-		$meta_input['_activitypub_actor_json'] = $this->to_json();
+		$meta_input['_activitypub_actor_json'] = wp_slash( $this->to_json() );
 
 		return $meta_input;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Changed: Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
+* Fixed: Followers with backslashes in their descriptions no longer break their actor representation.
 
 = 5.3.0 =
 

--- a/tests/includes/collection/class-test-followers.php
+++ b/tests/includes/collection/class-test-followers.php
@@ -62,10 +62,12 @@ class Test_Followers extends \WP_UnitTestCase {
 		),
 		'user2@example.com'    => array(
 			'id'                => 'https://user2.example.com',
+			'type'              => 'Person',
 			'url'               => 'https://user2.example.com',
 			'inbox'             => 'https://user2.example.com/inbox',
 			'name'              => 'úser2',
 			'preferredUsername' => 'user2',
+			'summary'           => 'father since 04\24',
 		),
 		'error@example.com'    => array(
 			'url'               => 'https://error.example.com',

--- a/tests/includes/collection/class-test-followers.php
+++ b/tests/includes/collection/class-test-followers.php
@@ -67,7 +67,7 @@ class Test_Followers extends \WP_UnitTestCase {
 			'inbox'             => 'https://user2.example.com/inbox',
 			'name'              => 'úser2',
 			'preferredUsername' => 'user2',
-			'summary'           => 'father since 04\24',
+			'summary'           => 'father since 04\24', // @ticket https://github.com/Automattic/wordpress-activitypub/pull/1373
 		),
 		'error@example.com'    => array(
 			'url'               => 'https://error.example.com',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When a Follower has a backslash in their description, it didn't get escaped and caused an error when decoding it.

See p1740498262448489/1740495261.546209-slack-C04TJ8P900J

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Slashes actor json before returning it in `Follower::get_post_meta_input()`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a Fediverse account outside of your test site, add a backslash in your description.
* Follow your test site.
* Find the actor json for your account and decode it. Make sure it doesn't cause an error.