### PR TITLE
Move: Add/Remove/Modify "Account Aliases"

### DIFF
--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -53,6 +53,7 @@ class Activitypub {
 
 		\add_action( 'updated_postmeta', array( self::class, 'updated_postmeta' ), 10, 4 );
 		\add_action( 'added_post_meta', array( self::class, 'updated_postmeta' ), 10, 4 );
+		\add_action( 'init', array( self::class, 'register_user_meta' ), 11 );
 
 		// Register several post_types.
 		self::register_post_types();
@@ -739,5 +740,40 @@ class Activitypub {
 		if ( 'activitypub_content_visibility' === $meta_key && empty( $meta_value ) ) {
 			\delete_post_meta( $object_id, 'activitypub_content_visibility' );
 		}
+	}
+
+	/**
+	 * Register user meta.
+	 */
+	public static function register_user_meta() {
+		\register_meta(
+			'user',
+			'activitypub_also_known_as',
+			array(
+				'type'              => 'array',
+				'description'       => 'An array of URLs that the user is known by.',
+				'single'            => false,
+				'default'           => array(),
+				'sanitize_callback' => array( self::class, 'sanitize_textarea_urls' ),
+			)
+		);
+	}
+
+	/**
+	 * Sanitize a list of URLs.
+	 *
+	 * @param string|array $value The value to sanitize.
+	 * @return array The sanitized list of URLs.
+	 */
+	public static function sanitize_textarea_urls( $value ) {
+		if ( ! is_array( $value ) ) {
+			$value = explode( PHP_EOL, $value );
+		}
+
+		$value = array_map( 'trim', $value );
+		$value = array_map( 'sanitize_url', $value );
+		$value = array_unique( $value );
+
+		return array_filter( $value );
 	}
 }

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -754,26 +754,8 @@ class Activitypub {
 				'description'       => 'An array of URLs that the user is known by.',
 				'single'            => false,
 				'default'           => array(),
-				'sanitize_callback' => array( self::class, 'sanitize_textarea_urls' ),
+				'sanitize_callback' => array( Sanitize::class, 'url_list' ),
 			)
 		);
-	}
-
-	/**
-	 * Sanitize a list of URLs.
-	 *
-	 * @param string|array $value The value to sanitize.
-	 * @return array The sanitized list of URLs.
-	 */
-	public static function sanitize_textarea_urls( $value ) {
-		if ( ! is_array( $value ) ) {
-			$value = explode( PHP_EOL, $value );
-		}
-
-		$value = array_map( 'trim', $value );
-		$value = array_map( 'sanitize_url', $value );
-		$value = array_unique( $value );
-
-		return array_filter( $value );
 	}
 }

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -39,18 +39,10 @@ class Move {
 		}
 
 		// Add the old account URL to alsoKnownAs.
-		$also_known_as   = (array) \get_user_option( 'activitypub_also_known_as', $user->get__id() );
-		$also_known_as[] = $from;
-		$also_known_as   = \array_unique( $also_known_as );
-
 		if ( $user->get__id() > 0 ) {
-			$also_known_as = array_map( 'trim', $also_known_as );
-			$also_known_as = array_map( 'esc_url', $also_known_as );
-			$also_known_as = array_filter( $also_known_as );
-
-			\update_user_option( $user->get__id(), 'activitypub_also_known_as', $also_known_as );
+			self::update_user_also_known_as( $user->get__id(), $from );
 		} else {
-			\update_option( 'activitypub_blog_user_also_known_as', $also_known_as );
+			self::update_blog_also_known_as( $from );
 		}
 
 		$response = Http::get_remote_object( $to );
