### PR TITLE
Replies Context: Account for single user mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Updates to certain user meta fields did not trigger an Update activity.
+* When viewing Reply Contexts, we'll now attribute the post to the blog user when the post author is disabled.
 
 ## [5.4.1] - 2025-03-04
 

--- a/includes/collection/class-replies.php
+++ b/includes/collection/class-replies.php
@@ -12,12 +12,14 @@ use WP_Comment;
 use WP_Error;
 
 use Activitypub\Comment;
+use Activitypub\Model\Blog;
 use Activitypub\Transformer\Post as PostTransformer;
 use Activitypub\Transformer\Comment as CommentTransformer;
 
 use function Activitypub\is_post_disabled;
 use function Activitypub\is_local_comment;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_user_disabled;
 
 /**
  * Class containing code for getting replies Collections and CollectionPages of posts and comments.
@@ -171,10 +173,16 @@ class Replies {
 		$post_uri = ( new PostTransformer( $post ) )->to_id();
 		\array_unshift( $ids, $post_uri );
 
+		if ( is_user_disabled( $post->post_author ) ) {
+			$author = new Blog();
+		} else {
+			$author = Actors::get_by_id( $post->post_author );
+		}
+
 		return array(
 			'type'         => 'OrderedCollection',
 			'url'          => \get_permalink( $post_id ),
-			'attributedTo' => Actors::get_by_id( $post->post_author )->get_id(),
+			'attributedTo' => $author->get_id(),
 			'totalItems'   => count( $ids ),
 			'items'        => $ids,
 		);

--- a/includes/collection/class-replies.php
+++ b/includes/collection/class-replies.php
@@ -19,7 +19,7 @@ use Activitypub\Transformer\Comment as CommentTransformer;
 use function Activitypub\is_post_disabled;
 use function Activitypub\is_local_comment;
 use function Activitypub\get_rest_url_by_path;
-use function Activitypub\is_user_disabled;
+use function Activitypub\is_user_type_disabled;
 
 /**
  * Class containing code for getting replies Collections and CollectionPages of posts and comments.
@@ -173,10 +173,13 @@ class Replies {
 		$post_uri = ( new PostTransformer( $post ) )->to_id();
 		\array_unshift( $ids, $post_uri );
 
-		if ( is_user_disabled( $post->post_author ) ) {
+		$author = Actors::get_by_id( $post->post_author );
+		if ( is_wp_error( $author ) ) {
+			if ( is_user_type_disabled( 'blog' ) ) {
+				return false;
+			}
+
 			$author = new Blog();
-		} else {
-			$author = Actors::get_by_id( $post->post_author );
 		}
 
 		return array(

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
+* Fixed: When viewing Reply Contexts, we'll now attribute the post to the blog user when the post author is disabled.
 
 = 5.4.1 =
 

--- a/tests/includes/collection/class-test-replies.php
+++ b/tests/includes/collection/class-test-replies.php
@@ -145,7 +145,14 @@ class Test_Replies extends \WP_UnitTestCase {
 	 * @covers ::get_context_collection
 	 */
 	public function test_get_context_collection_disabled_author() {
-		$context_post_id = self::factory()->post->create( array( 'post_author' => 1 ) );
+		$user_id         = self::factory()->user->create( array( 'role' => 'author' ) );
+		$context_post_id = self::factory()->post->create( array( 'post_author' => $user_id ) );
+		get_user_by( 'id', $user_id )->remove_cap( 'activitypub' );
+
+		// Author disabled, Blog user disabled.
+		$this->assertFalse( Replies::get_context_collection( $context_post_id ) );
+
+		// Enable Blog user.
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
 
 		$context = Replies::get_context_collection( $context_post_id );

--- a/tests/includes/collection/class-test-replies.php
+++ b/tests/includes/collection/class-test-replies.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests\Collection;
 
+use Activitypub\Collection\Actors;
 use Activitypub\Collection\Replies;
 
 /**
@@ -149,7 +150,7 @@ class Test_Replies extends \WP_UnitTestCase {
 
 		$context = Replies::get_context_collection( $context_post_id );
 
-		$this->assertSame( \get_author_posts_url( 1 ), $context['attributedTo'] );
+		$this->assertSame( \get_author_posts_url( Actors::BLOG_USER_ID ), $context['attributedTo'] );
 
 		\delete_option( 'activitypub_actor_mode' );
 	}

--- a/tests/includes/collection/class-test-replies.php
+++ b/tests/includes/collection/class-test-replies.php
@@ -137,4 +137,20 @@ class Test_Replies extends \WP_UnitTestCase {
 			wp_delete_comment( $comment_id, true );
 		}
 	}
+
+	/**
+	 * Test get_context_collection method with disabled author.
+	 *
+	 * @covers ::get_context_collection
+	 */
+	public function test_get_context_collection_disabled_author() {
+		$context_post_id = self::factory()->post->create( array( 'post_author' => 1 ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+
+		$context = Replies::get_context_collection( $context_post_id );
+
+		$this->assertSame( \get_author_posts_url( 1 ), $context['attributedTo'] );
+
+		\delete_option( 'activitypub_actor_mode' );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a fatal error when viewing Reply Context in single author mode.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Falls back to blog user when the post author is disabled.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

