### PR TITLE
Bail when $post is not a post

### DIFF
--- a/.github/changelog/1507-from-description
+++ b/.github/changelog/1507-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PHP warnings when scheduling post activities for an invalid post.

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -62,6 +62,7 @@ class Webfinger {
 		foreach ( $data['links'] as $link ) {
 			if (
 				'self' === $link['rel'] &&
+				isset( $link['type'] ) &&
 				(
 					'application/activity+json' === $link['type'] ||
 					'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' === $link['type']

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -114,10 +114,12 @@ class Actor {
 	 * @param \WP_Post $post       Post object.
 	 */
 	public static function schedule_post_activity( $new_status, $old_status, $post ) {
-		if ( Extra_Fields::USER_POST_TYPE === $post->post_type ) {
-			self::schedule_profile_update( $post->post_author );
-		} elseif ( Extra_Fields::BLOG_POST_TYPE === $post->post_type ) {
-			self::schedule_profile_update( Actors::BLOG_USER_ID );
+		if ( $post instanceof \WP_Post ) {
+			if ( Extra_Fields::USER_POST_TYPE === $post->post_type ) {
+				self::schedule_profile_update( $post->post_author );
+			} elseif ( Extra_Fields::BLOG_POST_TYPE === $post->post_type ) {
+				self::schedule_profile_update( Actors::BLOG_USER_ID );
+			}
 		}
 	}
 


### PR DESCRIPTION
`Warning: Attempt to read property "post_type" on null`


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check whether `type` is set before using it.
* Bails when `$post` is not a post.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

PHP warnings when scheduling post activities for an invalid post.

</details>
