### PR TITLE
Fix: Do not send self-replies

### DIFF
--- a/.github/changelog/1517-from-description
+++ b/.github/changelog/1517-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent self-replies on local comments.

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -335,6 +335,11 @@ class Dispatcher {
 		}
 
 		foreach ( $in_reply_to as $url ) {
+			// No need to self-notify.
+			if ( is_same_domain( $url ) ) {
+				continue;
+			}
+
 			$object = Http::get_remote_object( $url );
 
 			if (

--- a/tests/includes/class-test-dispatcher.php
+++ b/tests/includes/class-test-dispatcher.php
@@ -382,49 +382,38 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		// Create a test actor.
 		$actor_id = self::$user_id;
 
-		// Mock the HTTP response for the remote object.
-		add_filter(
-			'pre_http_request',
-			function ( $pre, $parsed_args, $url ) {
-				if ( 'https://mastodon.social/@user/123456789' === $url ) {
-					return array(
-						'response' => array( 'code' => 200 ),
-						'body'     => \wp_json_encode(
-							array(
-								'type'         => 'Note',
-								'id'           => 'https://mastodon.social/@user/123456789',
-								'attributedTo' => 'https://mastodon.social/@user',
-							)
-						),
-					);
-				}
-				return $pre;
-			},
-			10,
-			3
-		);
+		$callback = function ( $pre, $parsed_args, $url ) {
+			if ( 'https://mastodon.social/@user/123456789' === $url ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => \wp_json_encode(
+						array(
+							'type'         => 'Note',
+							'id'           => 'https://mastodon.social/@user/123456789',
+							'attributedTo' => 'https://mastodon.social/@user',
+						)
+					),
+				);
+			}
 
-		// Mock the HTTP response for the actor.
-		add_filter(
-			'pre_http_request',
-			function ( $pre, $parsed_args, $url ) {
-				if ( 'https://mastodon.social/@user' === $url ) {
-					return array(
-						'response' => array( 'code' => 200 ),
-						'body'     => \wp_json_encode(
-							array(
-								'type'  => 'Person',
-								'id'    => 'https://mastodon.social/@user',
-								'inbox' => 'https://mastodon.social/inbox',
-							)
-						),
-					);
-				}
-				return $pre;
-			},
-			10,
-			3
-		);
+			if ( 'https://mastodon.social/@user' === $url ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => \wp_json_encode(
+						array(
+							'type'  => 'Person',
+							'id'    => 'https://mastodon.social/@user',
+							'inbox' => 'https://mastodon.social/inbox',
+						)
+					),
+				);
+			}
+
+			return $pre;
+		};
+
+		// Mock the HTTP response for the remote object.
+		add_filter( 'pre_http_request', $callback, 10, 3 );
 
 		// Get inboxes for the activity.
 		$inboxes = Dispatcher::add_inboxes_of_replied_urls( array(), $actor_id, $activity );
@@ -433,6 +422,6 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$this->assertContains( 'https://mastodon.social/inbox', $inboxes, 'Inbox should be added for different domain in_reply_to URLs' );
 
 		// Clean up.
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'pre_http_request', $callback );
 	}
 }

--- a/tests/includes/class-test-dispatcher.php
+++ b/tests/includes/class-test-dispatcher.php
@@ -344,4 +344,81 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 			'endpoints'         => array( 'sharedInbox' => 'https://example.org/sharedInbox' ),
 		);
 	}
+
+	/**
+	 * Test that in_reply_to URLs from the same domain are ignored.
+	 *
+	 * @covers ::add_inboxes_of_replied_urls
+	 */
+	public function test_ignore_same_domain_in_reply_to() {
+		// Create a test activity with in_reply_to pointing to same domain
+		$activity = new Activity();
+		$activity->set_type( 'Create' );
+		$activity->set_id( 'https://example.com/test-id' );
+		$activity->set_in_reply_to( 'https://example.com/post/123' );
+
+		// Create a test actor
+		$actor_id = self::$user_id;
+
+		// Get inboxes for the activity
+		$inboxes = Dispatcher::add_inboxes_of_replied_urls( array(), $actor_id, $activity );
+
+		// Verify that no inboxes were added since the in_reply_to is from same domain
+		$this->assertEmpty( $inboxes, 'Inboxes should be empty for same domain in_reply_to URLs' );
+	}
+
+	/**
+	 * Test that in_reply_to URLs from different domains are processed.
+	 *
+	 * @covers ::add_inboxes_of_replied_urls
+	 */
+	public function test_process_different_domain_in_reply_to() {
+		// Create a test activity with in_reply_to pointing to different domain
+		$activity = new Activity();
+		$activity->set_type( 'Create' );
+		$activity->set_id( 'https://example.com/test-id' );
+		$activity->set_in_reply_to( 'https://mastodon.social/@user/123456789' );
+
+		// Create a test actor
+		$actor_id = self::$user_id;
+
+		// Mock the HTTP response for the remote object
+		add_filter( 'pre_http_request', function( $pre, $parsed_args, $url ) {
+			if ( 'https://mastodon.social/@user/123456789' === $url ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body' => json_encode( array(
+						'type' => 'Note',
+						'id' => 'https://mastodon.social/@user/123456789',
+						'attributedTo' => 'https://mastodon.social/@user',
+					) ),
+				);
+			}
+			return $pre;
+		}, 10, 3 );
+
+		// Mock the HTTP response for the actor
+		add_filter( 'pre_http_request', function( $pre, $parsed_args, $url ) {
+			if ( 'https://mastodon.social/@user' === $url ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body' => json_encode( array(
+						'type' => 'Person',
+						'id' => 'https://mastodon.social/@user',
+						'inbox' => 'https://mastodon.social/inbox',
+					) ),
+				);
+			}
+			return $pre;
+		}, 10, 3 );
+
+		// Get inboxes for the activity
+		$inboxes = Dispatcher::add_inboxes_of_replied_urls( array(), $actor_id, $activity );
+
+		// Verify that the inbox was added
+		$this->assertContains( 'https://mastodon.social/inbox', $inboxes, 'Inbox should be added for different domain in_reply_to URLs' );
+
+		// Clean up
+		remove_all_filters( 'pre_http_request' );
+	}
 }