@@ -70,5 +62,30 @@ class Move {
 
 		// Add to outbox.
 		return add_to_outbox( $actor, 'Move', $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+	}
+
+	/**
+	 * Update the alsoKnownAs property of a user.
+	 *
+	 * @param int    $user_id The user ID.
+	 * @param string $from    The current account URL.
+	 */
+	private static function update_user_also_known_as( $user_id, $from ) {
+		$also_known_as   = (array) \get_user_option( 'activitypub_also_known_as', $user_id );
+		$also_known_as[] = $from;
+
+		\update_user_option( $user_id, 'activitypub_also_known_as', $also_known_as );
+	}
+
+	/**
+	 * Update the alsoKnownAs property of the blog.
+	 *
+	 * @param string $from The current account URL.
+	 */
+	private static function update_blog_also_known_as( $from ) {
+		$also_known_as   = (array) \get_option( 'activitypub_blog_user_also_known_as' );
+		$also_known_as[] = $from;
+
+		\update_option( 'activitypub_blog_user_also_known_as', $also_known_as );
 	}
 }

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -44,6 +44,10 @@ class Move {
 		$also_known_as   = \array_unique( $also_known_as );
 
 		if ( $user->get__id() > 0 ) {
+			$also_known_as = array_map( 'trim', $also_known_as );
+			$also_known_as = array_map( 'esc_url', $also_known_as );
+			$also_known_as = array_filter( $also_known_as );
+
 			\update_user_option( $user->get__id(), 'activitypub_also_known_as', $also_known_as );
 		} else {
 			\update_option( 'activitypub_blog_user_also_known_as', $also_known_as );

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Sanitization file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub;
+
+/**
+ * Sanitization class.
+ */
+class Sanitize {
+	/**
+	 * Sanitize a list of URLs.
+	 *
+	 * @param string|array $value The value to sanitize.
+	 * @return array The sanitized list of URLs.
+	 */
+	public static function url_list( $value ) {
+		if ( ! is_array( $value ) ) {
+			$value = explode( PHP_EOL, $value );
+		}
+
+		$value = array_map( 'trim', $value );
+		$value = array_map( 'sanitize_url', $value );
+		$value = array_unique( $value );
+
+		return array_filter( $value );
+	}
+}

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -175,10 +175,6 @@ class Admin {
 
 		$also_known_as = ! empty( $_POST['activitypub_blog_user_also_known_as'] ) ? \sanitize_textarea_field( wp_unslash( $_POST['activitypub_blog_user_also_known_as'] ) ) : false;
 		if ( $also_known_as ) {
-			$also_known_as = explode( PHP_EOL, $also_known_as );
-			$also_known_as = array_map( 'trim', $also_known_as );
-			$also_known_as = array_filter( $also_known_as );
-			$also_known_as = array_map( 'esc_url', $also_known_as );
 			\update_user_option( $user_id, 'activitypub_also_known_as', $also_known_as );
 		} else {
 			\delete_user_option( $user_id, 'activitypub_also_known_as' );

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -173,7 +173,8 @@ class Admin {
 			\delete_user_option( $user_id, 'activitypub_header_image' );
 		}
 
-		$also_known_as = $_POST['activitypub_blog_user_also_known_as'];
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$also_known_as = \sanitize_text_field( \wp_unslash( isset( $_POST['activitypub_blog_user_also_known_as'] ) ? $_POST['activitypub_blog_user_also_known_as'] : '' ) );
 		if ( $also_known_as ) {
 			$also_known_as = explode( PHP_EOL, $also_known_as );
 			$also_known_as = array_map( 'trim', $also_known_as );

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -172,6 +172,17 @@ class Admin {
 		} else {
 			\delete_user_option( $user_id, 'activitypub_header_image' );
 		}
+
+		$also_known_as = $_POST['activitypub_blog_user_also_known_as'];
+		if ( $also_known_as ) {
+			$also_known_as = explode( PHP_EOL, $also_known_as );
+			$also_known_as = array_map( 'trim', $also_known_as );
+			$also_known_as = array_filter( $also_known_as );
+			$also_known_as = array_map( 'esc_url', $also_known_as );
+			\update_user_option( $user_id, 'activitypub_also_known_as', $also_known_as );
+		} else {
+			\delete_user_option( $user_id, 'activitypub_also_known_as' );
+		}
 	}
 
 	/**

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -173,8 +173,7 @@ class Admin {
 			\delete_user_option( $user_id, 'activitypub_header_image' );
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$also_known_as = \sanitize_text_field( \wp_unslash( isset( $_POST['activitypub_blog_user_also_known_as'] ) ? $_POST['activitypub_blog_user_also_known_as'] : '' ) );
+		$also_known_as = ! empty( $_POST['activitypub_blog_user_also_known_as'] ) ? \sanitize_textarea_field( wp_unslash( $_POST['activitypub_blog_user_also_known_as'] ) ) : false;
 		if ( $also_known_as ) {
 			$also_known_as = explode( PHP_EOL, $also_known_as );
 			$also_known_as = array_map( 'trim', $also_known_as );

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -70,6 +70,14 @@ class Blog_Settings_Fields {
 			'activitypub_blog_settings',
 			'activitypub_blog_profile'
 		);
+
+		add_settings_field(
+			'activitypub_blog_user_also_known_as',
+			__( 'Account Aliases', 'activitypub' ),
+			array( self::class, 'also_known_as_callback' ),
+			'activitypub_blog_settings',
+			'activitypub_blog_profile'
+		);
 	}
 
 	/**
@@ -221,6 +229,29 @@ class Blog_Settings_Fields {
 			<a href="<?php echo esc_url( admin_url( '/edit.php?post_type=ap_extrafield_blog' ) ); ?>">
 				<?php esc_html_e( 'Manage all', 'activitypub' ); ?>
 			</a>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Also Known As field callback.
+	 */
+	public static function also_known_as_callback() {
+		$also_known_as = \get_option( 'activitypub_blog_user_also_known_as' );
+		?>
+		<p class="description">
+			<?php esc_html_e( 'If you’re moving from another account to this one, you’ll need to create an alias here first before transferring your followers. This step is safe, reversible, and doesn’t affect anything on its own. The migration itself is initiated from your old account.', 'activitypub' ); ?>
+		</p>
+		<label for="activitypub_blog_user_also_known_as">
+			<textarea
+				class="large-text"
+				id="activitypub_blog_user_also_known_as"
+				name="activitypub_blog_user_also_known_as"
+				rows="5"
+			><?php echo esc_textarea( implode( PHP_EOL, (array) $also_known_as ) ); ?></textarea>
+		</label>
+		<p class="description">
+			<?php esc_html_e( 'Enter one URL per line.', 'activitypub' ); ?>
 		</p>
 		<?php
 	}

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -239,9 +239,6 @@ class Blog_Settings_Fields {
 	public static function also_known_as_callback() {
 		$also_known_as = \get_option( 'activitypub_blog_user_also_known_as' );
 		?>
-		<p class="description">
-			<?php esc_html_e( 'If you’re moving from another account to this one, you’ll need to create an alias here first before transferring your followers. This step is safe, reversible, and doesn’t affect anything on its own. The migration itself is initiated from your old account.', 'activitypub' ); ?>
-		</p>
 		<label for="activitypub_blog_user_also_known_as">
 			<textarea
 				class="large-text"
@@ -250,6 +247,9 @@ class Blog_Settings_Fields {
 				rows="5"
 			><?php echo esc_textarea( implode( PHP_EOL, (array) $also_known_as ) ); ?></textarea>
 		</label>
+		<p class="description">
+			<?php esc_html_e( 'If you’re moving from another account to this one, you’ll need to create an alias here first before transferring your followers. This step is safe, reversible, and doesn’t affect anything on its own. The migration itself is initiated from your old account.', 'activitypub' ); ?>
+		</p>
 		<p class="description">
 			<?php esc_html_e( 'Enter one URL per line.', 'activitypub' ); ?>
 		</p>

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -395,7 +395,13 @@ class Settings_Fields {
 	public static function render_attribution_domains_field() {
 		$value = get_option( 'activitypub_attribution_domains', \Activitypub\home_host() );
 		?>
-		<textarea id="activitypub_attribution_domains" name="activitypub_attribution_domains" class="large-text" cols="50" rows="5" placeholder="<?php echo esc_attr( \Activitypub\home_host() ); ?>"><?php echo esc_textarea( $value ); ?></textarea>
+		<textarea
+			id="activitypub_attribution_domains"
+			name="activitypub_attribution_domains"
+			class="large-text"
+			cols="50" rows="5"
+			placeholder="<?php echo esc_attr( \Activitypub\home_host() ); ?>"
+		><?php echo esc_textarea( $value ); ?></textarea>
 		<p class="description"><?php esc_html_e( 'Websites allowed to credit you, one per line. Protects from false attributions.', 'activitypub' ); ?></p>
 		<?php
 	}

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -249,9 +249,9 @@ class Settings {
 			'activitypub_blog',
 			'activitypub_blog_user_also_known_as',
 			array(
-				'type'        => 'array',
-				'description' => \__( 'Also Known As', 'activitypub' ),
-				'default'     => array(),
+				'type'              => 'array',
+				'description'       => \__( 'Also Known As', 'activitypub' ),
+				'default'           => array(),
 				'sanitize_callback' => function ( $value ) {
 					if ( ! is_array( $value ) ) {
 						$value = explode( PHP_EOL, $value );
@@ -261,7 +261,7 @@ class Settings {
 					$value = array_filter( array_map( 'esc_url', $value ) );
 
 					return $value;
-				}
+				},
 			)
 		);
 	}

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -250,7 +250,7 @@ class Settings {
 			'activitypub_blog_user_also_known_as',
 			array(
 				'type'              => 'array',
-				'description'       => \__( 'Also Known As', 'activitypub' ),
+				'description'       => \__( 'The Account Aliases for the Blog-Actor', 'activitypub' ),
 				'default'           => array(),
 				'sanitize_callback' => function ( $value ) {
 					if ( ! is_array( $value ) ) {
@@ -258,7 +258,7 @@ class Settings {
 					}
 
 					$value = array_filter( array_map( 'trim', $value ) );
-					$value = array_filter( array_map( 'esc_url', $value ) );
+					$value = array_filter( array_map( 'esc_url_raw', $value ) );
 
 					return $value;
 				},

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -7,9 +7,9 @@
 
 namespace Activitypub\WP_Admin;
 
-use Activitypub\Activitypub;
 use Activitypub\Collection\Actors;
 use Activitypub\Model\Blog;
+use Activitypub\Sanitize;
 use function Activitypub\is_user_disabled;
 
 /**
@@ -253,7 +253,7 @@ class Settings {
 				'type'              => 'array',
 				'description'       => 'An array of URLs that the blog user is known by.',
 				'default'           => array(),
-				'sanitize_callback' => array( Activitypub::class, 'sanitize_textarea_urls' ),
+				'sanitize_callback' => array( Sanitize::class, 'url_list' ),
 			)
 		);
 	}

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -259,6 +259,7 @@ class Settings {
 
 					$value = array_map( 'trim', $value );
 					$value = array_map( 'esc_url_raw', $value );
+					$value = array_unique( $value );
 
 					return array_filter( $value );
 				},

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -257,10 +257,10 @@ class Settings {
 						$value = explode( PHP_EOL, $value );
 					}
 
-					$value = array_filter( array_map( 'trim', $value ) );
-					$value = array_filter( array_map( 'esc_url_raw', $value ) );
+					$value = array_map( 'trim', $value );
+					$value = array_map( 'esc_url_raw', $value );
 
-					return $value;
+					return array_filter( $value );
 				},
 			)
 		);

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -244,6 +244,26 @@ class Settings {
 				'default'     => null,
 			)
 		);
+
+		\register_setting(
+			'activitypub_blog',
+			'activitypub_blog_user_also_known_as',
+			array(
+				'type'        => 'array',
+				'description' => \__( 'Also Known As', 'activitypub' ),
+				'default'     => array(),
+				'sanitize_callback' => function ( $value ) {
+					if ( ! is_array( $value ) ) {
+						$value = explode( PHP_EOL, $value );
+					}
+
+					$value = array_filter( array_map( 'trim', $value ) );
+					$value = array_filter( array_map( 'esc_url', $value ) );
+
+					return $value;
+				}
+			)
+		);
 	}
 
 	/**

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\WP_Admin;
 
+use Activitypub\Activitypub;
 use Activitypub\Collection\Actors;
 use Activitypub\Model\Blog;
 use function Activitypub\is_user_disabled;
@@ -250,18 +251,9 @@ class Settings {
 			'activitypub_blog_user_also_known_as',
 			array(
 				'type'              => 'array',
-				'description'       => \__( 'The Account Aliases for the Blog-Actor', 'activitypub' ),
+				'description'       => 'An array of URLs that the blog user is known by.',
 				'default'           => array(),
-				'sanitize_callback' => function ( $value ) {
-					if ( ! is_array( $value ) ) {
-						$value = explode( PHP_EOL, $value );
-					}
-
-					$value = array_map( 'trim', $value );
-					$value = array_map( 'esc_url_raw', $value );
-
-					return array_filter( $value );
-				},
+				'sanitize_callback' => array( Activitypub::class, 'sanitize_textarea_urls' ),
 			)
 		);
 	}

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -140,15 +140,15 @@ $user = \Activitypub\Collection\Actors::get_by_id( \get_current_user_id() ); ?>
 			</th>
 			<td>
 				<?php $also_known_as = \get_user_option( 'activitypub_also_known_as', \get_current_user_id() ); ?>
-				<p class="description">
-					<?php esc_html_e( 'If you’re moving from another account to this one, you’ll need to create an alias here first before transferring your followers. This step is safe, reversible, and doesn’t affect anything on its own. The migration itself is initiated from your old account.', 'activitypub' ); ?>
-				</p>
 				<textarea
 					class="large-text"
 					name="activitypub_blog_user_also_known_as"
 					id="activitypub_blog_user_also_known_as"
 					rows="5"
 				><?php echo esc_textarea( implode( PHP_EOL, (array) $also_known_as ) ); ?></textarea>
+				<p class="description">
+					<?php esc_html_e( 'If you’re moving from another account to this one, you’ll need to create an alias here first before transferring your followers. This step is safe, reversible, and doesn’t affect anything on its own. The migration itself is initiated from your old account.', 'activitypub' ); ?>
+				</p>
 				<p class="description">
 					<?php esc_html_e( 'Enter one URL per line.', 'activitypub' ); ?>
 				</p>

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -134,6 +134,26 @@ $user = \Activitypub\Collection\Actors::get_by_id( \get_current_user_id() ); ?>
 				</p>
 			</td>
 		</tr>
+		<tr scope="row">
+			<th>
+				<label><?php \esc_html_e( 'Account Aliases', 'activitypub' ); ?></label>
+			</th>
+			<td>
+				<?php $also_known_as = \get_user_option( 'activitypub_also_known_as', \get_current_user_id() ); ?>
+				<p class="description">
+					<?php esc_html_e( 'If you’re moving from another account to this one, you’ll need to create an alias here first before transferring your followers. This step is safe, reversible, and doesn’t affect anything on its own. The migration itself is initiated from your old account.', 'activitypub' ); ?>
+				</p>
+				<textarea
+					class="large-text"
+					name="activitypub_blog_user_also_known_as"
+					id="activitypub_blog_user_also_known_as"
+					rows="5"
+				><?php echo esc_textarea( implode( PHP_EOL, (array) $also_known_as ) ); ?></textarea>
+				<p class="description">
+					<?php esc_html_e( 'Enter one URL per line.', 'activitypub' ); ?>
+				</p>
+			</td>
+		</tr>
 	</tbody>
 </table>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This allows users to migrate their remote profiles to WordPress.

See: https://docs.joinmastodon.org/user/moving/#migration

## Blog-Profile

<img width="928" alt="Screenshot 2025-02-28 at 11 41 18" src="https://github.com/user-attachments/assets/6e7322f3-58d4-4453-91e9-28d99d4e605c" />

## User-Profile

<img width="1865" alt="Screenshot 2025-02-28 at 11 51 48" src="https://github.com/user-attachments/assets/58bdc8d9-eea9-43db-a240-44a254d0bc56" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the ability to add Aliases using the settings screens

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

