### PR TITLE
Actor Update: Add Updated

### DIFF
--- a/.github/changelog/1495-from-description
+++ b/.github/changelog/1495-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set `updated` field for profile updates, otherwise the `Update`-`Activity` wouldn't be handled by Mastodon.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -221,6 +221,10 @@ class Outbox {
 			$activity->set_object( $activity_object );
 		}
 
+		if ( 'Update' === $type ) {
+			$activity->set_updated( gmdate( 'Y-m-d H:i:s', strtotime( $outbox_item->post_modified ) ) );
+		}
+
 		/**
 		 * Filters the Activity object before it is returned.
 		 *

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -132,7 +132,12 @@ class Actor {
 		}
 
 		$actor = Actors::get_by_id( $user_id );
-		$actor->set_updated( time() );
+
+		if ( ! $actor || \is_wp_error( $actor ) ) {
+			return;
+		}
+
+		$actor->set_updated( gmdate( 'Y-m-d H:i:s', time() ) );
 
 		add_to_outbox( $actor, 'Update', $user_id );
 	}

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -131,6 +131,9 @@ class Actor {
 			return;
 		}
 
-		add_to_outbox( Actors::get_by_id( $user_id ), 'Update', $user_id );
+		$actor = Actors::get_by_id( $user_id );
+		$actor->set_updated( time() );
+
+		add_to_outbox( $actor, 'Update', $user_id );
 	}
 }

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -383,16 +383,16 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$object = $this->get_dummy_activity_object();
 		$object->set_content( 'Original content' );
 
-		// Create an Update activity
+		// Create an Update activity.
 		$id = \Activitypub\add_to_outbox( $object, 'Update', 1 );
 		$this->assertNotFalse( $id );
 
-		// Get the activity from the outbox
+		// Get the activity from the outbox.
 		$activity = Outbox::get_activity( $id );
 		$this->assertNotInstanceOf( \WP_Error::class, $activity );
 
-		// Verify the updated attribute is set and matches the post's modified date
-		$post = get_post( $id );
+		// Verify the updated attribute is set and matches the post's modified date.
+		$post             = get_post( $id );
 		$expected_updated = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) );
 		$this->assertEquals( $expected_updated, $activity->get_updated() );
 

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -373,4 +373,30 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		return $object;
 	}
+
+	/**
+	 * Test that Update activities have the updated attribute set.
+	 *
+	 * @covers ::get_activity
+	 */
+	public function test_update_activity_has_updated_attribute() {
+		$object = $this->get_dummy_activity_object();
+		$object->set_content( 'Original content' );
+
+		// Create an Update activity
+		$id = \Activitypub\add_to_outbox( $object, 'Update', 1 );
+		$this->assertNotFalse( $id );
+
+		// Get the activity from the outbox
+		$activity = Outbox::get_activity( $id );
+		$this->assertNotInstanceOf( \WP_Error::class, $activity );
+
+		// Verify the updated attribute is set and matches the post's modified date
+		$post = get_post( $id );
+		$expected_updated = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) );
+		$this->assertEquals( $expected_updated, $activity->get_updated() );
+
+		// Delete the Outbox item.
+		wp_delete_post( $id );
+	}
 }

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -305,19 +305,19 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 * @covers ::schedule_profile_update
 	 */
 	public function test_actor_profile_update_sets_updated_attribute() {
-		// Update the user's display name to trigger a profile update
+		// Update the user's display name to trigger a profile update.
 		self::factory()->user->update_object( self::$user_id, array( 'display_name' => 'Updated Display Name' ) );
 
 		$activitpub_id = Actors::get_by_id( self::$user_id )->get_id();
-		$post = $this->get_latest_outbox_item( $activitpub_id );
+		$post          = $this->get_latest_outbox_item( $activitpub_id );
 
-		// Verify the activity type is Update
+		// Verify the activity type is Update.
 		$this->assertEquals( 'Update', \get_post_meta( $post->ID, '_activitypub_activity_type', true ) );
 
-		// Get the activity from the outbox
+		// Get the activity from the outbox.
 		$activity = \json_decode( $post->post_content, true );
 
-		// Verify the updated attribute is set and matches the post's modified date
+		// Verify the updated attribute is set and matches the post's modified date.
 		$expected_updated = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) );
 		$this->assertEquals( $expected_updated, $activity['updated'] );
 	}

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -298,4 +298,27 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Clean up.
 		\wp_delete_post( $blog_post_id, true );
 	}
+
+	/**
+	 * Test that actor profile updates set the updated attribute.
+	 *
+	 * @covers ::schedule_profile_update
+	 */
+	public function test_actor_profile_update_sets_updated_attribute() {
+		// Update the user's display name to trigger a profile update
+		self::factory()->user->update_object( self::$user_id, array( 'display_name' => 'Updated Display Name' ) );
+
+		$activitpub_id = Actors::get_by_id( self::$user_id )->get_id();
+		$post = $this->get_latest_outbox_item( $activitpub_id );
+
+		// Verify the activity type is Update
+		$this->assertEquals( 'Update', \get_post_meta( $post->ID, '_activitypub_activity_type', true ) );
+
+		// Get the activity from the outbox
+		$activity = \json_decode( $post->post_content, true );
+
+		// Verify the updated attribute is set and matches the post's modified date
+		$expected_updated = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) );
+		$this->assertEquals( $expected_updated, $activity['updated'] );
+	}
 }


### PR DESCRIPTION
Set the `updated` field for profile updates, otherwise the `Activity` wouldn't be handled as an update.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set `updated` field for `Activity` and `Activity`-`Object`

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Set `updated` field for profile updates, otherwise the `Update`-`Activity` wouldn't be handled by Mastodon.

</details>
