### PR TITLE
Preview: Check attachments before using them

### DIFF
--- a/.github/changelog/1478-from-description
+++ b/.github/changelog/1478-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+No more PHP warnings when previewing posts without attachments.

--- a/templates/post-preview.php
+++ b/templates/post-preview.php
@@ -215,6 +215,7 @@ $user   = $transformer->get_actor_object();
 						<?php endif; ?>
 						<?php echo wp_kses( 'Article' === $object->get_type() ? $object->get_summary() : $object->get_content(), ACTIVITYPUB_MASTODON_HTML_SANITIZER ); ?>
 					</div>
+					<?php if ( $object->get_attachment() ) : ?>
 					<div class="attachments">
 						<?php foreach ( $object->get_attachment() as $attachment ) : ?>
 							<?php if ( 'Image' === $attachment['type'] ) : ?>
@@ -222,6 +223,7 @@ $user   = $transformer->get_actor_object();
 							<?php endif; ?>
 						<?php endforeach; ?>
 					</div>
+					<?php endif; ?>
 					<?php if ( $object->get_tag() ) : ?>
 					<div class="tags">
 						<?php foreach ( $object->get_tag() as $hashtag ) : ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds truthy check for attachments before using them in post preview template.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post in the Block editor.
* Only write text and save a draft.
* Preview the post using Fediverse Preview.
* No PHP warnings should show.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

No more PHP warnings when previewing posts without attachments.

</details>
