### PR TITLE
Onboarding: Redirect to "Welcome" page after plugin activation.

### DIFF
--- a/.github/changelog/1511-from-description
+++ b/.github/changelog/1511-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Redirect user to the welcome page after ActivityPub plugin is activated.

--- a/activitypub.php
+++ b/activitypub.php
@@ -113,6 +113,18 @@ function plugin_admin_init() {
 	)
 );
 
+/**
+ * Redirect to the welcome page after plugin activation.
+ *
+ * @param string $plugin The plugin basename.
+ */
+function activation_redirect( $plugin ) {
+	if( ACTIVITYPUB_PLUGIN_BASENAME === $plugin ) {
+		exit( \wp_redirect( \admin_url( 'options-general.php?page=activitypub' ) ) );
+	}
+}
+\add_action( 'activated_plugin', __NAMESPACE__ . '\activation_redirect' );
+
 \register_deactivation_hook(
 	__FILE__,
 	array(

--- a/activitypub.php
+++ b/activitypub.php
@@ -119,8 +119,9 @@ function plugin_admin_init() {
  * @param string $plugin The plugin basename.
  */
 function activation_redirect( $plugin ) {
-	if( ACTIVITYPUB_PLUGIN_BASENAME === $plugin ) {
-		exit( \wp_redirect( \admin_url( 'options-general.php?page=activitypub' ) ) );
+	if ( ACTIVITYPUB_PLUGIN_BASENAME === $plugin ) {
+		\wp_safe_redirect( \admin_url( 'options-general.php?page=activitypub' ) );
+		exit;
 	}
 }
 \add_action( 'activated_plugin', __NAMESPACE__ . '\activation_redirect' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The user will be redirected after they activated the plugin. It redirects to the "default" settings page, to allow loading an onboarding flow in between.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Redirect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to plugins page
* Install ActivityPub plugin
* Activate ActivityPub plugin

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Redirect user to the welcome page after ActivityPub plugin is activated.

</details>
