### PR TITLE
Releases: Exclude meta PRs from automated Changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+changelog:
+  exclude:
+    labels:
+      - "Skip Changelog"
+      - "Release"
+    authors:
+      - dependabot[bot]

--- a/bin/release.js
+++ b/bin/release.js
@@ -142,7 +142,7 @@ async function createRelease(version) {
 
 	// Create PR using GitHub CLI and capture the URL
 	console.log('\nCreating PR...');
-	const prUrl = execWithOutput(`gh pr create --title "Release ${version}" --body "Release version ${version}" --base trunk --head ${branchName} --reviewer "Automattic/fediverse" --assignee "${currentUser}"`);
+	const prUrl = execWithOutput(`gh pr create --title "Release ${version}" --body "Release version ${version}" --base trunk --head ${branchName} --reviewer "Automattic/fediverse" --assignee "${currentUser}" --label "Release"`);
 
 	// Open PR in browser if a URL was returned
 	if (prUrl && prUrl.includes('github.com')) {


### PR DESCRIPTION
See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Excludes PRs with "Skip Changelog" label, release PRs, and Dependabot PRs from generated release notes in the GitHub UI. 

If we were more disciplined with our PR labeling (or added an automation for it), we could even recreate the keepachangelog.com breakdown we have in `CHANGELOG.md`.