### PR TITLE
Move: Consistently use "moved_to" key

### DIFF
--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -758,6 +758,17 @@ class Activitypub {
 
 		\register_meta(
 			'user',
+			$blog_prefix . 'activitypub_moved_to',
+			array(
+				'type'              => 'string',
+				'description'       => 'The new URL of the user.',
+				'single'            => true,
+				'sanitize_callback' => 'sanitize_url',
+			)
+		);
+
+		\register_meta(
+			'user',
 			$blog_prefix . 'activitypub_description',
 			array(
 				'type'              => 'string',

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -33,7 +33,7 @@ class Move {
 
 		// Update the movedTo property.
 		if ( $user->get__id() > 0 ) {
-			\update_user_option( $user->get__id(), 'activitypub_move_to', $to );
+			\update_user_option( $user->get__id(), 'activitypub_moved_to', $to );
 		} else {
 			\update_option( 'activitypub_blog_user_moved_to', $to );
 		}

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -446,6 +446,6 @@ class User extends Actor {
 	 * @return string The movedTo.
 	 */
 	public function get_moved_to() {
-		return \get_user_option( 'activitypub_move_to', $this->_id );
+		return \get_user_option( 'activitypub_moved_to', $this->_id );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow up to #685 and #1413.
See https://github.com/Automattic/wordpress-activitypub/pull/1413/files#r1988090180

#1413 is not ready to be merged yet, but we should fix the meta key before the next release so we don't have to write an upgrade script for it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates user meta key to using `moved_to`, inline with blog user option key.
* Registers the user meta
