### PR TITLE
Add interaction settings

### DIFF
--- a/.github/changelog/add-reaction-setting
+++ b/.github/changelog/add-reaction-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+User setting to enable/disable Likes and Reblogs

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -50,6 +50,9 @@ class Activitypub {
 		\add_action( 'added_post_meta', array( self::class, 'updated_postmeta' ), 10, 4 );
 		\add_action( 'init', array( self::class, 'register_user_meta' ), 11 );
 
+		\add_filter( 'pre_option_activitypub_allow_likes', array( self::class, 'maybe_disable_interactions' ) );
+		\add_filter( 'pre_option_activitypub_allow_replies', array( self::class, 'maybe_disable_interactions' ) );
+
 		// Register several post_types.
 		self::register_post_types();
 	}
@@ -778,5 +781,19 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
+	}
+
+	/**
+	 * Disallow interactions if the constant is set.
+	 *
+	 * @param bool $pre_option The value of the option.
+	 * @return bool|string The value of the option.
+	 */
+	public static function maybe_disable_interactions( $pre_option ) {
+		if ( ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS ) {
+			return '0';
+		}
+
+		return $pre_option;
 	}
 }

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -86,6 +86,8 @@ class Activitypub {
 		Migration::update_comment_counts( 2000 );
 
 		delete_option( 'activitypub_actor_mode' );
+		delete_option( 'activitypub_allow_likes' );
+		delete_option( 'activitypub_allow_replies' );
 		delete_option( 'activitypub_attribution_domains' );
 		delete_option( 'activitypub_authorized_fetch' );
 		delete_option( 'activitypub_application_user_private_key' );

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -30,6 +30,8 @@ class Comment {
 		\add_action( 'pre_get_comments', array( static::class, 'comment_query' ) );
 		\add_filter( 'pre_comment_approved', array( static::class, 'pre_comment_approved' ), 10, 2 );
 		\add_filter( 'get_avatar_comment_types', array( static::class, 'get_avatar_comment_types' ), 99 );
+		\add_action( 'update_option_activitypub_allow_likes', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
+		\add_action( 'update_option_activitypub_allow_reposts', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
 	}
 
@@ -774,6 +776,20 @@ class Comment {
 	}
 
 	/**
+	 * Update comment counts when interaction settings are disabled.
+	 *
+	 * Triggers a recount when likes or reposts are disabled to ensure accurate comment counts.
+	 *
+	 * @param mixed $old_value The old option value.
+	 * @param mixed $value     The new option value.
+	 */
+	public static function maybe_update_comment_counts( $old_value, $value ) {
+		if ( '1' === $old_value && '1' !== $value ) {
+			Migration::update_comment_counts();
+		}
+	}
+
+	/**
 	 * Filters the comment count to exclude ActivityPub comment types.
 	 *
 	 * @param int|null $new_count The new comment count. Default null.
@@ -784,15 +800,26 @@ class Comment {
 	 */
 	public static function pre_wp_update_comment_count_now( $new_count, $old_count, $post_id ) {
 		if ( null === $new_count ) {
-			global $wpdb;
+			$excluded_types = array_filter( self::get_comment_type_slugs(), array( self::class, 'is_comment_type_enabled' ) );
 
-			$excluded_types = self::get_comment_type_slugs();
+			if ( ! empty( $excluded_types ) ) {
+				global $wpdb;
 
-			// phpcs:ignore WordPress.DB
-			$new_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type NOT IN ('" . implode( "','", $excluded_types ) . "')", $post_id ) );
-
+				// phpcs:ignore WordPress.DB
+				$new_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type NOT IN ('" . implode( "','", $excluded_types ) . "')", $post_id ) );
+			}
 		}
 
 		return $new_count;
+	}
+
+	/**
+	 * Check if a comment type is enabled.
+	 *
+	 * @param string $comment_type The comment type.
+	 * @return bool True if the comment type is enabled.
+	 */
+	private static function is_comment_type_enabled( $comment_type ) {
+		return '1' === get_option( "activitypub_allow_{$comment_type}s", '1' );
 	}
 }

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -819,7 +819,7 @@ class Comment {
 	 * @param string $comment_type The comment type.
 	 * @return bool True if the comment type is enabled.
 	 */
-	private static function is_comment_type_enabled( $comment_type ) {
+	public static function is_comment_type_enabled( $comment_type ) {
 		return '1' === get_option( "activitypub_allow_{$comment_type}s", '1' );
 	}
 }

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -44,6 +44,11 @@ class Announce {
 			return;
 		}
 
+		// Check if reposts are allowed.
+		if ( '1' !== \get_option( 'activitypub_allow_reposts', '1' ) ) {
+			return;
+		}
+
 		self::maybe_save_announce( $announcement, $user_id );
 
 		if ( is_string( $announcement['object'] ) ) {

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -45,7 +45,7 @@ class Announce {
 		}
 
 		// Check if reposts are allowed.
-		if ( '1' !== \get_option( 'activitypub_allow_reposts', '1' ) ) {
+		if ( ! Comment::is_comment_type_enabled( 'repost' ) ) {
 			return;
 		}
 

--- a/includes/handler/class-like.php
+++ b/includes/handler/class-like.php
@@ -31,7 +31,7 @@ class Like {
 	 * @param int   $user_id The ID of the local blog user.
 	 */
 	public static function handle_like( $like, $user_id ) {
-		if ( '1' !== \get_option( 'activitypub_allow_likes', '1' ) ) {
+		if ( ! Comment::is_comment_type_enabled( 'like' ) ) {
 			return;
 		}
 

--- a/includes/handler/class-like.php
+++ b/includes/handler/class-like.php
@@ -31,11 +31,6 @@ class Like {
 	 * @param int   $user_id The ID of the local blog user.
 	 */
 	public static function handle_like( $like, $user_id ) {
-		if ( ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS ) {
-			return;
-		}
-
-		// Check if likes are allowed.
 		if ( '1' !== \get_option( 'activitypub_allow_likes', '1' ) ) {
 			return;
 		}

--- a/includes/handler/class-like.php
+++ b/includes/handler/class-like.php
@@ -35,6 +35,11 @@ class Like {
 			return;
 		}
 
+		// Check if likes are allowed.
+		if ( '1' !== \get_option( 'activitypub_allow_likes', '1' ) ) {
+			return;
+		}
+
 		$url = object_to_uri( $like['object'] );
 
 		if ( empty( $url ) ) {

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -507,7 +507,7 @@ class Settings_Fields {
 			<p>
 				<label>
 					<input type="checkbox" name="activitypub_allow_announces" value="1" <?php checked( '1', $allow_reposts ); ?> />
-					<?php esc_html_e( 'Receive reblogs', 'activitypub' ); ?>
+					<?php esc_html_e( 'Receive reblogs (boosts)', 'activitypub' ); ?>
 				</label>
 			</p>
 			<p class="description"><?php esc_html_e( 'Types of interactions from the Fediverse your blog should accept.', 'activitypub' ); ?></p>

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -68,6 +68,14 @@ class Settings_Fields {
 			'activitypub_activities'
 		);
 
+		add_settings_field(
+			'activitypub_allow_interactions',
+			__( 'Post interactions', 'activitypub' ),
+			array( self::class, 'render_allow_interactions_field' ),
+			'activitypub_settings',
+			'activitypub_activities'
+		);
+
 		$object_type = \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
 		if ( 'note' === $object_type ) {
 			add_settings_field(
@@ -447,7 +455,34 @@ class Settings_Fields {
 	}
 
 	/**
-	 * Render use hashtags field.
+	 * Render allow interactions field.
+	 */
+	public static function render_allow_interactions_field() {
+		$allow_likes   = get_option( 'activitypub_allow_likes', '1' );
+		$allow_reposts = get_option( 'activitypub_allow_reposts', '1' );
+		?>
+		<fieldset>
+			<p><?php esc_html_e( 'Choose which fediverse interactions to receive as comments on your blog:', 'activitypub' ); ?></p>
+			<ul>
+				<li>
+					<label>
+						<input type="checkbox" name="activitypub_allow_likes" value="1" <?php checked( '1', $allow_likes ); ?> />
+						<?php esc_html_e( 'Receive likes', 'activitypub' ); ?>
+					</label>
+				</li>
+				<li>
+					<label>
+						<input type="checkbox" name="activitypub_allow_announces" value="1" <?php checked( '1', $allow_reposts ); ?> />
+						<?php esc_html_e( 'Receive reblogs', 'activitypub' ); ?>
+					</label>
+				</li>
+			</ul>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Render authorized fetch field.
 	 */
 	public static function render_authorized_fetch_field() {
 		$value = get_option( 'activitypub_authorized_fetch', '1' );

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -75,14 +75,6 @@ class Settings_Fields {
 			'activitypub_activities'
 		);
 
-		add_settings_field(
-			'activitypub_allow_interactions',
-			__( 'Post interactions', 'activitypub' ),
-			array( self::class, 'render_allow_interactions_field' ),
-			'activitypub_settings',
-			'activitypub_activities'
-		);
-
 		$object_type = \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
 		if ( 'note' === $object_type ) {
 			add_settings_field(
@@ -108,6 +100,14 @@ class Settings_Fields {
 			'activitypub_support_post_types',
 			__( 'Supported post types', 'activitypub' ),
 			array( self::class, 'render_support_post_types_field' ),
+			'activitypub_settings',
+			'activitypub_activities'
+		);
+
+		add_settings_field(
+			'activitypub_allow_interactions',
+			__( 'Post interactions', 'activitypub' ),
+			array( self::class, 'render_allow_interactions_field' ),
 			'activitypub_settings',
 			'activitypub_activities'
 		);

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -489,25 +489,28 @@ class Settings_Fields {
 	 * Render allow interactions field.
 	 */
 	public static function render_allow_interactions_field() {
+		if ( defined( 'ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS' ) && ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS ) {
+			echo '<p class="description">' . \esc_html__( '⚠ This setting is defined through server configuration by your blog&#8217;s administrator.', 'activitypub' ) . '</p>';
+			return;
+		}
+
 		$allow_likes   = get_option( 'activitypub_allow_likes', '1' );
 		$allow_reposts = get_option( 'activitypub_allow_reposts', '1' );
 		?>
 		<fieldset>
-			<p><?php esc_html_e( 'Choose which fediverse interactions to receive as comments on your blog:', 'activitypub' ); ?></p>
-			<ul>
-				<li>
-					<label>
-						<input type="checkbox" name="activitypub_allow_likes" value="1" <?php checked( '1', $allow_likes ); ?> />
-						<?php esc_html_e( 'Receive likes', 'activitypub' ); ?>
-					</label>
-				</li>
-				<li>
-					<label>
-						<input type="checkbox" name="activitypub_allow_announces" value="1" <?php checked( '1', $allow_reposts ); ?> />
-						<?php esc_html_e( 'Receive reblogs', 'activitypub' ); ?>
-					</label>
-				</li>
-			</ul>
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_allow_likes" value="1" <?php checked( '1', $allow_likes ); ?> />
+					<?php esc_html_e( 'Receive likes', 'activitypub' ); ?>
+				</label>
+			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_allow_announces" value="1" <?php checked( '1', $allow_reposts ); ?> />
+					<?php esc_html_e( 'Receive reblogs', 'activitypub' ); ?>
+				</label>
+			</p>
+			<p class="description"><?php esc_html_e( 'Types of interactions from the Fediverse your blog should accept.', 'activitypub' ); ?></p>
 		</fieldset>
 		<?php
 	}

--- a/tests/includes/collection/class-test-interactions.php
+++ b/tests/includes/collection/class-test-interactions.php
@@ -473,6 +473,44 @@ class Test_Interactions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that incoming likes and reposts are not collected when disabled.
+	 *
+	 * @covers ::add_reaction
+	 */
+	public function test_no_likes_reposts_when_disabled() {
+		\update_option( 'activitypub_allow_likes', false );
+
+		$activity = array(
+			'id'     => 'https://example.com/activity/1',
+			'type'   => 'Like',
+			'actor'  => 'https://example.com/actor/1',
+			'object' => 'https://example.com/post/1',
+		);
+
+		$result = Interactions::add_reaction( $activity );
+		$this->assertFalse( $result, 'Likes and reposts should not be collected when disabled.' );
+	}
+
+	/**
+	 * Test that incoming reposts are not collected when disabled.
+	 *
+	 * @covers ::add_reaction
+	 */
+	public function test_no_reposts_when_disabled() {
+		\update_option( 'activitypub_allow_reposts', false );
+
+		$activity = array(
+			'id'     => 'https://example.com/activity/2',
+			'type'   => 'Announce',
+			'actor'  => 'https://example.com/actor/2',
+			'object' => 'https://example.com/post/1',
+		);
+
+		$result = Interactions::add_reaction( $activity );
+		$this->assertFalse( $result, 'Reposts should not be collected when disabled.' );
+	}
+
+	/**
 	 * Test activity_to_comment sets webfinger as comment author email.
 	 *
 	 * @covers ::activity_to_comment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1140.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds setting to disable likes and repost.
* Adds override for ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS constant.
* Runs `Migration::update_comment_counts()` when an interaction type gets disabled.
* Adds unit tests.

#### After
<img width="825" alt="image" src="https://github.com/user-attachments/assets/e9706d39-242b-4d19-a93d-d8645bc6b286" />

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable/disable reaction types and attempt to send in a reaction of that type.
* Define the `ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS` constant and make sure it overrides the options.

