### PR TITLE
Create 5.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Followers with backslashes in their descriptions no longer break their actor representation.
 
-## [Unreleased]
+## [5.3.1] - 2025-02-26
 
 ### Fixed
 
@@ -1347,8 +1347,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * initial
 
-[Unreleased]: https://github.com/Automattic/wordpress-activitypub/compare/5.3.0...trunk
+[Unreleased]: https://github.com/Automattic/wordpress-activitypub/compare/5.3.1...trunk
 <!-- Add new release below and update "Unreleased" link -->
+[5.3.1]: https://github.com/Automattic/wordpress-activitypub/compare/5.3.0...5.3.1
 [5.3.0]: https://github.com/Automattic/wordpress-activitypub/compare/5.2.0...5.3.0
 [5.2.0]: https://github.com/Automattic/wordpress-activitypub/compare/5.1.0...5.2.0
 [5.1.0]: https://github.com/Automattic/wordpress-activitypub/compare/5.0.0...5.1.0

--- a/activitypub.php
+++ b/activitypub.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActivityPub
  * Plugin URI: https://github.com/Automattic/wordpress-activitypub
  * Description: The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
- * Version: 5.3.0
+ * Version: 5.3.1
  * Author: Matthias Pfefferle & Automattic
  * Author URI: https://automattic.com/
  * License: MIT
@@ -19,7 +19,7 @@ namespace Activitypub;
 
 use WP_CLI;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '5.3.0' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '5.3.1' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaf
 Tags: OStatus, fediverse, activitypub, activitystream
 Requires at least: 6.4
 Tested up to: 6.7
-Stable tag: 5.3.0
+Stable tag: 5.3.1
 Requires PHP: 7.2
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -134,7 +134,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Changed: Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
 * Fixed: Followers with backslashes in their descriptions no longer break their actor representation.
 
-= Unreleased =
+= 5.3.1 =
 
 * Fixed: Blog profile settings can be saved again without errors.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Second step to create 5.3.1 release.

This PR will be cherry-picked into a release branch and then tagged from there.

See https://github.com/Automattic/wordpress-activitypub/pull/1192