### PR TITLE
Onboarding: Allow skipping the welcome page

### DIFF
--- a/.github/changelog/1504-from-description
+++ b/.github/changelog/1504-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+The option to show/hide the "Welcome Page".

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -227,8 +227,7 @@ input.blog-user-identifier {
 	top: 0px;
 	right: 0px;
 	font-size: 13px;
-	padding: 2px 15px 10px 20px;
-	line-height: 1.23076923;
+	padding: 0 5px 0 20px;
 	text-decoration: none;
 	z-index: 1;
 }

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -1,6 +1,7 @@
 .activitypub-settings {
 	max-width: 800px;
 	margin: 0 auto;
+	position: relative;
 }
 
 .settings_page_activitypub .notice {
@@ -219,4 +220,25 @@ input.blog-user-identifier {
 .repost .dashboard-comment-wrap .comment-author,
 .like .dashboard-comment-wrap .comment-author {
 	margin-block: 0;
+}
+
+.activitypub-settings .welcome-tab-close {
+	position: absolute;
+	top: 0px;
+	right: 0px;
+	font-size: 13px;
+	padding: 2px 15px 10px 20px;
+	line-height: 1.23076923;
+	text-decoration: none;
+	z-index: 1;
+}
+
+.activitypub-settings .welcome-tab-close::before {
+	position: absolute;
+	top: 0px;
+	left: 0;
+	transition: all .1s ease-in-out;
+	font: normal 16px/20px dashicons;
+	content: '\f335';
+	font-size: 20px;
 }

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -482,7 +482,7 @@ class Settings {
 		}
 
 		$screen_settings = '<fieldset>
-		<legend class="screen-layout">' . __( 'Settings Pages', 'activitypub' ) . '</legend>
+		<legend class="screen-layout">' . \esc_html__( 'Settings Pages', 'activitypub' ) . '</legend>
 		<p>
 			' . __( 'Some settings pages can be shown or hidden by using the checkboxes.', 'activitypub' ) . '
 		</p>

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -23,8 +23,6 @@ class Settings {
 		\add_action( 'admin_init', array( self::class, 'register_settings' ), 11 );
 		\add_action( 'admin_menu', array( self::class, 'add_settings_page' ) );
 
-		\add_filter( 'screen_settings', array( self::class, 'add_screen_option' ), 10, 2 );
-
 		\add_filter(
 			'screen_options_show_submit',
 			function ( $show_submit, $screen ) {
@@ -37,37 +35,8 @@ class Settings {
 			10,
 			2
 		);
-	}
 
-	/**
-	 * Add screen option.
-	 *
-	 * @param string $screen_settings The screen settings.
-	 * @param object $screen The screen object.
-	 *
-	 * @return string The screen settings.
-	 */
-	public static function add_screen_option( $screen_settings, $screen ) {
-		if ( 'settings_page_activitypub' !== $screen->id ) {
-			return $screen_settings;
-		}
-
-		if ( isset( $_GET['welcome'] ) ) {
-			$welcome_checked = empty( $_GET['welcome'] ) ? 0 : 1;
-			\update_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', $welcome_checked );
-		}
-
-		$screen_settings = '<fieldset>
-		<legend class="screen-layout">' . __( 'Pages', 'activitypub' ) . '</legend>
-		<p>
-			' . __( 'Some pages can be shown or hidden by using the checkboxes.', 'activitypub' ) . '
-		</p>
-		<div class="metabox-prefs-container">
-			<label for="activitypub_show_welcome_tab"><input name="activitypub_show_welcome_tab" type="checkbox" id="activitypub_show_welcome_tab" value="1" ' . \checked( 1, \get_user_meta( get_current_user_id(), 'activitypub_show_welcome_tab', true ), false ) . ' />' . __( 'Welcome Page', 'activitypub' ) . '</label>
-		</div>
-	</fieldset>';
-
-		return $screen_settings;
+		\add_filter( 'screen_settings', array( self::class, 'add_screen_option' ), 10, 2 );
 	}
 
 	/**
@@ -345,7 +314,13 @@ class Settings {
 			$tab = $default_tab;
 		}
 
-		$labels       = wp_list_pluck( $settings_tabs, 'label' );
+		// Only show tabs if there are more than one.
+		if ( \count( $settings_tabs ) <= 1 ) {
+			$labels = array();
+		} else {
+			$labels = wp_list_pluck( $settings_tabs, 'label' );
+		}
+
 		$args         = array_fill_keys( array_keys( $labels ), '' );
 		$args[ $tab ] = 'active';
 		$args['tabs'] = $labels;
@@ -485,5 +460,50 @@ class Settings {
 			'<p>' . \__( '<a href="https://wordpress.org/support/plugin/activitypub/">Get support</a>', 'activitypub' ) . '</p>' . "\n" .
 			'<p>' . \__( '<a href="https://github.com/automattic/wordpress-activitypub/issues">Report an issue</a>', 'activitypub' ) . '</p>'
 		);
+	}
+
+	/**
+	 * Add screen option.
+	 *
+	 * @param string $screen_settings The screen settings.
+	 * @param object $screen          The screen object.
+	 *
+	 * @return string The screen settings.
+	 */
+	public static function add_screen_option( $screen_settings, $screen ) {
+		if ( 'settings_page_activitypub' !== $screen->id ) {
+			return $screen_settings;
+		}
+
+		if ( isset( $_GET['welcome'] ) ) {
+			$welcome_checked = empty( $_GET['welcome'] ) ? 0 : 1;
+			\update_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', $welcome_checked );
+		}
+
+		if ( isset( $_POST['activitypub_show_welcome_tab'] ) && isset( $_POST['screenoptionnonce'] ) ) {
+			$nonce   = sanitize_text_field( wp_unslash( $_POST['screenoptionnonce'] ) );
+			$welcome = sanitize_text_field( wp_unslash( $_POST['activitypub_show_welcome_tab'] ) );
+			// Verify screen options nonce.
+			if ( \wp_verify_nonce( $nonce, 'screen-options-nonce' ) ) {
+				$welcome_checked = empty( $welcome ) ? 0 : 1;
+				\update_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', $welcome_checked );
+			}
+		}
+
+		$screen_settings = '<fieldset>
+		<legend class="screen-layout">' . __( 'SettingsPages', 'activitypub' ) . '</legend>
+		<p>
+			' . __( 'Some settings pages can be shown or hidden by using the checkboxes.', 'activitypub' ) . '
+		</p>
+		<div class="metabox-prefs-container">
+			<label for="activitypub_show_welcome_tab">
+				<input name="activitypub_show_welcome_tab" type="hidden" value="0" />
+				<input name="activitypub_show_welcome_tab" type="checkbox" id="activitypub_show_welcome_tab" value="1" ' . \checked( 1, \get_user_meta( get_current_user_id(), 'activitypub_show_welcome_tab', true ), false ) . ' />
+				' . __( 'Welcome Page', 'activitypub' ) . '
+			</label>
+		</div>
+	</fieldset>';
+
+		return $screen_settings;
 	}
 }

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -22,6 +22,47 @@ class Settings {
 	public static function init() {
 		\add_action( 'admin_init', array( self::class, 'register_settings' ), 11 );
 		\add_action( 'admin_menu', array( self::class, 'add_settings_page' ) );
+
+		\add_filter( 'screen_settings', array( self::class, 'add_screen_option' ), 10, 2 );
+
+		\add_filter( 'screen_options_show_submit', function( $show_submit, $screen ) {
+			if ( 'settings_page_activitypub' !== $screen->id ) {
+				return $show_submit;
+			}
+
+			return true;
+		}, 10, 2 );
+	}
+
+	/**
+	 * Add screen option.
+	 *
+	 * @param string $screen_settings The screen settings.
+	 * @param object $screen The screen object.
+	 *
+	 * @return string The screen settings.
+	 */
+	public static function add_screen_option( $screen_settings, $screen ) {
+		if ( 'settings_page_activitypub' !== $screen->id ) {
+			return $screen_settings;
+		}
+
+		if ( isset( $_GET['welcome'] ) ) {
+			$welcome_checked = empty( $_GET['welcome'] ) ? 0 : 1;
+			\update_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', $welcome_checked );
+		}
+
+		$screen_settings = '<fieldset>
+		<legend class="screen-layout">' . __( 'Pages', 'activitypub' ) . '</legend>
+		<p>
+			' . __( 'Some pages can be shown or hidden by using the checkboxes.', 'activitypub' ) . '
+		</p>
+		<div class="metabox-prefs-container">
+			<label for="activitypub_show_welcome_tab"><input name="activitypub_show_welcome_tab" type="checkbox" id="activitypub_show_welcome_tab" value="1" ' . \checked( 1, \get_user_meta( get_current_user_id(), 'activitypub_show_welcome_tab', true ), false ) . ' />' . __( 'Welcome Page', 'activitypub' ) . '</label>
+		</div>
+	</fieldset>';
+
+		return $screen_settings;
 	}
 
 	/**
@@ -241,11 +282,6 @@ class Settings {
 	 * Load settings page.
 	 */
 	public static function settings_page() {
-		if ( isset( $_GET['welcome'] ) ) {
-			$welcome_checked = empty( $_GET['welcome'] ) ? 0 : 1;
-			\update_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', $welcome_checked );
-		}
-
 		$default_tab = \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ) ? 'welcome' : 'settings';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : $default_tab;

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -235,18 +235,19 @@ class Settings {
 	 * Load settings page.
 	 */
 	public static function settings_page() {
-		$default_tab = \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ) ? 'welcome' : 'settings';
+		$show_welcome_tab = \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true );
+		$default_tab      = $show_welcome_tab ? 'welcome' : 'settings';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : $default_tab;
 
 		// Redirect welcome tab to settings if skipped.
-		if ( 'welcome' === $tab && ! \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ) ) {
+		if ( 'welcome' === $tab && ! $show_welcome_tab ) {
 			$tab = 'settings';
 		}
 
 		$settings_tabs = array();
 
-		if ( \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ) ) {
+		if ( $show_welcome_tab ) {
 			$settings_tabs['welcome'] = array(
 				'label'    => __( 'Welcome', 'activitypub' ),
 				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/welcome.php',

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -242,10 +242,11 @@ class Settings {
 	 */
 	public static function settings_page() {
 		$default_tab = \get_option( 'activitypub_welcome_skip' ) ? 'settings' : 'welcome';
-		$tab         = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : $default_tab;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : $default_tab;
 
 		// Redirect welcome tab to settings if skipped.
-		if ( $tab === 'welcome' && \get_option( 'activitypub_welcome_skip' ) ) {
+		if ( 'welcome' === $tab && \get_option( 'activitypub_welcome_skip' ) ) {
 			$tab = 'settings';
 		}
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -241,15 +241,6 @@ class Settings {
 				'sanitize_callback' => array( Sanitize::class, 'url_list' ),
 			)
 		);
-
-		\register_setting(
-			'activitypub_welcome',
-			'activitypub_welcome_skip',
-			array(
-				'type'    => 'boolean',
-				'default' => false,
-			)
-		);
 	}
 
 	/**

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -226,25 +226,43 @@ class Settings {
 				'sanitize_callback' => array( Sanitize::class, 'url_list' ),
 			)
 		);
+
+		\register_setting(
+			'activitypub_welcome',
+			'activitypub_welcome_skip',
+			array(
+				'type'    => 'boolean',
+				'default' => false,
+			)
+		);
 	}
 
 	/**
 	 * Load settings page.
 	 */
 	public static function settings_page() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'welcome';
+		$default_tab = \get_option( 'activitypub_welcome_skip' ) ? 'settings' : 'welcome';
+		$tab         = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : $default_tab;
 
-		$settings_tabs = array(
-			'welcome'  => array(
+		// Redirect welcome tab to settings if skipped.
+		if ( $tab === 'welcome' && \get_option( 'activitypub_welcome_skip' ) ) {
+			$tab = 'settings';
+		}
+
+		$settings_tabs = array();
+
+		if ( ! \get_option( 'activitypub_welcome_skip' ) ) {
+			$settings_tabs['welcome'] = array(
 				'label'    => __( 'Welcome', 'activitypub' ),
 				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/welcome.php',
-			),
-			'settings' => array(
-				'label'    => __( 'Settings', 'activitypub' ),
-				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php',
-			),
+			);
+		}
+
+		$settings_tabs['settings'] = array(
+			'label'    => __( 'Settings', 'activitypub' ),
+			'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php',
 		);
+
 		if ( ! is_user_disabled( Actors::BLOG_USER_ID ) ) {
 			$settings_tabs['blog-profile'] = array(
 				'label'    => __( 'Blog Profile', 'activitypub' ),

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -25,13 +25,18 @@ class Settings {
 
 		\add_filter( 'screen_settings', array( self::class, 'add_screen_option' ), 10, 2 );
 
-		\add_filter( 'screen_options_show_submit', function( $show_submit, $screen ) {
-			if ( 'settings_page_activitypub' !== $screen->id ) {
-				return $show_submit;
-			}
+		\add_filter(
+			'screen_options_show_submit',
+			function ( $show_submit, $screen ) {
+				if ( 'settings_page_activitypub' !== $screen->id ) {
+					return $show_submit;
+				}
 
-			return true;
-		}, 10, 2 );
+				return true;
+			},
+			10,
+			2
+		);
 	}
 
 	/**

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -238,7 +238,7 @@ class Settings {
 		$show_welcome_tab = \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true );
 		$default_tab      = $show_welcome_tab ? 'welcome' : 'settings';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : $default_tab;
+		$tab = isset( $_GET['tab'] ) ? \sanitize_key( $_GET['tab'] ) : $default_tab;
 
 		// Redirect welcome tab to settings if skipped.
 		if ( 'welcome' === $tab && ! $show_welcome_tab ) {
@@ -280,13 +280,13 @@ class Settings {
 
 		switch ( $tab ) {
 			case 'blog-profile':
-				wp_enqueue_media();
-				wp_enqueue_script( 'activitypub-header-image' );
+				\wp_enqueue_media();
+				\wp_enqueue_script( 'activitypub-header-image' );
 				break;
 			case 'welcome':
-				wp_enqueue_script( 'plugin-install' );
-				add_thickbox();
-				wp_enqueue_script( 'updates' );
+				\wp_enqueue_script( 'plugin-install' );
+				\add_thickbox();
+				\wp_enqueue_script( 'updates' );
 				break;
 		}
 
@@ -298,10 +298,10 @@ class Settings {
 		if ( \count( $settings_tabs ) <= 1 ) {
 			$labels = array();
 		} else {
-			$labels = wp_list_pluck( $settings_tabs, 'label' );
+			$labels = \wp_list_pluck( $settings_tabs, 'label' );
 		}
 
-		$args         = array_fill_keys( array_keys( $labels ), '' );
+		$args         = \array_fill_keys( \array_keys( $labels ), '' );
 		$args[ $tab ] = 'active';
 		$args['tabs'] = $labels;
 
@@ -321,8 +321,8 @@ class Settings {
 			),
 		);
 
-		if ( ! is_user_disabled( get_current_user_id() ) ) {
-			$webfinger = Actors::get_by_id( get_current_user_id() )->get_webfinger();
+		if ( ! is_user_disabled( \get_current_user_id() ) ) {
+			$webfinger = Actors::get_by_id( \get_current_user_id() )->get_webfinger();
 		} else {
 			$webfinger = ( new Blog() )->get_webfinger();
 		}
@@ -461,8 +461,8 @@ class Settings {
 		}
 
 		if ( isset( $_POST['activitypub_show_welcome_tab'] ) && isset( $_POST['screenoptionnonce'] ) ) {
-			$nonce   = sanitize_text_field( wp_unslash( $_POST['screenoptionnonce'] ) );
-			$welcome = sanitize_text_field( wp_unslash( $_POST['activitypub_show_welcome_tab'] ) );
+			$nonce   = \sanitize_text_field( \wp_unslash( $_POST['screenoptionnonce'] ) );
+			$welcome = \sanitize_text_field( \wp_unslash( $_POST['activitypub_show_welcome_tab'] ) );
 			// Verify screen options nonce.
 			if ( \wp_verify_nonce( $nonce, 'screen-options-nonce' ) ) {
 				$welcome_checked = empty( $welcome ) ? 0 : 1;
@@ -473,13 +473,13 @@ class Settings {
 		$screen_settings = '<fieldset>
 		<legend class="screen-layout">' . \esc_html__( 'Settings Pages', 'activitypub' ) . '</legend>
 		<p>
-			' . __( 'Some settings pages can be shown or hidden by using the checkboxes.', 'activitypub' ) . '
+			' . \__( 'Some settings pages can be shown or hidden by using the checkboxes.', 'activitypub' ) . '
 		</p>
 		<div class="metabox-prefs-container">
 			<label for="activitypub_show_welcome_tab">
 				<input name="activitypub_show_welcome_tab" type="hidden" value="0" />
-				<input name="activitypub_show_welcome_tab" type="checkbox" id="activitypub_show_welcome_tab" value="1" ' . \checked( 1, \get_user_meta( get_current_user_id(), 'activitypub_show_welcome_tab', true ), false ) . ' />
-				' . __( 'Welcome Page', 'activitypub' ) . '
+				<input name="activitypub_show_welcome_tab" type="checkbox" id="activitypub_show_welcome_tab" value="1" ' . \checked( 1, \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ), false ) . ' />
+				' . \__( 'Welcome Page', 'activitypub' ) . '
 			</label>
 		</div>
 	</fieldset>';

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -294,6 +294,10 @@ class Settings {
 				break;
 		}
 
+		if ( ! isset( $settings_tabs[ $tab ] ) ) {
+			$tab = $default_tab;
+		}
+
 		$labels       = wp_list_pluck( $settings_tabs, 'label' );
 		$args         = array_fill_keys( array_keys( $labels ), '' );
 		$args[ $tab ] = 'active';

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -241,18 +241,23 @@ class Settings {
 	 * Load settings page.
 	 */
 	public static function settings_page() {
-		$default_tab = \get_option( 'activitypub_welcome_skip' ) ? 'settings' : 'welcome';
+		if ( isset( $_GET['welcome'] ) ) {
+			$welcome_checked = empty( $_GET['welcome'] ) ? 0 : 1;
+			\update_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', $welcome_checked );
+		}
+
+		$default_tab = \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ) ? 'welcome' : 'settings';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : $default_tab;
 
 		// Redirect welcome tab to settings if skipped.
-		if ( 'welcome' === $tab && \get_option( 'activitypub_welcome_skip' ) ) {
+		if ( 'welcome' === $tab && ! \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ) ) {
 			$tab = 'settings';
 		}
 
 		$settings_tabs = array();
 
-		if ( ! \get_option( 'activitypub_welcome_skip' ) ) {
+		if ( \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ) ) {
 			$settings_tabs['welcome'] = array(
 				'label'    => __( 'Welcome', 'activitypub' ),
 				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/welcome.php',

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -491,7 +491,7 @@ class Settings {
 		}
 
 		$screen_settings = '<fieldset>
-		<legend class="screen-layout">' . __( 'SettingsPages', 'activitypub' ) . '</legend>
+		<legend class="screen-layout">' . __( 'Settings Pages', 'activitypub' ) . '</legend>
 		<p>
 			' . __( 'Some settings pages can be shown or hidden by using the checkboxes.', 'activitypub' ) . '
 		</p>

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -23,20 +23,8 @@ class Settings {
 		\add_action( 'admin_init', array( self::class, 'register_settings' ), 11 );
 		\add_action( 'admin_menu', array( self::class, 'add_settings_page' ) );
 
-		\add_filter(
-			'screen_options_show_submit',
-			function ( $show_submit, $screen ) {
-				if ( 'settings_page_activitypub' !== $screen->id ) {
-					return $show_submit;
-				}
-
-				return true;
-			},
-			10,
-			2
-		);
-
 		\add_filter( 'screen_settings', array( self::class, 'add_screen_option' ), 10, 2 );
+		\add_filter( 'screen_options_show_submit', array( self::class, 'screen_options_show_submit' ), 10, 2 );
 	}
 
 	/**
@@ -496,5 +484,21 @@ class Settings {
 	</fieldset>';
 
 		return $screen_settings;
+	}
+
+	/**
+	 * Show the submit button on the screen options page.
+	 *
+	 * @param bool   $show_submit Whether to show the submit button.
+	 * @param object $screen      The screen object.
+	 *
+	 * @return bool Whether to show the submit button.
+	 */
+	public static function screen_options_show_submit( $show_submit, $screen ) {
+		if ( 'settings_page_activitypub' !== $screen->id ) {
+			return $show_submit;
+		}
+
+		return true;
 	}
 }

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -83,7 +83,12 @@ class Welcome_Fields {
 	 */
 	public static function render_welcome_intro_section() {
 		?>
-		<p><?php echo wp_kses( \__( 'Enter the fediverse with <strong>ActivityPub</strong>, broadcasting your blog to a wider audience. Attract followers, deliver updates, and receive comments from a diverse user base on <strong>Mastodon</strong>, <strong>Friendica</strong>, <strong>Pleroma</strong>, <strong>Pixelfed</strong>, and all <strong>ActivityPub</strong>-compliant platforms.', 'activitypub' ), array( 'strong' => array() ) ); ?></p>
+		<p><?php \esc_html_e( '...to the ActivityPub plugin for WordPress! This site gives you a quick overview of the most important informations you need to get started. You can skip this page if you are already familiar with the ActivityPub plugin.', 'activitypub' ); ?></p>
+		<form method="post" action="options.php">
+			<?php \settings_fields( 'activitypub_welcome' ); ?>
+			<input type="hidden" name="activitypub_welcome_skip" value="1" />
+			<?php \submit_button( \__( 'Skip this page', 'activitypub' ) ); ?>
+		</form>
 		<?php
 	}
 

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -83,7 +83,7 @@ class Welcome_Fields {
 	 */
 	public static function render_welcome_intro_section() {
 		?>
-		<a class="welcome-tab-close" href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&welcome=0' ) ); ?>" aria-label="Dismiss the welcome page">Dismiss Welcome Page</a>
+		<a class="welcome-tab-close" href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&welcome=0' ) ); ?>" aria-label="<?php \esc_attr_e( 'Dismiss the welcome page' ); ?>"><?php \esc_html_e( 'Dismiss Welcome Page' ); ?></a>
 		<p><?php echo wp_kses( \__( 'Enter the fediverse with <strong>ActivityPub</strong>, broadcasting your blog to a wider audience. Attract followers, deliver updates, and receive comments from a diverse user base on <strong>Mastodon</strong>, <strong>Friendica</strong>, <strong>Pleroma</strong>, <strong>Pixelfed</strong>, and all <strong>ActivityPub</strong>-compliant platforms.', 'activitypub' ), array( 'strong' => array() ) ); ?></p>
 		<?php
 	}

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -83,12 +83,8 @@ class Welcome_Fields {
 	 */
 	public static function render_welcome_intro_section() {
 		?>
+		<a class="welcome-tab-close" href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&welcome=0' ) ); ?>" aria-label="Dismiss the welcome tab">Dismiss Welcome Tab</a>
 		<p><?php \esc_html_e( '...to the ActivityPub plugin for WordPress! This site gives you a quick overview of the most important informations you need to get started. You can skip this page if you are already familiar with the ActivityPub plugin.', 'activitypub' ); ?></p>
-		<form method="post" action="options.php">
-			<?php \settings_fields( 'activitypub_welcome' ); ?>
-			<input type="hidden" name="activitypub_welcome_skip" value="1" />
-			<?php \submit_button( \__( 'Skip this page', 'activitypub' ) ); ?>
-		</form>
 		<?php
 	}
 

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -83,8 +83,8 @@ class Welcome_Fields {
 	 */
 	public static function render_welcome_intro_section() {
 		?>
-		<a class="welcome-tab-close" href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&welcome=0' ) ); ?>" aria-label="Dismiss the welcome tab">Dismiss Welcome Tab</a>
-		<p><?php \esc_html_e( '...to the ActivityPub plugin for WordPress! This site gives you a quick overview of the most important informations you need to get started. You can skip this page if you are already familiar with the ActivityPub plugin.', 'activitypub' ); ?></p>
+		<a class="welcome-tab-close" href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&welcome=0' ) ); ?>" aria-label="Dismiss the welcome page">Dismiss Welcome Page</a>
+		<p><?php echo wp_kses( \__( 'Enter the fediverse with <strong>ActivityPub</strong>, broadcasting your blog to a wider audience. Attract followers, deliver updates, and receive comments from a diverse user base on <strong>Mastodon</strong>, <strong>Friendica</strong>, <strong>Pleroma</strong>, <strong>Pixelfed</strong>, and all <strong>ActivityPub</strong>-compliant platforms.', 'activitypub' ), array( 'strong' => array() ) ); ?></p>
 		<?php
 	}
 

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -83,7 +83,7 @@ class Welcome_Fields {
 	 */
 	public static function render_welcome_intro_section() {
 		?>
-		<a class="welcome-tab-close" href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&welcome=0' ) ); ?>" aria-label="<?php \esc_attr_e( 'Dismiss the welcome page' ); ?>"><?php \esc_html_e( 'Dismiss Welcome Page' ); ?></a>
+		<a class="welcome-tab-close" href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&welcome=0' ) ); ?>" aria-label="<?php \esc_attr_e( 'Dismiss the welcome page', 'activitypub' ); ?>"><?php \esc_html_e( 'Dismiss Welcome Page', 'activitypub' ); ?></a>
 		<p><?php echo wp_kses( \__( 'Enter the fediverse with <strong>ActivityPub</strong>, broadcasting your blog to a wider audience. Attract followers, deliver updates, and receive comments from a diverse user base on <strong>Mastodon</strong>, <strong>Friendica</strong>, <strong>Pleroma</strong>, <strong>Pixelfed</strong>, and all <strong>ActivityPub</strong>-compliant platforms.', 'activitypub' ), array( 'strong' => array() ) ); ?></p>
 		<?php
 	}


### PR DESCRIPTION
The "Welcome" page should be the page, the admin ends up, after the onboarding process.

This PR allows to skip this page, to directly call the `settings` page instead.

<img width="1111" alt="Screenshot 2025-03-26 at 09 13 24" src="https://github.com/user-attachments/assets/7574e8b8-aaef-4784-a09e-689a93fd37df" />

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Re-use the same mechanism that Core uses to dismiss the welcome banner on the dashboard.
* When hidden, the page can be re-activated through the screen-options.
* The tab-menu only shows up if there is more than one tab.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

The option to show/hide the "Welcome Page".

</details>
