### PR TITLE
Fix: (Pixelfed) Follow

### DIFF
--- a/.github/changelog/1501-from-description
+++ b/.github/changelog/1501-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Properly set `to` audience of `Activity` instead of changing the `Follow` Object.

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -148,7 +148,10 @@ class Activity extends Base_Object {
 		}
 
 		foreach ( array( 'to', 'bto', 'cc', 'bcc', 'audience' ) as $i ) {
-			$this->set( $i, $data->get( $i ) );
+			$value = $data->get( $i );
+			if ( $value ) {
+				$this->set( $i, $value );
+			}
 		}
 
 		if ( $data->get_published() && ! $this->get_published() ) {

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -149,7 +149,7 @@ class Activity extends Base_Object {
 
 		foreach ( array( 'to', 'bto', 'cc', 'bcc', 'audience' ) as $i ) {
 			$value = $data->get( $i );
-			if ( $value ) {
+			if ( $value && ! $this->get( $i ) ) {
 				$this->set( $i, $value );
 			}
 		}
@@ -166,7 +166,7 @@ class Activity extends Base_Object {
 			$this->set( 'actor', $data->get_attributed_to() );
 		}
 
-		if ( $data->get_in_reply_to() ) {
+		if ( $data->get_in_reply_to() && ! $this->get_in_reply_to() ) {
 			$this->set( 'in_reply_to', $data->get_in_reply_to() );
 		}
 

--- a/includes/handler/class-follow.php
+++ b/includes/handler/class-follow.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Handler;
 
 use Activitypub\Notification;
+use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
 
@@ -102,9 +103,12 @@ class Follow {
 			)
 		);
 
-		// Send response only to the Follower.
-		$activity_object['to'] = array( $actor );
+		$activity = new Activity();
+		$activity->set_type( 'Accept' );
+		$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
+		$activity->set_object( $activity_object );
+		$activity->set_to( array( $actor ) );
 
-		add_to_outbox( $activity_object, 'Accept', $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+		add_to_outbox( $activity, null, $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 	}
 }

--- a/tests/includes/activity/class-test-activity.php
+++ b/tests/includes/activity/class-test-activity.php
@@ -159,12 +159,12 @@ class Test_Activity extends \WP_UnitTestCase {
 		$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
 		$activity->set_object( $activity_object );
 
-		$this->assertEquals( 'https://example.com/author/123', $activity->get_to()[0] );
+		$this->assertContains( 'https://example.com/author/123', $activity->get_to() );
 
 		$activity->set_to( array( 'https://example.com/author/456' ) );
 		$activity->set_object( $activity_object );
 
-		$this->assertEquals( 'https://example.com/author/456', $activity->get_to()[0] );
+		$this->assertContains( 'https://example.com/author/456', $activity->get_to() );
 
 		// Delete user.
 		\wp_delete_user( $user_id );

--- a/tests/includes/activity/class-test-activity.php
+++ b/tests/includes/activity/class-test-activity.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Tests\Activity;
 
 use Activitypub\Activity\Activity;
+use Activitypub\Collection\Actors;
 use DMS\PHPUnitExtensions\ArraySubset\Assert;
 
 /**
@@ -131,5 +132,41 @@ class Test_Activity extends \WP_UnitTestCase {
 		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );
 
 		$this->assertTrue( str_starts_with( $activity->get_id(), 'https://example.com/author/123#activity-update-' ) );
+	}
+
+	/**
+	 * Test activity object.
+	 */
+	public function test_activity_object_in_reply_to() {
+		// Create user with `activitypub` capabilities.
+		$user_id = self::factory()->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		// Only send minimal data.
+		$activity_object = array(
+			'id'     => 'https://example.com/post/123',
+			'type'   => 'Follow',
+			'actor'  => 'https://example.com/author/123',
+			'object' => 'https://example.com/post/123',
+			'to'     => array( 'https://example.com/author/123' ),
+		);
+
+		$activity = new Activity();
+		$activity->set_type( 'Accept' );
+		$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
+		$activity->set_object( $activity_object );
+
+		$this->assertEquals( 'https://example.com/author/123', $activity->get_to()[0] );
+
+		$activity->set_to( array( 'https://example.com/author/456' ) );
+		$activity->set_object( $activity_object );
+
+		$this->assertEquals( 'https://example.com/author/456', $activity->get_to()[0] );
+
+		// Delete user.
+		\wp_delete_user( $user_id );
 	}
 }

--- a/tests/includes/handler/class-test-follow.php
+++ b/tests/includes/handler/class-test-follow.php
@@ -115,7 +115,7 @@ class Test_Follow extends WP_UnitTestCase {
 
 		$this->assertEquals( 'Follow', $activity_json['object']['type'] );
 		$this->assertEquals( 'https://example.com/user/1', $activity_json['object']['object'] );
-		$this->assertEquals( array( $actor ), $activity_json['object']['to'] );
+		$this->assertEquals( array( $actor ), $activity_json['to'] );
 		$this->assertEquals( $actor, $activity_json['object']['actor'] );
 
 		// Clean up.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`add_to_outbox` only supports generic visibilities like for example `ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE` or 'ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC'. For custom audiences, we would have to add the `to`, `cc`, ... fields of the Activity. With the former implementation, we were only able to set the audience for the `Activity`>`Object` and these were up-merged to the Activity afterwards. In the case of an `Accept` of a `Follow` we were forced to update the `Follow`-`Activity`. But because the `Follow` was sent by a remote platform, adding a new field (`to` for example) would change the scope and could cause problems for remote verification.

With the rewrite to store the full `Activity` instead of the `Object`, we are now able to add the audience to this `Activity` and keep the `Object` untouched. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not rely on the Transformer
* Create the full Activity
* Add audience to Activity

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Send Follow `Activity` to inbox
* Check Outbox for `Accept`-`Activity`

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Properly set `to` audience of `Activity` instead of changing the `Follow` Object.

</details>
