### PR TITLE
Outbox: Don't schedule event when there are no followers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Outbox items only get sent to followers when there are any.
+
 ### Fixed
 
 * Updates to certain user meta fields did not trigger an Update activity.

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -395,6 +395,13 @@ class Dispatcher {
 			in_array( $actor->get_followers(), $audience, true )
 		);
 
+		if ( $send ) {
+			$followers = Followers::get_inboxes_for_activity( $activity->to_json(), $actor->get__id() );
+
+			// Only send if there are followers to send to.
+			$send = ! is_countable( $followers ) || 0 < count( $followers );
+		}
+
 		/**
 		 * Filters whether to send an Activity to followers.
 		 *

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ For reasons of data protection, it is not possible to see the followers of other
 
 = Unreleased =
 
+* Changed: Outbox items only get sent to followers when there are any.
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
 
 = 5.4.1 =


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check against the follower count for an outbox item.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a test site without followers, create an Outbox item (update a post).
* Run `wp cron event list` and make sure it doesn't contain an `activitypub_process_outbox` event.
* On a site with followers, create an Outbox item.
* * Run `wp cron event list` and make sure `activitypub_process_outbox` is scheduled.


