### PR TITLE
Changelog: allow generating a changelog entry from the PR description in a fork, too.

### DIFF
--- a/.github/changelog/fix-changelog-workflow-forks
+++ b/.github/changelog/fix-changelog-workflow-forks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Changelog entries: allow automating changelog entry generation from forks as well.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,6 @@
 name: "Changelog entry"
 on:
-  pull_request:
+  pull_request_target:
     # The specific activity types are listed here to include "labeled" and "unlabeled"
     # (which are not included by default for the "pull_request" trigger).
     # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,


### PR DESCRIPTION
## Proposed changes:

See https://github.com/Automattic/wordpress-activitypub/pull/1477#issuecomment-2739498385

External contributors should be able to generate a changelog entry in their fork using the workflow. Let's allow that by switching to triggering the workflow on `pull_request_target`, where the event has the necessary access to be able to run the workflow, but doesn't have the possibility of running the workflow from code they may have modified in their fork.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This cannot really be tested until it gets merged, I'm afraid, since we are changing the workflow itself in this PR.
