### PR TITLE
Added Constants to Site-Health debug informations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Documentation for migrating from a Mastodon instance to WordPress.
+* Added Constants to the Site-Health debug informations.
 
 ### Changed
 

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -112,10 +112,6 @@ class Sanitize {
 			return esc_attr( $value );
 		}
 
-		if ( is_array( $value ) ) {
-			return print_r( $value, true );
-		}
-
 		return $value;
 	}
 }

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -95,4 +95,27 @@ class Sanitize {
 
 		return $sanitized;
 	}
+
+	/**
+	 * Get the sanitized value of a constant.
+	 *
+	 * @param mixed $value The constant value.
+	 *
+	 * @return string The sanitized value.
+	 */
+	public static function constant_value( $value ) {
+		if ( is_bool( $value ) ) {
+			return $value ? 'true' : 'false';
+		}
+
+		if ( is_string( $value ) ) {
+			return esc_attr( $value );
+		}
+
+		if ( is_array( $value ) ) {
+			return print_r( $value, true );
+		}
+
+		return $value;
+	}
 }

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -355,12 +355,12 @@ class Health_Check {
 		$info['activitypub'] = array(
 			'label'  => __( 'ActivityPub', 'activitypub' ),
 			'fields' => array(
-				'webfinger'      => array(
+				'webfinger'  => array(
 					'label'   => __( 'WebFinger Resource', 'activitypub' ),
 					'value'   => Webfinger::get_user_resource( wp_get_current_user()->ID ),
 					'private' => false,
 				),
-				'author_url'     => array(
+				'author_url' => array(
 					'label'   => __( 'Author URL', 'activitypub' ),
 					'value'   => get_author_posts_url( wp_get_current_user()->ID ),
 					'private' => false,
@@ -374,21 +374,17 @@ class Health_Check {
 			return $info;
 		}
 
-		$output = array();
-
 		foreach ( $consts['user'] as $key => $value ) {
 			if ( ! str_starts_with( $key, 'ACTIVITYPUB_' ) ) {
 				continue;
 			}
 
-			$info['activitypub']['fields'][$key] = array(
+			$info['activitypub']['fields'][ $key ] = array(
 				'label'   => esc_attr( $key ),
 				'value'   => Sanitize::constant_value( $value ),
 				'private' => false,
 			);
 		}
-
-
 
 		return $info;
 	}

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -10,6 +10,8 @@ namespace Activitypub\WP_Admin;
 use Activitypub\Webfinger;
 use WP_Error;
 use Activitypub\Collection\Actors;
+use Activitypub\Sanitize;
+
 use function Activitypub\is_user_disabled;
 
 /**
@@ -356,20 +358,37 @@ class Health_Check {
 				'webfinger'      => array(
 					'label'   => __( 'WebFinger Resource', 'activitypub' ),
 					'value'   => Webfinger::get_user_resource( wp_get_current_user()->ID ),
-					'private' => true,
+					'private' => false,
 				),
 				'author_url'     => array(
 					'label'   => __( 'Author URL', 'activitypub' ),
 					'value'   => get_author_posts_url( wp_get_current_user()->ID ),
-					'private' => true,
-				),
-				'plugin_version' => array(
-					'label'   => __( 'Plugin Version', 'activitypub' ),
-					'value'   => ACTIVITYPUB_PLUGIN_VERSION,
-					'private' => true,
+					'private' => false,
 				),
 			),
 		);
+
+		$consts = get_defined_constants( true );
+
+		if ( ! isset( $consts['user'] ) ) {
+			return $info;
+		}
+
+		$output = array();
+
+		foreach ( $consts['user'] as $key => $value ) {
+			if ( ! str_starts_with( $key, 'ACTIVITYPUB_' ) ) {
+				continue;
+			}
+
+			$info['activitypub']['fields'][$key] = array(
+				'label'   => esc_attr( $key ),
+				'value'   => Sanitize::constant_value( $value ),
+				'private' => false,
+			);
+		}
+
+
 
 		return $info;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ For reasons of data protection, it is not possible to see the followers of other
 = Unreleased =
 
 * Added: Documentation for migrating from a Mastodon instance to WordPress.
+* Added: Added Constants to the Site-Health debug informations.
 * Changed: Outbox items only get sent to followers when there are any.
 * Fixed: Updates to certain user meta fields did not trigger an Update activity.
 * Fixed: No more PHP warnings when a header image gets cropped.


### PR DESCRIPTION
We currently have no easy way to debug the defined constants for ActivityPub. This PR adds all constant settings to the debug output, so that it can be easily shared in a support case.

<img width="895" alt="Screenshot 2025-03-11 at 10 48 05" src="https://github.com/user-attachments/assets/36fe541e-b0e2-480e-b0a9-8e64b17fb5c3" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout the PR
* Go to the site-health debug page: `/wp-admin/site-health.php?tab=debug`
* Check the constants output

