### PR TITLE
Update the text for Enable Mastodon Apps

### DIFF
--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -252,7 +252,22 @@ class Welcome_Fields {
 				</button>
 			</h4>
 			<div id="activitypub-settings-accordion-block-enable-mastodon-apps-plugin" class="activitypub-settings-accordion-panel plugin-card-block-enable-mastodon-apps" hidden="hidden">
-				<p><?php \esc_html_e( 'Use Mastodon Apps to connect your WordPress site to Mastodon. This plugin allows you to use Mastodon apps to authenticate users on your WordPress site.', 'activitypub' ); ?></p>
+				<p>
+					<?php
+					echo \wp_kses(
+						\sprintf(
+							// translators: %s is a URL.
+							\__( 'Interact with your WordPress site using <a href="%s" target="_blank">Mastodon apps</a>. This gives you a wide choice of apps that you can use to read or write posts that will be federated using the ActivityPub plugin.', 'activitypub' ),
+							'https://joinmastodon.org/apps'
+						),
+						array(
+							'a' => array(
+								'href' => true,
+							),
+						)
+					);
+					?>
+				</p>
 				<p><a href="<?php echo \esc_url( \admin_url( 'plugin-install.php?tab=plugin-information&plugin=enable-mastodon-apps&TB_iframe=true' ) ); ?>" class="thickbox open-plugin-details-modal button install-now" target="_blank"><?php \esc_html_e( 'Install the Enable Mastodon Apps Plugin', 'activitypub' ); ?></a></p>
 			</div>
 			<?php endif; ?>

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -257,7 +257,7 @@ class Welcome_Fields {
 					echo \wp_kses(
 						\sprintf(
 							// translators: %s is a URL.
-							\__( 'Interact with your WordPress site using <a href="%s" target="_blank">Mastodon apps</a>. This gives you a wide choice of apps that you can use to read or write posts that will be federated using the ActivityPub plugin.', 'activitypub' ),
+							\__( 'Enable the use of a wide variety of <a href="%s" target="_blank">Mastodon apps</a>to interact with your WordPress site, for example write posts that can then be federated via the ActivityPub plugin.', 'activitypub' ),
 							'https://joinmastodon.org/apps'
 						),
 						array(

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -262,7 +262,8 @@ class Welcome_Fields {
 						),
 						array(
 							'a' => array(
-								'href' => true,
+								'href'   => true,
+								'target' => true,
 							),
 						)
 					);


### PR DESCRIPTION
Follow-up to #1450, as discussed in https://github.com/Automattic/wordpress-activitypub/pull/1450/files/9ec32dfaa0a0dbe4575be8e8529f26149c9b379d#r1998156842
