### PR TITLE
Combine sanitization functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Upgrade script to fix Follower json representations with unescaped backslashes.
+* Centralized place for sanitization functions.
 
 ### Changed
 

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -33,6 +33,34 @@ class Sanitize {
 	}
 
 	/**
+	 * Sanitize a list of hosts.
+	 *
+	 * @param string $value The value to sanitize.
+	 * @return string The sanitized list of hosts.
+	 */
+	public static function host_list( $value ) {
+		$value = \explode( PHP_EOL, $value );
+		$value = \array_map(
+			function ( $host ) {
+				$host = \trim( $host );
+				$host = \strtolower( $host );
+				$host = \set_url_scheme( $host );
+				$host = \sanitize_url( $host, array( 'http', 'https' ) );
+
+				// Remove protocol.
+				if ( \str_contains( $host, 'http' ) ) {
+					$host = \wp_parse_url( $host, PHP_URL_HOST );
+				}
+
+				return \filter_var( $host, FILTER_VALIDATE_DOMAIN );
+			},
+			$value
+		);
+
+		return \implode( PHP_EOL, \array_filter( $value ) );
+	}
+
+	/**
 	 * Sanitize a blog identifier.
 	 *
 	 * @param string $value The value to sanitize.

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Sanitization file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub;
+
+use Activitypub\Model\Blog;
+
+/**
+ * Sanitization class.
+ */
+class Sanitize {
+	/**
+	 * Sanitize a list of URLs.
+	 *
+	 * @param string|array $value The value to sanitize.
+	 * @return array The sanitized list of URLs.
+	 */
+	public static function url_list( $value ) {
+		if ( ! \is_array( $value ) ) {
+			$value = \explode( PHP_EOL, $value );
+		}
+
+		$value = \array_map( 'trim', $value );
+		$value = \array_filter( $value );
+		$value = \array_map( 'sanitize_url', $value );
+		$value = \array_unique( $value );
+
+		return \array_values( $value );
+	}
+
+	/**
+	 * Sanitize a blog identifier.
+	 *
+	 * @param string $value The value to sanitize.
+	 * @return string The sanitized blog identifier.
+	 */
+	public static function blog_identifier( $value ) {
+		// Hack to allow dots in the username.
+		$parts     = \explode( '.', $value );
+		$sanitized = \array_map( 'sanitize_title', $parts );
+		$sanitized = \implode( '.', $sanitized );
+
+		// Check for login or nicename.
+		$user = new \WP_User_Query(
+			array(
+				'search'         => $sanitized,
+				'search_columns' => array( 'user_login', 'user_nicename' ),
+				'number'         => 1,
+				'hide_empty'     => true,
+				'fields'         => 'ID',
+			)
+		);
+
+		if ( $user->get_results() ) {
+			\add_settings_error(
+				'activitypub_blog_identifier',
+				'activitypub_blog_identifier',
+				\esc_html__( 'You cannot use an existing author&#8217;s name for the blog profile ID.', 'activitypub' )
+			);
+
+			return Blog::get_default_username();
+		}
+
+		return $sanitized;
+	}
+}

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -9,6 +9,7 @@ namespace Activitypub\WP_Admin;
 
 use Activitypub\Collection\Actors;
 use Activitypub\Model\Blog;
