### PR TITLE
Changelog: don't post duplicate comments for external contributors

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -202,6 +202,7 @@ jobs:
             const isFromFork = head_repo.full_name !== `${owner}/${repo}`;
 
             if ( isFromFork ) {
+              core.info( 'PR is from a fork, so we cannot create the changelog file automatically.' );
               // For forks, we cannot create the file automatically, so we add a helpful comment to the PR,
               // asking the contributor to create the file manually.
               const commentBody = `👋 Thanks for your contribution!
@@ -220,12 +221,36 @@ jobs:
 
               Once you've committed and pushed the file to your PR branch, the checks will pass automatically.`;
 
-              await github.rest.issues.createComment( {
+              // Check for existing comments first
+              let hasExistingComment = false;
+              for await ( const response of github.paginate.iterator( github.rest.issues.listComments, {
                 owner,
                 repo,
-                issue_number: number,
-                body: commentBody
-              } );
+                issue_number: +number,
+                per_page: 100,
+              } ) ) {
+                for ( const comment of response.data ) {
+                  if ( comment.body.includes('👋 Thanks for your contribution!') ) {
+                    hasExistingComment = true;
+                    break;
+                  }
+                }
+                if ( hasExistingComment ) {
+                  core.info( 'A comment already exists, so we will not add another one.' );
+                  break;
+                }
+              }
+
+              // Only post the comment if we haven't posted one before
+              if ( ! hasExistingComment ) {
+                core.info( 'No existing comment found, so we will add a new one.' );
+                await github.rest.issues.createComment( {
+                  owner,
+                  repo,
+                  issue_number: number,
+                  body: commentBody
+                } );
+              }
               return;
             }
 


### PR DESCRIPTION
Follow-up to #1479 and #1482

## Proposed changes:

Hopefully that's the last one in this series! Sorry for the extra review work!

See https://github.com/Automattic/wordpress-activitypub/pull/1480#issuecomment-2739831347

When posting comments to invite contributors to add a changelog entry, we now first check if such a comment was already posted, to avoid duplication.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This can only be tested in a fork.
