### PR TITLE
Changelog: invite external contributors to add changelog file

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -162,7 +162,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { repo: { owner, repo }, payload : { pull_request : { number, head : { ref } } } } = context;
+            const { repo: { owner, repo }, payload : { pull_request : { number, head : { ref, repo: head_repo } } } } = context;
 
             // Get the changelog information from the previous step.
             const significance = '${{ steps.check-pr-body.outputs.significance }}';
@@ -198,8 +198,39 @@ jobs:
             const path = `.github/changelog/${ number }-from-description`;
             core.info( `Creating changelog file: ${ path }` );
 
+            // Check if PR is from a fork
+            const isFromFork = head_repo.full_name !== `${owner}/${repo}`;
+
+            if ( isFromFork ) {
+              // For forks, we cannot create the file automatically, so we add a helpful comment to the PR,
+              // asking the contributor to create the file manually.
+              const commentBody = `👋 Thanks for your contribution!
+
+              I see you have provided all the required changelog information in your PR description. To complete the process, you'll need to create a changelog file in your branch.
+
+              Please create a file named \`.github/changelog/${number}-from-description\` with this content:
+
+              \`\`\`
+              ${content}
+              \`\`\`
+
+              You can do this by either:
+              1. Running \`composer changelog:add\` in your local repository, or
+              2. Creating the file manually with the content above
+
+              Once you've committed and pushed the file to your PR branch, the checks will pass automatically.`;
+
+              await github.rest.issues.createComment( {
+                owner,
+                repo,
+                issue_number: number,
+                body: commentBody
+              } );
+              return;
+            }
+
             try {
-              // Create or update the file in the repository
+              // For internal PRs, create the file automatically
               await github.rest.repos.createOrUpdateFileContents( {
                 owner,
                 repo,


### PR DESCRIPTION
Follow-up to #1479.

## Proposed changes:

I was wrong in #1479. We cannot add a file to their branch automatically, unfortunately. We'll consequently take a different approach: if the PR is from a fork and the contributor provided changelog information in the PR description, we'll leave a comment on the PR inviting them to add the changelog file manually.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This can only be tested in a fork until this PR is merged. Here is how the comment would look like:

<img width="938" alt="image" src="https://github.com/user-attachments/assets/55f20f9b-9394-478d-9297-ee41c85bf42e" />