--- a/tests/includes/class-test-dispatcher.php
+++ b/tests/includes/class-test-dispatcher.php
@@ -351,19 +351,19 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 	 * @covers ::add_inboxes_of_replied_urls
 	 */
 	public function test_ignore_same_domain_in_reply_to() {
-		// Create a test activity with in_reply_to pointing to same domain
+		// Create a test activity with in_reply_to pointing to same domain.
 		$activity = new Activity();
 		$activity->set_type( 'Create' );
 		$activity->set_id( 'https://example.com/test-id' );
 		$activity->set_in_reply_to( 'https://example.com/post/123' );
 
-		// Create a test actor
+		// Create a test actor.
 		$actor_id = self::$user_id;
 
-		// Get inboxes for the activity
+		// Get inboxes for the activity.
 		$inboxes = Dispatcher::add_inboxes_of_replied_urls( array(), $actor_id, $activity );
 
-		// Verify that no inboxes were added since the in_reply_to is from same domain
+		// Verify that no inboxes were added since the in_reply_to is from same domain.
 		$this->assertEmpty( $inboxes, 'Inboxes should be empty for same domain in_reply_to URLs' );
 	}
 
@@ -373,52 +373,66 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 	 * @covers ::add_inboxes_of_replied_urls
 	 */
 	public function test_process_different_domain_in_reply_to() {
-		// Create a test activity with in_reply_to pointing to different domain
+		// Create a test activity with in_reply_to pointing to different domain.
 		$activity = new Activity();
 		$activity->set_type( 'Create' );
 		$activity->set_id( 'https://example.com/test-id' );
 		$activity->set_in_reply_to( 'https://mastodon.social/@user/123456789' );
 
-		// Create a test actor
+		// Create a test actor.
 		$actor_id = self::$user_id;
 
-		// Mock the HTTP response for the remote object
-		add_filter( 'pre_http_request', function( $pre, $parsed_args, $url ) {
-			if ( 'https://mastodon.social/@user/123456789' === $url ) {
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body' => json_encode( array(
-						'type' => 'Note',
-						'id' => 'https://mastodon.social/@user/123456789',
-						'attributedTo' => 'https://mastodon.social/@user',
-					) ),
-				);
-			}
-			return $pre;
-		}, 10, 3 );
+		// Mock the HTTP response for the remote object.
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $parsed_args, $url ) {
+				if ( 'https://mastodon.social/@user/123456789' === $url ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => \wp_json_encode(
+							array(
+								'type'         => 'Note',
+								'id'           => 'https://mastodon.social/@user/123456789',
+								'attributedTo' => 'https://mastodon.social/@user',
+							)
+						),
+					);
+				}
+				return $pre;
+			},
+			10,
+			3
+		);
 
-		// Mock the HTTP response for the actor
-		add_filter( 'pre_http_request', function( $pre, $parsed_args, $url ) {
-			if ( 'https://mastodon.social/@user' === $url ) {
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body' => json_encode( array(
-						'type' => 'Person',
-						'id' => 'https://mastodon.social/@user',
-						'inbox' => 'https://mastodon.social/inbox',
-					) ),
-				);
-			}
-			return $pre;
-		}, 10, 3 );
+		// Mock the HTTP response for the actor.
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $parsed_args, $url ) {
+				if ( 'https://mastodon.social/@user' === $url ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => \wp_json_encode(
+							array(
+								'type'  => 'Person',
+								'id'    => 'https://mastodon.social/@user',
+								'inbox' => 'https://mastodon.social/inbox',
+							)
+						),
+					);
+				}
+				return $pre;
+			},
+			10,
+			3
+		);
 
-		// Get inboxes for the activity
+		// Get inboxes for the activity.
 		$inboxes = Dispatcher::add_inboxes_of_replied_urls( array(), $actor_id, $activity );
 
-		// Verify that the inbox was added
+		// Verify that the inbox was added.
 		$this->assertContains( 'https://mastodon.social/inbox', $inboxes, 'Inbox should be added for different domain in_reply_to URLs' );
 
-		// Clean up
+		// Clean up.
 		remove_all_filters( 'pre_http_request' );
 	}
 }


### PR DESCRIPTION
While debugging the Outbox-Scheduler I noticed, that the blogs own outbox was listed in the `send_to_additional_inboxes` call, after writing a local comment. This is because the post is listed in the `in_reply_to` of the comment and the code check this field to ping all recipients.

With this PR, self domain replies will be ignored for the `inbox` retrieval process.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ignore replies to a local URL

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Prevent self-replies on local comments.

</details>
