### PR TITLE
Re-Add: Announce Updates and Deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Updates to certain user meta fields did not trigger an Update activity.
+* Properly re-added support for `Update` and `Delete` `Announce`ments.
 
 ## [5.4.1] - 2025-03-04
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -413,8 +413,8 @@ class Scheduler {
 
 		$activity_type = \get_post_meta( $outbox_activity_id, '_activitypub_activity_type', true );
 
-		// Only if the activity is a Create.
-		if ( ! in_array( $activity_type, array( 'Create' ), true ) ) {
+		// Only if the activity is a Create, Update or Delete.
+		if ( ! in_array( $activity_type, array( 'Create', 'Update', 'Delete' ), true ) ) {
 			return;
 		}
 

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -110,6 +110,11 @@ class Outbox {
 	 * @return void
 	 */
 	private static function invalidate_existing_items( $object_id, $activity_type, $current_id ) {
+		// Do not invalidate items for Announce activities.
+		if ( 'Announce' === $activity_type ) {
+			return;
+		}
+
 		$meta_query = array(
 			array(
 				'key'   => '_activitypub_object_id',

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
+* Fixed: Properly re-added support for `Update` and `Delete` `Announce`ments.
 
 = 5.4.1 =
 

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -63,6 +63,30 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test that publishing a post schedules a Create activity.
+	 *
+	 * @ticket https://github.com/Automattic/wordpress-activitypub/pull/1408
+	 * @covers ::schedule_post_activity
+	 */
+	public function test_activity_type_on_publish() {
+		$post_id       = self::factory()->post->create(
+			array(
+				'post_author' => self::$user_id,
+				'post_status' => 'draft',
+			)
+		);
+		$activitpub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
+
+		\wp_publish_post( $post_id );
+
+		$post = $this->get_latest_outbox_item( $activitpub_id );
+		$type = \get_post_meta( $post->ID, '_activitypub_activity_type', true );
+		$this->assertSame( 'Create', $type );
+
+		\wp_delete_post( $post_id, true );
+	}
+
+	/**
 	 * Test post activity scheduling during bulk edits.
 	 *
 	 * @covers ::schedule_post_activity


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Supersedes #1420

Follow up to #1408 to re-add `Announce` support for `Update` and `Delete` and unit test.

## Proposed changes:

* Adds unit test for the fix in #1408.
* Re-Add `Announce` support for `Update` and `Delete`.

## Other information:

* [X] Have you written new tests for your changes, if applicable?
