### PR TITLE
Fix: Announces

### DIFF
--- a/.github/changelog/1500-from-description
+++ b/.github/changelog/1500-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+`Scheduler::schedule_announce_activity` to handle Activities instead of Activity-Objects.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub;
 
+use Activitypub\Activity\Activity;
 use Activitypub\Scheduler\Post;
 use Activitypub\Scheduler\Actor;
 use Activitypub\Scheduler\Comment;
@@ -391,11 +392,11 @@ class Scheduler {
 	 * Send announces.
 	 *
 	 * @param int                            $outbox_activity_id The outbox activity ID.
-	 * @param \Activitypub\Activity\Activity $activity_object    The activity object.
+	 * @param \Activitypub\Activity\Activity $activity           The activity object.
 	 * @param int                            $actor_id           The actor ID.
 	 * @param int                            $content_visibility The content visibility.
 	 */
-	public static function schedule_announce_activity( $outbox_activity_id, $activity_object, $actor_id, $content_visibility ) {
+	public static function schedule_announce_activity( $outbox_activity_id, $activity, $actor_id, $content_visibility ) {
 		// Only if we're in both Blog and User modes.
 		if ( ACTIVITYPUB_ACTOR_AND_BLOG_MODE !== \get_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE ) ) {
 			return;
@@ -411,28 +412,26 @@ class Scheduler {
 			return;
 		}
 
-		$activity_type = \get_post_meta( $outbox_activity_id, '_activitypub_activity_type', true );
-
 		// Only if the activity is a Create, Update or Delete.
-		if ( ! in_array( $activity_type, array( 'Create', 'Update', 'Delete' ), true ) ) {
+		if ( ! in_array( $activity->get_type(), array( 'Create', 'Update', 'Delete' ), true ) ) {
+			return;
+		}
+
+		if ( ! is_object( $activity->get_object() ) ) {
 			return;
 		}
 
 		// Check if the object is an article, image, audio, video, event or document and ignore profile updates and other activities.
-		if ( ! in_array( $activity_object->get_type(), array( 'Note', 'Article', 'Image', 'Audio', 'Video', 'Event', 'Document' ), true ) ) {
+		if ( ! in_array( $activity->get_object()->get_type(), array( 'Note', 'Article', 'Image', 'Audio', 'Video', 'Event', 'Document' ), true ) ) {
 			return;
 		}
 
-		$transformer = Factory::get_transformer( $activity_object );
-		if ( ! $transformer || \is_wp_error( $transformer ) ) {
-			return;
-		}
+		$announce_activity = new Activity();
+		$announce_activity->set_type( 'Announce' );
+		$announce_activity->set_actor( Actors::get_by_id( Actors::BLOG_USER_ID )->get_id() );
+		$announce_activity->set_object( $activity );
 
-		$post     = get_post( $outbox_activity_id );
-		$activity = $transformer->to_activity( $activity_type );
-		$activity->set_id( $post->guid );
-
-		$outbox_activity_id = Outbox::add( $activity, 'Announce', Actors::BLOG_USER_ID );
+		$outbox_activity_id = Outbox::add( $announce_activity, Actors::BLOG_USER_ID );
 
 		if ( ! $outbox_activity_id ) {
 			return;

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -421,7 +421,7 @@ class Scheduler {
 			return;
 		}
 
-		// Check if the object is an article, image, audio, video, event or document and ignore profile updates and other activities.
+		// Check if the object is an article, image, audio, video, event, or document and ignore profile updates and other activities.
 		if ( ! in_array( $activity->get_object()->get_type(), array( 'Note', 'Article', 'Image', 'Audio', 'Video', 'Event', 'Document' ), true ) ) {
 			return;
 		}

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -426,12 +426,12 @@ class Scheduler {
 			return;
 		}
 
-		$announce_activity = new Activity();
-		$announce_activity->set_type( 'Announce' );
-		$announce_activity->set_actor( Actors::get_by_id( Actors::BLOG_USER_ID )->get_id() );
-		$announce_activity->set_object( $activity );
+		$announce = new Activity();
+		$announce->set_type( 'Announce' );
+		$announce->set_actor( Actors::get_by_id( Actors::BLOG_USER_ID )->get_id() );
+		$announce->set_object( $activity );
 
-		$outbox_activity_id = Outbox::add( $announce_activity, Actors::BLOG_USER_ID );
+		$outbox_activity_id = Outbox::add( $announce, Actors::BLOG_USER_ID );
 
 		if ( ! $outbox_activity_id ) {
 			return;


### PR DESCRIPTION
With the re-write of how we store Activities in the Outbox, the Announces do no longer work. This PR fixes that.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Handle `Activity` instead of `Activity`>`Object`

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish a new Post
* Check Outbox for `Create` and `Announce` Activity

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

`Scheduler::schedule_announce_activity` to handle Activities instead of Activity-Objects.

</details>
