### PR TITLE
Transformer: Make sure field exists before using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When viewing Reply Contexts, we'll now attribute the post to the blog user when the post author is disabled.
 * Properly re-added support for `Update` and `Delete` `Announce`ments.
 * Fix a fatal error in the Preview when a post contains no (hash)tags.
-* PHP warnings when trying to process empty tags.
+* PHP warnings when trying to process empty tags or image blocks without ID attributes.
 
 ## [5.4.1] - 2025-03-04
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -735,7 +735,7 @@ class Post extends Base {
 
 						$found = false;
 						foreach ( $media['image'] as $i => $image ) {
-							if ( $image['id'] === $block['attrs']['id'] ) {
+							if ( isset( $image['id'] ) && $image['id'] === $block['attrs']['id'] ) {
 								$media['image'][ $i ]['alt'] = $alt;
 								$found                       = true;
 								break;

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,7 @@ For reasons of data protection, it is not possible to see the followers of other
 * Fixed: Properly re-added support for `Update` and `Delete` `Announce`ments.
 * Fixed: Show "full content" preview even if post is in still in draft mode.
 * Fixed: Fix a fatal error in the Preview when a post contains no (hash)tags.
-* Fixed: PHP warnings when trying to process empty tags.
+* Fixed: PHP warnings when trying to process empty tags or image blocks without ID attributes.
 
 = 5.4.1 =
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I've not been able to reproduce this myself, unfortunately.

See p1741641194159339-slack-C04TJ8P900J (PHP Warning on Dotcom)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check for `id` before using it.

