### PR TITLE
Return error when Outbox item is invalid

### DIFF
--- a/.github/changelog/1506-from-description
+++ b/.github/changelog/1506-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PHP Warnings when attempting to get an author rom an invalid outbox item.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -242,6 +242,10 @@ class Outbox {
 	 * @return \Activitypub\Model\User|\Activitypub\Model\Blog|\WP_Error The Actor object or WP_Error.
 	 */
 	public static function get_actor( $outbox_item ) {
+		if ( ! $outbox_item instanceof \WP_Post ) {
+			return new \WP_Error( 'invalid_outbox_item', 'Invalid Outbox item.' );
+		}
+
 		$actor_type = \get_post_meta( $outbox_item->ID, '_activitypub_activity_actor', true );
 
 		switch ( $actor_type ) {

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -210,12 +210,15 @@ class Outbox_Controller extends \WP_REST_Controller {
 	/**
 	 * Prepares the item for the REST response.
 	 *
-	 * @param mixed            $item    WordPress representation of the item.
+	 * @param \WP_Post         $item    WordPress representation of the item.
 	 * @param \WP_REST_Request $request Request object.
-	 * @return array Response object on success, or WP_Error object on failure.
+	 * @return array|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function prepare_item_for_response( $item, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$activity = Outbox::get_activity( $item->ID );
+		$activity = Outbox::get_activity( $item );
+		if ( is_wp_error( $activity ) ) {
+			return $activity;
+		}
 
 		return $activity->to_array( false );
 	}


### PR DESCRIPTION
`Warning: Attempt to read property "ID" on null`
`Warning: Attempt to read property "post_author" on null`

We use `Outbox::get_activity()` in quite a few places without checking for WP_Errors being returned. So far it looks like it works just fine—just something I noticed while working on this.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Returns WP_Error when passing a an invalid post to `get_actor()`.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

PHP Warnings when attempting to get an author rom an invalid outbox item.

</details>
