### PR TITLE
Admin: Fix warnings on image crop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Updates to certain user meta fields did not trigger an Update activity.
+* No more PHP warnings when a header image gets cropped.
+* Images with the correct aspect ratio no longer get sent through the crop step again.
 
 ## [5.4.1] - 2025-03-04
 

--- a/assets/js/activitypub-header-image.js
+++ b/assets/js/activitypub-header-image.js
@@ -128,14 +128,15 @@
 					title: $el.data( 'choose-text' ),
 					library: wp.media.query( mediaQuery ),
 					date: false,
-					suggestedWidth: $el.data( 'size' ),
-					suggestedHeight: $el.data( 'size' ),
+					suggestedWidth: $el.data( 'width' ),
+					suggestedHeight: $el.data( 'height' ),
 				} ),
 				new ImageCropperNoCustomizer( {
 					control: {
+						id: 'activitypub-header-image',
 						params: {
-							width: $el.data( 'size' ),
-							height: $el.data( 'size' ),
+							width: $el.data( 'width' ),
+							height: $el.data( 'height' ),
 						},
 					},
 					imgSelectOptions: calculateImageSelectOptions,
@@ -155,17 +156,26 @@
 		// When an image is selected, run a callback.
 		frame.on( 'select', function () {
 			// Grab the selected attachment.
-			var attachment = frame.state().get( 'selection' ).first();
+			var attachment = frame.state().get( 'selection' ).first(),
+				targetRatio = $el.data( 'width' ) / $el.data( 'height' ),
+				currentRatio = attachment.attributes.width / attachment.attributes.height,
+				alreadyCropped = false;
 
-			if (
-				attachment.attributes.height === $el.data( 'size' ) &&
-				$el.data( 'size' ) === attachment.attributes.width
-			) {
+			// Check if the image already has the correct aspect ratio (with a small tolerance)
+			if ( Math.abs(currentRatio - targetRatio) < 0.01 ) {
+				// Check if this is the same image that was already selected
+				if ( attachment.id !== parseInt( $hiddenDataField.val(), 10 ) ) {
+					// This is a new image with the correct aspect ratio.
+					$hiddenDataField.val( attachment.id );
+				}
+
+				alreadyCropped = true;
+			}
+
+			if ( alreadyCropped ) {
+				// Skip cropping for already cropped images
 				switchToUpdate( attachment.attributes );
 				frame.close();
-
-				// Set the value of the hidden input to the attachment id.
-				$hiddenDataField.val( attachment.id );
 			} else {
 				frame.setState( 'cropper' );
 			}

--- a/assets/js/activitypub-header-image.js
+++ b/assets/js/activitypub-header-image.js
@@ -161,9 +161,9 @@
 				currentRatio = attachment.attributes.width / attachment.attributes.height,
 				alreadyCropped = false;
 
-			// Check if the image already has the correct aspect ratio (with a small tolerance)
-			if ( Math.abs(currentRatio - targetRatio) < 0.01 ) {
-				// Check if this is the same image that was already selected
+			// Check if the image already has the correct aspect ratio (with a small tolerance).
+			if ( Math.abs( currentRatio - targetRatio ) < 0.01 ) {
+				// Check if this is the same image that was already selected.
 				if ( attachment.id !== parseInt( $hiddenDataField.val(), 10 ) ) {
 					// This is a new image with the correct aspect ratio.
 					$hiddenDataField.val( attachment.id );
@@ -173,7 +173,7 @@
 			}
 
 			if ( alreadyCropped ) {
-				// Skip cropping for already cropped images
+				// Skip cropping for already cropped images.
 				switchToUpdate( attachment.attributes );
 				frame.close();
 			} else {

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -128,6 +128,8 @@ class Blog_Settings_Fields {
 			data-choose-text="<?php esc_attr_e( 'Choose a Header Image', 'activitypub' ); ?>"
 			data-update-text="<?php esc_attr_e( 'Change Header Icon', 'activitypub' ); ?>"
 			data-update="<?php esc_attr_e( 'Set as Header Image', 'activitypub' ); ?>"
+			data-width="1500"
+			data-height="500"
 			data-state="<?php echo esc_attr( (int) get_option( 'activitypub_header_image', 0 ) ); ?>">
 			<?php if ( (int) get_option( 'activitypub_header_image', 0 ) ) : ?>
 				<?php esc_html_e( 'Change Header Image', 'activitypub' ); ?>

--- a/includes/wp-admin/class-user-settings-fields.php
+++ b/includes/wp-admin/class-user-settings-fields.php
@@ -151,6 +151,8 @@ class User_Settings_Fields {
 			data-choose-text="<?php \esc_attr_e( 'Choose a Header Image', 'activitypub' ); ?>"
 			data-update-text="<?php \esc_attr_e( 'Change Header Image', 'activitypub' ); ?>"
 			data-update="<?php \esc_attr_e( 'Set as Header Image', 'activitypub' ); ?>"
+			data-width="1500"
+			data-height="500"
 			<?php
 			if ( ! \current_user_can( 'edit_others_posts' ) ) :
 				\printf( 'data-user-id="%s"', \esc_attr( \get_current_user_id() ) );

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,8 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
+* Fixed: No more PHP warnings when a header image gets cropped.
+* Fixed: Images with the correct aspect ratio no longer get sent through the crop step again.
 
 = 5.4.1 =
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1405.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds height and width to header image buttons.
* Sets control id so it can be passed to the cropper.
* Skips crop step when selected image already has the right dimensions.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Users > Profile and select a new header image.
* Save the profile.
* Update the header image and select the same image again.
* Make sure it skips the crop step.
* Same steps for the blog user header image.
