### PR TITLE
Comment: Send announce for all new comments

### DIFF
--- a/.github/changelog/1515-from-description
+++ b/.github/changelog/1515-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Incoming comments create an Announce activity so other instances get notified about it.

--- a/includes/handler/class-create.php
+++ b/includes/handler/class-create.php
@@ -9,6 +9,7 @@ namespace Activitypub\Handler;
 
 use Activitypub\Collection\Interactions;
 
+use function Activitypub\add_to_outbox;
 use function Activitypub\is_self_ping;
 use function Activitypub\is_activity_reply;
 use function Activitypub\is_activity_public;
@@ -78,6 +79,8 @@ class Create {
 		if ( $state && ! \is_wp_error( $state ) ) {
 			$reaction = \get_comment( $state );
 		}
+
+		add_to_outbox( $activity, 'Announce', $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
 
 		/**
 		 * Fires after a Create activity has been handled.

--- a/includes/handler/class-create.php
+++ b/includes/handler/class-create.php
@@ -80,6 +80,7 @@ class Create {
 			$reaction = \get_comment( $state );
 		}
 
+		/* @ticket https://github.com/Automattic/wordpress-activitypub/issues/1001 */
 		add_to_outbox( $activity, 'Announce', $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
 
 		/**


### PR DESCRIPTION
Fixes #1001.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Creates an Announce outbox item for every incoming comment.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to a WP test site that's accessible online.
* Comment on a post from a fediverse instance of your choice.
* Check the Outbox and make sure it created an Announce activity.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Incoming comments create an Announce activity so other instances get notified about it.

</details>
