### PR TITLE
Fix: Reply-Context link is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Followers with backslashes in their descriptions no longer break their actor representation.
+* Remove `activitypub_reply_block` Filter after Activity-JSON is rendered, to not affect the HTML representation.
 
 ## [5.3.1] - 2025-02-26
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -480,7 +480,7 @@ class Post extends Base {
 	 * @return string The content.
 	 */
 	protected function get_content() {
-		add_filter( 'activitypub_reply_block', '__return_empty_string' );
+		\add_filter( 'activitypub_reply_block', '__return_empty_string' );
 
 		// Remove Content from drafts.
 		if ( 'draft' === \get_post_status( $this->item ) ) {
@@ -530,6 +530,8 @@ class Post extends Base {
 
 		// Don't need these anymore, should never appear in a post.
 		Shortcodes::unregister();
+
+		\remove_filter( 'activitypub_reply_block', '__return_empty_string' );
 
 		return $content;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 * Changed: Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
 * Fixed: Followers with backslashes in their descriptions no longer break their actor representation.
+* Fixed: Remove `activitypub_reply_block` Filter after Activity-JSON is rendered, to not affect the HTML representation.
 
 = 5.3.1 =
 


### PR DESCRIPTION

Fixes #1381

## Proposed changes:
With the new update of the Query, the JSON representation is called before the HTML presentation, so the `activitypub_reply_block` was removed but never re-added.
* Remove filter after JSON is rendered

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

See #1381
