### PR TITLE
Move: Fix `get(_user)_options` handling

### DIFF
--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -71,7 +71,7 @@ class Move {
 	 * @param string $from    The current account URL.
 	 */
 	private static function update_user_also_known_as( $user_id, $from ) {
-		$also_known_as   = (array) \get_user_option( 'activitypub_also_known_as', $user_id );
+		$also_known_as   = \get_user_option( 'activitypub_also_known_as', $user_id ) ?? array();
 		$also_known_as[] = $from;
 
 		\update_user_option( $user_id, 'activitypub_also_known_as', $also_known_as );
@@ -83,7 +83,7 @@ class Move {
 	 * @param string $from The current account URL.
 	 */
 	private static function update_blog_also_known_as( $from ) {
-		$also_known_as   = (array) \get_option( 'activitypub_blog_user_also_known_as' );
+		$also_known_as   = \get_option( 'activitypub_blog_user_also_known_as' ) ?? array();
 		$also_known_as[] = $from;
 
 		\update_option( 'activitypub_blog_user_also_known_as', $also_known_as );

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -71,7 +71,7 @@ class Move {
 	 * @param string $from    The current account URL.
 	 */
 	private static function update_user_also_known_as( $user_id, $from ) {
-		$also_known_as   = \get_user_option( 'activitypub_also_known_as', $user_id, array() );
+		$also_known_as   = \get_user_option( 'activitypub_also_known_as', $user_id ) ?: array();
 		$also_known_as[] = $from;
 
 		\update_user_option( $user_id, 'activitypub_also_known_as', $also_known_as );

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -71,6 +71,7 @@ class Move {
 	 * @param string $from    The current account URL.
 	 */
 	private static function update_user_also_known_as( $user_id, $from ) {
+		// phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 		$also_known_as   = \get_user_option( 'activitypub_also_known_as', $user_id ) ?: array();
 		$also_known_as[] = $from;
 

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -71,7 +71,7 @@ class Move {
 	 * @param string $from    The current account URL.
 	 */
 	private static function update_user_also_known_as( $user_id, $from ) {
-		$also_known_as   = \get_user_option( 'activitypub_also_known_as', $user_id ) ?? array();
+		$also_known_as   = \get_user_option( 'activitypub_also_known_as', $user_id, array() );
 		$also_known_as[] = $from;
 
 		\update_user_option( $user_id, 'activitypub_also_known_as', $also_known_as );
@@ -83,7 +83,7 @@ class Move {
 	 * @param string $from The current account URL.
 	 */
 	private static function update_blog_also_known_as( $from ) {
-		$also_known_as   = \get_option( 'activitypub_blog_user_also_known_as' ) ?? array();
+		$also_known_as   = \get_option( 'activitypub_blog_user_also_known_as', array() );
 		$also_known_as[] = $from;
 
 		\update_option( 'activitypub_blog_user_also_known_as', $also_known_as );

--- a/tests/includes/class-test-move.php
+++ b/tests/includes/class-test-move.php
@@ -137,7 +137,7 @@ class Test_Move extends \WP_UnitTestCase {
 		\Activitypub\Move::account( $from, $to );
 
 		$also_known_as = Actors::get_by_id( Actors::BLOG_USER_ID )->get_also_known_as();
-		$this->assertCount( 2, $also_known_as );
+		$this->assertCount( 1, $also_known_as );
 		$this->assertContains( $from, $also_known_as );
 
 		\delete_option( 'activitypub_actor_mode' );

--- a/tests/includes/class-test-sanitize.php
+++ b/tests/includes/class-test-sanitize.php
@@ -57,6 +57,14 @@ class Test_Sanitize extends \WP_UnitTestCase {
 				),
 			),
 			'empty_array'                     => array( array(), array() ),
+			'unsupported'                     => array(
+				array(
+					'',
+					false,
+					null,
+				),
+				array(),
+			),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes the handling of `get(_user)_options`.

If `\get_option( 'activitypub_blog_user_also_known_as' )` returns `false` it results in `array( false );`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

