### PR TITLE
Fixed: Do not escape slashes in `json_encode`

### DIFF
--- a/.github/changelog/1488-from-description
+++ b/.github/changelog/1488-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use `JSON_UNESCAPED_SLASHES` because Mastodon seems to have problems with encoded URLs.

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -293,7 +293,7 @@ class Generic_Object {
 	 */
 	public function to_json( $include_json_ld_context = true ) {
 		$array   = $this->to_array( $include_json_ld_context );
-		$options = \JSON_HEX_TAG | \JSON_HEX_AMP | \JSON_HEX_QUOT;
+		$options = \JSON_HEX_TAG | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_UNESCAPED_SLASHES;
 
 		/**
 		 * Options to be passed to json_encode()

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -296,7 +296,7 @@ class Generic_Object {
 		$options = \JSON_HEX_TAG | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_UNESCAPED_SLASHES;
 
 		/**
-		 * Options to be passed to json_encode()
+		 * Options to be passed to json_encode().
 		 *
 		 * @param int $options The current options flags.
 		 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It seems that Mastodon is not able to read the `alsoKnownAs` aliases without `JSON_UNESCAPED_SLASHES`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `JSON_UNESCAPED_SLASHES` to the `wp_json_encode` options.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch and try to move a Mastodon Account to WordPress

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Use `JSON_UNESCAPED_SLASHES` because Mastodon seems to have problems with encoded URLs.

</details>
