### PR TITLE
Move: Add docs for Mastodon migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Documentation for migrating from a Mastodon instance to WordPress and vice versa.
+
 ### Fixed
 
 * Updates to certain user meta fields did not trigger an Update activity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Documentation for migrating from a Mastodon instance to WordPress and vice versa.
+* Documentation for migrating from a Mastodon instance to WordPress.
 
 ### Fixed
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -349,7 +349,7 @@ class Settings {
 					'<ol>' . "\n" .
 					'<li>' . \wp_kses(
 						\sprintf(
-						/* translators: %s is the URL to the profile page */
+							/* translators: %s is the URL to the profile page */
 							\__( 'In your WordPress profile, go to the <a href="%s">Account Aliases</a> section and add your Mastodon profile URL (e.g., <code>https://mastodon.social/@username</code>).', 'activitypub' ),
 							\esc_url( \admin_url( 'profile.php#activitypub_blog_user_also_known_as' ) )
 						),
@@ -360,7 +360,7 @@ class Settings {
 					'<li>' . \esc_html__( 'Go to Preferences > Account > Move to a different account.', 'activitypub' ) . '</li>' . "\n" .
 					'<li>' . \wp_kses(
 						\sprintf(
-						/* translators: %s is the user's ActivityPub username */
+							/* translators: %s is the user's ActivityPub username */
 							\__( 'Enter your WordPress ActivityPub username (e.g., <code>%s</code>) in the "Handle of the new account" field.', 'activitypub' ),
 							\esc_html( $webfinger )
 						),
@@ -368,39 +368,7 @@ class Settings {
 					) . '</li>' . "\n" .
 					'<li>' . \esc_html__( 'Confirm the migration in Mastodon by entering your password.', 'activitypub' ) . '</li>' . "\n" .
 					'<li>' . \esc_html__( 'Your followers will be notified and redirected to follow your WordPress account.', 'activitypub' ) . '</li>' . "\n" .
-					'</ol>' . "\n" .
-
-					'<h3>' . \esc_html__( 'Migrating from WordPress to Mastodon', 'activitypub' ) . '</h3>' . "\n" .
-					'<ol>' . "\n" .
-					'<li>' . \esc_html__( 'Create a Mastodon account if you don\'t already have one.', 'activitypub' ) . '</li>' . "\n" .
-					'<li>' . \esc_html__( 'In your Mastodon profile settings, go to Account > Moving From a Different Account.', 'activitypub' ) . '</li>' . "\n" .
-					'<li>' . \wp_kses(
-						\sprintf(
-						/* translators: %s is the user's ActivityPub username */
-							\__( 'Add your WordPress ActivityPub username (e.g., <code>%s</code>) as an alias.', 'activitypub' ),
-							\esc_html( $webfinger )
-						),
-						$code_html
-					) . '</li>' . "\n" .
-					'<li>' . \esc_html__( 'Save your Mastodon profile changes.', 'activitypub' ) . '</li>' . "\n" .
-					'<li>' . \wp_kses(
-						\sprintf(
-						/* translators: %s is the URL to the profile page */
-							\__( 'In your WordPress profile, go to the <a href="%s">Account Aliases</a> section.', 'activitypub' ),
-							\esc_url( \admin_url( 'profile.php#activitypub_blog_user_also_known_as' ) )
-						),
-						$anchor_html
-					) . '</li>' . "\n" .
-					'<li>' . \wp_kses( \__( 'Add your Mastodon profile URL (e.g., <code>https://mastodon.social/@username</code>).', 'activitypub' ), $code_html ) . '</li>' . "\n" .
-					'<li>' . \esc_html__( 'Save your WordPress profile changes.', 'activitypub' ) . '</li>' . "\n" .
-					'<li>' . \esc_html__( 'Go back to your Mastodon account settings.', 'activitypub' ) . '</li>' . "\n" .
-					'<li>' . \esc_html__( 'Go to Preferences > Account > Move to a different account.', 'activitypub' ) . '</li>' . "\n" .
-					'<li>' . \wp_kses( \__( 'Enter your Mastodon handle (e.g., <code>username@mastodon.social</code>) in the "Handle of the new account" field.', 'activitypub' ), $code_html ) . '</li>' . "\n" .
-					'<li>' . \esc_html__( 'Confirm the migration in Mastodon.', 'activitypub' ) . '</li>' . "\n" .
-					'<li>' . \esc_html__( 'Your followers will be notified and redirected to follow your Mastodon account.', 'activitypub' ) . '</li>' . "\n" .
-					'</ol>' . "\n" .
-
-					'<p>' . \esc_html__( 'Note: The account migration process is designed to be safe and reversible. Adding an alias does not affect your account until you initiate the actual migration.', 'activitypub' ) . '</p>',
+					'</ol>' . "\n",
 			)
 		);
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -286,6 +286,12 @@ class Settings {
 			),
 		);
 
+		if ( ! is_user_disabled( get_current_user_id() ) ) {
+			$webfinger = Actors::get_by_id( get_current_user_id() )->get_webfinger();
+		} else {
+			$webfinger = ( new Blog() )->get_webfinger();
+		}
+
 		\get_current_screen()->add_help_tab(
 			array(
 				'id'      => 'template-tags',
@@ -328,6 +334,73 @@ class Settings {
 					'<p>' . \esc_html__( 'You may also use any Shortcode normally available to you on your site, however be aware that Shortcodes may significantly increase the size of your content depending on what they do.', 'activitypub' ) . '</p>' . "\n" .
 					'<p>' . \esc_html__( 'Note: the old Template Tags are now deprecated and automatically converted to the new ones.', 'activitypub' ) . '</p>' . "\n" .
 					'<p>' . \wp_kses( \__( '<a href="https://github.com/automattic/wordpress-activitypub/issues/new" target="_blank">Let us know</a> if you miss a Template Tag.', 'activitypub' ), $anchor_html ) . '</p>',
+			)
+		);
+
+		\get_current_screen()->add_help_tab(
+			array(
+				'id'      => 'account-migration',
+				'title'   => \__( 'Account Migration', 'activitypub' ),
+				'content' =>
+					'<h2>' . \esc_html__( 'Migrating Between Mastodon and WordPress', 'activitypub' ) . '</h2>' . "\n" .
+					'<p>' . \esc_html__( 'The ActivityPub plugin allows you to migrate your account between WordPress and Mastodon (or other ActivityPub-compatible platforms) while bringing your followers with you.', 'activitypub' ) . '</p>' . "\n" .
+
+					'<h3>' . \esc_html__( 'Migrating from Mastodon to WordPress', 'activitypub' ) . '</h3>' . "\n" .
+					'<ol>' . "\n" .
+					'<li>' . \wp_kses(
+						\sprintf(
+						/* translators: %s is the URL to the profile page */
+							\__( 'In your WordPress profile, go to the <a href="%s">Account Aliases</a> section and add your Mastodon profile URL (e.g., <code>https://mastodon.social/@username</code>).', 'activitypub' ),
+							\esc_url( \admin_url( 'profile.php#activitypub_blog_user_also_known_as' ) )
+						),
+						array_merge( $code_html, $anchor_html )
+					) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Save your WordPress profile changes.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Log in to your Mastodon account.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Go to Preferences > Account > Move to a different account.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \wp_kses(
+						\sprintf(
+						/* translators: %s is the user's ActivityPub username */
+							\__( 'Enter your WordPress ActivityPub username (e.g., <code>%s</code>) in the "Handle of the new account" field.', 'activitypub' ),
+							\esc_html( $webfinger )
+						),
+						$code_html
+					) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Confirm the migration in Mastodon by entering your password.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Your followers will be notified and redirected to follow your WordPress account.', 'activitypub' ) . '</li>' . "\n" .
+					'</ol>' . "\n" .
+
+					'<h3>' . \esc_html__( 'Migrating from WordPress to Mastodon', 'activitypub' ) . '</h3>' . "\n" .
+					'<ol>' . "\n" .
+					'<li>' . \esc_html__( 'Create a Mastodon account if you don\'t already have one.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'In your Mastodon profile settings, go to Account > Moving From a Different Account.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \wp_kses(
+						\sprintf(
+						/* translators: %s is the user's ActivityPub username */
+							\__( 'Add your WordPress ActivityPub username (e.g., <code>%s</code>) as an alias.', 'activitypub' ),
+							\esc_html( $webfinger )
+						),
+						$code_html
+					) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Save your Mastodon profile changes.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \wp_kses(
+						\sprintf(
+						/* translators: %s is the URL to the profile page */
+							\__( 'In your WordPress profile, go to the <a href="%s">Account Aliases</a> section.', 'activitypub' ),
+							\esc_url( \admin_url( 'profile.php#activitypub_blog_user_also_known_as' ) )
+						),
+						$anchor_html
+					) . '</li>' . "\n" .
+					'<li>' . \wp_kses( \__( 'Add your Mastodon profile URL (e.g., <code>https://mastodon.social/@username</code>).', 'activitypub' ), $code_html ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Save your WordPress profile changes.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Go back to your Mastodon account settings.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Go to Preferences > Account > Move to a different account.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \wp_kses( \__( 'Enter your Mastodon handle (e.g., <code>username@mastodon.social</code>) in the "Handle of the new account" field.', 'activitypub' ), $code_html ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Confirm the migration in Mastodon.', 'activitypub' ) . '</li>' . "\n" .
+					'<li>' . \esc_html__( 'Your followers will be notified and redirected to follow your Mastodon account.', 'activitypub' ) . '</li>' . "\n" .
+					'</ol>' . "\n" .
+
+					'<p>' . \esc_html__( 'Note: The account migration process is designed to be safe and reversible. Adding an alias does not affect your account until you initiate the actual migration.', 'activitypub' ) . '</p>',
 			)
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 = Unreleased =
 
+* Added: Documentation for migrating from a Mastodon instance to WordPress and vice versa.
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
 
 = 5.4.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -131,7 +131,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 = Unreleased =
 
-* Added: Documentation for migrating from a Mastodon instance to WordPress and vice versa.
+* Added: Documentation for migrating from a Mastodon instance to WordPress.
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
 
 = 5.4.1 =

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -5,6 +5,9 @@
  * @package Activitypub
  */
 
+use Activitypub\Collection\Actors;
+
+$user = false;
 ?>
 
 <div class="activitypub-settings activitypub-welcome-page hide-if-no-js">
@@ -44,8 +47,8 @@
 		<?php
 	endif;
 
-	if ( ! \Activitypub\is_user_disabled( \Activitypub\Collection\Actors::BLOG_USER_ID ) ) :
-		$blog_user = new \Activitypub\Model\Blog();
+	if ( ! \Activitypub\is_user_disabled( Actors::BLOG_USER_ID ) ) :
+		$user = new \Activitypub\Model\Blog();
 		?>
 	<div class="box">
 		<h3><?php \esc_html_e( 'Blog profile', 'activitypub' ); ?></h3>
@@ -56,13 +59,13 @@
 			<label for="activitypub-blog-identifier"><?php \esc_html_e( 'Username', 'activitypub' ); ?></label>
 		</p>
 		<p>
-			<input type="text" class="regular-text" id="activitypub-blog-identifier" value="<?php echo \esc_attr( $blog_user->get_webfinger() ); ?>" readonly />
+			<input type="text" class="regular-text" id="activitypub-blog-identifier" value="<?php echo \esc_attr( $user->get_webfinger() ); ?>" readonly />
 		</p>
 		<p>
 			<label for="activitypub-blog-url"><?php \esc_html_e( 'Profile URL', 'activitypub' ); ?></label>
 		</p>
 		<p>
-			<input type="text" class="regular-text" id="activitypub-blog-url" value="<?php echo \esc_attr( $blog_user->get_url() ); ?>" readonly />
+			<input type="text" class="regular-text" id="activitypub-blog-url" value="<?php echo \esc_attr( $user->get_url() ); ?>" readonly />
 		</p>
 		<p>
 			<?php \esc_html_e( 'This blog profile will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
@@ -77,7 +80,7 @@
 
 	<?php
 	if ( ! \Activitypub\is_user_disabled( get_current_user_id() ) ) :
-		$user = \Activitypub\Collection\Actors::get_by_id( wp_get_current_user()->ID );
+		$user = Actors::get_by_id( get_current_user_id() );
 		?>
 	<div class="box">
 		<h3><?php \esc_html_e( 'Author profile', 'activitypub' ); ?></h3>
@@ -123,6 +126,56 @@
 				'default'
 			);
 			?>
+		</p>
+	</div>
+
+	<div class="box">
+		<h3><?php \esc_html_e( 'Account Migration', 'activitypub' ); ?></h3>
+		<p>
+			<?php \esc_html_e( 'You can migrate your followers between Mastodon and WordPress. This allows you to move your social presence without losing your audience.', 'activitypub' ); ?>
+		</p>
+		<h4><?php \esc_html_e( 'Migrating from Mastodon to WordPress', 'activitypub' ); ?></h4>
+		<p>
+			<?php
+			echo \wp_kses(
+				\sprintf(
+					/* translators: %1$s is the URL to the profile page, %2$s is the user's ActivityPub username */
+					\__(
+						'To migrate your followers from Mastodon to WordPress, add your Mastodon profile URL to the <a href="%1$s">Account Aliases</a> section in your WordPress profile, then initiate the migration from your Mastodon account settings. Your WordPress ActivityPub username is <code>%2$s</code>.',
+						'activitypub'
+					),
+					\esc_url( \admin_url( 'profile.php#activitypub_blog_user_also_known_as' ) ),
+					\esc_html( $user->get_webfinger() )
+				),
+				array(
+					'a'    => array( 'href' => array() ),
+					'code' => array(),
+				)
+			);
+			?>
+		</p>
+		<h4><?php \esc_html_e( 'Migrating from WordPress to Mastodon', 'activitypub' ); ?></h4>
+		<p>
+			<?php
+			echo \wp_kses(
+				\sprintf(
+					/* translators: %1$s is the URL to the profile page, %2$s is the user's ActivityPub username */
+					\__(
+						'To migrate your followers from WordPress to Mastodon, add your WordPress ActivityPub username (<code>%2$s</code>) as an alias in your Mastodon profile, then add your Mastodon profile URL to the <a href="%1$s">Account Aliases</a> section in WordPress, and finally initiate the migration from Mastodon.',
+						'activitypub'
+					),
+					\esc_url( \admin_url( 'profile.php#activitypub_blog_user_also_known_as' ) ),
+					\esc_html( $user->get_webfinger() )
+				),
+				array(
+					'a'    => array( 'href' => array() ),
+					'code' => array(),
+				)
+			);
+			?>
+		</p>
+		<p>
+			<?php \esc_html_e( 'For detailed migration instructions, click the "Help" tab in the top-right corner of this screen, then select "Account Migration".', 'activitypub' ); ?>
 		</p>
 	</div>
 

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -5,9 +5,6 @@
  * @package Activitypub
  */
 
-use Activitypub\Collection\Actors;
-
-$user = false;
 ?>
 
 <div class="activitypub-settings activitypub-welcome-page hide-if-no-js">
@@ -47,8 +44,8 @@ $user = false;
 		<?php
 	endif;
 
-	if ( ! \Activitypub\is_user_disabled( Actors::BLOG_USER_ID ) ) :
-		$user = new \Activitypub\Model\Blog();
+	if ( ! \Activitypub\is_user_disabled( \Activitypub\Collection\Actors::BLOG_USER_ID ) ) :
+		$blog_user = new \Activitypub\Model\Blog();
 		?>
 	<div class="box">
 		<h3><?php \esc_html_e( 'Blog profile', 'activitypub' ); ?></h3>
@@ -59,13 +56,13 @@ $user = false;
 			<label for="activitypub-blog-identifier"><?php \esc_html_e( 'Username', 'activitypub' ); ?></label>
 		</p>
 		<p>
-			<input type="text" class="regular-text" id="activitypub-blog-identifier" value="<?php echo \esc_attr( $user->get_webfinger() ); ?>" readonly />
+			<input type="text" class="regular-text" id="activitypub-blog-identifier" value="<?php echo \esc_attr( $blog_user->get_webfinger() ); ?>" readonly />
 		</p>
 		<p>
 			<label for="activitypub-blog-url"><?php \esc_html_e( 'Profile URL', 'activitypub' ); ?></label>
 		</p>
 		<p>
-			<input type="text" class="regular-text" id="activitypub-blog-url" value="<?php echo \esc_attr( $user->get_url() ); ?>" readonly />
+			<input type="text" class="regular-text" id="activitypub-blog-url" value="<?php echo \esc_attr( $blog_user->get_url() ); ?>" readonly />
 		</p>
 		<p>
 			<?php \esc_html_e( 'This blog profile will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
@@ -80,7 +77,7 @@ $user = false;
 
 	<?php
 	if ( ! \Activitypub\is_user_disabled( get_current_user_id() ) ) :
-		$user = Actors::get_by_id( get_current_user_id() );
+		$user = \Activitypub\Collection\Actors::get_by_id( wp_get_current_user()->ID );
 		?>
 	<div class="box">
 		<h3><?php \esc_html_e( 'Author profile', 'activitypub' ); ?></h3>
@@ -126,56 +123,6 @@ $user = false;
 				'default'
 			);
 			?>
-		</p>
-	</div>
-
-	<div class="box">
-		<h3><?php \esc_html_e( 'Account Migration', 'activitypub' ); ?></h3>
-		<p>
-			<?php \esc_html_e( 'You can migrate your followers between Mastodon and WordPress. This allows you to move your social presence without losing your audience.', 'activitypub' ); ?>
-		</p>
-		<h4><?php \esc_html_e( 'Migrating from Mastodon to WordPress', 'activitypub' ); ?></h4>
-		<p>
-			<?php
-			echo \wp_kses(
-				\sprintf(
-					/* translators: %1$s is the URL to the profile page, %2$s is the user's ActivityPub username */
-					\__(
-						'To migrate your followers from Mastodon to WordPress, add your Mastodon profile URL to the <a href="%1$s">Account Aliases</a> section in your WordPress profile, then initiate the migration from your Mastodon account settings. Your WordPress ActivityPub username is <code>%2$s</code>.',
-						'activitypub'
-					),
-					\esc_url( \admin_url( 'profile.php#activitypub_blog_user_also_known_as' ) ),
-					\esc_html( $user->get_webfinger() )
-				),
-				array(
-					'a'    => array( 'href' => array() ),
-					'code' => array(),
-				)
-			);
-			?>
-		</p>
-		<h4><?php \esc_html_e( 'Migrating from WordPress to Mastodon', 'activitypub' ); ?></h4>
-		<p>
-			<?php
-			echo \wp_kses(
-				\sprintf(
-					/* translators: %1$s is the URL to the profile page, %2$s is the user's ActivityPub username */
-					\__(
-						'To migrate your followers from WordPress to Mastodon, add your WordPress ActivityPub username (<code>%2$s</code>) as an alias in your Mastodon profile, then add your Mastodon profile URL to the <a href="%1$s">Account Aliases</a> section in WordPress, and finally initiate the migration from Mastodon.',
-						'activitypub'
-					),
-					\esc_url( \admin_url( 'profile.php#activitypub_blog_user_also_known_as' ) ),
-					\esc_html( $user->get_webfinger() )
-				),
-				array(
-					'a'    => array( 'href' => array() ),
-					'code' => array(),
-				)
-			);
-			?>
-		</p>
-		<p>
-			<?php \esc_html_e( 'For detailed migration instructions, click the "Help" tab in the top-right corner of this screen, then select "Account Migration".', 'activitypub' ); ?>
 		</p>
 	</div>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a help tab with migration instructions for migrating between WP and Mastodon instances. 
 
### After

<img width="1470" alt="Screenshot 2025-03-04 at 12 56 50 PM" src="https://github.com/user-attachments/assets/90193d48-0a35-43e0-898b-b3b26ba66165" />



