### PR TITLE
Rest API: Use Collection and CollectionPage more accurately

### DIFF
--- a/.github/changelog/add-nav-trait
+++ b/.github/changelog/add-nav-trait
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+OrderedCollection and OrderedCollectionPage behave closer to spec now

--- a/.github/changelog/add-nav-trait
+++ b/.github/changelog/add-nav-trait
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-OrderedCollection and OrderedCollectionPage behave closer to spec now
+OrderedCollection and OrderedCollectionPage behave closer to spec now.

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -22,6 +22,8 @@ use function Activitypub\get_masked_wp_version;
  * @see https://www.w3.org/TR/activitypub/#inbox
  */
 class Actors_Inbox_Controller extends Actors_Controller {
+	use Collection_Links;
+
 	/**
 	 * Register routes.
 	 */
@@ -121,9 +123,6 @@ class Actors_Inbox_Controller extends Actors_Controller {
 		 */
 		\do_action( 'activitypub_rest_inbox_pre' );
 
-		$page     = $request->get_param( 'page' );
-		$per_page = $request->get_param( 'per_page' );
-
 		$response = array(
 			'@context'     => get_context(),
 			'id'           => get_rest_url_by_path( \sprintf( 'actors/%d/inbox', $user->get__id() ) ),
@@ -132,7 +131,6 @@ class Actors_Inbox_Controller extends Actors_Controller {
 			'partOf'       => get_rest_url_by_path( \sprintf( 'actors/%d/inbox', $user->get__id() ) ),
 			'totalItems'   => 0,
 			'orderedItems' => array(),
-			'first'        => get_rest_url_by_path( \sprintf( 'actors/%d/inbox', $user->get__id() ) ),
 		);
 
 		/**
@@ -142,24 +140,9 @@ class Actors_Inbox_Controller extends Actors_Controller {
 		 */
 		$response = \apply_filters( 'activitypub_rest_inbox_array', $response );
 
-		$max_pages = \ceil( $response['totalItems'] / $per_page );
-
-		if ( $page > $max_pages ) {
-			return new \WP_Error(
-				'rest_post_invalid_page_number',
-				'The page number requested is larger than the number of pages available.',
-				array( 'status' => 400 )
-			);
-		}
-
-		$response['last'] = \add_query_arg( 'page', \max( $max_pages, 1 ), $response['partOf'] );
-
-		if ( $max_pages > $page ) {
-			$response['next'] = \add_query_arg( 'page', $page + 1, $response['partOf'] );
-		}
-
-		if ( $page > 1 ) {
-			$response['prev'] = \add_query_arg( 'page', $page - 1, $response['partOf'] );
+		$response = $this->add_collection_links( $response, $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
 		/**

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -48,6 +48,7 @@ class Actors_Inbox_Controller extends Actors_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
+							'minimum'     => 1,
 							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -210,73 +210,18 @@ class Actors_Inbox_Controller extends Actors_Controller {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		$schema = array(
-			'$schema'    => 'https://json-schema.org/draft-04/schema#',
-			'title'      => 'inbox',
-			'type'       => 'object',
-			'properties' => array(
-				'@context'     => array(
-					'description' => 'The JSON-LD context for the collection.',
-					'type'        => array( 'string', 'array', 'object' ),
-					'required'    => true,
-				),
-				'id'           => array(
-					'description' => 'The unique identifier for the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'required'    => true,
-				),
-				'type'         => array(
-					'description' => 'The type of the collection.',
-					'type'        => 'string',
-					'enum'        => array( 'OrderedCollection', 'OrderedCollectionPage' ),
-					'required'    => true,
-				),
-				'totalItems'   => array(
-					'description' => 'The total number of items in the collection.',
-					'type'        => 'integer',
-					'minimum'     => 0,
-					'required'    => true,
-				),
-				'orderedItems' => array(
-					'description' => 'The items in the collection.',
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'object',
-					),
-					'required'    => true,
-				),
-				'first'        => array(
-					'description' => 'The first page of the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-				'last'         => array(
-					'description' => 'The last page of the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-				'next'         => array(
-					'description' => 'The next page of the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-				'prev'         => array(
-					'description' => 'The previous page of the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-				'partOf'       => array(
-					'description' => 'The collection this page is part of.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-				'generator'    => array(
-					'description' => 'The software used to generate the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-			),
+		$item_schema = array(
+			'type' => 'object',
+		);
+
+		$schema = $this->get_collection_schema( $item_schema );
+
+		// Add inbox-specific properties.
+		$schema['title']                   = 'inbox';
+		$schema['properties']['generator'] = array(
+			'description' => 'The software used to generate the collection.',
+			'type'        => 'string',
+			'format'      => 'uri',
 		);
 
 		$this->schema = $schema;

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -49,7 +49,7 @@ class Actors_Inbox_Controller extends Actors_Controller {
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
 							'minimum'     => 1,
-							// No default so we differentiate between Collection and CollectionPage requests.
+							// No default so we can differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -140,7 +140,7 @@ class Actors_Inbox_Controller extends Actors_Controller {
 		$response = \apply_filters( 'activitypub_rest_inbox_array', $response );
 
 		$response = $this->prepare_collection_response( $response, $request );
-		if ( is_wp_error( $response ) ) {
+		if ( \is_wp_error( $response ) ) {
 			return $response;
 		}
 

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -22,7 +22,7 @@ use function Activitypub\get_masked_wp_version;
  * @see https://www.w3.org/TR/activitypub/#inbox
  */
 class Actors_Inbox_Controller extends Actors_Controller {
-	use Collection_Links;
+	use Collection;
 
 	/**
 	 * Register routes.
@@ -138,7 +138,7 @@ class Actors_Inbox_Controller extends Actors_Controller {
 		 */
 		$response = \apply_filters( 'activitypub_rest_inbox_array', $response );
 
-		$response = $this->add_collection_links( $response, $request );
+		$response = $this->prepare_collection_response( $response, $request );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -48,8 +48,7 @@ class Actors_Inbox_Controller extends Actors_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
-							'default'     => 1,
-							'minimum'     => 1,
+							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',
@@ -127,8 +126,7 @@ class Actors_Inbox_Controller extends Actors_Controller {
 			'@context'     => get_context(),
 			'id'           => get_rest_url_by_path( \sprintf( 'actors/%d/inbox', $user->get__id() ) ),
 			'generator'    => 'https://wordpress.org/?v=' . get_masked_wp_version(),
-			'type'         => 'OrderedCollectionPage',
-			'partOf'       => get_rest_url_by_path( \sprintf( 'actors/%d/inbox', $user->get__id() ) ),
+			'type'         => 'OrderedCollection',
 			'totalItems'   => 0,
 			'orderedItems' => array(),
 		);

--- a/includes/rest/class-collections-controller.php
+++ b/includes/rest/class-collections-controller.php
@@ -102,7 +102,7 @@ class Collections_Controller extends Actors_Controller {
 				$response = new \WP_Error( 'rest_unknown_collection_type', 'Unknown collection type.', array( 'status' => 404 ) );
 		}
 
-		if ( is_wp_error( $response ) ) {
+		if ( \is_wp_error( $response ) ) {
 			return $response;
 		}
 

--- a/includes/rest/class-collections-controller.php
+++ b/includes/rest/class-collections-controller.php
@@ -59,6 +59,7 @@ class Collections_Controller extends Actors_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
+							'minimum'     => 1,
 							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(

--- a/includes/rest/class-collections-controller.php
+++ b/includes/rest/class-collections-controller.php
@@ -28,6 +28,8 @@ use function Activitypub\get_rest_url_by_path;
  * @see https://www.w3.org/TR/activitypub/#collections
  */
 class Collections_Controller extends Actors_Controller {
+	use Collection;
+
 	/**
 	 * Register routes.
 	 */
@@ -53,6 +55,19 @@ class Collections_Controller extends Actors_Controller {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => '__return_true',
+					'args'                => array(
+						'page'     => array(
+							'description' => 'Current page of the collection.',
+							'type'        => 'integer',
+							// No default so we differentiate between Collection and CollectionPage requests.
+						),
+						'per_page' => array(
+							'description' => 'Maximum number of items to be returned in result set.',
+							'type'        => 'integer',
+							'default'     => 20,
+							'minimum'     => 1,
+						),
+					),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
@@ -85,6 +100,10 @@ class Collections_Controller extends Actors_Controller {
 
 			default:
 				$response = new \WP_Error( 'rest_unknown_collection_type', 'Unknown collection type.', array( 'status' => 404 ) );
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
 		$response = \rest_ensure_response( $response );
@@ -131,7 +150,7 @@ class Collections_Controller extends Actors_Controller {
 			);
 		}
 
-		return $response;
+		return $this->prepare_collection_response( $response, $request );
 	}
 
 	/**
@@ -190,7 +209,7 @@ class Collections_Controller extends Actors_Controller {
 			$response['orderedItems'][] = $transformer->to_object()->to_array( false );
 		}
 
-		return $response;
+		return $this->prepare_collection_response( $response, $request );
 	}
 
 	/**
@@ -203,64 +222,47 @@ class Collections_Controller extends Actors_Controller {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'featured',
-			'type'       => 'object',
-			'properties' => array(
-				'@context'   => array(
-					'type'     => 'array',
-					'items'    => array(
-						'type' => array( 'string', 'object' ),
-					),
-					'required' => true,
+		$schema = $this->get_collection_schema();
+
+		// Add collections-specific properties.
+		$schema['title']                   = 'featured';
+		$schema['properties']['generator'] = array(
+			'description' => 'The software used to generate the collection.',
+			'type'        => 'string',
+			'format'      => 'uri',
+		);
+		$schema['properties']['oneOf']     = array(
+			'orderedItems' => array(
+				'type'  => 'array',
+				'items' => array(
+					'type' => 'object',
 				),
-				'id'         => array(
-					'type'     => 'string',
-					'format'   => 'uri',
-					'required' => true,
-				),
-				'type'       => array(
-					'type'     => 'string',
-					'enum'     => array( 'Collection', 'OrderedCollection' ),
-					'required' => true,
-				),
-				'totalItems' => array(
-					'type'     => 'integer',
-					'required' => true,
-				),
-				'oneOf'      => array(
-					'orderedItems' => array(
-						'type'  => 'array',
-						'items' => array(
-							'type' => 'object',
+			),
+			'items'        => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'type' => array(
+							'type'     => 'string',
+							'enum'     => array( 'Hashtag' ),
+							'required' => true,
 						),
-					),
-					'items'        => array(
-						'type'  => 'array',
-						'items' => array(
-							'type'       => 'object',
-							'properties' => array(
-								'type' => array(
-									'type'     => 'string',
-									'enum'     => array( 'Hashtag' ),
-									'required' => true,
-								),
-								'href' => array(
-									'type'     => 'string',
-									'format'   => 'uri',
-									'required' => true,
-								),
-								'name' => array(
-									'type'     => 'string',
-									'required' => true,
-								),
-							),
+						'href' => array(
+							'type'     => 'string',
+							'format'   => 'uri',
+							'required' => true,
+						),
+						'name' => array(
+							'type'     => 'string',
+							'required' => true,
 						),
 					),
 				),
 			),
 		);
+
+		unset( $schema['properties']['orderedItems'] );
 
 		$this->schema = $schema;
 

--- a/includes/rest/class-collections-controller.php
+++ b/includes/rest/class-collections-controller.php
@@ -60,7 +60,7 @@ class Collections_Controller extends Actors_Controller {
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
 							'minimum'     => 1,
-							// No default so we differentiate between Collection and CollectionPage requests.
+							// No default so we can differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -8,10 +8,9 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Collection\Actors;
-use Activitypub\Collection\Followers as Follower_Collection;
-
-use function Activitypub\get_rest_url_by_path;
+use Activitypub\Collection\Followers;
 use function Activitypub\get_masked_wp_version;
+use function Activitypub\get_rest_url_by_path;
 
 /**
  * Followers_Controller class.
@@ -98,7 +97,7 @@ class Followers_Controller extends Actors_Controller {
 		$page     = $request->get_param( 'page' ) ?? 1;
 		$context  = $request->get_param( 'context' );
 
-		$data = Follower_Collection::get_followers_with_count( $user_id, $per_page, $page, array( 'order' => \ucwords( $order ) ) );
+		$data = Followers::get_followers_with_count( $user_id, $per_page, $page, array( 'order' => \ucwords( $order ) ) );
 
 		// Special case: WP_Query doesn't return the total number of items when it runs out of items.
 		if ( 0 === $data['total'] && $page > 1 ) {
@@ -148,144 +147,85 @@ class Followers_Controller extends Actors_Controller {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		$this->schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'followers',
-			'type'       => 'object',
-			'properties' => array(
-				'@context'     => array(
-					'description' => 'The JSON-LD context for the response.',
-					'type'        => array( 'array', 'object' ),
-					'readonly'    => true,
+		// Define the schema for items in the followers collection.
+		$item_schema = array(
+			'oneOf' => array(
+				array(
+					'type'   => 'string',
+					'format' => 'uri',
 				),
-				'id'           => array(
-					'description' => 'The unique identifier for the followers collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'generator'    => array(
-					'description' => 'The generator of the followers collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'actor'        => array(
-					'description' => 'The actor who owns the followers collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'type'         => array(
-					'description' => 'The type of the followers collection.',
-					'type'        => 'string',
-					'enum'        => array( 'OrderedCollectionPage' ),
-					'readonly'    => true,
-				),
-				'totalItems'   => array(
-					'description' => 'The total number of items in the followers collection.',
-					'type'        => 'integer',
-					'readonly'    => true,
-				),
-				'partOf'       => array(
-					'description' => 'The collection this page is part of.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'orderedItems' => array(
-					'description' => 'The items in the followers collection.',
-					'type'        => 'array',
-					'items'       => array(
-						'oneOf' => array(
-							array(
-								'type'   => 'string',
-								'format' => 'uri',
-							),
-							array(
-								'type'       => 'object',
-								'properties' => array(
-									'id'                => array(
-										'type'   => 'string',
-										'format' => 'uri',
-									),
-									'type'              => array(
-										'type' => 'string',
-									),
-									'name'              => array(
-										'type' => 'string',
-									),
-									'icon'              => array(
-										'type'       => 'object',
-										'properties' => array(
-											'type'      => array(
-												'type' => 'string',
-											),
-											'mediaType' => array(
-												'type' => 'string',
-											),
-											'url'       => array(
-												'type'   => 'string',
-												'format' => 'uri',
-											),
-										),
-									),
-									'published'         => array(
-										'type'   => 'string',
-										'format' => 'date-time',
-									),
-									'summary'           => array(
-										'type' => 'string',
-									),
-									'updated'           => array(
-										'type'   => 'string',
-										'format' => 'date-time',
-									),
-									'url'               => array(
-										'type'   => 'string',
-										'format' => 'uri',
-									),
-									'streams'           => array(
-										'type' => 'array',
-									),
-									'preferredUsername' => array(
-										'type' => 'string',
-									),
-									'manuallyApprovesFollowers' => array(
-										'type' => 'boolean',
-									),
+				array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'                => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
+						'type'              => array(
+							'type' => 'string',
+						),
+						'name'              => array(
+							'type' => 'string',
+						),
+						'icon'              => array(
+							'type'       => 'object',
+							'properties' => array(
+								'type'      => array(
+									'type' => 'string',
+								),
+								'mediaType' => array(
+									'type' => 'string',
+								),
+								'url'       => array(
+									'type'   => 'string',
+									'format' => 'uri',
 								),
 							),
 						),
+						'published'         => array(
+							'type'   => 'string',
+							'format' => 'date-time',
+						),
+						'summary'           => array(
+							'type' => 'string',
+						),
+						'updated'           => array(
+							'type'   => 'string',
+							'format' => 'date-time',
+						),
+						'url'               => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
+						'streams'           => array(
+							'type' => 'array',
+						),
+						'preferredUsername' => array(
+							'type' => 'string',
+						),
 					),
-					'readonly'    => true,
-				),
-				'next'         => array(
-					'description' => 'The next page in the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'prev'         => array(
-					'description' => 'The previous page in the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'first'        => array(
-					'description' => 'The first page in the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'last'         => array(
-					'description' => 'The last page in the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
 				),
 			),
 		);
+
+		$schema = $this->get_collection_schema( $item_schema );
+
+		// Add followers-specific properties.
+		$schema['title']                   = 'followers';
+		$schema['properties']['actor']     = array(
+			'description' => 'The actor who owns the followers collection.',
+			'type'        => 'string',
+			'format'      => 'uri',
+			'readonly'    => true,
+		);
+		$schema['properties']['generator'] = array(
+			'description' => 'The generator of the followers collection.',
+			'type'        => 'string',
+			'format'      => 'uri',
+			'readonly'    => true,
+		);
+
+		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
 	}

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -21,7 +21,7 @@ use function Activitypub\get_masked_wp_version;
  * @see https://www.w3.org/TR/activitypub/#followers
  */
 class Followers_Controller extends Actors_Controller {
-	use Collection_Links;
+	use Collection;
 
 	/**
 	 * Register routes.
@@ -127,7 +127,7 @@ class Followers_Controller extends Actors_Controller {
 			),
 		);
 
-		$response = $this->add_collection_links( $response, $request );
+		$response = $this->prepare_collection_response( $response, $request );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -9,6 +9,8 @@ namespace Activitypub\Rest;
 
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+
+use function Activitypub\get_context;
 use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_rest_url_by_path;
 
@@ -109,7 +111,7 @@ class Followers_Controller extends Actors_Controller {
 		}
 
 		$response = array(
-			'@context'     => \Activitypub\get_context(),
+			'@context'     => get_context(),
 			'id'           => get_rest_url_by_path( \sprintf( 'actors/%d/followers', $user->get__id() ) ),
 			'generator'    => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'actor'        => $user->get_id(),

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -48,6 +48,7 @@ class Followers_Controller extends Actors_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
+							'minimum'     => 1,
 							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
@@ -100,15 +101,6 @@ class Followers_Controller extends Actors_Controller {
 		$context  = $request->get_param( 'context' );
 
 		$data = Followers::get_followers_with_count( $user_id, $per_page, $page, array( 'order' => \ucwords( $order ) ) );
-
-		// Special case: WP_Query doesn't return the total number of items when it runs out of items.
-		if ( 0 === $data['total'] && $page > 1 ) {
-			return new \WP_Error(
-				'rest_post_invalid_page_number',
-				'The page number requested is larger than the number of pages available.',
-				array( 'status' => 400 )
-			);
-		}
 
 		$response = array(
 			'@context'     => get_context(),

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -47,8 +47,7 @@ class Followers_Controller extends Actors_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
-							'default'     => 1,
-							'minimum'     => 1,
+							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',
@@ -96,7 +95,7 @@ class Followers_Controller extends Actors_Controller {
 
 		$order    = $request->get_param( 'order' );
 		$per_page = $request->get_param( 'per_page' );
-		$page     = $request->get_param( 'page' );
+		$page     = $request->get_param( 'page' ) ?? 1;
 		$context  = $request->get_param( 'context' );
 
 		$data = Follower_Collection::get_followers_with_count( $user_id, $per_page, $page, array( 'order' => \ucwords( $order ) ) );
@@ -115,9 +114,8 @@ class Followers_Controller extends Actors_Controller {
 			'id'           => get_rest_url_by_path( \sprintf( 'actors/%d/followers', $user->get__id() ) ),
 			'generator'    => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'actor'        => $user->get_id(),
-			'type'         => 'OrderedCollectionPage',
+			'type'         => 'OrderedCollection',
 			'totalItems'   => $data['total'],
-			'partOf'       => get_rest_url_by_path( \sprintf( 'actors/%d/followers', $user->get__id() ) ),
 			'orderedItems' => array_map(
 				function ( $item ) use ( $context ) {
 					if ( 'full' === $context ) {

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -49,7 +49,7 @@ class Followers_Controller extends Actors_Controller {
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
 							'minimum'     => 1,
-							// No default so we differentiate between Collection and CollectionPage requests.
+							// No default so we can differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -21,6 +21,7 @@ use function Activitypub\get_masked_wp_version;
  * @see https://www.w3.org/TR/activitypub/#followers
  */
 class Followers_Controller extends Actors_Controller {
+	use Collection_Links;
 
 	/**
 	 * Register routes.
@@ -100,6 +101,15 @@ class Followers_Controller extends Actors_Controller {
 
 		$data = Follower_Collection::get_followers_with_count( $user_id, $per_page, $page, array( 'order' => \ucwords( $order ) ) );
 
+		// Special case: WP_Query doesn't return the total number of items when it runs out of items.
+		if ( 0 === $data['total'] && $page > 1 ) {
+			return new \WP_Error(
+				'rest_post_invalid_page_number',
+				'The page number requested is larger than the number of pages available.',
+				array( 'status' => 400 )
+			);
+		}
+
 		$response = array(
 			'@context'     => \Activitypub\get_context(),
 			'id'           => get_rest_url_by_path( \sprintf( 'actors/%d/followers', $user->get__id() ) ),
@@ -119,25 +129,9 @@ class Followers_Controller extends Actors_Controller {
 			),
 		);
 
-		$max_pages = \ceil( $response['totalItems'] / $per_page );
-
-		if ( $page > $max_pages ) {
-			return new \WP_Error(
-				'rest_post_invalid_page_number',
-				'The page number requested is larger than the number of pages available.',
-				array( 'status' => 400 )
-			);
-		}
-
-		$response['first'] = \add_query_arg( 'page', 1, $response['partOf'] );
-		$response['last']  = \add_query_arg( 'page', \max( $max_pages, 1 ), $response['partOf'] );
-
-		if ( $max_pages > $page ) {
-			$response['next'] = \add_query_arg( 'page', $page + 1, $response['partOf'] );
-		}
-
-		if ( $page > 1 ) {
-			$response['prev'] = \add_query_arg( 'page', $page - 1, $response['partOf'] );
+		$response = $this->add_collection_links( $response, $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
 		$response = \rest_ensure_response( $response );

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -20,7 +20,7 @@ use function Activitypub\get_masked_wp_version;
  * @see https://www.w3.org/TR/activitypub/#following
  */
 class Following_Controller extends Actors_Controller {
-	use Collection_Links;
+	use Collection;
 
 	/**
 	 * Initialize the class, registering WordPress hooks.
@@ -107,7 +107,7 @@ class Following_Controller extends Actors_Controller {
 		$response['totalItems']   = \is_countable( $items ) ? \count( $items ) : 0;
 		$response['orderedItems'] = $items;
 
-		$response = $this->add_collection_links( $response, $request );
+		$response = $this->prepare_collection_response( $response, $request );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -8,7 +8,6 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Collection\Actors;
-
 use function Activitypub\is_single_user;
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_masked_wp_version;
@@ -21,6 +20,8 @@ use function Activitypub\get_masked_wp_version;
  * @see https://www.w3.org/TR/activitypub/#following
  */
 class Following_Controller extends Actors_Controller {
+	use Collection_Links;
+
 	/**
 	 * Initialize the class, registering WordPress hooks.
 	 */
@@ -49,11 +50,18 @@ class Following_Controller extends Actors_Controller {
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( 'Activitypub\Rest\Server', 'verify_signature' ),
 					'args'                => array(
-						'page' => array(
+						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
 							'default'     => 1,
 							'minimum'     => 1,
+						),
+						'per_page' => array(
+							'description' => 'Maximum number of items to be returned in result set.',
+							'type'        => 'integer',
+							'default'     => 10,
+							'minimum'     => 1,
+							'maximum'     => 100,
 						),
 					),
 				),
@@ -100,7 +108,11 @@ class Following_Controller extends Actors_Controller {
 
 		$response['totalItems']   = \is_countable( $items ) ? \count( $items ) : 0;
 		$response['orderedItems'] = $items;
-		$response['first']        = $response['partOf'];
+
+		$response = $this->add_collection_links( $response, $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
 		$response = \rest_ensure_response( $response );
 		$response->header( 'Content-Type', 'application/activity+json; charset=' . \get_option( 'blog_charset' ) );

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -55,6 +55,7 @@ class Following_Controller extends Actors_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
+							'minimum'     => 1,
 							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -151,68 +151,29 @@ class Following_Controller extends Actors_Controller {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		$this->schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'following',
-			'type'       => 'object',
-			'properties' => array(
-				'@context'     => array(
-					'description' => 'The JSON-LD context for the response.',
-					'type'        => array( 'array', 'object' ),
-					'readonly'    => true,
-				),
-				'id'           => array(
-					'description' => 'The unique identifier for the following collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'generator'    => array(
-					'description' => 'The generator of the following collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'actor'        => array(
-					'description' => 'The actor who owns the following collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'type'         => array(
-					'description' => 'The type of the following collection.',
-					'type'        => 'string',
-					'enum'        => array( 'OrderedCollectionPage' ),
-					'readonly'    => true,
-				),
-				'totalItems'   => array(
-					'description' => 'The total number of items in the following collection.',
-					'type'        => 'integer',
-					'readonly'    => true,
-				),
-				'partOf'       => array(
-					'description' => 'The collection this page is part of.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'orderedItems' => array(
-					'description' => 'The items in the following collection.',
-					'type'        => 'array',
-					'items'       => array(
-						'type'   => 'string',
-						'format' => 'uri',
-					),
-					'readonly'    => true,
-				),
-				'first'        => array(
-					'description' => 'The first page in the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-			),
+		$item_schema = array(
+			'type'   => 'string',
+			'format' => 'uri',
 		);
+
+		$schema = $this->get_collection_schema( $item_schema );
+
+		// Add following-specific properties.
+		$schema['title']                   = 'following';
+		$schema['properties']['actor']     = array(
+			'description' => 'The actor who owns the following collection.',
+			'type'        => 'string',
+			'format'      => 'uri',
+			'readonly'    => true,
+		);
+		$schema['properties']['generator'] = array(
+			'description' => 'The generator of the following collection.',
+			'type'        => 'string',
+			'format'      => 'uri',
+			'readonly'    => true,
+		);
+
+		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
 	}

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -8,6 +8,8 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Collection\Actors;
+
+use function Activitypub\get_context;
 use function Activitypub\is_single_user;
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_masked_wp_version;
@@ -89,7 +91,7 @@ class Following_Controller extends Actors_Controller {
 		\do_action( 'activitypub_rest_following_pre' );
 
 		$response = array(
-			'@context'  => \Activitypub\get_context(),
+			'@context'  => get_context(),
 			'id'        => get_rest_url_by_path( \sprintf( 'actors/%d/following', $user->get__id() ) ),
 			'generator' => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'actor'     => $user->get_id(),

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -53,8 +53,7 @@ class Following_Controller extends Actors_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
-							'default'     => 1,
-							'minimum'     => 1,
+							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',
@@ -94,8 +93,7 @@ class Following_Controller extends Actors_Controller {
 			'id'        => get_rest_url_by_path( \sprintf( 'actors/%d/following', $user->get__id() ) ),
 			'generator' => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'actor'     => $user->get_id(),
-			'type'      => 'OrderedCollectionPage',
-			'partOf'    => get_rest_url_by_path( \sprintf( 'actors/%d/following', $user->get__id() ) ),
+			'type'      => 'OrderedCollection',
 		);
 
 		/**

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -56,7 +56,7 @@ class Following_Controller extends Actors_Controller {
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
 							'minimum'     => 1,
-							// No default so we differentiate between Collection and CollectionPage requests.
+							// No default so we can differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',

--- a/includes/rest/class-moderators-controller.php
+++ b/includes/rest/class-moderators-controller.php
@@ -7,8 +7,9 @@
 
 namespace Activitypub\Rest;
 
-use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
+
+use function Activitypub\get_context;
 use function Activitypub\get_rest_url_by_path;
 
 /**
@@ -69,7 +70,7 @@ class Moderators_Controller extends \WP_REST_Controller {
 		$actors = apply_filters( 'activitypub_rest_moderators', $actors );
 
 		$response = array(
-			'@context'     => Actor::JSON_LD_CONTEXT,
+			'@context'     => get_context(),
 			'id'           => get_rest_url_by_path( 'collections/moderators' ),
 			'type'         => 'OrderedCollection',
 			'orderedItems' => $actors,

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -70,7 +70,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 						),
 					),
 				),
-				'schema' => array( $this, 'get_collection_schema' ),
+				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
 	}
@@ -223,74 +223,29 @@ class Outbox_Controller extends \WP_REST_Controller {
 	 *
 	 * @return array Collection schema data.
 	 */
-	public function get_collection_schema() {
+	public function get_item_schema() {
 		if ( $this->schema ) {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'outbox',
-			'type'       => 'object',
-			'properties' => array(
-				'@context'     => array(
-					'description' => 'The JSON-LD context for the collection.',
-					'type'        => array( 'string', 'array', 'object' ),
-					'required'    => true,
-				),
-				'id'           => array(
-					'description' => 'The unique identifier for the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'required'    => true,
-				),
-				'type'         => array(
-					'description' => 'The type of the collection.',
-					'type'        => 'string',
-					'enum'        => array( 'OrderedCollection', 'OrderedCollectionPage' ),
-					'required'    => true,
-				),
-				'actor'        => array(
-					'description' => 'The actor who owns this outbox.',
-					'type'        => 'string',
-					'format'      => 'uri',
-					'required'    => true,
-				),
-				'totalItems'   => array(
-					'description' => 'The total number of items in the collection.',
-					'type'        => 'integer',
-					'minimum'     => 0,
-					'required'    => true,
-				),
-				'orderedItems' => array(
-					'description' => 'The items in the collection.',
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'object',
-					),
-					'required'    => true,
-				),
-				'first'        => array(
-					'description' => 'The first page of the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-				'last'         => array(
-					'description' => 'The last page of the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-				'next'         => array(
-					'description' => 'The next page of the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-				'prev'         => array(
-					'description' => 'The previous page of the collection.',
-					'type'        => 'string',
-					'format'      => 'uri',
-				),
-			),
+		$item_schema = array(
+			'type' => 'object',
+		);
+
+		$schema = $this->get_collection_schema( $item_schema );
+
+		// Add outbox-specific properties.
+		$schema['title']                   = 'outbox';
+		$schema['properties']['actor']     = array(
+			'description' => 'The actor who owns this outbox.',
+			'type'        => 'string',
+			'format'      => 'uri',
+			'required'    => true,
+		);
+		$schema['properties']['generator'] = array(
+			'description' => 'The software used to generate the collection.',
+			'type'        => 'string',
+			'format'      => 'uri',
 		);
 
 		$this->schema = $schema;

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -61,7 +61,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
 							'minimum'     => 1,
-							// No default so we differentiate between Collection and CollectionPage requests.
+							// No default so we can differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -59,13 +59,12 @@ class Outbox_Controller extends \WP_REST_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
-							'default'     => 1,
-							'minimum'     => 1,
+							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(
 							'description' => 'Maximum number of items to be returned in result set.',
 							'type'        => 'integer',
-							'default'     => 10,
+							'default'     => 20,
 							'minimum'     => 1,
 							'maximum'     => 100,
 						),
@@ -99,7 +98,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 		$user_id = $request->get_param( 'user_id' );
-		$page    = $request->get_param( 'page' );
+		$page    = $request->get_param( 'page' ) ?? 1;
 		$user    = Actors::get_by_various( $user_id );
 
 		/**
@@ -170,8 +169,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 			'id'           => get_rest_url_by_path( sprintf( 'actors/%d/outbox', $user_id ) ),
 			'generator'    => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'actor'        => $user->get_id(),
-			'type'         => 'OrderedCollectionPage',
-			'partOf'       => get_rest_url_by_path( sprintf( 'actors/%d/outbox', $user_id ) ),
+			'type'         => 'OrderedCollection',
 			'totalItems'   => $outbox_query->found_posts,
 			'orderedItems' => array(),
 		);

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -20,6 +20,8 @@ use function ActivityPub\get_rest_url_by_path;
  * @see https://www.w3.org/TR/activitypub/#outbox
  */
 class Outbox_Controller extends \WP_REST_Controller {
+	use Collection_Links;
+
 	/**
 	 * The namespace of this controller's route.
 	 *
@@ -179,23 +181,16 @@ class Outbox_Controller extends \WP_REST_Controller {
 			$response['orderedItems'][] = $this->prepare_item_for_response( $outbox_item, $request );
 		}
 
-		$max_pages         = \ceil( $response['totalItems'] / $request->get_param( 'per_page' ) );
-		$response['first'] = \add_query_arg( 'page', 1, $response['partOf'] );
-		$response['last']  = \add_query_arg( 'page', \max( $max_pages, 1 ), $response['partOf'] );
-
-		if ( $max_pages > $page ) {
-			$response['next'] = \add_query_arg( 'page', $page + 1, $response['partOf'] );
-		}
-
-		if ( $page > 1 ) {
-			$response['prev'] = \add_query_arg( 'page', $page - 1, $response['partOf'] );
+		$response = $this->add_collection_links( $response, $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
 		/**
 		 * Filter the ActivityPub outbox array.
 		 *
-		 * @param array $response The ActivityPub outbox array.
-		 * @param \WP_REST_Request $request The request object.
+		 * @param array            $response The ActivityPub outbox array.
+		 * @param \WP_REST_Request $request  The request object.
 		 */
 		$response = \apply_filters( 'activitypub_rest_outbox_array', $response, $request );
 

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Rest;
 
+use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
 use function Activitypub\get_masked_wp_version;
@@ -165,7 +166,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 		$query_result = $outbox_query->query( $args );
 
 		$response = array(
-			'@context'     => array( 'https://www.w3.org/ns/activitystreams' ),
+			'@context'     => Base_Object::JSON_LD_CONTEXT,
 			'id'           => get_rest_url_by_path( sprintf( 'actors/%d/outbox', $user_id ) ),
 			'generator'    => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'actor'        => $user->get_id(),

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -60,6 +60,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 						'page'     => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
+							'minimum'     => 1,
 							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 						'per_page' => array(

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -20,7 +20,7 @@ use function ActivityPub\get_rest_url_by_path;
  * @see https://www.w3.org/TR/activitypub/#outbox
  */
 class Outbox_Controller extends \WP_REST_Controller {
-	use Collection_Links;
+	use Collection;
 
 	/**
 	 * The namespace of this controller's route.
@@ -179,7 +179,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 			$response['orderedItems'][] = $this->prepare_item_for_response( $outbox_item, $request );
 		}
 
-		$response = $this->add_collection_links( $response, $request );
+		$response = $this->prepare_collection_response( $response, $request );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/includes/rest/class-replies-controller.php
+++ b/includes/rest/class-replies-controller.php
@@ -67,8 +67,7 @@ class Replies_Controller extends \WP_REST_Controller {
 						'page' => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
-							'default'     => 1,
-							'minimum'     => 1,
+							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 					),
 				),
@@ -143,7 +142,7 @@ class Replies_Controller extends \WP_REST_Controller {
 		$page = $request->get_param( 'page' );
 
 		// If the request parameter page is present get the CollectionPage otherwise the Replies collection.
-		if ( $page <= 1 ) {
+		if ( null === $page ) {
 			$response = Replies::get_collection( $wp_object );
 		} else {
 			$response = Replies::get_collection_page( $wp_object, $page );

--- a/includes/rest/class-replies-controller.php
+++ b/includes/rest/class-replies-controller.php
@@ -68,7 +68,7 @@ class Replies_Controller extends \WP_REST_Controller {
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
 							'minimum'     => 1,
-							// No default so we differentiate between Collection and CollectionPage requests.
+							// No default so we can differentiate between Collection and CollectionPage requests.
 						),
 					),
 				),

--- a/includes/rest/class-replies-controller.php
+++ b/includes/rest/class-replies-controller.php
@@ -67,6 +67,7 @@ class Replies_Controller extends \WP_REST_Controller {
 						'page' => array(
 							'description' => 'Current page of the collection.',
 							'type'        => 'integer',
+							'minimum'     => 1,
 							// No default so we differentiate between Collection and CollectionPage requests.
 						),
 					),

--- a/includes/rest/trait-collection-links.php
+++ b/includes/rest/trait-collection-links.php
@@ -28,6 +28,11 @@ trait Collection_Links {
 		$per_page  = $request->get_param( 'per_page' );
 		$max_pages = \ceil( $response['totalItems'] / $per_page );
 
+		// No need to add links if there's only one page.
+		if ( 1 >= $max_pages ) {
+			return $response;
+		}
+
 		if ( $max_pages && $page > $max_pages ) {
 			return new \WP_Error(
 				'rest_post_invalid_page_number',
@@ -36,15 +41,28 @@ trait Collection_Links {
 			);
 		}
 
-		$response['first'] = \add_query_arg( 'page', 1, $response['partOf'] );
-		$response['last']  = \add_query_arg( 'page', \max( $max_pages, 1 ), $response['partOf'] );
+		$response['first'] = \add_query_arg( 'page', 1, $response['id'] );
+		$response['last']  = \add_query_arg( 'page', $max_pages, $response['id'] );
 
-		if ( $max_pages > $page ) {
-			$response['next'] = \add_query_arg( 'page', $page + 1, $response['partOf'] );
+		// If this is a Collection request, return early.
+		if ( null === $page ) {
+			// No items in Collections, only links to CollectionPages.
+			unset( $response['items'], $response['orderedItems'] );
+
+			return $response;
 		}
 
-		if ( $response['totalItems'] > 0 && $page > 1 ) {
-			$response['prev'] = \add_query_arg( 'page', $page - 1, $response['partOf'] );
+		// Still here, so this is a Page request. Append the type.
+		$response['type']  .= 'Page';
+		$response['partOf'] = $response['id'];
+		$response['id']    .= '?page=' . $page;
+
+		if ( $max_pages > $page ) {
+			$response['next'] = \add_query_arg( 'page', $page + 1, $response['id'] );
+		}
+
+		if ( $page > 1 ) {
+			$response['prev'] = \add_query_arg( 'page', $page - 1, $response['id'] );
 		}
 
 		return $response;

--- a/includes/rest/trait-collection-links.php
+++ b/includes/rest/trait-collection-links.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Collection Links Trait file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Rest;
+
+/**
+ * Collection Links Trait.
+ *
+ * Provides methods for adding navigation links to collection responses.
+ */
+trait Collection_Links {
+	/**
+	 * Adds navigation links to a collection response.
+	 *
+	 * Adds first, last, next, and previous page links to a collection response
+	 * based on the current page and total items.
+	 *
+	 * @param array            $response The collection response array.
+	 * @param \WP_REST_Request $request  The request object.
+	 * @return array|\WP_Error The response array with navigation links or WP_Error on invalid page.
+	 */
+	protected function add_collection_links( $response, $request ) {
+		$page      = $request->get_param( 'page' );
+		$per_page  = $request->get_param( 'per_page' );
+		$max_pages = \ceil( $response['totalItems'] / $per_page );
+
+		if ( $max_pages && $page > $max_pages ) {
+			return new \WP_Error(
+				'rest_post_invalid_page_number',
+				'The page number requested is larger than the number of pages available.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$response['first'] = \add_query_arg( 'page', 1, $response['partOf'] );
+		$response['last']  = \add_query_arg( 'page', \max( $max_pages, 1 ), $response['partOf'] );
+
+		if ( $max_pages > $page ) {
+			$response['next'] = \add_query_arg( 'page', $page + 1, $response['partOf'] );
+		}
+
+		if ( $response['totalItems'] > 0 && $page > 1 ) {
+			$response['prev'] = \add_query_arg( 'page', $page - 1, $response['partOf'] );
+		}
+
+		return $response;
+	}
+}

--- a/includes/rest/trait-collection.php
+++ b/includes/rest/trait-collection.php
@@ -30,17 +30,17 @@ trait Collection {
 		$per_page  = $request->get_param( 'per_page' );
 		$max_pages = \ceil( $response['totalItems'] / $per_page );
 
-		// No need to add links if there's only one page.
-		if ( 1 >= $max_pages ) {
-			return $response;
-		}
-
-		if ( $max_pages && $page > $max_pages ) {
+		if ( $page > $max_pages ) {
 			return new \WP_Error(
 				'rest_post_invalid_page_number',
 				'The page number requested is larger than the number of pages available.',
 				array( 'status' => 400 )
 			);
+		}
+
+		// No need to add links if there's only one page.
+		if ( 1 >= $max_pages && null === $page ) {
+			return $response;
 		}
 
 		$response['first'] = \add_query_arg( 'page', 1, $response['id'] );

--- a/includes/rest/trait-collection.php
+++ b/includes/rest/trait-collection.php
@@ -25,7 +25,7 @@ trait Collection {
 	 * @param \WP_REST_Request $request  The request object.
 	 * @return array|\WP_Error The response array with navigation links or WP_Error on invalid page.
 	 */
-	protected function prepare_collection_response( $response, $request ) {
+	public function prepare_collection_response( $response, $request ) {
 		$page      = $request->get_param( 'page' );
 		$per_page  = $request->get_param( 'per_page' );
 		$max_pages = \ceil( $response['totalItems'] / $per_page );
@@ -68,5 +68,80 @@ trait Collection {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Get the schema for an ActivityPub OrderedCollection.
+	 *
+	 * Returns a schema definition for ActivityPub OrderedCollection and OrderedCollectionPage
+	 * that controllers can use to compose their full schema by passing in their
+	 * item schema.
+	 *
+	 * @param array $item_schema The schema for the items in the collection.
+	 * @return array The ordered collection schema.
+	 */
+	public function get_collection_schema( $item_schema ) {
+		$collection_schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'collection',
+			'type'       => 'object',
+			'properties' => array(
+				'@context'     => array(
+					'description' => 'The JSON-LD context of the OrderedCollection.',
+					'type'        => array( 'string', 'array', 'object' ),
+				),
+				'id'           => array(
+					'description' => 'The unique identifier for the OrderedCollection.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+				'type'         => array(
+					'description' => 'The type of the object. Either OrderedCollection or OrderedCollectionPage.',
+					'type'        => 'string',
+					'enum'        => array( 'OrderedCollection', 'OrderedCollectionPage' ),
+				),
+				'totalItems'   => array(
+					'description' => 'The total number of items in the collection.',
+					'type'        => 'integer',
+					'minimum'     => 0,
+				),
+				'orderedItems' => array(
+					'description' => 'The ordered items in the collection.',
+					'type'        => 'array',
+				),
+				'first'        => array(
+					'description' => 'Link to the first page of the collection.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+				'last'         => array(
+					'description' => 'Link to the last page of the collection.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+				'next'         => array(
+					'description' => 'Link to the next page of the collection.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+				'prev'         => array(
+					'description' => 'Link to the previous page of the collection.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+				'partOf'       => array(
+					'description' => 'The OrderedCollection to which this OrderedCollectionPage belongs.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+			),
+		);
+
+		// Add the orderedItems property based on the provided item schema.
+		if ( ! empty( $item_schema ) ) {
+			$collection_schema['properties']['orderedItems']['items'] = $item_schema;
+		}
+
+		return $collection_schema;
 	}
 }

--- a/includes/rest/trait-collection.php
+++ b/includes/rest/trait-collection.php
@@ -71,16 +71,15 @@ trait Collection {
 	}
 
 	/**
-	 * Get the schema for an ActivityPub OrderedCollection.
+	 * Get the schema for an ActivityPub Collection.
 	 *
-	 * Returns a schema definition for ActivityPub OrderedCollection and OrderedCollectionPage
-	 * that controllers can use to compose their full schema by passing in their
-	 * item schema.
+	 * Returns a schema definition for ActivityPub (Ordered)Collection and (Ordered)CollectionPage
+	 * that controllers can use to compose their full schema by passing in their item schema.
 	 *
-	 * @param array $item_schema The schema for the items in the collection.
-	 * @return array The ordered collection schema.
+	 * @param array $item_schema Optional. The schema for the items in the collection. Default empty array.
+	 * @return array The collection schema.
 	 */
-	public function get_collection_schema( $item_schema ) {
+	public function get_collection_schema( $item_schema = array() ) {
 		$collection_schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'collection',
@@ -98,7 +97,7 @@ trait Collection {
 				'type'         => array(
 					'description' => 'The type of the object. Either OrderedCollection or OrderedCollectionPage.',
 					'type'        => 'string',
-					'enum'        => array( 'OrderedCollection', 'OrderedCollectionPage' ),
+					'enum'        => array( 'Collection', 'CollectionPage', 'OrderedCollection', 'OrderedCollectionPage' ),
 				),
 				'totalItems'   => array(
 					'description' => 'The total number of items in the collection.',

--- a/includes/rest/trait-collection.php
+++ b/includes/rest/trait-collection.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Collection Links Trait file.
+ * Collection Trait file.
  *
  * @package Activitypub
  */
@@ -8,22 +8,24 @@
 namespace Activitypub\Rest;
 
 /**
- * Collection Links Trait.
+ * Collection Trait.
  *
- * Provides methods for adding navigation links to collection responses.
+ * Provides methods for handling ActivityPub Collections, including pagination
+ * and type transitions between Collection and CollectionPage.
  */
-trait Collection_Links {
+trait Collection {
 	/**
-	 * Adds navigation links to a collection response.
+	 * Prepares a collection response by adding navigation links and handling pagination.
 	 *
 	 * Adds first, last, next, and previous page links to a collection response
-	 * based on the current page and total items.
+	 * based on the current page and total items. Also handles the transformation
+	 * between Collection and CollectionPage types.
 	 *
 	 * @param array            $response The collection response array.
 	 * @param \WP_REST_Request $request  The request object.
 	 * @return array|\WP_Error The response array with navigation links or WP_Error on invalid page.
 	 */
-	protected function add_collection_links( $response, $request ) {
+	protected function prepare_collection_response( $response, $request ) {
 		$page      = $request->get_param( 'page' );
 		$per_page  = $request->get_param( 'per_page' );
 		$max_pages = \ceil( $response['totalItems'] / $per_page );

--- a/tests/includes/rest/class-test-actors-controller.php
+++ b/tests/includes/rest/class-test-actors-controller.php
@@ -12,6 +12,7 @@ use Activitypub\Rest\Actors_Controller;
 /**
  * Tests for Actors REST API endpoint.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Actors_Controller
  */
 class Test_Actors_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {

--- a/tests/includes/rest/class-test-application-controller.php
+++ b/tests/includes/rest/class-test-application-controller.php
@@ -10,6 +10,7 @@ namespace Activitypub\Tests\Rest;
 /**
  * Tests for Application REST API endpoint.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Application_Controller
  */
 class Test_Application_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {

--- a/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/includes/rest/class-test-followers-controller.php
@@ -12,6 +12,7 @@ use Activitypub\Collection\Followers;
 /**
  * Tests for Followers REST API endpoint.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Followers_Controller
  */
 class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {
@@ -87,6 +88,7 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
 
 		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/followers' );
+		$request->set_param( 'page', 1 );
 		$request->set_param( 'context', 'simple' );
 		$response = rest_get_server()->dispatch( $request );
 
@@ -104,8 +106,6 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		$this->assertArrayHasKey( 'generator', $data );
 		$this->assertArrayHasKey( 'actor', $data );
 		$this->assertArrayHasKey( 'totalItems', $data );
-		$this->assertArrayHasKey( 'partOf', $data );
-		$this->assertArrayHasKey( 'orderedItems', $data );
 
 		// Test property values.
 		$this->assertEquals( 'OrderedCollectionPage', $data['type'] );
@@ -123,6 +123,7 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
 
 		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/followers' );
+		$request->set_param( 'page', 1 );
 		$request->set_param( 'context', 'full' );
 		$response = rest_get_server()->dispatch( $request );
 

--- a/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/includes/rest/class-test-followers-controller.php
@@ -71,7 +71,6 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		$this->assertEquals( 'uri', $schema['properties']['generator']['format'] );
 		$this->assertEquals( 'string', $schema['properties']['actor']['type'] );
 		$this->assertEquals( 'uri', $schema['properties']['actor']['format'] );
-		$this->assertEquals( array( 'OrderedCollection', 'OrderedCollectionPage' ), $schema['properties']['type']['enum'] );
 		$this->assertEquals( 'integer', $schema['properties']['totalItems']['type'] );
 		$this->assertEquals( 'string', $schema['properties']['partOf']['type'] );
 		$this->assertEquals( 'uri', $schema['properties']['partOf']['format'] );

--- a/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/includes/rest/class-test-followers-controller.php
@@ -71,7 +71,7 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		$this->assertEquals( 'uri', $schema['properties']['generator']['format'] );
 		$this->assertEquals( 'string', $schema['properties']['actor']['type'] );
 		$this->assertEquals( 'uri', $schema['properties']['actor']['format'] );
-		$this->assertEquals( array( 'OrderedCollectionPage' ), $schema['properties']['type']['enum'] );
+		$this->assertEquals( array( 'OrderedCollection', 'OrderedCollectionPage' ), $schema['properties']['type']['enum'] );
 		$this->assertEquals( 'integer', $schema['properties']['totalItems']['type'] );
 		$this->assertEquals( 'string', $schema['properties']['partOf']['type'] );
 		$this->assertEquals( 'uri', $schema['properties']['partOf']['format'] );

--- a/tests/includes/rest/class-test-following-controller.php
+++ b/tests/includes/rest/class-test-following-controller.php
@@ -66,10 +66,10 @@ class Test_Following_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		$schema = $response['schema'];
 
 		// Test specific property types.
-		$this->assertEquals( array( 'array', 'object' ), $schema['properties']['@context']['type'] );
+		$this->assertEquals( array( 'string', 'array', 'object' ), $schema['properties']['@context']['type'] );
 		$this->assertEquals( 'string', $schema['properties']['id']['type'] );
 		$this->assertEquals( 'uri', $schema['properties']['id']['format'] );
-		$this->assertEquals( array( 'OrderedCollectionPage' ), $schema['properties']['type']['enum'] );
+		$this->assertEquals( array( 'OrderedCollection', 'OrderedCollectionPage' ), $schema['properties']['type']['enum'] );
 		$this->assertEquals( 'array', $schema['properties']['orderedItems']['type'] );
 		$this->assertEquals( 'string', $schema['properties']['orderedItems']['items']['type'] );
 		$this->assertEquals( 'string', $schema['properties']['generator']['type'] );

--- a/tests/includes/rest/class-test-following-controller.php
+++ b/tests/includes/rest/class-test-following-controller.php
@@ -69,7 +69,6 @@ class Test_Following_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		$this->assertEquals( array( 'string', 'array', 'object' ), $schema['properties']['@context']['type'] );
 		$this->assertEquals( 'string', $schema['properties']['id']['type'] );
 		$this->assertEquals( 'uri', $schema['properties']['id']['format'] );
-		$this->assertEquals( array( 'OrderedCollection', 'OrderedCollectionPage' ), $schema['properties']['type']['enum'] );
 		$this->assertEquals( 'array', $schema['properties']['orderedItems']['type'] );
 		$this->assertEquals( 'string', $schema['properties']['orderedItems']['items']['type'] );
 		$this->assertEquals( 'string', $schema['properties']['generator']['type'] );

--- a/tests/includes/rest/class-test-following-controller.php
+++ b/tests/includes/rest/class-test-following-controller.php
@@ -10,6 +10,7 @@ namespace Activitypub\Tests\Rest;
 /**
  * Tests for Following REST API endpoint.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Following_Controller
  */
 class Test_Following_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {
@@ -100,13 +101,10 @@ class Test_Following_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		$this->assertArrayHasKey( 'actor', $data );
 		$this->assertArrayHasKey( 'totalItems', $data );
 		$this->assertArrayHasKey( 'orderedItems', $data );
-		$this->assertArrayHasKey( 'partOf', $data );
-		$this->assertArrayHasKey( 'first', $data );
 
 		// Test property values.
-		$this->assertEquals( 'OrderedCollectionPage', $data['type'] );
+		$this->assertEquals( 'OrderedCollection', $data['type'] );
 		$this->assertStringContainsString( 'wordpress.org', $data['generator'] );
-		$this->assertIsArray( $data['orderedItems'] );
 
 		\update_option( 'activitypub_actor_mode', $actor_mode );
 	}

--- a/tests/includes/rest/class-test-following-controller.php
+++ b/tests/includes/rest/class-test-following-controller.php
@@ -106,7 +106,6 @@ class Test_Following_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		// Test property values.
 		$this->assertEquals( 'OrderedCollectionPage', $data['type'] );
 		$this->assertStringContainsString( 'wordpress.org', $data['generator'] );
-		$this->assertEquals( $data['partOf'], $data['first'] );
 		$this->assertIsArray( $data['orderedItems'] );
 
 		\update_option( 'activitypub_actor_mode', $actor_mode );

--- a/tests/includes/rest/class-test-interaction-controller.php
+++ b/tests/includes/rest/class-test-interaction-controller.php
@@ -10,6 +10,7 @@ namespace Activitypub\Tests\Rest;
 /**
  * Tests for Interaction REST API endpoint.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Interaction_Controller
  */
 class Test_Interaction_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {

--- a/tests/includes/rest/class-test-moderators-controller.php
+++ b/tests/includes/rest/class-test-moderators-controller.php
@@ -7,7 +7,7 @@
 
 namespace Activitypub\Tests\Rest;
 
-use Activitypub\Activity\Actor;
+use function Activitypub\get_context;
 
 /**
  * Test Moderators REST Endpoint.
@@ -64,7 +64,7 @@ class Test_Moderators_Controller extends \Activitypub\Tests\Test_REST_Controller
 
 		// Test response structure.
 		$this->assertArrayHasKey( '@context', $data );
-		$this->assertEquals( Actor::JSON_LD_CONTEXT, $data['@context'] );
+		$this->assertEquals( get_context(), $data['@context'] );
 		$this->assertArrayHasKey( 'id', $data );
 		$this->assertArrayHasKey( 'type', $data );
 		$this->assertEquals( 'OrderedCollection', $data['type'] );

--- a/tests/includes/rest/class-test-nodeinfo-controller.php
+++ b/tests/includes/rest/class-test-nodeinfo-controller.php
@@ -10,6 +10,7 @@ namespace Activitypub\Tests\Rest;
 /**
  * Tests for NodeInfo REST API endpoint.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Nodeinfo_Controller
  */
 class Test_Nodeinfo_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {

--- a/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/includes/rest/class-test-outbox-controller.php
@@ -120,7 +120,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 		$request  = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$schema   = ( new Outbox_Controller() )->get_collection_schema();
+		$schema   = ( new Outbox_Controller() )->get_item_schema();
 
 		$valid = \rest_validate_value_from_schema( $data, $schema );
 		$this->assertNotWPError( $valid, 'Response failed schema validation: ' . ( \is_wp_error( $valid ) ? $valid->get_error_message() : '' ) );

--- a/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/includes/rest/class-test-outbox-controller.php
@@ -14,6 +14,7 @@ use Activitypub\Rest\Outbox_Controller;
 /**
  * Tests for Outbox REST API endpoint.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Outbox_Controller
  */
 class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {
@@ -149,9 +150,8 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 		$response = \rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertStringContainsString( 'page=1', $data['last'] );
-		$this->assertArrayNotHasKey( 'prev', $data );
-		$this->assertArrayNotHasKey( 'next', $data );
+		$this->assertArrayNotHasKey( 'first', $data );
+		$this->assertArrayNotHasKey( 'last', $data );
 	}
 
 	/**
@@ -169,7 +169,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 		$this->assertArrayHasKey( 'type', $data );
 		$this->assertArrayHasKey( 'totalItems', $data );
 		$this->assertArrayHasKey( 'orderedItems', $data );
-		$this->assertEquals( 'OrderedCollectionPage', $data['type'] );
+		$this->assertEquals( 'OrderedCollection', $data['type'] );
 		$this->assertIsArray( $data['orderedItems'] );
 
 		$headers = $response->get_headers();
@@ -273,6 +273,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 	 */
 	public function test_get_items_minimum_per_page() {
 		$request = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
+		$request->set_param( 'page', 1 );
 		$request->set_param( 'per_page', 1 );
 		$response = \rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();

--- a/tests/includes/rest/class-test-post.php
+++ b/tests/includes/rest/class-test-post.php
@@ -16,6 +16,7 @@ use WP_REST_Response;
 /**
  * Test Post REST Endpoints.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Post
  */
 class Test_Post extends WP_UnitTestCase {

--- a/tests/includes/rest/class-test-signature-verification.php
+++ b/tests/includes/rest/class-test-signature-verification.php
@@ -12,6 +12,7 @@ use Activitypub\Signature;
 /**
  * Test class for Signature Verification.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Signature
  */
 class Test_Signature_Verification extends \WP_UnitTestCase {

--- a/tests/includes/rest/class-test-trait-collection-links.php
+++ b/tests/includes/rest/class-test-trait-collection-links.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Test Collection Links Trait.
+ *
+ * @package ActivityPub
+ */
+
+namespace Activitypub\Tests\Rest;
+
+use Activitypub\Rest\Collection_Links;
+
+/**
+ * Test Collection Links Trait.
+ *
+ * @group rest
+ * @coversDefaultClass \Activitypub\Rest\Collection_Links
+ */
+class Test_Trait_Collection_Links extends \WP_UnitTestCase {
+
+	/**
+	 * Test class instance.
+	 *
+	 * @var object
+	 */
+	protected $instance;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Create a test class that uses the trait.
+		$this->instance = new class() {
+			use Collection_Links;
+		};
+	}
+
+	/**
+	 * Test adding collection links when there's only one page.
+	 *
+	 * @covers ::add_collection_links
+	 */
+	public function add_collection_links_single_page() {
+		$request = new \WP_REST_Request();
+		$request->set_param( 'per_page', 10 );
+
+		$response = array(
+			'type'       => 'Collection',
+			'id'         => 'https://example.org/collection',
+			'totalItems' => 5,
+			'items'      => array( 'item1', 'item2', 'item3', 'item4', 'item5' ),
+		);
+
+		$result = $this->instance->add_collection_links( $response, $request );
+
+		$this->assertEquals( $response, $result );
+		$this->assertArrayNotHasKey( 'first', $result );
+		$this->assertArrayNotHasKey( 'last', $result );
+		$this->assertArrayNotHasKey( 'next', $result );
+		$this->assertArrayNotHasKey( 'prev', $result );
+	}
+
+	/**
+	 * Test adding collection links for a Collection (not a page).
+	 *
+	 * @covers ::add_collection_links
+	 */
+	public function add_collection_links_collection() {
+		$request = new \WP_REST_Request();
+		$request->set_param( 'per_page', 10 );
+
+		$response = array(
+			'type'       => 'Collection',
+			'id'         => 'https://example.org/collection',
+			'totalItems' => 25,
+			'items'      => array( 'item1', 'item2', 'item3' ),
+		);
+
+		$result = $this->instance->add_collection_links( $response, $request );
+
+		$this->assertEquals( 'Collection', $result['type'] );
+		$this->assertEquals( 'https://example.org/collection?page=1', $result['first'] );
+		$this->assertEquals( 'https://example.org/collection?page=3', $result['last'] );
+		$this->assertArrayNotHasKey( 'items', $result );
+		$this->assertArrayNotHasKey( 'orderedItems', $result );
+	}
+
+	/**
+	 * Test adding collection links for a CollectionPage.
+	 *
+	 * @covers ::add_collection_links
+	 */
+	public function add_collection_links_collection_page() {
+		$request = new \WP_REST_Request();
+		$request->set_param( 'page', 2 );
+		$request->set_param( 'per_page', 10 );
+
+		$response = array(
+			'type'       => 'Collection',
+			'id'         => 'https://example.org/collection',
+			'totalItems' => 25,
+			'items'      => array( 'item11', 'item12', 'item13' ),
+		);
+
+		$result = $this->instance->add_collection_links( $response, $request );
+
+		$this->assertEquals( 'CollectionPage', $result['type'] );
+		$this->assertEquals( 'https://example.org/collection', $result['partOf'] );
+		$this->assertEquals( 'https://example.org/collection?page=2', $result['id'] );
+		$this->assertEquals( 'https://example.org/collection?page=1', $result['first'] );
+		$this->assertEquals( 'https://example.org/collection?page=3', $result['last'] );
+		$this->assertEquals( 'https://example.org/collection?page=3', $result['next'] );
+		$this->assertEquals( 'https://example.org/collection?page=1', $result['prev'] );
+	}
+
+	/**
+	 * Test adding collection links for the first page.
+	 *
+	 * @covers ::add_collection_links
+	 */
+	public function add_collection_links_first_page() {
+		$request = new \WP_REST_Request();
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 10 );
+
+		$response = array(
+			'type'       => 'OrderedCollection',
+			'id'         => 'https://example.org/collection',
+			'totalItems' => 25,
+			'items'      => array( 'item1', 'item2', 'item3' ),
+		);
+
+		$result = $this->instance->add_collection_links( $response, $request );
+
+		$this->assertEquals( 'OrderedCollectionPage', $result['type'] );
+		$this->assertEquals( 'https://example.org/collection?page=1', $result['id'] );
+		$this->assertEquals( 'https://example.org/collection?page=2', $result['next'] );
+		$this->assertArrayNotHasKey( 'prev', $result );
+	}
+
+	/**
+	 * Test adding collection links for the last page.
+	 *
+	 * @covers ::add_collection_links
+	 */
+	public function add_collection_links_last_page() {
+		$request = new \WP_REST_Request();
+		$request->set_param( 'page', 3 );
+		$request->set_param( 'per_page', 10 );
+
+		$response = array(
+			'type'       => 'Collection',
+			'id'         => 'https://example.org/collection',
+			'totalItems' => 25,
+			'items'      => array( 'item21', 'item22', 'item23', 'item24', 'item25' ),
+		);
+
+		$result = $this->instance->add_collection_links( $response, $request );
+
+		$this->assertEquals( 'CollectionPage', $result['type'] );
+		$this->assertEquals( 'https://example.org/collection?page=3', $result['id'] );
+		$this->assertEquals( 'https://example.org/collection?page=2', $result['prev'] );
+		$this->assertArrayNotHasKey( 'next', $result );
+	}
+
+	/**
+	 * Test invalid page number.
+	 *
+	 * @covers ::add_collection_links
+	 */
+	public function add_collection_links_invalid_page() {
+		$request = new \WP_REST_Request();
+		$request->set_param( 'page', 5 );
+		$request->set_param( 'per_page', 10 );
+
+		$response = array(
+			'type'       => 'Collection',
+			'id'         => 'https://example.org/collection',
+			'totalItems' => 25,
+			'items'      => array(),
+		);
+
+		$result = $this->instance->add_collection_links( $response, $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'rest_post_invalid_page_number', $result->get_error_code() );
+		$this->assertEquals( 400, $result->get_error_data()['status'] );
+	}
+}

--- a/tests/includes/rest/class-test-trait-collection.php
+++ b/tests/includes/rest/class-test-trait-collection.php
@@ -41,7 +41,7 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 	 *
 	 * @covers ::prepare_collection_response
 	 */
-	public function prepare_collection_response_single_page() {
+	public function test_prepare_collection_response_single_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'per_page', 10 );
 
@@ -66,7 +66,7 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 	 *
 	 * @covers ::prepare_collection_response
 	 */
-	public function prepare_collection_response_collection() {
+	public function test_prepare_collection_response_collection() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'per_page', 10 );
 
@@ -91,7 +91,7 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 	 *
 	 * @covers ::prepare_collection_response
 	 */
-	public function prepare_collection_response_collection_page() {
+	public function test_prepare_collection_response_collection_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'page', 2 );
 		$request->set_param( 'per_page', 10 );
@@ -119,7 +119,7 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 	 *
 	 * @covers ::prepare_collection_response
 	 */
-	public function prepare_collection_response_first_page() {
+	public function test_prepare_collection_response_first_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'page', 1 );
 		$request->set_param( 'per_page', 10 );
@@ -144,7 +144,7 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 	 *
 	 * @covers ::prepare_collection_response
 	 */
-	public function prepare_collection_response_last_page() {
+	public function test_prepare_collection_response_last_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'page', 3 );
 		$request->set_param( 'per_page', 10 );
@@ -169,7 +169,7 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 	 *
 	 * @covers ::prepare_collection_response
 	 */
-	public function prepare_collection_response_invalid_page() {
+	public function test_prepare_collection_response_invalid_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'page', 5 );
 		$request->set_param( 'per_page', 10 );

--- a/tests/includes/rest/class-test-trait-collection.php
+++ b/tests/includes/rest/class-test-trait-collection.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * Test Collection Links Trait.
+ * Test Collection Trait.
  *
  * @package ActivityPub
  */
 
 namespace Activitypub\Tests\Rest;
 
-use Activitypub\Rest\Collection_Links;
+use Activitypub\Rest\Collection;
 
 /**
- * Test Collection Links Trait.
+ * Test Collection Trait.
  *
  * @group rest
- * @coversDefaultClass \Activitypub\Rest\Collection_Links
+ * @coversDefaultClass Collection
  */
-class Test_Trait_Collection_Links extends \WP_UnitTestCase {
+class Test_Trait_Collection extends \WP_UnitTestCase {
 
 	/**
 	 * Test class instance.
@@ -27,21 +27,21 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 	/**
 	 * Set up.
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 
 		// Create a test class that uses the trait.
 		$this->instance = new class() {
-			use Collection_Links;
+			use Collection;
 		};
 	}
 
 	/**
 	 * Test adding collection links when there's only one page.
 	 *
-	 * @covers ::add_collection_links
+	 * @covers ::prepare_collection_response
 	 */
-	public function add_collection_links_single_page() {
+	public function prepare_collection_response_single_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'per_page', 10 );
 
@@ -52,7 +52,7 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 			'items'      => array( 'item1', 'item2', 'item3', 'item4', 'item5' ),
 		);
 
-		$result = $this->instance->add_collection_links( $response, $request );
+		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( $response, $result );
 		$this->assertArrayNotHasKey( 'first', $result );
@@ -64,9 +64,9 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 	/**
 	 * Test adding collection links for a Collection (not a page).
 	 *
-	 * @covers ::add_collection_links
+	 * @covers ::prepare_collection_response
 	 */
-	public function add_collection_links_collection() {
+	public function prepare_collection_response_collection() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'per_page', 10 );
 
@@ -77,7 +77,7 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 			'items'      => array( 'item1', 'item2', 'item3' ),
 		);
 
-		$result = $this->instance->add_collection_links( $response, $request );
+		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'Collection', $result['type'] );
 		$this->assertEquals( 'https://example.org/collection?page=1', $result['first'] );
@@ -89,9 +89,9 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 	/**
 	 * Test adding collection links for a CollectionPage.
 	 *
-	 * @covers ::add_collection_links
+	 * @covers ::prepare_collection_response
 	 */
-	public function add_collection_links_collection_page() {
+	public function prepare_collection_response_collection_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'page', 2 );
 		$request->set_param( 'per_page', 10 );
@@ -103,7 +103,7 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 			'items'      => array( 'item11', 'item12', 'item13' ),
 		);
 
-		$result = $this->instance->add_collection_links( $response, $request );
+		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'CollectionPage', $result['type'] );
 		$this->assertEquals( 'https://example.org/collection', $result['partOf'] );
@@ -117,9 +117,9 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 	/**
 	 * Test adding collection links for the first page.
 	 *
-	 * @covers ::add_collection_links
+	 * @covers ::prepare_collection_response
 	 */
-	public function add_collection_links_first_page() {
+	public function prepare_collection_response_first_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'page', 1 );
 		$request->set_param( 'per_page', 10 );
@@ -131,7 +131,7 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 			'items'      => array( 'item1', 'item2', 'item3' ),
 		);
 
-		$result = $this->instance->add_collection_links( $response, $request );
+		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'OrderedCollectionPage', $result['type'] );
 		$this->assertEquals( 'https://example.org/collection?page=1', $result['id'] );
@@ -142,9 +142,9 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 	/**
 	 * Test adding collection links for the last page.
 	 *
-	 * @covers ::add_collection_links
+	 * @covers ::prepare_collection_response
 	 */
-	public function add_collection_links_last_page() {
+	public function prepare_collection_response_last_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'page', 3 );
 		$request->set_param( 'per_page', 10 );
@@ -156,7 +156,7 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 			'items'      => array( 'item21', 'item22', 'item23', 'item24', 'item25' ),
 		);
 
-		$result = $this->instance->add_collection_links( $response, $request );
+		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'CollectionPage', $result['type'] );
 		$this->assertEquals( 'https://example.org/collection?page=3', $result['id'] );
@@ -167,9 +167,9 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 	/**
 	 * Test invalid page number.
 	 *
-	 * @covers ::add_collection_links
+	 * @covers ::prepare_collection_response
 	 */
-	public function add_collection_links_invalid_page() {
+	public function prepare_collection_response_invalid_page() {
 		$request = new \WP_REST_Request();
 		$request->set_param( 'page', 5 );
 		$request->set_param( 'per_page', 10 );
@@ -181,7 +181,7 @@ class Test_Trait_Collection_Links extends \WP_UnitTestCase {
 			'items'      => array(),
 		);
 
-		$result = $this->instance->add_collection_links( $response, $request );
+		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertEquals( 'rest_post_invalid_page_number', $result->get_error_code() );

--- a/tests/includes/rest/class-test-trait-collection.php
+++ b/tests/includes/rest/class-test-trait-collection.php
@@ -27,8 +27,8 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 	/**
 	 * Set up.
 	 */
-	public function setUp(): void {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Create a test class that uses the trait.
 		$this->instance = new class() {

--- a/tests/includes/rest/class-test-trait-collection.php
+++ b/tests/includes/rest/class-test-trait-collection.php
@@ -186,5 +186,14 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertEquals( 'rest_post_invalid_page_number', $result->get_error_code() );
 		$this->assertEquals( 400, $result->get_error_data()['status'] );
+
+		// No items.
+		$request->set_param( 'page', 1 );
+		$response['totalItems'] = 0;
+
+		$result = $this->instance->prepare_collection_response( $response, $request );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'rest_post_invalid_page_number', $result->get_error_code() );
+		$this->assertEquals( 400, $result->get_error_data()['status'] );
 	}
 }

--- a/tests/includes/rest/class-test-webfinger-controller.php
+++ b/tests/includes/rest/class-test-webfinger-controller.php
@@ -10,6 +10,7 @@ namespace Activitypub\Tests\Rest;
 /**
  * Tests for WebFinger REST API endpoint.
  *
+ * @group rest
  * @coversDefaultClass \Activitypub\Rest\Webfinger_Controller
  */
 class Test_Webfinger_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

What started as a first pass at standardizing collection links across API endpoints ended up as a second pass on how we structure `Collection`s and `CollectionPage`s. In this form it's much closer to [how the spec describes them](https://www.w3.org/TR/activitystreams-core/#collection).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `Collection` trait for reusability across API endpoints.
* Updates `page` parameters to no longer have a default, so we can differentiate between `Collection` and `CollectionPage` requests.
* `Collection` responses include items when the amount of total items is below the `per_page` parameter (if it doesn't need to be paged).
* `Collection` responses don't include items when there are so many items that they need to be paged, only links to `CollectionPage`s.
* `Collection` responses don't include `partOf`, `next`, and `prev` properties anymore, as they are exclusive to `CollectionPage` objects.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

### Before
* No differentiation between `OrderedCollection` and `OrderedCollectionPage`.
* `page` parameter was ambiguous for first page.
* `id` didn't account for `page` parameter.
* `id` and `partOf` were always the same and inaccurate.

```json
{
	"@context": [
		"https://www.w3.org/ns/activitystreams"
	],
	"id": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox",
	"generator": "https://wordpress.org/?v=6.7.2",
	"actor": "http://localhost:8888/?author=0",
	"type": "OrderedCollectionPage",
	"partOf": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox",
	"totalItems": 37,
	"orderedItems": [],
	"first": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=1",
	"last": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=4",
	"next": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=2"
}
```
### After

#### Outbox `Collection`
```json
{
	"@context": [
		"https://www.w3.org/ns/activitystreams"
	],
	"id": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox",
	"generator": "https://wordpress.org/?v=6.7.2",
	"actor": "http://localhost:8888/?author=0",
	"type": "OrderedCollection",
	"totalItems": 37,
	"first": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=1",
	"last": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=2"
}
```

#### Outbox `CollectionPage`

```json
{
	"@context": [
		"https://www.w3.org/ns/activitystreams"
	],
	"id": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=1",
	"generator": "https://wordpress.org/?v=6.7.2",
	"actor": "http://localhost:8888/?author=0",
	"type": "OrderedCollectionPage",
	"totalItems": 37,
	"orderedItems": [ ... ],
	"first": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=1",
	"last": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=2",
	"partOf": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox",
	"next": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/outbox?page=2"
}
```

#### Followers `Collection` with fewer items than `per_page`

```json
{
	"@context": [
		"https://www.w3.org/ns/activitystreams"
	],
	"id": "http://localhost:8888/wp-json/activitypub/1.0/actors/0/followers",
	"generator": "https://wordpress.org/?v=6.7",
	"actor": "http://localhost:8888/?author=0",
	"type": "OrderedCollection",
	"totalItems": 1,
	"orderedItems": [
		"https://mastodon.social/users/obenland"
	]
}
```

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the patch
* Go through API responses and make sure they return a format [as described in the spec](https://www.w3.org/TR/activitystreams-core/#collection).

