### PR TITLE
Outbox: Add support for full activities

### DIFF
--- a/.github/changelog/1474-from-description
+++ b/.github/changelog/1474-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Outbox items now contain the full activity, not just activity objects.

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -171,8 +171,10 @@ class Activity extends Base_Object {
 			$id = strtok( $data->get_id(), '#' );
 			if ( $data->get_updated() ) {
 				$updated = $data->get_updated();
-			} else {
+			} elseif ( $data->get_published() ) {
 				$updated = $data->get_published();
+			} else {
+				$updated = time();
 			}
 			$this->set( 'id', $id . '#activity-' . strtolower( $this->get_type() ) . '-' . $updated );
 		}

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -449,7 +449,7 @@ class Activitypub {
 		}
 
 		$activity->set_id( $guid );
-		$content        = wp_slash( $activity->to_json() );
+		$content = wp_slash( $activity->to_json() );
 
 		wp_update_post(
 			array(

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -19,14 +19,6 @@ use Activitypub\Collection\Extra_Fields;
  * @author Matthias Pfefferle
  */
 class Activitypub {
-
-	/**
-	 * Supported activity types.
-	 *
-	 * @var string[] The supported activity types.
-	 */
-	public static $activity_types = array( 'Accept', 'Add', 'Announce', 'Arrive', 'Block', 'Create', 'Delete', 'Dislike', 'Flag', 'Follow', 'Ignore', 'Invite', 'Join', 'Leave', 'Like', 'Listen', 'Move', 'Offer', 'Question', 'Reject', 'Read', 'Remove', 'TentativeReject', 'TentativeAccept', 'Travel', 'Undo', 'Update', 'View' );
-
 	/**
 	 * Initialize the class, registering WordPress hooks.
 	 */
@@ -626,7 +618,7 @@ class Activitypub {
 					$value  = ucfirst( strtolower( $value ) );
 					$schema = array(
 						'type'    => 'string',
-						'enum'    => self::$activity_types,
+						'enum'    => array( 'Accept', 'Add', 'Announce', 'Arrive', 'Block', 'Create', 'Delete', 'Dislike', 'Flag', 'Follow', 'Ignore', 'Invite', 'Join', 'Leave', 'Like', 'Listen', 'Move', 'Offer', 'Question', 'Reject', 'Read', 'Remove', 'TentativeReject', 'TentativeAccept', 'Travel', 'Undo', 'Update', 'View' ),
 						'default' => 'Announce',
 					);
 

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -64,6 +64,7 @@ class Activitypub {
 		\add_action( 'updated_postmeta', array( self::class, 'updated_postmeta' ), 10, 4 );
 		\add_action( 'added_post_meta', array( self::class, 'updated_postmeta' ), 10, 4 );
 		\add_filter( 'pre_option_activitypub_actor_mode', array( self::class, 'pre_get_option' ) );
+		\add_action( 'save_post_ap_outbox', array( self::class, 'save_post_ap_outbox' ), 10, 3 );
 
 		\add_action( 'init', array( self::class, 'register_user_meta' ), 11 );
 
@@ -420,6 +421,40 @@ class Activitypub {
 		}
 
 		return $pre;
+	}
+
+	/**
+	 * Save the post ap outbox.
+	 *
+	 * @param int     $post_id The post ID.
+	 * @param WP_Post $post    The post object.
+	 * @param bool    $update  Whether the post is being updated.
+	 */
+	public static function save_post_ap_outbox( $post_id, $post, $update ) {
+		if ( $update ) {
+			return;
+		}
+
+		$guid    = get_the_guid( $post_id );
+		$content = get_post_field( 'post_content', $post_id );
+
+		if ( ! $guid || ! $content ) {
+			return;
+		}
+
+		$activity = json_decode( $content, true );
+
+		if ( ! $activity || ! is_array( $activity ) ) {
+			return;
+		}
+
+		$activity['id'] = $guid;
+		$content        = json_encode( $activity );
+
+		wp_update_post( array(
+			'ID' => $post_id,
+			'post_content' => $content,
+		) );
 	}
 
 	/**

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -64,7 +64,6 @@ class Activitypub {
 		\add_action( 'updated_postmeta', array( self::class, 'updated_postmeta' ), 10, 4 );
 		\add_action( 'added_post_meta', array( self::class, 'updated_postmeta' ), 10, 4 );
 		\add_filter( 'pre_option_activitypub_actor_mode', array( self::class, 'pre_get_option' ) );
-		\add_action( 'save_post_ap_outbox', array( self::class, 'save_post_ap_outbox' ), 10, 3 );
 
 		\add_action( 'init', array( self::class, 'register_user_meta' ), 11 );
 
@@ -421,42 +420,6 @@ class Activitypub {
 		}
 
 		return $pre;
-	}
-
-	/**
-	 * Save the post ap outbox.
-	 *
-	 * @param int     $post_id The post ID.
-	 * @param WP_Post $post    The post object.
-	 * @param bool    $update  Whether the post is being updated.
-	 */
-	public static function save_post_ap_outbox( $post_id, $post, $update ) {
-		if ( $update ) {
-			return;
-		}
-
-		$guid    = get_the_guid( $post_id );
-		$content = get_post_field( 'post_content', $post_id );
-
-		if ( ! $guid || ! $content ) {
-			return;
-		}
-
-		$activity = Activity::init_from_json( $content );
-
-		if ( ! $activity || \is_wp_error( $activity ) ) {
-			return;
-		}
-
-		$activity->set_id( $guid );
-		$content = wp_slash( $activity->to_json() );
-
-		wp_update_post(
-			array(
-				'ID'           => $post_id,
-				'post_content' => $content,
-			)
-		);
 	}
 
 	/**

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -19,6 +19,20 @@ use Activitypub\Collection\Extra_Fields;
  * @author Matthias Pfefferle
  */
 class Activitypub {
+
+	/**
+	 * Supported activity types.
+	 *
+	 * @var string[] The supported activity types.
+	 */
+	public static $activity_types = array( 'Accept', 'Add', 'Announce', 'Arrive', 'Block', 'Create', 'Delete', 'Dislike', 'Flag', 'Follow', 'Ignore', 'Invite', 'Join', 'Leave', 'Like', 'Listen', 'Move', 'Offer', 'Question', 'Reject', 'Read', 'Remove', 'TentativeReject', 'TentativeAccept', 'Travel', 'Undo', 'Update', 'View' );
+
+	/**
+	 * Supported object types.
+	 *
+	 * @var string[] The supported object types.
+	 */
+	public static $object_types = array( 'Article', 'Audio', 'Document', 'Event', 'Image', 'Note', 'Page', 'Place', 'Profile', 'Relationship', 'Tombstone', 'Video' );
 	/**
 	 * Initialize the class, registering WordPress hooks.
 	 */
@@ -593,7 +607,7 @@ class Activitypub {
 					$value  = ucfirst( strtolower( $value ) );
 					$schema = array(
 						'type'    => 'string',
-						'enum'    => array( 'Accept', 'Add', 'Announce', 'Arrive', 'Block', 'Create', 'Delete', 'Dislike', 'Flag', 'Follow', 'Ignore', 'Invite', 'Join', 'Leave', 'Like', 'Listen', 'Move', 'Offer', 'Question', 'Reject', 'Read', 'Remove', 'TentativeReject', 'TentativeAccept', 'Travel', 'Undo', 'Update', 'View' ),
+						'enum'    => self::$activity_types,
 						'default' => 'Announce',
 					);
 

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -442,19 +442,21 @@ class Activitypub {
 			return;
 		}
 
-		$activity = json_decode( $content, true );
+		$activity = Activity::from_json( $content );
 
-		if ( ! $activity || ! is_array( $activity ) ) {
+		if ( ! $activity || \is_wp_error( $activity ) ) {
 			return;
 		}
 
-		$activity['id'] = $guid;
-		$content        = json_encode( $activity );
+		$activity->set_id( $guid );
+		$content        = wp_slash( $activity->to_json() );
 
-		wp_update_post( array(
-			'ID' => $post_id,
-			'post_content' => $content,
-		) );
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $content,
+			)
+		);
 	}
 
 	/**

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -28,12 +28,6 @@ class Activitypub {
 	public static $activity_types = array( 'Accept', 'Add', 'Announce', 'Arrive', 'Block', 'Create', 'Delete', 'Dislike', 'Flag', 'Follow', 'Ignore', 'Invite', 'Join', 'Leave', 'Like', 'Listen', 'Move', 'Offer', 'Question', 'Reject', 'Read', 'Remove', 'TentativeReject', 'TentativeAccept', 'Travel', 'Undo', 'Update', 'View' );
 
 	/**
-	 * Supported object types.
-	 *
-	 * @var string[] The supported object types.
-	 */
-	public static $object_types = array( 'Article', 'Audio', 'Document', 'Event', 'Image', 'Note', 'Page', 'Place', 'Profile', 'Relationship', 'Tombstone', 'Video' );
-	/**
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -442,7 +442,7 @@ class Activitypub {
 			return;
 		}
 
-		$activity = Activity::from_json( $content );
+		$activity = Activity::init_from_json( $content );
 
 		if ( ! $activity || \is_wp_error( $activity ) ) {
 			return;

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -228,7 +228,7 @@ class Cli extends WP_CLI_Command {
 		if ( is_wp_error( $outbox_item_id ) ) {
 			WP_CLI::error( $outbox_item_id->get_error_message() );
 		} else {
-			WP_CLI::success( 'Moved Scheduled.' );
+			WP_CLI::success( 'Move Scheduled.' );
 		}
 	}
 }

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -9,7 +9,6 @@ namespace Activitypub;
 
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
-use Activitypub\Collection\Outbox;
 use Activitypub\Transformer\Factory;
 
 /**
@@ -767,7 +766,7 @@ class Migration {
 			}
 		}
 
-		$post_id = Outbox::add( $activity, $activity_type, $user_id, $visibility );
+		$post_id = add_to_outbox( $activity, $activity_type, $user_id, $visibility );
 
 		// Immediately set to publish, no federation needed.
 		\wp_publish_post( $post_id );

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -9,6 +9,7 @@ namespace Activitypub;
 
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use Activitypub\Collection\Outbox;
 use Activitypub\Transformer\Factory;
 
 /**
@@ -752,7 +753,7 @@ class Migration {
 			return;
 		}
 
-		$activity = $transformer->to_object();
+		$activity = $transformer->to_activity( $activity_type );
 		if ( ! $activity || \is_wp_error( $activity ) ) {
 			return;
 		}
@@ -766,7 +767,7 @@ class Migration {
 			}
 		}
 
-		$post_id = add_to_outbox( $activity, $activity_type, $user_id, $visibility );
+		$post_id = Outbox::add( $activity, $user_id, $visibility );
 
 		// Immediately set to publish, no federation needed.
 		\wp_publish_post( $post_id );

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -35,8 +35,8 @@ class Outbox {
 		$object_id  = false;
 		$title      = '';
 		if ( $activity->get_object() ) {
-			$object_id  = is_string( $activity->get_object() ) ? $activity->get_object() : $activity->get_object()->get_id();
-			$title      = self::recursively_get_title( $activity->get_object() );
+			$object_id = is_string( $activity->get_object() ) ? $activity->get_object() : $activity->get_object()->get_id();
+			$title     = self::recursively_get_title( $activity->get_object() );
 		}
 
 		$outbox_item = array(

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -34,18 +34,8 @@ class Outbox {
 	 * @return false|int|\WP_Error The added item or an error.
 	 */
 	public static function add( $activity_object, $activity_type, $user_id, $content_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
-		$actor_type            = Actors::get_type_by_id( $user_id );
-		$title                 = $activity_object->get_name() ?? $activity_object->get_content();
-		$activitypub_object_id = $activity_object->get_id();
-
-		if ( ! $title && is_activity( $activity_object ) && $activity_object->get_object() instanceof \Activitypub\Activity\Base_Object ) {
-			$title                 = $activity_object->get_object()->get_name() ?? $activity_object->get_object()->get_content();
-			$activitypub_object_id = $activity_object->get_object()->get_id();
-		}
-
-    if ( null === $activity_type ) {
-			$activity_type = $activity_object->get_type();
-		}
+		$actor_type                        = Actors::get_type_by_id( $user_id );
+		[ $title, $activitypub_object_id ] = self::recursively_get_activity_meta( $activity_object );
 
 		$outbox_item = array(
 			'post_type'    => self::POST_TYPE,
@@ -288,5 +278,22 @@ class Outbox {
 		}
 
 		return self::get_activity( $outbox_item );
+	}
+
+	/**
+	 * Get the metadata of an activity recursively.
+	 *
+	 * @param \Activitypub\Activity\Base_Object $activity The activity object.
+	 * @return array The meta data.
+	 */
+	private static function recursively_get_activity_meta( $activity ) {
+		$title                 = $activity->get_name() ?? $activity->get_content();
+		$activitypub_object_id = $activity->get_id();
+
+		if ( ! $title && is_activity( $activity ) && $activity->get_object() instanceof \Activitypub\Activity\Base_Object ) {
+			return self::recursively_get_activity_meta( $activity->get_object() );
+		}
+
+		return array( $title, $activitypub_object_id );
 	}
 }

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -66,11 +66,11 @@ class Outbox {
 		// Update the activity ID if the post was inserted successfully.
 		if ( $id && ! \is_wp_error( $id ) ) {
 			$activity->set_id( \get_the_guid( $id ) );
-			$content = \wp_slash( $activity->to_json() );
+
 			\wp_update_post(
 				array(
 					'ID'           => $id,
-					'post_content' => $content,
+					'post_content' => \wp_slash( $activity->to_json() ),
 				)
 			);
 		}

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -11,7 +11,6 @@ use Activitypub\Dispatcher;
 use Activitypub\Scheduler;
 use Activitypub\Activity\Activity;
 
-use function Activitypub\is_activity;
 use function Activitypub\add_to_outbox;
 
 /**
@@ -32,8 +31,9 @@ class Outbox {
 	 * @return false|int|\WP_Error The added item or an error.
 	 */
 	public static function add( $activity, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
-		$actor_type                        = Actors::get_type_by_id( $user_id );
-		[ $title, $activitypub_object_id ] = self::recursively_get_activity_meta( $activity );
+		$actor_type = Actors::get_type_by_id( $user_id );
+		$object_id  = is_string( $activity->get_object() ) ? $activity->get_object() : $activity->get_object()->get_id();
+		$title      = self::recursively_get_title( $activity->get_object() );
 
 		$outbox_item = array(
 			'post_type'    => self::POST_TYPE,
@@ -48,7 +48,7 @@ class Outbox {
 			'post_author'  => \max( $user_id, 0 ),
 			'post_status'  => 'pending',
 			'meta_input'   => array(
-				'_activitypub_object_id'         => $activitypub_object_id,
+				'_activitypub_object_id'         => $object_id,
 				'_activitypub_activity_type'     => $activity->get_type(),
 				'_activitypub_activity_actor'    => $actor_type,
 				'activitypub_content_visibility' => $visibility,
@@ -87,7 +87,7 @@ class Outbox {
 			return false;
 		}
 
-		self::invalidate_existing_items( $activitypub_object_id, $activity->get_type(), $id );
+		self::invalidate_existing_items( $object_id, $activity->get_type(), $id );
 
 		return $id;
 	}
@@ -290,19 +290,24 @@ class Outbox {
 	}
 
 	/**
-	 * Get the metadata of an activity recursively.
+	 * Get the title of an activity recursively.
 	 *
-	 * @param \Activitypub\Activity\Base_Object $activity The activity object.
-	 * @return array The meta data.
+	 * @param \Activitypub\Activity\Base_Object $activity_object The activity object.
+	 * @return string The title.
 	 */
-	private static function recursively_get_activity_meta( $activity ) {
-		$title                 = $activity->get_name() ?? $activity->get_content();
-		$activitypub_object_id = $activity->get_id();
+	private static function recursively_get_title( $activity_object ) {
+		if ( is_string( $activity_object ) ) {
+			$post_id = url_to_postid( $activity_object );
 
-		if ( ! $title && is_activity( $activity ) && $activity->get_object() instanceof \Activitypub\Activity\Base_Object ) {
-			return self::recursively_get_activity_meta( $activity->get_object() );
+			return $post_id ? get_the_title( $post_id ) : '';
 		}
 
-		return array( $title, $activitypub_object_id );
+		$title = $activity_object->get_name() ?? $activity_object->get_content();
+
+		if ( ! $title && $activity_object->get_object() instanceof \Activitypub\Activity\Base_Object ) {
+			$title = $activity_object->get_object()->get_name() ?? $activity_object->get_object()->get_content();
+		}
+
+		return $title;
 	}
 }

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -30,7 +30,7 @@ class Outbox {
 	 *
 	 * @return false|int|\WP_Error The added item or an error.
 	 */
-	public static function add( $activity, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
+	public static function add( Activity $activity, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
 		$actor_type = Actors::get_type_by_id( $user_id );
 		$object_id  = is_string( $activity->get_object() ) ? $activity->get_object() : $activity->get_object()->get_id();
 		$title      = self::recursively_get_title( $activity->get_object() );

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -32,17 +32,13 @@ class Outbox {
 	 */
 	public static function add( Activity $activity, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
 		$actor_type = Actors::get_type_by_id( $user_id );
-		$object_id  = false;
-		$title      = '';
-		if ( $activity->get_object() ) {
-			$object_id = is_string( $activity->get_object() ) ? $activity->get_object() : $activity->get_object()->get_id();
-			$title     = self::recursively_get_title( $activity->get_object() );
-		}
+		$object_id  = self::get_object_id( $activity );
+		$title      = self::get_object_title( $activity->get_object() );
 
 		$outbox_item = array(
 			'post_type'    => self::POST_TYPE,
 			'post_title'   => sprintf(
-				/* translators: 1. Activity type, 2. Object type, 3. Object Title or Excerpt */
+				/* translators: 1. Activity type, 2. Object Title or Excerpt */
 				__( '[%1$s] %2$s', 'activitypub' ),
 				$activity->get_type(),
 				\wp_trim_words( $title, 5 )
@@ -52,15 +48,12 @@ class Outbox {
 			'post_author'  => \max( $user_id, 0 ),
 			'post_status'  => 'pending',
 			'meta_input'   => array(
+				'_activitypub_object_id'         => $object_id,
 				'_activitypub_activity_type'     => $activity->get_type(),
 				'_activitypub_activity_actor'    => $actor_type,
 				'activitypub_content_visibility' => $visibility,
 			),
 		);
-
-		if ( $object_id ) {
-			$outbox_item['meta_input']['_activitypub_object_id'] = $object_id;
-		}
 
 		$has_kses = false !== \has_filter( 'content_save_pre', 'wp_filter_post_kses' );
 		if ( $has_kses ) {
@@ -297,16 +290,41 @@ class Outbox {
 	}
 
 	/**
+	 * Get the object ID of an activity.
+	 *
+	 * @param Activity $activity The activity object.
+	 * @return string The object ID.
+	 */
+	private static function get_object_id( $activity ) {
+		// Most common.
+		if ( is_object( $activity->get_object() ) ) {
+			return $activity->get_object()->get_id();
+		}
+
+		// Rare.
+		if ( is_string( $activity->get_object() ) ) {
+			return $activity->get_object();
+		}
+
+		// Exceptional.
+		return $activity->get_actor() ?? $activity->get_id();
+	}
+
+	/**
 	 * Get the title of an activity recursively.
 	 *
 	 * @param \Activitypub\Activity\Base_Object $activity_object The activity object.
 	 * @return string The title.
 	 */
-	private static function recursively_get_title( $activity_object ) {
+	private static function get_object_title( $activity_object ) {
 		if ( is_string( $activity_object ) ) {
 			$post_id = url_to_postid( $activity_object );
 
 			return $post_id ? get_the_title( $post_id ) : '';
+		}
+
+		if ( null === $activity_object ) {
+			return '';
 		}
 
 		$title = $activity_object->get_name() ?? $activity_object->get_content();

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -25,34 +25,33 @@ class Outbox {
 	/**
 	 * Add an Item to the outbox.
 	 *
-	 * @param \Activitypub\Activity\Base_Object $activity_object    The object of the activity that will be added to the outbox.
-	 * @param int                               $user_id            The real or imaginary user ID of the actor that published the activity that will be added to the outbox.
-	 * @param string                            $content_visibility Optional. The visibility of the content. Default: `ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC`. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
+	 * @param Activity $activity   Full Activity object that will be added to the outbox.
+	 * @param int      $user_id    The real or imaginary user ID of the actor that published the activity that will be added to the outbox.
+	 * @param string   $visibility Optional. The visibility of the content. Default: `ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC`. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
 	 *
 	 * @return false|int|\WP_Error The added item or an error.
 	 */
-	public static function add( $activity_object, $user_id, $content_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
+	public static function add( $activity, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
 		$actor_type                        = Actors::get_type_by_id( $user_id );
-		[ $title, $activitypub_object_id ] = self::recursively_get_activity_meta( $activity_object );
+		[ $title, $activitypub_object_id ] = self::recursively_get_activity_meta( $activity );
 
 		$outbox_item = array(
 			'post_type'    => self::POST_TYPE,
 			'post_title'   => sprintf(
 				/* translators: 1. Activity type, 2. Object type, 3. Object Title or Excerpt */
-				__( '[%1$s] %2$s: %3$s', 'activitypub' ),
-				$activity_type,
-				$activity_object->get_type(),
+				__( '[%1$s] %2$s', 'activitypub' ),
+				$activity->get_type(),
 				\wp_trim_words( $title, 5 )
 			),
-			'post_content' => wp_slash( $activity_object->to_json() ),
+			'post_content' => wp_slash( $activity->to_json() ),
 			// ensure that user ID is not below 0.
 			'post_author'  => \max( $user_id, 0 ),
 			'post_status'  => 'pending',
 			'meta_input'   => array(
 				'_activitypub_object_id'         => $activitypub_object_id,
-				'_activitypub_activity_type'     => $activity_type,
+				'_activitypub_activity_type'     => $activity->get_type(),
 				'_activitypub_activity_actor'    => $actor_type,
-				'activitypub_content_visibility' => $content_visibility,
+				'activitypub_content_visibility' => $visibility,
 			),
 		);
 
@@ -76,7 +75,7 @@ class Outbox {
 			return false;
 		}
 
-		self::invalidate_existing_items( $activitypub_object_id, $activity_type, $id );
+		self::invalidate_existing_items( $activitypub_object_id, $activity->get_type(), $id );
 
 		return $id;
 	}

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -219,17 +219,18 @@ class Outbox {
 			return $actor;
 		}
 
-		$type = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
+		$activity_object = \json_decode( $outbox_item->post_content, true );
+		$type            = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
 
-		if ( in_array( $type, Activitypub::$object_types, true ) ) {
+		if ( in_array( $activity_object['type'], Activitypub::$object_types, true ) || in_array( $type, array( 'Delete', 'Remove', 'Undo' ), true ) ) {
 			$activity = new Activity();
 			$activity->set_type( $type );
 			$activity->set_id( $outbox_item->guid );
 			$activity->set_actor( $actor->get_id() );
 			// Pre-fill the Activity with data (for example cc and to).
-			$activity->set_object( \json_decode( $outbox_item->post_content, true ) );
+			$activity->set_object( $activity_object );
 		} else {
-			$activity = Activity::init_from_array( \json_decode( $outbox_item->post_content, true ) );
+			$activity = Activity::init_from_array( $activity_object );
 		}
 
 		/**

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -317,14 +317,14 @@ class Outbox {
 	 * @return string The title.
 	 */
 	private static function get_object_title( $activity_object ) {
+		if ( ! $activity_object ) {
+			return '';
+		}
+
 		if ( is_string( $activity_object ) ) {
 			$post_id = url_to_postid( $activity_object );
 
 			return $post_id ? get_the_title( $post_id ) : '';
-		}
-
-		if ( null === $activity_object ) {
-			return '';
 		}
 
 		$title = $activity_object->get_name() ?? $activity_object->get_content();

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -307,7 +307,7 @@ class Outbox {
 		}
 
 		// Exceptional.
-		return $activity->get_actor();
+		return $activity->get_actor() ?? $activity->get_id();
 	}
 
 	/**

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -42,7 +42,7 @@ class Outbox {
 			$title                 = $activity_object->get_object()->get_name() ?? $activity_object->get_object()->get_content();
 			$activitypub_object_id = $activity_object->get_object()->get_id();
 		}
-    
+
     if ( null === $activity_type ) {
 			$activity_type = $activity_object->get_type();
 		}
@@ -211,15 +211,15 @@ class Outbox {
 		$activity_object = \json_decode( $outbox_item->post_content, true );
 		$type            = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
 
-		if ( in_array( $activity_object['type'], Activitypub::$object_types, true ) || in_array( $type, array( 'Delete', 'Remove', 'Undo' ), true ) ) {
+		if ( $activity_object['type'] === $type ) {
+			$activity = Activity::init_from_array( $activity_object );
+		} else {
 			$activity = new Activity();
 			$activity->set_type( $type );
 			$activity->set_id( $outbox_item->guid );
 			$activity->set_actor( $actor->get_id() );
 			// Pre-fill the Activity with data (for example cc and to).
 			$activity->set_object( $activity_object );
-		} else {
-			$activity = Activity::init_from_array( $activity_object );
 		}
 
 		/**

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -63,6 +63,18 @@ class Outbox {
 
 		$id = \wp_insert_post( $outbox_item, true );
 
+		// Update the activity ID if the post was inserted successfully.
+		if ( $id && ! \is_wp_error( $id ) ) {
+			$activity->set_id( \get_the_guid( $id ) );
+			$content = \wp_slash( $activity->to_json() );
+			\wp_update_post(
+				array(
+					'ID'           => $id,
+					'post_content' => $content,
+				)
+			);
+		}
+
 		if ( $has_kses ) {
 			\kses_init_filters();
 		}

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -7,7 +7,6 @@
 
 namespace Activitypub\Collection;
 
-use Activitypub\Activitypub;
 use Activitypub\Dispatcher;
 use Activitypub\Scheduler;
 use Activitypub\Activity\Activity;

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -26,13 +26,12 @@ class Outbox {
 	 * Add an Item to the outbox.
 	 *
 	 * @param \Activitypub\Activity\Base_Object $activity_object    The object of the activity that will be added to the outbox.
-	 * @param null|string                       $activity_type      The activity type. null if the full activity is provided in $activity_object.
 	 * @param int                               $user_id            The real or imaginary user ID of the actor that published the activity that will be added to the outbox.
 	 * @param string                            $content_visibility Optional. The visibility of the content. Default: `ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC`. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
 	 *
 	 * @return false|int|\WP_Error The added item or an error.
 	 */
-	public static function add( $activity_object, $activity_type, $user_id, $content_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
+	public static function add( $activity_object, $user_id, $content_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
 		$actor_type                        = Actors::get_type_by_id( $user_id );
 		[ $title, $activitypub_object_id ] = self::recursively_get_activity_meta( $activity_object );
 

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -307,7 +307,7 @@ class Outbox {
 		}
 
 		// Exceptional.
-		return $activity->get_actor() ?? $activity->get_id();
+		return $activity->get_actor();
 	}
 
 	/**

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -32,8 +32,12 @@ class Outbox {
 	 */
 	public static function add( Activity $activity, $user_id, $visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ) {
 		$actor_type = Actors::get_type_by_id( $user_id );
-		$object_id  = is_string( $activity->get_object() ) ? $activity->get_object() : $activity->get_object()->get_id();
-		$title      = self::recursively_get_title( $activity->get_object() );
+		$object_id  = false;
+		$title      = '';
+		if ( $activity->get_object() ) {
+			$object_id  = is_string( $activity->get_object() ) ? $activity->get_object() : $activity->get_object()->get_id();
+			$title      = self::recursively_get_title( $activity->get_object() );
+		}
 
 		$outbox_item = array(
 			'post_type'    => self::POST_TYPE,
@@ -48,12 +52,15 @@ class Outbox {
 			'post_author'  => \max( $user_id, 0 ),
 			'post_status'  => 'pending',
 			'meta_input'   => array(
-				'_activitypub_object_id'         => $object_id,
 				'_activitypub_activity_type'     => $activity->get_type(),
 				'_activitypub_activity_actor'    => $actor_type,
 				'activitypub_content_visibility' => $visibility,
 			),
 		);
+
+		if ( $object_id ) {
+			$outbox_item['meta_input']['_activitypub_object_id'] = $object_id;
+		}
 
 		$has_kses = false !== \has_filter( 'content_save_pre', 'wp_filter_post_kses' );
 		if ( $has_kses ) {

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Collection;
 
+use Activitypub\Activitypub;
 use Activitypub\Dispatcher;
 use Activitypub\Scheduler;
 use Activitypub\Activity\Activity;
@@ -26,7 +27,7 @@ class Outbox {
 	 * Add an Item to the outbox.
 	 *
 	 * @param \Activitypub\Activity\Base_Object $activity_object    The object of the activity that will be added to the outbox.
-	 * @param string                            $activity_type      The activity type.
+	 * @param null|string                       $activity_type      The activity type. null if the full activity is provided in $activity_object.
 	 * @param int                               $user_id            The real or imaginary user ID of the actor that published the activity that will be added to the outbox.
 	 * @param string                            $content_visibility Optional. The visibility of the content. Default: `ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC`. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
 	 *
@@ -43,6 +44,10 @@ class Outbox {
 			default:
 				$actor_type = 'user';
 				break;
+		}
+
+		if ( null === $activity_type ) {
+			$activity_type = $activity_object->get_type();
 		}
 
 		$title                 = $activity_object->get_name() ?? $activity_object->get_content();
@@ -214,13 +219,18 @@ class Outbox {
 			return $actor;
 		}
 
-		$activity = new Activity();
-		$type     = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
-		$activity->set_type( $type );
-		$activity->set_id( $outbox_item->guid );
-		$activity->set_actor( $actor->get_id() );
-		// Pre-fill the Activity with data (for example cc and to).
-		$activity->set_object( \json_decode( $outbox_item->post_content, true ) );
+		$type = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
+
+		if ( in_array( $type, Activitypub::$object_types, true ) ) {
+			$activity = new Activity();
+			$activity->set_type( $type );
+			$activity->set_id( $outbox_item->guid );
+			$activity->set_actor( $actor->get_id() );
+			// Pre-fill the Activity with data (for example cc and to).
+			$activity->set_object( \json_decode( $outbox_item->post_content, true ) );
+		} else {
+			$activity = Activity::init_from_array( \json_decode( $outbox_item->post_content, true ) );
+		}
 
 		/**
 		 * Filters the Activity object before it is returned.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1460,9 +1460,9 @@ function is_self_ping( $id ) {
  * Add an object to the outbox.
  *
  * @param mixed       $data               The object to add to the outbox.
- * @param string|null $activity_type      The type of the Activity or null if `$data` is an Activity.
- * @param integer     $user_id            The User-ID.
- * @param string      $content_visibility The visibility of the content. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
+ * @param string|null $activity_type      Optional. The type of the Activity or null if `$data` is an Activity. Default null.
+ * @param integer     $user_id            Optional. The User-ID. Default 0.
+ * @param string      $content_visibility Optional. The visibility of the content. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`. Default null.
  *
  * @return boolean|int The ID of the outbox item or false on failure.
  */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1479,7 +1479,11 @@ function add_to_outbox( $data, $activity_type = null, $user_id = 0, $content_vis
 		$content_visibility = $transformer->get_content_visibility();
 	}
 
-	$activity = $transformer->to_object();
+	if ( $activity_type ) {
+		$activity = $transformer->to_activity( $activity_type );
+	} else {
+		$activity = $transformer->to_object();
+	}
 
 	if ( ! $activity || \is_wp_error( $activity ) ) {
 		return false;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1459,14 +1459,14 @@ function is_self_ping( $id ) {
 /**
  * Add an object to the outbox.
  *
- * @param mixed   $data               The object to add to the outbox.
- * @param string  $activity_type      The type of the Activity.
- * @param integer $user_id            The User-ID.
- * @param string  $content_visibility The visibility of the content. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
+ * @param mixed       $data               The object to add to the outbox.
+ * @param string|null $activity_type      The type of the Activity or null if `$data` is an Activity.
+ * @param integer     $user_id            The User-ID.
+ * @param string      $content_visibility The visibility of the content. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
  *
  * @return boolean|int The ID of the outbox item or false on failure.
  */
-function add_to_outbox( $data, $activity_type = 'Create', $user_id = 0, $content_visibility = null ) {
+function add_to_outbox( $data, $activity_type = null, $user_id = 0, $content_visibility = null ) {
 	$transformer = Transformer_Factory::get_transformer( $data );
 
 	if ( ! $transformer || is_wp_error( $transformer ) ) {
@@ -1479,9 +1479,9 @@ function add_to_outbox( $data, $activity_type = 'Create', $user_id = 0, $content
 		$content_visibility = $transformer->get_content_visibility();
 	}
 
-	$activity_object = $transformer->to_object();
+	$activity = $transformer->to_object();
 
-	if ( ! $activity_object || \is_wp_error( $activity_object ) ) {
+	if ( ! $activity || \is_wp_error( $activity ) ) {
 		return false;
 	}
 
@@ -1494,7 +1494,7 @@ function add_to_outbox( $data, $activity_type = 'Create', $user_id = 0, $content
 		}
 	}
 
-	$outbox_activity_id = Outbox::add( $activity_object, $activity_type, $user_id, $content_visibility );
+	$outbox_activity_id = Outbox::add( $activity, $user_id, $content_visibility );
 
 	if ( ! $outbox_activity_id ) {
 		return false;
@@ -1503,12 +1503,12 @@ function add_to_outbox( $data, $activity_type = 'Create', $user_id = 0, $content
 	/**
 	 * Action triggered after an object has been added to the outbox.
 	 *
-	 * @param int                               $outbox_activity_id The ID of the outbox item.
-	 * @param \Activitypub\Activity\Base_Object $activity_object    The activity object.
-	 * @param int                               $user_id            The User-ID.
-	 * @param string                            $content_visibility The visibility of the content. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
+	 * @param int                            $outbox_activity_id The ID of the outbox item.
+	 * @param \Activitypub\Activity\Activity $activity           The activity object.
+	 * @param int                            $user_id            The User-ID.
+	 * @param string                         $content_visibility The visibility of the content. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
 	 */
-	\do_action( 'post_activitypub_add_to_outbox', $outbox_activity_id, $activity_object, $user_id, $content_visibility );
+	\do_action( 'post_activitypub_add_to_outbox', $outbox_activity_id, $activity, $user_id, $content_visibility );
 
 	set_wp_object_state( $data, 'federated' );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1530,38 +1530,7 @@ function is_activity( $data ) {
 	 *
 	 * @param array $types The activity types.
 	 */
-	$types = apply_filters(
-		'activitypub_activity_types',
-		array(
-			'Accept',
-			'Add',
-			'Announce',
-			'Arrive',
-			'Block',
-			'Create',
-			'Delete',
-			'Dislike',
-			'Follow',
-			'Flag',
-			'Ignore',
-			'Invite',
-			'Join',
-			'Leave',
-			'Like',
-			'Listen',
-			'Move',
-			'Offer',
-			'Read',
-			'Reject',
-			'Remove',
-			'TentativeAccept',
-			'TentativeReject',
-			'Travel',
-			'Undo',
-			'Update',
-			'View',
-		)
-	);
+	$types = apply_filters( 'activitypub_activity_types', Activitypub::$activity_types );
 
 	if ( is_string( $data ) ) {
 		return in_array( $data, $types, true );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1507,10 +1507,10 @@ function add_to_outbox( $data, $activity_type = null, $user_id = 0, $content_vis
 	/**
 	 * Action triggered after an object has been added to the outbox.
 	 *
-	 * @param int                            $outbox_activity_id The ID of the outbox item.
-	 * @param \Activitypub\Activity\Activity $activity           The activity object.
-	 * @param int                            $user_id            The User-ID.
-	 * @param string                         $content_visibility The visibility of the content. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
+	 * @param int      $outbox_activity_id The ID of the outbox item.
+	 * @param Activity $activity           The activity object.
+	 * @param int      $user_id            The User-ID.
+	 * @param string   $content_visibility The visibility of the content. See `constants.php` for possible values: `ACTIVITYPUB_CONTENT_VISIBILITY_*`.
 	 */
 	\do_action( 'post_activitypub_add_to_outbox', $outbox_activity_id, $activity, $user_id, $content_visibility );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1534,7 +1534,38 @@ function is_activity( $data ) {
 	 *
 	 * @param array $types The activity types.
 	 */
-	$types = apply_filters( 'activitypub_activity_types', Activitypub::$activity_types );
+	$types = apply_filters(
+		'activitypub_activity_types',
+		array(
+			'Accept',
+			'Add',
+			'Announce',
+			'Arrive',
+			'Block',
+			'Create',
+			'Delete',
+			'Dislike',
+			'Follow',
+			'Flag',
+			'Ignore',
+			'Invite',
+			'Join',
+			'Leave',
+			'Like',
+			'Listen',
+			'Move',
+			'Offer',
+			'Read',
+			'Reject',
+			'Remove',
+			'TentativeAccept',
+			'TentativeReject',
+			'Travel',
+			'Undo',
+			'Update',
+			'View',
+		)
+	);
 
 	if ( is_string( $data ) ) {
 		return in_array( $data, $types, true );

--- a/tests/includes/class-test-query.php
+++ b/tests/includes/class-test-query.php
@@ -16,7 +16,7 @@ use WP_UnitTestCase;
  *
  * @coversDefaultClass \Activitypub\Query
  */
-class Test_Query extends ActivityPub_Outbox_TestCase {
+class Test_Query extends \WP_UnitTestCase {
 	/**
 	 * Test user ID.
 	 *
@@ -335,7 +335,17 @@ class Test_Query extends ActivityPub_Outbox_TestCase {
 	 */
 	public function test_outbox_item_visibility() {
 		$post_id     = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
-		$outbox_item = $this->get_latest_outbox_item();
+		$outbox_item = \current(
+			\get_posts(
+				array(
+					'post_type'      => Outbox::POST_TYPE,
+					'posts_per_page' => 1,
+					'post_status'    => 'pending',
+					'orderby'        => 'date',
+					'order'          => 'DESC',
+				)
+			)
+		);
 
 		Query::get_instance()->__destruct();
 		$this->go_to( get_permalink( $outbox_item->ID ) );

--- a/tests/includes/class-test-query.php
+++ b/tests/includes/class-test-query.php
@@ -16,7 +16,7 @@ use WP_UnitTestCase;
  *
  * @coversDefaultClass \Activitypub\Query
  */
-class Test_Query extends WP_UnitTestCase {
+class Test_Query extends ActivityPub_Outbox_TestCase {
 	/**
 	 * Test user ID.
 	 *
@@ -334,19 +334,8 @@ class Test_Query extends WP_UnitTestCase {
 	 * @covers ::get_activitypub_object
 	 */
 	public function test_outbox_item_visibility() {
-		$outbox_item_id = $this->factory->post->create(
-			array(
-				'post_author' => self::$user_id,
-				'post_type'   => Outbox::POST_TYPE,
-				'post_status' => 'any',
-				'meta_input'  => array(
-					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
-					'_activitypub_activity_type'     => 'Create',
-				),
-			)
-		);
-
-		$outbox_item = get_post( $outbox_item_id );
+		$post_id     = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$outbox_item = $this->get_latest_outbox_item();
 
 		Query::get_instance()->__destruct();
 		$this->go_to( get_permalink( $outbox_item->ID ) );
@@ -366,6 +355,6 @@ class Test_Query extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $outbox_item->ID ) );
 		$this->assertNull( Query::get_instance()->get_activitypub_object() );
 
-		\wp_delete_post( $outbox_item->ID, true );
+		\wp_delete_post( $post_id, true );
 	}
 }

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Activity\Activity;
 use Activitypub\Scheduler;
 use Activitypub\Collection\Outbox;
 use Activitypub\Activity\Base_Object;
@@ -52,28 +53,19 @@ class Test_Scheduler extends WP_UnitTestCase {
 	 */
 	public function test_reprocess_outbox() {
 		// Create test activity objects.
-		$activity_object = new Base_Object();
-		$activity_object->set_content( 'Test Content' );
-		$activity_object->set_type( 'Note' );
-		$activity_object->set_id( 'https://example.com/test-id' );
+		$activity = new Activity();
+		$activity->set_object( array( 'content' => 'Test Content' ) );
+		$activity->set_type( 'Create' );
+		$activity->set_id( 'https://example.com/test-id' );
 
 		// Add multiple pending activities.
 		$pending_ids = array();
 		for ( $i = 0; $i < 3; $i++ ) {
-			$pending_ids[] = Outbox::add(
-				$activity_object,
-				'Create',
-				self::$user_id,
-				ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC
-			);
+			$pending_ids[] = Outbox::add( $activity, self::$user_id );
 		}
 
-		$pending_ids[] = Outbox::add(
-			$activity_object,
-			'Update',
-			self::$user_id,
-			ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC
-		);
+		$activity->set_type( 'Update' );
+		$pending_ids[] = Outbox::add( $activity, self::$user_id );
 
 		// Track scheduled events.
 		$scheduled_events = array();
@@ -96,12 +88,7 @@ class Test_Scheduler extends WP_UnitTestCase {
 		$this->assertContains( $pending_ids[3], $scheduled_events, "Activity $pending_ids[3] should be scheduled" );
 
 		// Test with published activities (should not be scheduled).
-		$published_id = Outbox::add(
-			$activity_object,
-			'Create',
-			self::$user_id,
-			ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC
-		);
+		$published_id = Outbox::add( $activity, self::$user_id );
 		wp_update_post(
 			array(
 				'ID'          => $published_id,

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -12,6 +12,7 @@ use Activitypub\Scheduler;
 use Activitypub\Collection\Outbox;
 use Activitypub\Activity\Base_Object;
 use WP_UnitTestCase;
+use function Activitypub\add_to_outbox;
 
 /**
  * Test class for Scheduler.
@@ -151,7 +152,7 @@ class Test_Scheduler extends WP_UnitTestCase {
 		$activity_object->set_type( 'Note' );
 		$activity_object->set_id( 'https://example.com/test-id-2' );
 
-		$pending_id = Outbox::add(
+		$pending_id = add_to_outbox(
 			$activity_object,
 			'Create',
 			self::$user_id,

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -147,17 +147,12 @@ class Test_Scheduler extends WP_UnitTestCase {
 	 */
 	public function test_reprocess_outbox_scheduling() {
 		// Create a test activity.
-		$activity_object = new Base_Object();
-		$activity_object->set_content( 'Test Content' );
-		$activity_object->set_type( 'Note' );
-		$activity_object->set_id( 'https://example.com/test-id-2' );
+		$activity = new Activity();
+		$activity->set_object( array( 'content' => 'Test Content' ) );
+		$activity->set_type( 'Create' );
+		$activity->set_id( 'https://example.com/test-id' );
 
-		$pending_id = add_to_outbox(
-			$activity_object,
-			'Create',
-			self::$user_id,
-			ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC
-		);
+		$pending_id = Outbox::add( $activity, self::$user_id );
 
 		// Track scheduled events and their timing.
 		$scheduled_time = 0;

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -38,6 +38,11 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		$post = \get_post( $id );
 
+		// Replace the post ID in the JSON with the actual post ID.
+		$json       = json_decode( $json, true );
+		$json['id'] = add_query_arg( 'p', $id, $json['id'] );
+		$json       = wp_json_encode( $json, JSON_UNESCAPED_SLASHES );
+
 		$this->assertInstanceOf( 'WP_Post', $post );
 		$this->assertEquals( 'pending', $post->post_status );
 		$this->assertJsonStringEqualsJsonString( $json, $post->post_content );

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -7,8 +7,10 @@
 
 namespace Activitypub\Tests\Collection;
 
+use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Activity\Extended_Object\Event;
+use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
 
 /**
@@ -246,17 +248,35 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	}
 
 	/**
-	 * Helper method to create a dummy activity object for testing.
+	 * Test get_object_id with various activity object types using reflection.
 	 *
-	 * @return \Activitypub\Activity\Activity
+	 * @covers ::get_object_id
 	 */
-	private function get_dummy_activity_object() {
-		$object = new \Activitypub\Activity\Activity();
-		$object->set_id( 'https://example.com/test-object' );
-		$object->set_type( 'Note' );
-		$object->set_content( 'Test content' );
+	public function test_get_object_id() {
+		$object = $this->get_dummy_activity_object();
 
-		return $object;
+		// Activity object of type object.
+		$create_id = \Activitypub\add_to_outbox( $object, 'Create', 1 );
+		$this->assertEquals( 'https://example.com/test-object', get_post_meta( $create_id, '_activitypub_object_id', true ) );
+
+		// Activity object of type string.
+		$activity = new Activity();
+		$activity->set_type( 'Like' );
+		$activity->set_object( 'https://example.com/test-string' );
+
+		$like_id = \Activitypub\add_to_outbox( $activity, null, 1 );
+		$this->assertEquals( 'https://example.com/test-string', get_post_meta( $like_id, '_activitypub_object_id', true ) );
+
+		// No object.
+		$actor    = Actors::get_by_id( 1 );
+		$activity = new Activity();
+		$activity->set_type( 'Move' );
+		$activity->set_actor( $actor->get_id() );
+		$activity->set_origin( $actor->get_id() );
+		$activity->set_target( home_url( '/author/1' ) );
+
+		$move_id = \Activitypub\add_to_outbox( $activity, null, 1 );
+		$this->assertEquals( $actor->get_id(), get_post_meta( $move_id, '_activitypub_object_id', true ) );
 	}
 
 	/**
@@ -303,5 +323,19 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			array( 'Update', 'Undo' ),
 			array( 'Add', 'Remove' ),
 		);
+	}
+
+	/**
+	 * Helper method to create a dummy activity object for testing.
+	 *
+	 * @return Activity
+	 */
+	private function get_dummy_activity_object() {
+		$object = new Activity();
+		$object->set_id( 'https://example.com/test-object' );
+		$object->set_type( 'Note' );
+		$object->set_content( 'Test content' );
+
+		return $object;
 	}
 }

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -72,7 +72,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				1,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/1#activity-create-","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/1","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"http:\/\/example.org\/?post_type=ap_outbox\u0026p=351","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/1","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
 			),
 			array(
 				array(
@@ -83,7 +83,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				2,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2#activity-create-","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"http:\/\/example.org\/?post_type=ap_outbox\u0026p=352","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
 			),
 			array(
 				Event::init_from_array(
@@ -120,7 +120,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				1,
-				'{"@context":["https:\/\/schema.org\/","https:\/\/www.w3.org\/ns\/activitystreams",{"pt":"https:\/\/joinpeertube.org\/ns#","mz":"https:\/\/joinmobilizon.org\/ns#","status":"http:\/\/www.w3.org\/2002\/12\/cal\/ical#status","commentsEnabled":"pt:commentsEnabled","isOnline":"mz:isOnline","timezone":"mz:timezone","participantCount":"mz:participantCount","anonymousParticipationEnabled":"mz:anonymousParticipationEnabled","joinMode":{"@id":"mz:joinMode","@type":"mz:joinModeType"},"externalParticipationUrl":{"@id":"mz:externalParticipationUrl","@type":"schema:URL"},"repliesModerationOption":{"@id":"mz:repliesModerationOption","@type":"@vocab"},"contacts":{"@id":"mz:contacts","@type":"@id"}}],"id":"https:\/\/example.com\/3#activity-create-","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/3","type":"Event","content":"\u003Cp\u003EYou should not miss this Event!\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EYou should not miss this Event!\u003C\/p\u003E"},"name":"WP Test Event","nameMap":{"en":"WP Test Event"},"endTime":"2030-02-29T17:00:00+01:00","location":[{"id":"https:\/\/example.com\/place\/1","type":"Place","attributedTo":"https:\/\/wp-test.event-federation.eu\/@test","name":"Fediverse Place","address":{"type":"PostalAddress","addressCountry":"FediCountry","addressLocality":"FediTown","postalCode":"1337","streetAddress":"FediStreet"}},{"type":"VirtualLocation","url":"https:\/\/example.com\/VirtualMeetingRoom"}],"startTime":"2030-02-29T16:00:00+01:00","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html","timezone":"Europe\/Vienna","category":"MOVEMENTS_POLITICS","joinMode":"external"}}',
+				'{"@context":["https:\/\/schema.org\/","https:\/\/www.w3.org\/ns\/activitystreams",{"pt":"https:\/\/joinpeertube.org\/ns#","mz":"https:\/\/joinmobilizon.org\/ns#","status":"http:\/\/www.w3.org\/2002\/12\/cal\/ical#status","commentsEnabled":"pt:commentsEnabled","isOnline":"mz:isOnline","timezone":"mz:timezone","participantCount":"mz:participantCount","anonymousParticipationEnabled":"mz:anonymousParticipationEnabled","joinMode":{"@id":"mz:joinMode","@type":"mz:joinModeType"},"externalParticipationUrl":{"@id":"mz:externalParticipationUrl","@type":"schema:URL"},"repliesModerationOption":{"@id":"mz:repliesModerationOption","@type":"@vocab"},"contacts":{"@id":"mz:contacts","@type":"@id"}}],"id":"http:\/\/example.org\/?post_type=ap_outbox\u0026p=353","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/3","type":"Event","content":"\u003Cp\u003EYou should not miss this Event!\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EYou should not miss this Event!\u003C\/p\u003E"},"name":"WP Test Event","nameMap":{"en":"WP Test Event"},"endTime":"2030-02-29T17:00:00+01:00","location":[{"id":"https:\/\/example.com\/place\/1","type":"Place","attributedTo":"https:\/\/wp-test.event-federation.eu\/@test","name":"Fediverse Place","address":{"type":"PostalAddress","addressCountry":"FediCountry","addressLocality":"FediTown","postalCode":"1337","streetAddress":"FediStreet"}},{"type":"VirtualLocation","url":"https:\/\/example.com\/VirtualMeetingRoom"}],"startTime":"2030-02-29T16:00:00+01:00","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html","timezone":"Europe\/Vienna","category":"MOVEMENTS_POLITICS","joinMode":"external"}}',
 			),
 		);
 	}
@@ -166,6 +166,8 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 	/**
 	 * Test invalidating existing outbox items.
+	 *
+	 * @covers ::invalidate_existing_items
 	 */
 	public function test_invalidate_existing_items() {
 		$object        = $this->get_dummy_activity_object();
@@ -188,6 +190,8 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 	/**
 	 * Test that only items with matching object_id and activity_type are invalidated.
+	 *
+	 * @covers ::invalidate_existing_items
 	 */
 	public function test_selective_invalidation() {
 		$object1 = $this->get_dummy_activity_object();
@@ -210,6 +214,8 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 	/**
 	 * Test that Delete activities invalidate all existing items for the object.
+	 *
+	 * @covers ::invalidate_existing_items
 	 */
 	public function test_delete_invalidates_all_activities() {
 		$object = $this->get_dummy_activity_object();

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -66,13 +66,13 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			array(
 				array(
 					'@context' => 'https://www.w3.org/ns/activitystreams',
-					'id'       => 'https://example.com/' . self::$user_id,
+					'id'       => 'https://example.com/1',
 					'type'     => 'Note',
 					'content'  => '<p>This is a note</p>',
 				),
 				'Create',
 				1,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/' . self::$user_id . '","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/1#activity-create-","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/1","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
 			),
 			array(
 				array(
@@ -83,7 +83,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				2,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"id":"https:\/\/example.com\/2#activity-create-","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
 			),
 			array(
 				Event::init_from_array(
@@ -120,7 +120,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				1,
-				'{"@context":["https:\/\/schema.org\/","https:\/\/www.w3.org\/ns\/activitystreams",{"pt":"https:\/\/joinpeertube.org\/ns#","mz":"https:\/\/joinmobilizon.org\/ns#","status":"http:\/\/www.w3.org\/2002\/12\/cal\/ical#status","commentsEnabled":"pt:commentsEnabled","isOnline":"mz:isOnline","timezone":"mz:timezone","participantCount":"mz:participantCount","anonymousParticipationEnabled":"mz:anonymousParticipationEnabled","joinMode":{"@id":"mz:joinMode","@type":"mz:joinModeType"},"externalParticipationUrl":{"@id":"mz:externalParticipationUrl","@type":"schema:URL"},"repliesModerationOption":{"@id":"mz:repliesModerationOption","@type":"@vocab"},"contacts":{"@id":"mz:contacts","@type":"@id"}}],"type":"Event","name":"WP Test Event","timezone":"Europe\/Vienna","category":"MOVEMENTS_POLITICS","joinMode":"external","id":"https:\/\/example.com\/3","nameMap":{"en":"WP Test Event"},"endTime":"2030-02-29T17:00:00+01:00","location":[{"id":"https:\/\/example.com\/place\/1","type":"Place","attributedTo":"https:\/\/wp-test.event-federation.eu\/@test","name":"Fediverse Place","address":{"type":"PostalAddress","addressCountry":"FediCountry","addressLocality":"FediTown","postalCode":"1337","streetAddress":"FediStreet"}},{"type":"VirtualLocation","url":"https:\/\/example.com\/VirtualMeetingRoom"}],"startTime":"2030-02-29T16:00:00+01:00","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html","content":"\u003Cp\u003EYou should not miss this Event!\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EYou should not miss this Event!\u003C\/p\u003E"}}',
+				'{"@context":["https:\/\/schema.org\/","https:\/\/www.w3.org\/ns\/activitystreams",{"pt":"https:\/\/joinpeertube.org\/ns#","mz":"https:\/\/joinmobilizon.org\/ns#","status":"http:\/\/www.w3.org\/2002\/12\/cal\/ical#status","commentsEnabled":"pt:commentsEnabled","isOnline":"mz:isOnline","timezone":"mz:timezone","participantCount":"mz:participantCount","anonymousParticipationEnabled":"mz:anonymousParticipationEnabled","joinMode":{"@id":"mz:joinMode","@type":"mz:joinModeType"},"externalParticipationUrl":{"@id":"mz:externalParticipationUrl","@type":"schema:URL"},"repliesModerationOption":{"@id":"mz:repliesModerationOption","@type":"@vocab"},"contacts":{"@id":"mz:contacts","@type":"@id"}}],"id":"https:\/\/example.com\/3#activity-create-","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/3","type":"Event","content":"\u003Cp\u003EYou should not miss this Event!\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EYou should not miss this Event!\u003C\/p\u003E"},"name":"WP Test Event","nameMap":{"en":"WP Test Event"},"endTime":"2030-02-29T17:00:00+01:00","location":[{"id":"https:\/\/example.com\/place\/1","type":"Place","attributedTo":"https:\/\/wp-test.event-federation.eu\/@test","name":"Fediverse Place","address":{"type":"PostalAddress","addressCountry":"FediCountry","addressLocality":"FediTown","postalCode":"1337","streetAddress":"FediStreet"}},{"type":"VirtualLocation","url":"https:\/\/example.com\/VirtualMeetingRoom"}],"startTime":"2030-02-29T16:00:00+01:00","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html","timezone":"Europe\/Vienna","category":"MOVEMENTS_POLITICS","joinMode":"external"}}',
 			),
 		);
 	}
@@ -272,9 +272,10 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Only ID for Deletes.
 		if ( 'Delete' === $expected ) {
-			$this->assertSame( get_permalink( $id ), $activity->get_object() );
+			$this->assertSame( get_permalink( $id ), $activity->get_object()->get_object() );
 		} else {
-			$this->assertEquals( json_decode( get_post( $undo_id )->post_content, true ), $activity->get_object()->to_array() );
+			$outbox_activity = json_decode( get_post( $undo_id )->post_content, true );
+			$this->assertEquals( $outbox_activity['object'], $activity->get_object()->to_array( false ) );
 		}
 
 		$this->assertSame( $expected, $activity->get_type() );

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -45,9 +45,9 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$activity = json_decode( $post->post_content );
 
 		if ( is_array( $data ) ) {
-			$this->assertSame( $data['content'], $activity->content );
+			$this->assertSame( $data['content'], $activity->object->content );
 		} elseif ( $data instanceof Base_Object ) {
-			$this->assertSame( $data->get_content(), $activity->content );
+			$this->assertSame( $data->get_content(), $activity->object->content );
 		}
 		$this->assertEquals( $type, \get_post_meta( $id, '_activitypub_activity_type', true ) );
 
@@ -272,7 +272,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Only ID for Deletes.
 		if ( 'Delete' === $expected ) {
-			$this->assertSame( get_permalink( $id ), $activity->get_object()->get_object() );
+			$this->assertSame( get_permalink( $id ), $activity->get_object() );
 		} else {
 			$outbox_activity = json_decode( get_post( $undo_id )->post_content, true );
 			$this->assertEquals( $outbox_activity['object'], $activity->get_object()->to_array( false ) );

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -19,7 +19,6 @@ use Activitypub\Collection\Outbox;
  * @coversDefaultClass \Activitypub\Collection\Outbox
  */
 class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
-
 	/**
 	 * Test add an item to the outbox.
 	 *
@@ -61,6 +60,42 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Fall back to blog if user does not have the activitypub capability.
 		$actor_type = \user_can( $user_id, 'activitypub' ) ? 'user' : 'blog';
 		$this->assertEquals( $actor_type, \get_post_meta( $id, '_activitypub_activity_actor', true ) );
+	}
+
+	/**
+	 * Test comparing objects.
+	 *
+	 * @covers ::add
+	 */
+	public function test_compare_objects() {
+		$object1 = new Base_Object();
+		$object1->set_id( 'https://example.com/1' );
+		$object1->set_type( 'Note' );
+		$object1->set_content( '<p>Test content</p>' );
+
+		$id1 = \Activitypub\add_to_outbox( $object1, 'Create', 1 );
+
+		$post1     = \get_post( $id1 );
+		$activity1 = json_decode( $post1->post_content );
+
+		$object2 = new Activity();
+		$object2->set_id( 'https://example.com/1' );
+		$object2->set_type( 'Create' );
+		$object2->set_object(
+			array(
+				'id'      => 'https://example.com/1',
+				'type'    => 'Note',
+				'content' => '<p>Test content</p>',
+			)
+		);
+
+		$id2 = \Activitypub\add_to_outbox( $object2, null, 1 );
+
+		$post2     = \get_post( $id2 );
+		$activity2 = json_decode( $post2->post_content );
+
+		$this->assertEquals( $activity1->object->type, $activity2->object->type );
+		$this->assertEquals( $activity1->object->content, $activity2->object->content );
 	}
 
 	/**

--- a/tests/includes/handler/class-test-follow.php
+++ b/tests/includes/handler/class-test-follow.php
@@ -113,10 +113,10 @@ class Test_Follow extends WP_UnitTestCase {
 		$this->assertEquals( 'Accept', $activity_type );
 		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility );
 
-		$this->assertEquals( 'Follow', $activity_json['type'] );
-		$this->assertEquals( 'https://example.com/user/1', $activity_json['object'] );
-		$this->assertEquals( array( $actor ), $activity_json['to'] );
-		$this->assertEquals( $actor, $activity_json['actor'] );
+		$this->assertEquals( 'Follow', $activity_json['object']['type'] );
+		$this->assertEquals( 'https://example.com/user/1', $activity_json['object']['object'] );
+		$this->assertEquals( array( $actor ), $activity_json['object']['to'] );
+		$this->assertEquals( $actor, $activity_json['object']['actor'] );
 
 		// Clean up.
 		wp_delete_post( $outbox_post->ID, true );

--- a/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/includes/rest/class-test-outbox-controller.php
@@ -609,7 +609,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertSame( 1, (int) $data['totalItems'] );
 		$this->assertCount( 1, $data['orderedItems'] );
-		$this->assertSame( 'https://example.org/activity/1', $data['orderedItems'][0]['object']['id'] );
+		$this->assertSame( 'https://example.org/note/1', $data['orderedItems'][0]['object']['id'] );
 
 		// Test blog outbox only returns blog actor type.
 		$request  = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/0/outbox', ACTIVITYPUB_REST_NAMESPACE ) );
@@ -698,7 +698,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertSame( 1, (int) $data['totalItems'] );
 		$this->assertCount( 1, $data['orderedItems'] );
-		$this->assertSame( 'https://example.org/activity/1', $data['orderedItems'][0]['object']['id'] );
+		$this->assertSame( 'https://example.org/note/1', $data['orderedItems'][0]['object']['id'] );
 
 		// Test as privileged user.
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -182,7 +182,7 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$activity = \json_decode( $post->post_content, true );
 		$this->assertArrayHasKey( 'object', $activity );
 		$this->assertArrayHasKey( $field, $activity['object'] );
-		$this->assertStringContainsString( $expected, $activity['object'][ $field ] );
+		$this->assertSame( $expected, $activity['object'][ $field ] );
 	}
 
 	/**

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -179,9 +179,10 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$activitpub_id = Actors::get_by_id( Actors::BLOG_USER_ID )->get_id();
 		$post          = $this->get_latest_outbox_item( $activitpub_id );
 
-		$activity_object = \json_decode( $post->post_content, true );
-		$this->assertArrayHasKey( $field, $activity_object );
-		$this->assertSame( $expected, $activity_object[ $field ] );
+		$activity = \json_decode( $post->post_content, true );
+		$this->assertArrayHasKey( 'object', $activity );
+		$this->assertArrayHasKey( $field, $activity['object'] );
+		$this->assertStringContainsString( $expected, $activity['object'][ $field ] );
 	}
 
 	/**
@@ -216,9 +217,10 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$activitpub_id = Actors::get_by_id( Actors::BLOG_USER_ID )->get_id();
 		$post          = $this->get_latest_outbox_item( $activitpub_id );
 
-		$activity_object = \json_decode( $post->post_content, true );
-		$this->assertArrayHasKey( $field, $activity_object );
-		$this->assertStringContainsString( $value, $activity_object[ $field ] );
+		$activity = \json_decode( $post->post_content, true );
+		$this->assertArrayHasKey( 'object', $activity );
+		$this->assertArrayHasKey( $field, $activity['object'] );
+		$this->assertStringContainsString( $value, $activity['object'][ $field ] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Moves the Outbox from saving activity objects to full Activities with back compat for 3rd-party plugins.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Outbox::add()` only accepts full Activities now.
* `add_to_outbox()` now transforms data to full objects, based on what shape of data it receives.
* Updated unit tests to account for the new data shape.


### Other information:

- [x] Have you written new tests for your changes, if applicable?


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Outbox items now contain the full activity, not just activity objects.

</details>
