### PR TITLE
Changelogger: automatically create a changelog entry from info extracted from PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,41 @@ Fixes #
 * Go to '..'
 *
 
+### Changelog entry
+
+<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
+<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->
+
+<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
+<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->
+
+<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->
+
+-   [ ] Automatically create a changelog entry from the details below.
+
+<details>
+
+<summary>Changelog Entry Details</summary>
+
+#### Significance
+
+<!-- Choose only one -->
+
+-   [ ] Patch
+-   [ ] Minor
+-   [ ] Major
+
+#### Type
+
+<!-- Choose only one -->
+
+-   [ ] Added - for new features
+-   [ ] Changed - for changes in existing functionality
+-   [ ] Deprecated - for soon-to-be removed features
+-   [ ] Removed - for now removed features
+-   [ ] Fixed - for any bug fixes
+-   [ ] Security - in case of vulnerabilities
+
+#### Message <!-- Add a changelog message here -->
+
+</details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -55,6 +55,8 @@ Fixes #
 -   [ ] Fixed - for any bug fixes
 -   [ ] Security - in case of vulnerabilities
 
-#### Message <!-- Add a changelog message here -->
+#### Message
+
+<!-- Add a changelog message here -->
 
 </details>

--- a/.github/changelog/add-changelogger-from-pr-description
+++ b/.github/changelog/add-changelogger-from-pr-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Development environment: allow contributors to specify a changelog entry directly from their Pull Request description.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,11 +12,12 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - name: "Check changelog requirements"
+      - name: "Check for Skip Changelog label"
+        id: check-skip-label
         uses: actions/github-script@v7
         with:
           script: |
-            const { repo: { owner, repo }, payload : { pull_request : { number, labels } } } = context;
+            const { payload : { pull_request : { number, labels } } } = context;
 
             // Check for Skip Changelog label
             core.debug( 'Changelog check: Check for Skip Changelog label' );
@@ -26,10 +27,20 @@ jobs:
 
             if ( hasSkipLabel ) {
               core.info( `Skipping changelog requirement for this PR (#${ number }) because of the "${ skipLabel }" label.` );
-              return;
+              core.setOutput('skip-changelog', 'true');
+            } else {
+              core.info( `No "${ skipLabel }" label found for PR #${ number }. Will check for changelog file.` );
+              core.setOutput('skip-changelog', 'false');
             }
 
-            // If no skip label, check for changelog file
+      - name: "Check for changelog file"
+        if: steps.check-skip-label.outputs.skip-changelog != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo: { owner, repo }, payload : { pull_request : { number } } } = context;
+
+            // Check for changelog file
             core.debug( `Changelog check: Get list of files modified in ${ owner }/${ repo } #${ number }.` );
 
             const fileList = [];

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -153,3 +153,44 @@ jobs:
             core.setOutput( 'type', type );
             core.setOutput( 'message', changelogMessage );
             core.setOutput( 'has-changelog-info', 'true' );
+
+      - name: "Create changelog file from PR description"
+        id: create-changelog-file
+        if: steps.check-skip-label.outputs.skip-changelog != 'true' && steps.check-changelog-file.outputs.has-changelog-file != 'true' && steps.check-pr-body.outputs.has-changelog-info == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo: { owner, repo }, payload : { pull_request : { number, head : { ref } } } } = context;
+
+            // Get the changelog information from the previous step
+            const significance = '${{ steps.check-pr-body.outputs.significance }}';
+            const type = '${{ steps.check-pr-body.outputs.type }}';
+            const message = '${{ steps.check-pr-body.outputs.message }}';
+
+            // Create the changelog file content
+            const content = [
+              `Significance: ${ significance }`,
+              `Type: ${ type }`,
+              '',
+              message,
+              ''
+            ].join( '\n' );
+
+            const path = `.github/changelog/${ number }-from-description`;
+            core.info( `Creating changelog file: ${ path }` );
+
+            try {
+              // Create or update the file in the repository
+              await github.rest.repos.createOrUpdateFileContents( {
+                owner,
+                repo,
+                path,
+                message: 'Add changelog',
+                content: Buffer.from( content ).toString( 'base64' ),
+                branch: ref
+              } );
+
+              core.info( `Successfully created changelog file: ${ path }`);
+            } catch ( error ) {
+              core.setFailed( `Failed to create changelog file: ${ error.message }` );
+            }

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,14 +27,15 @@ jobs:
 
             if ( hasSkipLabel ) {
               core.info( `Skipping changelog requirement for this PR (#${ number }) because of the "${ skipLabel }" label.` );
-              core.setOutput('skip-changelog', 'true');
+              core.setOutput( 'skip-changelog', 'true' );
             } else {
               core.info( `No "${ skipLabel }" label found for PR #${ number }. Will check for changelog file.` );
-              core.setOutput('skip-changelog', 'false');
+              core.setOutput( 'skip-changelog', 'false' );
             }
 
       - name: "Check for changelog file"
         if: steps.check-skip-label.outputs.skip-changelog != 'true'
+        id: check-changelog-file
         uses: actions/github-script@v7
         with:
           script: |
