### PR TITLE
Remote Reply: Improve logged-out display

### DIFF
--- a/.github/changelog/1509-from-description
+++ b/.github/changelog/1509-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Logged-out remote reply button markup to look closer to logged-in version.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -47,8 +47,7 @@ class Comment {
 	 */
 	public static function comment_reply_link( $link, $args, $comment ) {
 		if ( self::are_comments_allowed( $comment ) ) {
-			$user_id = get_current_user_id();
-			if ( $user_id && self::was_received( $comment ) && \user_can( $user_id, 'activitypub' ) ) {
+			if ( \current_user_can( 'activitypub' ) && self::was_received( $comment ) ) {
 				return self::create_fediverse_reply_link( $link, $args );
 			}
 
@@ -61,7 +60,7 @@ class Comment {
 		);
 
 		$div = sprintf(
-			'<div class="activitypub-remote-reply" data-attrs="%s"></div>',
+			'<div class="reply activitypub-remote-reply" data-attrs="%s"></div>',
 			esc_attr( wp_json_encode( $attrs ) )
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Not sure if we should go one step further and replace the button with an anchor element?

Fixes #1505.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `.reply` class to wrapper element to closer resemble logged-in reply link markup.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* View a post with comment from the Fediverse logged-in and logged-out.
* Compare the markup in both versions using your web inspector.
* See that they look similar or closer to similar with this PR than in trunk.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Logged-out remote reply button markup to look closer to logged-in version.

</details>