+use Activitypub\Sanitize;
 use function Activitypub\is_user_disabled;
 
 /**
@@ -137,12 +138,7 @@ class Settings {
 				'description'       => \__( 'Websites allowed to credit you.', 'activitypub' ),
 				'default'           => \Activitypub\home_host(),
 				'sanitize_callback' => function ( $value ) {
-					$value = explode( PHP_EOL, $value );
-					$value = array_filter( array_map( 'trim', $value ) );
-					$value = array_filter( array_map( 'esc_attr', $value ) );
-					$value = implode( PHP_EOL, $value );
-
-					return $value;
+					return implode( PHP_EOL, Sanitize::url_list( $value ) );
 				},
 			)
 		);
@@ -197,41 +193,7 @@ class Settings {
 				'description'       => \esc_html__( 'The Identifier of the Blog-User', 'activitypub' ),
 				'show_in_rest'      => true,
 				'default'           => Blog::get_default_username(),
-				'sanitize_callback' => function ( $value ) {
-					// Hack to allow dots in the username.
-					$parts     = explode( '.', $value );
-					$sanitized = array();
-
-					foreach ( $parts as $part ) {
-						$sanitized[] = \sanitize_title( $part );
-					}
-
-					$sanitized = implode( '.', $sanitized );
-
-					// Check for login or nicename.
-					$user = new \WP_User_Query(
-						array(
-							'search'         => $sanitized,
-							'search_columns' => array( 'user_login', 'user_nicename' ),
-							'number'         => 1,
-							'hide_empty'     => true,
-							'fields'         => 'ID',
-						)
-					);
-
-					if ( $user->results ) {
-						add_settings_error(
-							'activitypub_blog_identifier',
-							'activitypub_blog_identifier',
-							\esc_html__( 'You cannot use an existing author\'s name for the blog profile ID.', 'activitypub' ),
-							'error'
-						);
-
-						return Blog::get_default_username();
-					}
-
-					return $sanitized;
-				},
+				'sanitize_callback' => array( Sanitize::class, 'blog_identifier' ),
 			)
 		);
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -137,9 +137,7 @@ class Settings {
 				'type'              => 'string',
 				'description'       => \__( 'Websites allowed to credit you.', 'activitypub' ),
 				'default'           => \Activitypub\home_host(),
-				'sanitize_callback' => function ( $value ) {
-					return implode( PHP_EOL, Sanitize::url_list( $value ) );
-				},
+				'sanitize_callback' => array( Sanitize::class, 'host_list' ),
 			)
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Added: Upgrade script to fix Follower json representations with unescaped backslashes.
+* Added: Centralized place for sanitization functions.
 * Changed: Bumped minimum required WordPress version to 6.4.
 * Changed: Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
 * Changed: Use webfinger as author email for comments from the Fediverse.

--- a/tests/includes/class-test-sanitize.php
+++ b/tests/includes/class-test-sanitize.php
@@ -74,6 +74,49 @@ class Test_Sanitize extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for host list tests.
+	 *
+	 * @return array Test data.
+	 */
+	public function host_list_provider() {
+		return array(
+			'single_valid_host'    => array(
+				'example.com',
+				'example.com',
+			),
+			'multiple_valid_hosts' => array(
+				"ftp://example.com\nhttp://wordpress.org\nhttps://test.example.com",
+				"example.com\nwordpress.org\ntest.example.com",
+			),
+			'mixed_case_hosts'     => array(
+				"ExAmPlE.cOm\nWoRdPrEsS.oRg",
+				"example.com\nwordpress.org",
+			),
+			'invalid_hosts'        => array(
+				"   not-a-domain\n\nexample.com\n\t@invalid.com",
+				"not-a-domain\nexample.com\ninvalid.com",
+			),
+			'empty_string'         => array(
+				'',
+				'',
+			),
+		);
+	}
+
+	/**
+	 * Test host_list with various inputs.
+	 *
+	 * @dataProvider host_list_provider
+	 * @covers ::host_list
+	 *
+	 * @param string $input    Input value.
+	 * @param string $expected Expected output.
+	 */
+	public function test_host_list( $input, $expected ) {
+		$this->assertEquals( $expected, Sanitize::host_list( $input ) );
+	}
+
+	/**
 	 * Data provider for blog identifier tests.
 	 *
 	 * @return array Test data.

--- a/tests/includes/class-test-sanitize.php
+++ b/tests/includes/class-test-sanitize.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Test file for Sanitize class.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+use Activitypub\Sanitize;
+
+/**
+ * Test class for Sanitize.
+ *
+ * @coversDefaultClass \Activitypub\Sanitize
+ */
+class Test_Sanitize extends \WP_UnitTestCase {
+
+	/**
+	 * Data provider for URL list tests.
+	 *
+	 * @return array Test data.
+	 */
+	public function url_list_provider() {
+		return array(
+			'duplicate_urls'                  => array(
+				array(
+					'https://example.com',
+					'https://example.com',
+					'not-a-url',
+					'https://wordpress.org',
+				),
+				array(
+					'https://example.com',
+					'http://not-a-url',
+					'https://wordpress.org',
+				),
+			),
+			'mixed_urls_in_string_whitespace' => array(
+				"https://example.com\nnot-a-url\nhttps://wordpress.org  ",
+				array(
+					'https://example.com',
+					'http://not-a-url',
+					'https://wordpress.org',
+				),
+			),
+			'special_characters'              => array(
+				array(
+					'https://example.com/path with spaces ',
+					'https://example.com/über/path',
+					'https://example.com/path?param=value&param2=value2#section',
+				),
+				array(
+					'https://example.com/path%20with%20spaces',
+					'https://example.com/über/path',
+					'https://example.com/path?param=value&param2=value2#section',
+				),
+			),
+			'empty_array'                     => array( array(), array() ),
+		);
+	}
+
+	/**
+	 * Test url_list with various inputs.
+	 *
+	 * @dataProvider url_list_provider
+	 * @covers ::url_list
+	 *
+	 * @param mixed $input    Input value.
+	 * @param array $expected Expected output.
+	 */
+	public function test_url_list( $input, $expected ) {
+		$this->assertEquals( $expected, Sanitize::url_list( $input ) );
+	}
+
+	/**
+	 * Data provider for blog identifier tests.
+	 *
+	 * @return array Test data.
+	 */
+	public function blog_identifier_provider() {
+		return array(
+			'simple_string' => array( 'test-Blog', 'test-blog' ),
+			'with_spaces'   => array( 'test blog', 'test-blog' ),
+			'with_dots'     => array( 'test.blog', 'test.blog' ),
+			'special_chars' => array( 'test@#$%^&*blog', 'testblog' ),
+			'multiple_dots' => array( 'test.blog.name', 'test.blog.name' ),
+		);
+	}
+
+	/**
+	 * Test blog_identifier with various inputs.
+	 *
+	 * @dataProvider blog_identifier_provider
+	 * @covers ::blog_identifier
+	 *
+	 * @param string $input    Input value.
+	 * @param string $expected Expected output.
+	 */
+	public function test_blog_identifier( $input, $expected ) {
+		$this->assertEquals( $expected, Sanitize::blog_identifier( $input ) );
+	}
+
+	/**
+	 * Test blog_identifier with an existing username.
+	 *
+	 * @covers ::blog_identifier
+	 */
+	public function test_blog_identifier_with_existing_user() {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login'    => 'existing-user',
+				'user_nicename' => 'test-nicename',
+			)
+		);
+
+		$result = Sanitize::blog_identifier( 'existing-user' );
+
+		$this->assertEquals( \Activitypub\Model\Blog::get_default_username(), $result );
+		$this->assertNotEmpty( get_settings_errors( 'activitypub_blog_identifier' ) );
+
+		// Reset.
+		$GLOBALS['wp_settings_errors'] = array();
+
+		$result = Sanitize::blog_identifier( 'test-nicename' );
+
+		$this->assertEquals( \Activitypub\Model\Blog::get_default_username(), $result );
+		$this->assertNotEmpty( get_settings_errors( 'activitypub_blog_identifier' ) );
+
+		\wp_delete_user( $user_id );
+	}
+}


### PR DESCRIPTION
Creates a central place for sanitization functions used in settings, meta, etc.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `url_list()` sanitization to sanitize a text area list of urls.
* Moves `blog_identifier()` sanitization.
* Moves and updates `host_list()` sanitization to increase the chance of only getting host names.
* Adds unit tests for both.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Activitypub settings and make sure updating the blog identifier and attribution domains still works as expected.