@@ -69,7 +70,86 @@ jobs:
 
             if ( hasChangelogFile ) {
                 core.info( `PR #${ number } includes a changelog file.` );
+                core.setOutput('has-changelog-file', 'true');
             } else {
                 core.info( `PR #${ number } does not include a changelog file.` );
-                core.setFailed( 'Your PR does not include a changelog file. Please add a changelog entry by running `composer changelog:add`, checking in the resulting file, and pushing that change to your branch.' );
+                core.setOutput('has-changelog-file', 'false');
             }
+
+      - name: "Check for changelog information in PR body"
+        id: check-pr-body
+        if: steps.check-skip-label.outputs.skip-changelog != 'true' && steps.check-changelog-file.outputs.has-changelog-file != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo: { owner, repo }, payload : { pull_request : { number, body } } } = context;
+
+            // Check if the PR body exists.
+            if ( ! body ) {
+              core.info( `PR #${ number } has no description.` );
+              core.setFailed( 'Your PR does not include a changelog file and has no description to extract changelog information from. Please generate a changelog entry manually by running `composer changelog:add`.' );
+              return;
+            }
+
+            // Check if the "Automatically create a changelog entry" checkbox is checked.
+            const autoCreateRegex = /-\s+\[x\]\s+Automatically\s+create\s+a\s+changelog\s+entry\s+from\s+the\s+details\s+below/i;
+            const isAutoCreateChecked = autoCreateRegex.test( body );
+
+            if (! isAutoCreateChecked ) {
+              core.info( `PR #${ number } does not have the "Automatically create a changelog entry" checkbox checked.` );
+              core.setFailed( 'Your PR does not include a changelog file, and does not have the "Automatically create a changelog entry" checkbox checked. Please check the "Automatically create a changelog entry" checkbox and fill in all required information.' );
+              return;
+            }
+
+            core.info( `PR #${ number } has the "Automatically create a changelog entry" checkbox checked. Checking for changelog details...` );
+
+            // Extract all sections.
+            const significanceSection = body.match(/#### Significance[\s\S]*?(?=####|$)/);
+            const typeSection = body.match(/#### Type[\s\S]*?(?=####|$)/);
+            const messageSection = body.match(/#### Message\s*\n+([\s\S]*?)(?=####|<\/details>|$)/);
+
+            // Bail early if any section is missing.
+            if ( ! significanceSection || ! typeSection || ! messageSection ) {
+              core.setFailed( 'Your PR is missing one or more required sections in the changelog details. Please generate a changelog entry manually by running `composer changelog:add`.' );
+              return;
+            }
+
+            // Process significance section.
+            const significanceMatches = Array.from(
+              significanceSection[0].matchAll( /-\s+\[x\]\s+(Patch|Minor|Major)/gi )
+            );
+            if ( significanceMatches.length !== 1 ) {
+              core.setFailed( 'Your PR must have exactly one significance level checked (Patch, Minor, or Major) in the changelog details.' );
+              return;
+            }
+            const significance = significanceMatches[0][1].toLowerCase();
+
+            // Process type section.
+            const typeMatches = Array.from(
+              typeSection[0].matchAll( /-\s+\[x\]\s+(Added|Changed|Deprecated|Removed|Fixed|Security)/gi )
+            );
+            if ( typeMatches.length !== 1 ) {
+              core.setFailed( 'Your PR must have exactly one type checked (Added, Changed, Deprecated, Removed, Fixed, or Security) in the changelog details.' );
+              return;
+            }
+            const type = typeMatches[0][1].toLowerCase();
+
+            // Process message section
+            let changelogMessage = '';
+            if ( messageSection ) {
+              // Get the message and trim whitespace
+              changelogMessage = messageSection[1].trim();
+
+              // If still empty after trimming, fail
+              if ( ! changelogMessage ) {
+                core.setFailed( 'Your PR has an empty changelog message. Please provide a meaningful message in the changelog details.' );
+                return;
+              }
+            }
+
+            // All information is available, output it
+            core.info( `Extracted changelog information - Significance: ${ significance }, Type: ${ type }, Message: ${ changelogMessage }` );
+            core.setOutput( 'significance', significance );
+            core.setOutput( 'type', type );
+            core.setOutput( 'message', changelogMessage );
+            core.setOutput( 'has-changelog-info', 'true' );

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ on:
     # (which are not included by default for the "pull_request" trigger).
     # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
     # as defined in the (optional) "skipLabels" property.
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
   # Enforces the addition of a changelog entry (a file in the .github/changelog directory) every pull request.


### PR DESCRIPTION
Follow-up to #1452

## Proposed changes:

Now that we have a CLI tool that allows us to create changelog entries on the fly, let's introduce a way to create those entries directly from the PR description. It should help folks who may not use the CLI in their daily development flow.

This PR makes the following changes:

1. It updates the existing PR template to include new fields the PR author (or a reviewer) can fill in.
2. It adds a new step to the existing changelog workflow. When no changelog is detected, and when the "Skip Changelog" label is not found on the PR, look for changelog info in the PR body.
3. It adds another step that will run when info is found in the PR body ; it will create a changelog file with the extracted information, and commit it to that branch for you.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This is better tested directly in a PR: https://github.com/Automattic/wordpress-activitypub/pull/1457
