### PR TITLE
Separate init hook for WP-Admin

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -102,7 +102,7 @@ function plugin_admin_init() {
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Blog_Settings_Fields', 'init' ) );
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\User_Settings_Fields', 'init' ) );
 }
-\add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_admin_init', 11 );
+\add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_admin_init' );
 
 \register_activation_hook(
 	__FILE__,

--- a/activitypub.php
+++ b/activitypub.php
@@ -77,15 +77,6 @@ function plugin_init() {
 	\add_action( 'init', array( __NAMESPACE__ . '\Link', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Mailer', 'init' ) );
 
-	// Menus are registered before `admin_init`, because of course they are.
-	\add_action( 'admin_menu', array( __NAMESPACE__ . '\WP_Admin\Menu', 'admin_menu' ) );
-	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Admin', 'init' ) );
-	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Health_Check', 'init' ) );
-	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Settings', 'init' ) );
-	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Settings_Fields', 'init' ) );
-	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Blog_Settings_Fields', 'init' ) );
-	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\User_Settings_Fields', 'init' ) );
-
 	if ( site_supports_blocks() ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\Blocks', 'init' ) );
 	}
@@ -97,6 +88,21 @@ function plugin_init() {
 	}
 }
 \add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init' );
+
+/**
+ * Initialize plugin admin.
+ */
+function plugin_admin_init() {
+	// Menus are registered before `admin_init`, because of course they are.
+	\add_action( 'admin_menu', array( __NAMESPACE__ . '\WP_Admin\Menu', 'admin_menu' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Admin', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Health_Check', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Settings', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Settings_Fields', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Blog_Settings_Fields', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\User_Settings_Fields', 'init' ) );
+}
+\add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_admin_init', 11 );
 
 \register_activation_hook(
 	__FILE__,


### PR DESCRIPTION
This PR introduces a separate hook for all admin hooks (`admin_menu` and `admin_init`) to allow unhooking the complete ActivityPub WP-Admin area.

props @obenland 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* encapsulate the `admin_init` and `admin_menu` in a `plugin_admin_init` hook

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

