### PR TITLE
Fix: Outgoing Move Activity

### DIFF
--- a/includes/class-handler.php
+++ b/includes/class-handler.php
@@ -12,6 +12,7 @@ use Activitypub\Handler\Create;
 use Activitypub\Handler\Delete;
 use Activitypub\Handler\Follow;
 use Activitypub\Handler\Like;
+use Activitypub\Handler\Move;
 use Activitypub\Handler\Undo;
 use Activitypub\Handler\Update;
 
@@ -37,6 +38,7 @@ class Handler {
 		Undo::init();
 		Update::init();
 		Like::init();
+		Move::init();
 
 		/**
 		 * Register additional handlers.

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -25,7 +25,7 @@ class Move {
 	 * @return int|bool|\WP_Error The ID of the outbox item or false or WP_Error on failure.
 	 */
 	public static function account( $from, $to ) {
-		$user = Actors::get_by_resource( $from );
+		$user = Actors::get_by_various( $from );
 
 		if ( \is_wp_error( $user ) ) {
 			return $user;
@@ -55,7 +55,7 @@ class Move {
 		$actor->from_array( $response );
 
 		// Check if the `Move` Activity is valid.
-		$also_known_as = $actor->get_also_known_as();
+		$also_known_as = $actor->get_also_known_as() ?? array();
 		if ( ! in_array( $from, $also_known_as, true ) ) {
 			return new \WP_Error( 'invalid_target', __( 'Invalid target', 'activitypub' ) );
 		}


### PR DESCRIPTION
The `Move` handler was not initiated, so the filter, that marks up the `Activity` properly, was never called.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

