### PR TITLE
Auto-changelog: use a custom PAT instead of default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -161,6 +161,7 @@ jobs:
           PR_MESSAGE: '${{ steps.check-pr-body.outputs.message }}'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.API_TOKEN_GITHUB }}
           script: |
             const { repo: { owner, repo }, payload : { pull_request : { number, head : { ref, repo: head_repo } } } } = context;
 


### PR DESCRIPTION
Follow-up to #1479, #1482, and #1483

## Proposed changes:

This fixes an issue with the automatically generated commit that adds a changelog entry to your PR when you fill in the information in the PR template. 
That automatically generated commit (in practice, a `push` event to the branch) does not trigger any workflow, so workflows that currently listen to the `push` event, the `pull_request` event, or the `pull_request_target` event, are not triggered after that commit.

This is done on purpose by GitHub, as per the docs:

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
-- https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

A possible work-around in such cases is to use a personal access token instead of `GITHUB_TOKEN` to trigger events that require a token.

Lucky for us, `actions/github-script` allows using the github-token input to pass your own custom token.

I've consequently passed it a custom token used within Automattic.

Internal reference: p1742490748985489-slack-C04TJ8P900J

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This cannot be tested until it gets merged, unforunately.
