### PR TITLE
Fix: Send a create as a first activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Updates to certain user meta fields did not trigger an Update activity.
+* Fixed transition handling of posts to ensure that `Create` and `Update` activities are properly processed.
 
 ## [5.4.0] - 2025-03-03
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -413,8 +413,8 @@ class Scheduler {
 
 		$activity_type = \get_post_meta( $outbox_activity_id, '_activitypub_activity_type', true );
 
-		// Only if the activity is a Create, Update or Delete.
-		if ( ! in_array( $activity_type, array( 'Create', 'Update', 'Delete' ), true ) ) {
+		// Only if the activity is a Create.
+		if ( ! in_array( $activity_type, array( 'Create' ), true ) ) {
 			return;
 		}
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -439,6 +439,6 @@ class Scheduler {
 		}
 
 		// Schedule the outbox item for federation.
-		self::schedule_outbox_activity_for_federation( $outbox_activity_id, 30 );
+		self::schedule_outbox_activity_for_federation( $outbox_activity_id, 120 );
 	}
 }

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -54,7 +54,7 @@ class Post {
 
 		switch ( $new_status ) {
 			case 'publish':
-				$type = ( ! $old_status || 'auto-draft' === $old_status ) ? 'Create' : 'Update';
+				$type = ( 'publish' === $old_status ) ? 'Update' : 'Create';
 				break;
 
 			case 'draft':

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -54,7 +54,7 @@ class Post {
 
 		switch ( $new_status ) {
 			case 'publish':
-				$type = $update ? 'Update' : 'Create';
+				$type = ( ! $old_status || 'auto-draft' === $old_status ) ? 'Create' : 'Update';
 				break;
 
 			case 'draft':

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
+* Fixed: Transition handling of posts to ensure that `Create` and `Update` activities are properly processed.
 
 = 5.4.0 =
 


### PR DESCRIPTION
This fixes an issue with the newly reworked transition state system. The current code falsely detects a `create` activity as an `update`.

Fix #1406