### PR TITLE
Interaction: Fix deleting comments

### DIFF
--- a/.github/changelog/1485-from-description
+++ b/.github/changelog/1485-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Comments from Fediverse actors will now be purged as expected.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -179,20 +179,19 @@ class Interactions {
 			$actor = object_to_uri( $meta['url'] );
 		}
 
-		$args          = array(
-			'nopaging'   => true,
-			'author_url' => $actor,
+		$args = array(
+			'nopaging'           => true,
+			'comment_author_url' => $actor,
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query' => array(
+			'meta_query'         => array(
 				array(
-					'key'     => 'protocol',
-					'value'   => 'activitypub',
-					'compare' => '=',
+					'key'   => 'protocol',
+					'value' => 'activitypub',
 				),
 			),
 		);
-		$comment_query = new WP_Comment_Query( $args );
-		return $comment_query->comments;
+
+		return get_comments( $args );
 	}
 
 	/**

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -180,10 +180,10 @@ class Interactions {
 		}
 
 		$args = array(
-			'nopaging'           => true,
-			'comment_author_url' => $actor,
+			'nopaging'   => true,
+			'author_url' => $actor,
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query'         => array(
+			'meta_query' => array(
 				array(
 					'key'   => 'protocol',
 					'value' => 'activitypub',

--- a/includes/handler/class-delete.php
+++ b/includes/handler/class-delete.php
@@ -136,10 +136,8 @@ class Delete {
 	public static function delete_interactions( $actor ) {
 		$comments = Interactions::get_interactions_by_actor( $actor );
 
-		if ( is_array( $comments ) ) {
-			foreach ( $comments as $comment ) {
-				wp_delete_comment( $comment->comment_ID, true );
-			}
+		foreach ( $comments as $comment ) {
+			wp_delete_comment( $comment->comment_ID, true );
 		}
 	}
 

--- a/includes/handler/class-delete.php
+++ b/includes/handler/class-delete.php
@@ -137,7 +137,7 @@ class Delete {
 		$comments = Interactions::get_interactions_by_actor( $actor );
 
 		foreach ( $comments as $comment ) {
-			wp_delete_comment( $comment->comment_ID, true );
+			wp_delete_comment( $comment, true );
 		}
 	}
 

--- a/tests/includes/handler/class-test-delete.php
+++ b/tests/includes/handler/class-test-delete.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Test file for Delete handler.
+ *
+ * @package ActivityPub
+ */
+
+namespace Activitypub\Tests\Handler;
+
+use Activitypub\Handler\Delete;
+
+/**
+ * Test class for Delete handler.
+ *
+ * @coversDefaultClass \Activitypub\Handler\Delete
+ */
+class Test_Delete extends \WP_UnitTestCase {
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Create fake data before tests run.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public static function tear_down_after_class() {
+		wp_delete_user( self::$user_id );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		\add_filter( 'pre_get_remote_metadata_by_actor', array( self::class, 'get_remote_metadata_by_actor' ), 0, 2 );
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tear_down() {
+		\remove_filter( 'pre_get_remote_metadata_by_actor', array( self::class, 'get_remote_metadata_by_actor' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test delete interactions.
+	 */
+	public function test_delete_interactions() {
+		self::factory()->comment->create_many(
+			5,
+			array(
+				'user_id'      => self::$user_id,
+				'author_url'   => get_author_posts_url( self::$user_id ),
+				'comment_meta' => array( 'protocol' => 'activitypub' ),
+			)
+		);
+
+		Delete::delete_interactions( self::$user_id );
+
+		$this->assertEmpty( get_comments( array( 'user_id' => self::$user_id ) ) );
+	}
+
+	/**
+	 * Get remote metadata by actor.
+	 *
+	 * @param string $value Value.
+	 * @param string $actor Actor.
+	 * @return array
+	 */
+	public static function get_remote_metadata_by_actor( $value, $actor ) {
+		return array(
+			'name' => 'Example User',
+			'icon' => array(
+				'url' => 'https://example.com/icon',
+			),
+			'url'  => get_author_posts_url( $actor ),
+			'id'   => 'http://example.org/users/example',
+		);
+	}
+}

--- a/tests/includes/handler/class-test-delete.php
+++ b/tests/includes/handler/class-test-delete.php
@@ -65,13 +65,12 @@ class Test_Delete extends \WP_UnitTestCase {
 		self::factory()->comment->create_many(
 			5,
 			array(
-				'user_id'      => self::$user_id,
 				'author_url'   => get_author_posts_url( self::$user_id ),
 				'comment_meta' => array( 'protocol' => 'activitypub' ),
 			)
 		);
 
-		Delete::delete_interactions( self::$user_id );
+		Delete::delete_interactions( get_author_posts_url( self::$user_id ) );
 
 		$this->assertEmpty( get_comments( array( 'user_id' => self::$user_id ) ) );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

While reading through code for the PHPStan changed I came across `get_interactions_by_actor()` and noticed the use of `WP_Comment_Query` in a way that I've not considered it before. Decided to write a test to make sure it works and found an unrelated bug :D

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates comment query arg to catch comment author url.
* Adds test for `get_interactions_by_actor()`

### Other information:

- [x] Have you written new tests for your changes, if applicable?


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Comments from Fediverse actors will now be purged as expected.

</details>
