### PR TITLE
Move: use `$from` for object in `Move::internally`

### DIFF
--- a/.github/changelog/1516-from-description
+++ b/.github/changelog/1516-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use the `$from` account for the object in Move activity for internal Moves

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -130,7 +130,7 @@ class Move {
 		$activity->set_type( 'Move' );
 		$activity->set_actor( $actor );
 		$activity->set_origin( $actor );
-		$activity->set_object( $to );
+		$activity->set_object( $actor );
 		$activity->set_target( $to );
 
 		return add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

See #1513 especially [this comment](https://github.com/Automattic/wordpress-activitypub/issues/1513#issuecomment-2759529509)

According to the [Draft Data Portability spec, section 4.1](https://swicg.github.io/activitypub-data-portability/#process-0):

> The user sends a Move activity from the old actor to all followers.
```
{
  "@context": "https://www.w3.org/ns/activitystreams",
  "type": "Move",
  "actor": "https://old.example/users/username",
  "object": "https://old.example/users/username",
  "target": "https://new.example/users/username"
}
```


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set `object` to the `$from` param rather than the `$to` param in `Move::internally`

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

The testing is performed in the tests. You can manually call `Move::internally` yourself to verify if you wish.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Use the `$from` account for the object in Move activity for internal Moves</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Use the `$from` account for the object in Move activity for internal Moves

</details>
