### PR TITLE
Add webfinger as comment author email if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
+* Use webfinger as author email for comments from the Fediverse.
 
 ## [5.3.0] - 2025-02-25
 

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -84,6 +84,8 @@ class Webfinger {
 	/**
 	 * Transform a URI to an acct <identifier>@<host>.
 	 *
+	 * @see https://swicg.github.io/activitypub-webfinger/#reverse-discovery
+	 *
 	 * @param string $uri The URI (acct:, mailto:, http:, https:).
 	 *
 	 * @return string|WP_Error Error or acct URI.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Collection;
 
+use Activitypub\Webfinger;
 use WP_Comment_Query;
 use Activitypub\Comment;
 
@@ -256,12 +257,19 @@ class Interactions {
 			$comment_content = \addslashes( $activity['object']['content'] );
 		}
 
+		$webfinger = Webfinger::uri_to_acct( $url );
+		if ( is_wp_error( $webfinger ) ) {
+			$webfinger = '';
+		} else {
+			$webfinger = str_replace( 'acct:', '', $webfinger );
+		}
+
 		$commentdata = array(
 			'comment_author'       => \esc_attr( $comment_author ),
 			'comment_author_url'   => \esc_url_raw( $url ),
 			'comment_content'      => $comment_content,
 			'comment_type'         => 'comment',
-			'comment_author_email' => '',
+			'comment_author_email' => $webfinger,
 			'comment_meta'         => array(
 				'source_id' => \esc_url_raw( object_to_uri( $activity['object'] ) ),
 				'protocol'  => 'activitypub',

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Changed: Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
+* Changed: Use webfinger as author email for comments from the Fediverse.
 
 = 5.3.0 =
 

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -580,4 +580,99 @@ class Test_Migration extends ActivityPub_TestCase_Cache_HTTP {
 		$result = Migration::create_comment_outbox_items( 1, 1000 );
 		$this->assertNull( $result );
 	}
+
+	/**
+	 * Test update_comment_author_emails updates emails with webfinger addresses.
+	 *
+	 * @covers ::update_comment_author_emails
+	 */
+	public function test_update_comment_author_emails() {
+		$author_url = 'https://example.com/users/test';
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => self::$fixtures['posts'][0],
+				'comment_author'       => 'Test User',
+				'comment_author_url'   => $author_url,
+				'comment_author_email' => '',
+				'comment_type'         => 'comment',
+				'comment_meta'         => array( 'protocol' => 'activitypub' ),
+			)
+		);
+
+		// Mock the HTTP request.
+		\add_filter( 'pre_http_request', array( $this, 'mock_webfinger' ) );
+
+		$result = Migration::update_comment_author_emails( 50, 0 );
+
+		$this->assertNull( $result );
+
+		$updated_comment = \get_comment( $comment_id );
+		$this->assertEquals( 'test@example.com', $updated_comment->comment_author_email );
+
+		// Clean up.
+		\remove_filter( 'pre_http_request', array( $this, 'mock_webfinger' ) );
+		\wp_delete_comment( $comment_id, true );
+	}
+
+	/**
+	 * Test update_comment_author_emails handles batching correctly.
+	 *
+	 * @covers ::update_comment_author_emails
+	 */
+	public function test_update_comment_author_emails_batching() {
+		// Create multiple comments.
+		$comment_ids = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$comment_ids[] = self::factory()->comment->create(
+				array(
+					'comment_post_ID'      => self::$fixtures['posts'][0],
+					'comment_author'       => "Test User $i",
+					'comment_author_url'   => "https://example.com/users/test$i",
+					'comment_author_email' => '',
+					'comment_content'      => "Test comment $i",
+					'comment_type'         => 'comment',
+					'comment_meta'         => array( 'protocol' => 'activitypub' ),
+				)
+			);
+		}
+
+		// Mock the HTTP request.
+		\add_filter( 'pre_http_request', array( $this, 'mock_webfinger' ) );
+
+		// Process first batch of 2 comments.
+		$result = Migration::update_comment_author_emails( 2, 0 );
+		$this->assertEqualSets(
+			array(
+				'batch_size' => 2,
+				'offset'     => 2,
+			),
+			$result
+		);
+
+		// Process second batch with remaining comment.
+		$result = Migration::update_comment_author_emails( 2, 2 );
+		$this->assertNull( $result );
+
+		// Verify all comments were updated.
+		foreach ( $comment_ids as $comment_id ) {
+			$comment = \get_comment( $comment_id );
+			$this->assertEquals( 'test@example.com', $comment->comment_author_email );
+
+			wp_delete_comment( $comment_id, true );
+		}
+
+		\remove_filter( 'pre_http_request', array( $this, 'mock_webfinger' ) );
+	}
+
+	/**
+	 * Mock webfinger response.
+	 *
+	 * @return array
+	 */
+	public function mock_webfinger() {
+		return array(
+			'body'     => wp_json_encode( array( 'subject' => 'acct:test@example.com' ) ),
+			'response' => array( 'code' => 200 ),
+		);
+	}
 }

--- a/tests/includes/collection/class-test-interactions.php
+++ b/tests/includes/collection/class-test-interactions.php
@@ -471,4 +471,35 @@ class Test_Interactions extends WP_UnitTestCase {
 
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
 	}
+
+	/**
+	 * Test activity_to_comment sets webfinger as comment author email.
+	 *
+	 * @covers ::activity_to_comment
+	 */
+	public function test_activity_to_comment_sets_webfinger_email() {
+		$actor_url = 'https://example.com/users/tester';
+		$activity  = array(
+			'type'   => 'Create',
+			'actor'  => $actor_url,
+			'object' => array(
+				'content' => 'Test comment content',
+				'id'      => 'https://example.com/activities/1',
+			),
+		);
+
+		$filter = function () {
+			return array(
+				'body'     => wp_json_encode( array( 'subject' => 'acct:tester@example.com' ) ),
+				'response' => array( 'code' => 200 ),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter );
+
+		$comment_data = Interactions::activity_to_comment( $activity );
+
+		$this->assertEquals( 'tester@example.com', $comment_data['comment_author_email'] );
+
+		\remove_filter( 'pre_http_request', $filter );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1355.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use webfinger account as comment author email.
* Adds upgrade routine to backfill existing comments.
* Adds tests for both.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your test site.
* Comment on a federated post from a federated account, like mastodon.
* Verify in comment list that the number of approved comments is accurate.
