### PR TITLE
Fix: Fediverse Previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fixed transition handling of posts to ensure that `Create` and `Update` activities are properly processed.
+* Show "full content" preview even if post is in still in draft mode.
 
 ## [5.4.0] - 2025-03-03
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -483,7 +483,7 @@ class Post extends Base {
 		\add_filter( 'activitypub_reply_block', '__return_empty_string' );
 
 		// Remove Content from drafts.
-		if ( 'draft' === \get_post_status( $this->item ) ) {
+		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
 			return \__( '(This post is being modified)', 'activitypub' );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
+* Fixed: Show "full content" preview even if post is in still in draft mode.
 
 = 5.4.1 =
 


### PR DESCRIPTION
Allows to display preview when post is still a draft. The current version only supports it for the summary. This PR also adds support for the content.

Fixes #1424

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set "Activity-Object-Type" to automatic
* Create a new draft of an `Article`
* Preview the draft before publishing it
* The preview should show the full post

