### PR TITLE
Outbox: Account for user option prefix and added meta data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
 * Use webfinger as author email for comments from the Fediverse.
 
+### Fixed
+
+* Updates to certain user meta fields did not trigger an Update activity.
+
 ## [5.3.2] - 2025-02-27
 
 ### Fixed

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -63,10 +63,12 @@ class Actor {
 			return;
 		}
 
+		$blog_prefix = $GLOBALS['wpdb']->get_blog_prefix();
+
 		// The user meta fields that affect a profile.
 		$fields = array(
-			'activitypub_description',
-			'activitypub_header_image',
+			$blog_prefix . 'activitypub_description',
+			$blog_prefix . 'activitypub_header_image',
 			'description',
 			'user_url',
 			'display_name',

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -68,11 +68,11 @@ class Actor {
 		// The user meta fields that affect a profile.
 		$fields = array(
 			$blog_prefix . 'activitypub_description',
-			$blog_prefix . 'activitypub_icon',
 			$blog_prefix . 'activitypub_header_image',
+			$blog_prefix . 'activitypub_icon',
 			'description',
-			'user_url',
 			'display_name',
+			'user_url',
 		);
 
 		if ( in_array( $meta_key, $fields, true ) ) {

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -68,6 +68,7 @@ class Actor {
 		// The user meta fields that affect a profile.
 		$fields = array(
 			$blog_prefix . 'activitypub_description',
+			$blog_prefix . 'activitypub_icon',
 			$blog_prefix . 'activitypub_header_image',
 			'description',
 			'user_url',

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -39,6 +39,7 @@ class Actor {
 		// Profile updates for user options.
 		if ( ! is_user_type_disabled( 'user' ) ) {
 			\add_action( 'profile_update', array( self::class, 'user_update' ) );
+			\add_action( 'added_user_meta', array( self::class, 'user_meta_update' ), 10, 3 );
 			\add_action( 'updated_user_meta', array( self::class, 'user_meta_update' ), 10, 3 );
 			// @todo figure out a feasible way of updating the header image since it's not unique to any user.
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Changed: Bumped minimum required WordPress version to 6.4.
 * Changed: Use a later hook for Posts to get published to the Outbox, to get sure all `post_meta`s and `taxonomy`s are set stored properly.
 * Changed: Use webfinger as author email for comments from the Fediverse.
+* Fixed: Updates to certain user meta fields did not trigger an Update activity.
 
 = 5.3.2 =
 

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -106,6 +106,15 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		\wp_delete_post( $post->ID, true );
 
+		// Update activitypub_icon.
+		$actor->update_icon( self::$attachment_id );
+
+		$post = $this->get_latest_outbox_item( $actor->get_id() );
+		$id   = \get_post_meta( $post->ID, '_activitypub_object_id', true );
+		$this->assertSame( $actor->get_id(), $id );
+
+		\wp_delete_post( $post->ID, true );
+
 		// Update activitypub_header_image.
 		$actor->update_header( self::$attachment_id );
 

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -46,8 +46,6 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 */
 	public function user_meta_provider() {
 		return array(
-			array( 'activitypub_description' ),
-			array( 'activitypub_header_image' ),
 			array( 'description' ),
 			array( 'user_url' ),
 			array( 'display_name' ),
@@ -69,6 +67,41 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$post          = $this->get_latest_outbox_item( $activitpub_id );
 		$id            = \get_post_meta( $post->ID, '_activitypub_object_id', true );
 		$this->assertSame( $activitpub_id, $id );
+	}
+
+
+
+	/**
+	 * Data provider for user option update scheduling.
+	 *
+	 * @return string[][]
+	 */
+	public function user_option_provider() {
+		return array(
+			array( 'activitypub_description', 'test value' ),
+			array( 'activitypub_header_image', 2 ),
+		);
+	}
+
+	/**
+	 * Test user option update scheduling.
+	 *
+	 * @dataProvider user_option_provider
+	 * @covers ::user_meta_update
+	 *
+	 * @param string $option_key   User option key to test.
+	 * @param mixed  $option_value User option value to test.
+	 */
+	public function test_user_option_update( $option_key, $option_value ) {
+		_delete_all_posts();
+		\update_user_option( self::$user_id, $option_key, $option_value );
+
+		$activitpub_id = Actors::get_by_id( self::$user_id )->get_id();
+		$post          = $this->get_latest_outbox_item( $activitpub_id );
+		$id            = \get_post_meta( $post->ID, '_activitypub_object_id', true );
+		$this->assertSame( $activitpub_id, $id );
+
+		\wp_delete_post( $post->ID, true );
 	}
 
 	/**

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -95,7 +95,9 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	public function test_user_option_update() {
 		$actor = Actors::get_by_id( self::$user_id );
 		$post  = $this->get_latest_outbox_item( $actor->get_id() );
-		\wp_delete_post( $post->ID, true );
+		if ( $post ) {
+			\wp_delete_post( $post->ID, true );
+		}
 
 		// Update activitypub_description.
 		$actor->update_summary( 'test summary' );

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -19,13 +19,6 @@ use Activitypub\Scheduler\Actor;
 class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 	/**
-	 * Attachment ID.
-	 *
-	 * @var int
-	 */
-	public static $attachment_id;
-
-	/**
 	 * Set up test resources.
 	 */
 	public static function set_up_before_class() {
@@ -44,17 +37,6 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 			)
 		);
-
-		self::$attachment_id = self::factory()->attachment->create_upload_object( dirname( __DIR__, 2 ) . '/assets/test.jpg' );
-	}
-
-	/**
-	 * Tear down test resources.
-	 */
-	public static function tear_down_after_class() {
-		parent::tear_down_after_class();
-
-		\wp_delete_attachment( self::$attachment_id, true );
 	}
 
 	/**
@@ -99,6 +81,8 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			\wp_delete_post( $post->ID, true );
 		}
 
+		$attachment_id = self::factory()->attachment->create_upload_object( dirname( __DIR__, 2 ) . '/assets/test.jpg' );
+
 		// Update activitypub_description.
 		$actor->update_summary( 'test summary' );
 
@@ -109,7 +93,7 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		\wp_delete_post( $post->ID, true );
 
 		// Update activitypub_icon.
-		$actor->update_icon( self::$attachment_id );
+		$actor->update_icon( $attachment_id );
 
 		$post = $this->get_latest_outbox_item( $actor->get_id() );
 		$id   = \get_post_meta( $post->ID, '_activitypub_object_id', true );
@@ -118,13 +102,14 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		\wp_delete_post( $post->ID, true );
 
 		// Update activitypub_header_image.
-		$actor->update_header( self::$attachment_id );
+		$actor->update_header( $attachment_id );
 
 		$post = $this->get_latest_outbox_item( $actor->get_id() );
 		$id   = \get_post_meta( $post->ID, '_activitypub_object_id', true );
 		$this->assertSame( $actor->get_id(), $id );
 
 		\wp_delete_post( $post->ID, true );
+		\wp_delete_attachment( $attachment_id, true );
 	}
 
 	/**

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -19,6 +19,13 @@ use Activitypub\Scheduler\Actor;
 class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 	/**
+	 * Attachment ID.
+	 *
+	 * @var int
+	 */
+	public static $attachment_id;
+
+	/**
 	 * Set up test resources.
 	 */
 	public static function set_up_before_class() {
@@ -37,6 +44,17 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 			)
 		);
+
+		self::$attachment_id = self::factory()->attachment->create_upload_object( dirname( __DIR__, 2 ) . '/assets/test.jpg' );
+	}
+
+	/**
+	 * Tear down test resources.
+	 */
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
+
+		\wp_delete_attachment( self::$attachment_id, true );
 	}
 
 	/**
@@ -69,37 +87,31 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$this->assertSame( $activitpub_id, $id );
 	}
 
-
-
-	/**
-	 * Data provider for user option update scheduling.
-	 *
-	 * @return string[][]
-	 */
-	public function user_option_provider() {
-		return array(
-			array( 'activitypub_description', 'test value' ),
-			array( 'activitypub_header_image', 2 ),
-		);
-	}
-
 	/**
 	 * Test user option update scheduling.
 	 *
-	 * @dataProvider user_option_provider
 	 * @covers ::user_meta_update
-	 *
-	 * @param string $option_key   User option key to test.
-	 * @param mixed  $option_value User option value to test.
 	 */
-	public function test_user_option_update( $option_key, $option_value ) {
-		_delete_all_posts();
-		\update_user_option( self::$user_id, $option_key, $option_value );
+	public function test_user_option_update() {
+		$actor = Actors::get_by_id( self::$user_id );
+		$post  = $this->get_latest_outbox_item( $actor->get_id() );
+		\wp_delete_post( $post->ID, true );
 
-		$activitpub_id = Actors::get_by_id( self::$user_id )->get_id();
-		$post          = $this->get_latest_outbox_item( $activitpub_id );
-		$id            = \get_post_meta( $post->ID, '_activitypub_object_id', true );
-		$this->assertSame( $activitpub_id, $id );
+		// Update activitypub_description.
+		$actor->update_summary( 'test summary' );
+
+		$post = $this->get_latest_outbox_item( $actor->get_id() );
+		$id   = \get_post_meta( $post->ID, '_activitypub_object_id', true );
+		$this->assertSame( $actor->get_id(), $id );
+
+		\wp_delete_post( $post->ID, true );
+
+		// Update activitypub_header_image.
+		$actor->update_header( self::$attachment_id );
+
+		$post = $this->get_latest_outbox_item( $actor->get_id() );
+		$id   = \get_post_meta( $post->ID, '_activitypub_object_id', true );
+		$this->assertSame( $actor->get_id(), $id );
 
 		\wp_delete_post( $post->ID, true );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a bug where changes to activitypub description and header image didn't trigger an Outbox item by themselves (profile update created the item)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added hook to run user_meta_update also when a meta gets added for the first time.
* Updates user meta key to account for activitypub user options.
* Added `activitypub_icon` to user meta allow list.
* Updates unit tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
