### PR TITLE
Fix spacing issue

### DIFF
--- a/.github/changelog/pr-1477
+++ b/.github/changelog/pr-1477
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved readability in Mastodon Apps plugin string.

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -257,7 +257,7 @@ class Welcome_Fields {
 					echo \wp_kses(
 						\sprintf(
 							// translators: %s is a URL.
-							\__( 'Enable the use of a wide variety of <a href="%s" target="_blank">Mastodon apps</a>to interact with your WordPress site, for example write posts that can then be federated via the ActivityPub plugin.', 'activitypub' ),
+							\__( 'Enable the use of a wide variety of <a href="%s" target="_blank">Mastodon apps</a> to interact with your WordPress site, for example write posts that can then be federated via the ActivityPub plugin.', 'activitypub' ),
 							'https://joinmastodon.org/apps'
 						),
 						array(

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === ActivityPub ===
-Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaformat, nuriapena, cavalierlife, andremenrath
+Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaformat, nuriapena, cavalierlife, andremenrath, edent
 Tags: OStatus, fediverse, activitypub, activitystream
 Requires at least: 6.4
 Tested up to: 6.7

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === ActivityPub ===
-Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaformat, nuriapena, cavalierlife, andremenrath, edent
+Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaformat, nuriapena, cavalierlife, andremenrath
 Tags: OStatus, fediverse, activitypub, activitystream
 Requires at least: 6.4
 Tested up to: 6.7


### PR DESCRIPTION
Current text looks like this:

![image](https://github.com/user-attachments/assets/af09c325-8b19-4f18-9333-d8b68d75e41a)


## Proposed changes:

* Add a space for readability



-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Improved readability in Mastodon Apps plugin string.

</details>

