### PR TITLE
Fix: Properly traverse the object hierarchy to get the ID

### DIFF
--- a/.github/changelog/1518-from-description
+++ b/.github/changelog/1518-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Support multiple layers of nested Outbox activities when searching for the Object ID.

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -9,7 +9,8 @@
 
 namespace Activitypub\Activity;
 
-use Activitypub\Link;
+use Activitypub\Activity\Extended_Object\Event;
+use Activitypub\Activity\Extended_Object\Place;
 
 /**
  * \Activitypub\Activity\Activity implements the common
@@ -21,6 +22,43 @@ use Activitypub\Link;
 class Activity extends Base_Object {
 	const JSON_LD_CONTEXT = array(
 		'https://www.w3.org/ns/activitystreams',
+	);
+
+	/**
+	 * The default types for Activities.
+	 *
+	 * @see https://www.w3.org/TR/activitystreams-vocabulary/#activity-types
+	 *
+	 * @var array
+	 */
+	const DEFAULT_TYPES = array(
+		'Accept',
+		'Add',
+		'Announce',
+		'Arrive',
+		'Block',
+		'Create',
+		'Delete',
+		'Dislike',
+		'Follow',
+		'Flag',
+		'Ignore',
+		'Invite',
+		'Join',
+		'Leave',
+		'Like',
+		'Listen',
+		'Move',
+		'Offer',
+		'Read',
+		'Reject',
+		'Remove',
+		'TentativeAccept',
+		'TentativeReject',
+		'Travel',
+		'Undo',
+		'Update',
+		'View',
 	);
 
 	/**
@@ -124,58 +162,85 @@ class Activity extends Base_Object {
 	 *
 	 * @see https://www.w3.org/TR/activitypub/#object-without-create
 	 *
-	 * @param array|string|Base_Object|Link|null $data Activity object.
+	 * @param array|string|Base_Object|Activity|Actor|null $data     Activity object.
+	 * @param bool                                         $pre_fill Whether to pre-fill the activity with object properties.
 	 */
-	public function set_object( $data ) {
-		// Convert array to object.
+	public function set_object( $data, $pre_fill = true ) {
+		$object = $data;
+
+		// Convert array to appropriate object type.
 		if ( is_array( $data ) ) {
-			$data = Generic_Object::init_from_array( $data );
+			$type = $data['type'] ?? null;
+
+			if ( in_array( $type, self::DEFAULT_TYPES, true ) ) {
+				$object = self::init_from_array( $data );
+			} elseif ( in_array( $type, Actor::DEFAULT_TYPES, true ) ) {
+				$object = Actor::init_from_array( $data );
+			} elseif ( in_array( $type, Base_Object::DEFAULT_TYPES, true ) ) {
+				$object = match ( $type ) {
+					'Event' => Event::init_from_array( $data ),
+					'Place' => Place::init_from_array( $data ),
+					default => Base_Object::init_from_array( $data ),
+				};
+			} else {
+				$object = Generic_Object::init_from_array( $data );
+			}
 		}
 
-		// Set object.
-		$this->set( 'object', $data );
+		$this->set( 'object', $object );
+
+		if ( $pre_fill ) {
+			$this->pre_fill_activity_from_object();
+		}
+	}
+
+	/**
+	 * Fills the Activity with the specified activity object.
+	 */
+	public function pre_fill_activity_from_object() {
+		$object = $this->get_object();
 
 		// Check if `$data` is a URL and use it to generate an ID then.
-		if ( is_string( $data ) && filter_var( $data, FILTER_VALIDATE_URL ) && ! $this->get_id() ) {
-			$this->set( 'id', $data . '#activity-' . strtolower( $this->get_type() ) . '-' . time() );
+		if ( is_string( $object ) && filter_var( $object, FILTER_VALIDATE_URL ) && ! $this->get_id() ) {
+			$this->set( 'id', $object . '#activity-' . strtolower( $this->get_type() ) . '-' . time() );
 
 			return;
 		}
 
 		// Check if `$data` is an object and copy some properties otherwise do nothing.
-		if ( ! is_object( $data ) ) {
+		if ( ! is_object( $object ) ) {
 			return;
 		}
 
 		foreach ( array( 'to', 'bto', 'cc', 'bcc', 'audience' ) as $i ) {
-			$value = $data->get( $i );
+			$value = $object->get( $i );
 			if ( $value && ! $this->get( $i ) ) {
 				$this->set( $i, $value );
 			}
 		}
 
-		if ( $data->get_published() && ! $this->get_published() ) {
-			$this->set( 'published', $data->get_published() );
+		if ( $object->get_published() && ! $this->get_published() ) {
+			$this->set( 'published', $object->get_published() );
 		}
 
-		if ( $data->get_updated() && ! $this->get_updated() ) {
-			$this->set( 'updated', $data->get_updated() );
+		if ( $object->get_updated() && ! $this->get_updated() ) {
+			$this->set( 'updated', $object->get_updated() );
 		}
 
-		if ( $data->get_attributed_to() && ! $this->get_actor() ) {
-			$this->set( 'actor', $data->get_attributed_to() );
+		if ( $object->get_attributed_to() && ! $this->get_actor() ) {
+			$this->set( 'actor', $object->get_attributed_to() );
 		}
 
-		if ( $data->get_in_reply_to() && ! $this->get_in_reply_to() ) {
-			$this->set( 'in_reply_to', $data->get_in_reply_to() );
+		if ( $object->get_in_reply_to() && ! $this->get_in_reply_to() ) {
+			$this->set( 'in_reply_to', $object->get_in_reply_to() );
 		}
 
-		if ( $data->get_id() && ! $this->get_id() ) {
-			$id = strtok( $data->get_id(), '#' );
-			if ( $data->get_updated() ) {
-				$updated = $data->get_updated();
-			} elseif ( $data->get_published() ) {
-				$updated = $data->get_published();
+		if ( $object->get_id() && ! $this->get_id() ) {
+			$id = strtok( $object->get_id(), '#' );
+			if ( $object->get_updated() ) {
+				$updated = $object->get_updated();
+			} elseif ( $object->get_published() ) {
+				$updated = $object->get_published();
 			} else {
 				$updated = time();
 			}

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -31,7 +31,7 @@ class Activity extends Base_Object {
 	 *
 	 * @var array
 	 */
-	const DEFAULT_TYPES = array(
+	const TYPES = array(
 		'Accept',
 		'Add',
 		'Announce',
@@ -171,11 +171,11 @@ class Activity extends Base_Object {
 		if ( is_array( $data ) ) {
 			$type = $data['type'] ?? null;
 
-			if ( in_array( $type, self::DEFAULT_TYPES, true ) ) {
+			if ( in_array( $type, self::TYPES, true ) ) {
 				$object = self::init_from_array( $data );
-			} elseif ( in_array( $type, Actor::DEFAULT_TYPES, true ) ) {
+			} elseif ( in_array( $type, Actor::TYPES, true ) ) {
 				$object = Actor::init_from_array( $data );
-			} elseif ( in_array( $type, Base_Object::DEFAULT_TYPES, true ) ) {
+			} elseif ( in_array( $type, Base_Object::TYPES, true ) ) {
 				switch ( $type ) {
 					case 'Event':
 						$object = Event::init_from_array( $data );

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -177,11 +177,17 @@ class Activity extends Base_Object {
 			} elseif ( in_array( $type, Actor::DEFAULT_TYPES, true ) ) {
 				$object = Actor::init_from_array( $data );
 			} elseif ( in_array( $type, Base_Object::DEFAULT_TYPES, true ) ) {
-				$object = match ( $type ) {
-					'Event' => Event::init_from_array( $data ),
-					'Place' => Place::init_from_array( $data ),
-					default => Base_Object::init_from_array( $data ),
-				};
+				switch ( $type ) {
+					case 'Event':
+						$object = Event::init_from_array( $data );
+						break;
+					case 'Place':
+						$object = Place::init_from_array( $data );
+						break;
+					default:
+						$object = Base_Object::init_from_array( $data );
+						break;
+				}
 			} else {
 				$object = Generic_Object::init_from_array( $data );
 			}

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -163,9 +163,8 @@ class Activity extends Base_Object {
 	 * @see https://www.w3.org/TR/activitypub/#object-without-create
 	 *
 	 * @param array|string|Base_Object|Activity|Actor|null $data     Activity object.
-	 * @param bool                                         $pre_fill Whether to pre-fill the activity with object properties.
 	 */
-	public function set_object( $data, $pre_fill = true ) {
+	public function set_object( $data ) {
 		$object = $data;
 
 		// Convert array to appropriate object type.
@@ -194,10 +193,7 @@ class Activity extends Base_Object {
 		}
 
 		$this->set( 'object', $object );
-
-		if ( $pre_fill ) {
-			$this->pre_fill_activity_from_object();
-		}
+		$this->pre_fill_activity_from_object();
 	}
 
 	/**

--- a/includes/activity/class-actor.php
+++ b/includes/activity/class-actor.php
@@ -62,6 +62,21 @@ class Actor extends Base_Object {
 	);
 
 	/**
+	 * The default types for Actors.
+	 *
+	 * @see https://www.w3.org/TR/activitystreams-vocabulary/#actor-types
+	 *
+	 * @var array
+	 */
+	const DEFAULT_TYPES = array(
+		'Application',
+		'Group',
+		'Organization',
+		'Person',
+		'Service',
+	);
+
+	/**
 	 * The type of the object.
 	 *
 	 * @var string

--- a/includes/activity/class-actor.php
+++ b/includes/activity/class-actor.php
@@ -68,7 +68,7 @@ class Actor extends Base_Object {
 	 *
 	 * @var array
 	 */
-	const DEFAULT_TYPES = array(
+	const TYPES = array(
 		'Application',
 		'Group',
 		'Organization',

--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -85,7 +85,7 @@ class Base_Object extends Generic_Object {
 	 *
 	 * @var array
 	 */
-	const DEFAULT_TYPES = array(
+	const TYPES = array(
 		'Article',
 		'Audio',
 		'Document',

--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -79,6 +79,28 @@ class Base_Object extends Generic_Object {
 	);
 
 	/**
+	 * The default types for Objects.
+	 *
+	 * @see https://www.w3.org/TR/activitystreams-vocabulary/#object-types
+	 *
+	 * @var array
+	 */
+	const DEFAULT_TYPES = array(
+		'Article',
+		'Audio',
+		'Document',
+		'Event',
+		'Image',
+		'Note',
+		'Page',
+		'Place',
+		'Profile',
+		'Relationship',
+		'Tombstone',
+		'Video',
+	);
+
+	/**
 	 * The type of the object.
 	 *
 	 * @var string

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -10,7 +10,7 @@ namespace Activitypub\Collection;
 use Activitypub\Dispatcher;
 use Activitypub\Scheduler;
 use Activitypub\Activity\Activity;
-
+use Activitypub\Activity\Generic_Object;
 use function Activitypub\add_to_outbox;
 
 /**
@@ -296,28 +296,35 @@ class Outbox {
 	/**
 	 * Get the object ID of an activity.
 	 *
-	 * @param Activity $activity The activity object.
+	 * @param Generic_Object $data The activity object.
+	 *
 	 * @return string The object ID.
 	 */
-	private static function get_object_id( $activity ) {
+	private static function get_object_id( $data ) {
+		// If the object is an array, convert it to a Generic_Object.
+		if ( is_array( $data->get_object() ) ) {
+			$data->set_object( Generic_Object::init_from_array( $data->get_object() ) );
+		}
+
 		// Most common.
-		if ( is_object( $activity->get_object() ) ) {
-			return $activity->get_object()->get_id();
+		if ( is_object( $data->get_object() ) ) {
+			return self::get_object_id( $data->get_object() );
 		}
 
 		// Rare.
-		if ( is_string( $activity->get_object() ) ) {
-			return $activity->get_object();
+		if ( is_string( $data->get_object() ) ) {
+			return $data->get_object();
 		}
 
 		// Exceptional.
-		return $activity->get_actor() ?? $activity->get_id();
+		return $data->get_id() ?? $data->get_actor();
 	}
 
 	/**
 	 * Get the title of an activity recursively.
 	 *
 	 * @param \Activitypub\Activity\Base_Object $activity_object The activity object.
+	 *
 	 * @return string The title.
 	 */
 	private static function get_object_title( $activity_object ) {

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\Collection;
 
+use Activitypub\Activity\Base_Object;
 use Activitypub\Dispatcher;
 use Activitypub\Scheduler;
 use Activitypub\Activity\Activity;
-use Activitypub\Activity\Generic_Object;
 use function Activitypub\add_to_outbox;
 
 /**
@@ -296,34 +296,28 @@ class Outbox {
 	/**
 	 * Get the object ID of an activity.
 	 *
-	 * @param Generic_Object $data The activity object.
+	 * @param Activity|Base_Object|string $data The activity object.
 	 *
 	 * @return string The object ID.
 	 */
 	private static function get_object_id( $data ) {
-		// If the object is an array, convert it to a Generic_Object.
-		if ( is_array( $data->get_object() ) ) {
-			$data->set_object( Generic_Object::init_from_array( $data->get_object() ) );
+		$object = $data->get_object();
+
+		if ( is_object( $object ) ) {
+			return self::get_object_id( $object );
 		}
 
-		// Most common.
-		if ( is_object( $data->get_object() ) ) {
-			return self::get_object_id( $data->get_object() );
+		if ( is_string( $object ) ) {
+			return $object;
 		}
 
-		// Rare.
-		if ( is_string( $data->get_object() ) ) {
-			return $data->get_object();
-		}
-
-		// Exceptional.
 		return $data->get_id() ?? $data->get_actor();
 	}
 
 	/**
 	 * Get the title of an activity recursively.
 	 *
-	 * @param \Activitypub\Activity\Base_Object $activity_object The activity object.
+	 * @param Base_Object $activity_object The activity object.
 	 *
 	 * @return string The title.
 	 */
@@ -340,7 +334,7 @@ class Outbox {
 
 		$title = $activity_object->get_name() ?? $activity_object->get_content();
 
-		if ( ! $title && $activity_object->get_object() instanceof \Activitypub\Activity\Base_Object ) {
+		if ( ! $title && $activity_object->get_object() instanceof Base_Object ) {
 			$title = $activity_object->get_object()->get_name() ?? $activity_object->get_object()->get_content();
 		}
 

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -7,10 +7,11 @@
 
 namespace Activitypub\Collection;
 
-use Activitypub\Activity\Base_Object;
 use Activitypub\Dispatcher;
 use Activitypub\Scheduler;
 use Activitypub\Activity\Activity;
+use Activitypub\Activity\Base_Object;
+
 use function Activitypub\add_to_outbox;
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1538,7 +1538,7 @@ function is_activity( $data ) {
 	 */
 	$types = apply_filters(
 		'activitypub_activity_types',
-		Activity::DEFAULT_TYPES
+		Activity::TYPES
 	);
 
 	if ( is_string( $data ) ) {
@@ -1573,7 +1573,7 @@ function is_actor( $data ) {
 	 */
 	$types = apply_filters(
 		'activitypub_actor_types',
-		Actor::DEFAULT_TYPES
+		Actor::TYPES
 	);
 
 	if ( is_string( $data ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1536,10 +1536,7 @@ function is_activity( $data ) {
 	 *
 	 * @param array $types The activity types.
 	 */
-	$types = apply_filters(
-		'activitypub_activity_types',
-		Activity::TYPES
-	);
+	$types = apply_filters( 'activitypub_activity_types', Activity::TYPES );
 
 	if ( is_string( $data ) ) {
 		return in_array( $data, $types, true );
@@ -1571,10 +1568,7 @@ function is_actor( $data ) {
 	 *
 	 * @param array $types The actor types.
 	 */
-	$types = apply_filters(
-		'activitypub_actor_types',
-		Actor::TYPES
-	);
+	$types = apply_filters( 'activitypub_actor_types', Actor::TYPES );
 
 	if ( is_string( $data ) ) {
 		return in_array( $data, $types, true );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -9,6 +9,7 @@ namespace Activitypub;
 
 use WP_Error;
 use Activitypub\Activity\Activity;
+use Activitypub\Activity\Actor;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
@@ -1537,35 +1538,7 @@ function is_activity( $data ) {
 	 */
 	$types = apply_filters(
 		'activitypub_activity_types',
-		array(
-			'Accept',
-			'Add',
-			'Announce',
-			'Arrive',
-			'Block',
-			'Create',
-			'Delete',
-			'Dislike',
-			'Follow',
-			'Flag',
-			'Ignore',
-			'Invite',
-			'Join',
-			'Leave',
-			'Like',
-			'Listen',
-			'Move',
-			'Offer',
-			'Read',
-			'Reject',
-			'Remove',
-			'TentativeAccept',
-			'TentativeReject',
-			'Travel',
-			'Undo',
-			'Update',
-			'View',
-		)
+		Activity::DEFAULT_TYPES
 	);
 
 	if ( is_string( $data ) ) {
@@ -1600,13 +1573,7 @@ function is_actor( $data ) {
 	 */
 	$types = apply_filters(
 		'activitypub_actor_types',
-		array(
-			'Application',
-			'Group',
-			'Organization',
-			'Person',
-			'Service',
-		)
+		Actor::DEFAULT_TYPES
 	);
 
 	if ( is_string( $data ) ) {

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -9,6 +9,7 @@ namespace Activitypub\Tests\Collection;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
+use Activitypub\Activity\Generic_Object;
 use Activitypub\Activity\Extended_Object\Event;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
@@ -283,35 +284,94 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	}
 
 	/**
-	 * Test get_object_id with various activity object types using reflection.
+	 * Test get_object_id with different nested structures.
 	 *
+	 * @dataProvider data_provider_get_object_id
 	 * @covers ::get_object_id
+	 *
+	 * @param array  $activity_data The activity data to test.
+	 * @param string $expected      The expected object ID.
 	 */
-	public function test_get_object_id() {
-		$object = $this->get_dummy_activity_object();
+	public function test_get_object_id( $activity_data, $expected ) {
+		$activity = Generic_Object::init_from_array( $activity_data );
 
-		// Activity object of type object.
-		$create_id = \Activitypub\add_to_outbox( $object, 'Create', 1 );
-		$this->assertEquals( 'https://example.com/test-object', get_post_meta( $create_id, '_activitypub_object_id', true ) );
+		// Get the object ID using reflection since it's a private method.
+		$get_object_id = new \ReflectionMethod( Outbox::class, 'get_object_id' );
+		$get_object_id->setAccessible( true );
 
-		// Activity object of type string.
-		$activity = new Activity();
-		$activity->set_type( 'Like' );
-		$activity->set_object( 'https://example.com/test-string' );
+		$result = $get_object_id->invoke( null, $activity );
 
-		$like_id = \Activitypub\add_to_outbox( $activity, null, 1 );
-		$this->assertEquals( 'https://example.com/test-string', get_post_meta( $like_id, '_activitypub_object_id', true ) );
+		$this->assertEquals( $expected, $result );
+	}
 
-		// No object.
-		$actor    = Actors::get_by_id( 1 );
-		$activity = new Activity();
-		$activity->set_type( 'Move' );
-		$activity->set_actor( $actor->get_id() );
-		$activity->set_origin( $actor->get_id() );
-		$activity->set_target( home_url( '/author/1' ) );
-
-		$move_id = \Activitypub\add_to_outbox( $activity, null, 1 );
-		$this->assertEquals( $actor->get_id(), get_post_meta( $move_id, '_activitypub_object_id', true ) );
+	/**
+	 * Data provider for test_get_object_id.
+	 *
+	 * @return array
+	 */
+	public function data_provider_get_object_id() {
+		return array(
+			'object is a string'             => array(
+				'activity' => array(
+					'type'   => 'Create',
+					'object' => 'https://example.com/note/123',
+				),
+				'expected' => 'https://example.com/note/123',
+			),
+			'object is an object with id'    => array(
+				'activity' => array(
+					'type'   => 'Create',
+					'object' => array(
+						'type' => 'Note',
+						'id'   => 'https://example.com/note/123',
+					),
+				),
+				'expected' => 'https://example.com/note/123',
+			),
+			'object is an object without id' => array(
+				'activity' => array(
+					'type'   => 'Create',
+					'object' => array(
+						'type'    => 'Note',
+						'content' => 'Test content',
+					),
+				),
+				'expected' => null, // Will use activity ID as fallback.
+			),
+			'nested object with id'          => array(
+				'activity' => array(
+					'type'   => 'Create',
+					'object' => array(
+						'type'   => 'Article',
+						'object' => array(
+							'type' => 'Note',
+							'id'   => 'https://example.com/note/123',
+						),
+					),
+				),
+				'expected' => 'https://example.com/note/123',
+			),
+			'nested object without id'       => array(
+				'activity' => array(
+					'type'   => 'Create',
+					'object' => array(
+						'type'   => 'Article',
+						'object' => array(
+							'type'    => 'Note',
+							'content' => 'Test content',
+						),
+					),
+				),
+				'expected' => null, // Will use activity ID as fallback.
+			),
+			'activity with no object'        => array(
+				'activity' => array(
+					'type'  => 'Delete',
+					'actor' => 'https://example.com/user/1',
+				),
+				'expected' => 'https://example.com/user/1', // Will use actor as fallback.
+			),
+		);
 	}
 
 	/**

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -289,12 +289,10 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 * @dataProvider data_provider_get_object_id
 	 * @covers ::get_object_id
 	 *
-	 * @param array  $activity_data The activity data to test.
-	 * @param string $expected      The expected object ID.
+	 * @param Activity $activity The activity data to test.
+	 * @param string   $expected The expected object ID.
 	 */
-	public function test_get_object_id( $activity_data, $expected ) {
-		$activity = Generic_Object::init_from_array( $activity_data );
-
+	public function test_get_object_id( $activity, $expected ) {
 		// Get the object ID using reflection since it's a private method.
 		$get_object_id = new \ReflectionMethod( Outbox::class, 'get_object_id' );
 		$get_object_id->setAccessible( true );
@@ -310,64 +308,67 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 * @return array
 	 */
 	public function data_provider_get_object_id() {
+		$create_with_id = Activity::init_from_array(
+			array(
+				'type'   => 'Create',
+				'object' => array(
+					'type' => 'Note',
+					'id'   => 'https://example.com/note/123',
+				),
+			)
+		);
+		$create_no_id   = Activity::init_from_array(
+			array(
+				'type'   => 'Create',
+				'object' => array(
+					'type'    => 'Note',
+					'content' => 'Test content',
+				),
+			)
+		);
+
 		return array(
 			'object is a string'             => array(
-				'activity' => array(
-					'type'   => 'Create',
-					'object' => 'https://example.com/note/123',
+				'activity' => Activity::init_from_array(
+					array(
+						'type'   => 'Create',
+						'object' => 'https://example.com/note/123',
+					)
 				),
 				'expected' => 'https://example.com/note/123',
 			),
 			'object is an object with id'    => array(
-				'activity' => array(
-					'type'   => 'Create',
-					'object' => array(
-						'type' => 'Note',
-						'id'   => 'https://example.com/note/123',
-					),
-				),
+				'activity' => $create_with_id,
 				'expected' => 'https://example.com/note/123',
 			),
 			'object is an object without id' => array(
-				'activity' => array(
-					'type'   => 'Create',
-					'object' => array(
-						'type'    => 'Note',
-						'content' => 'Test content',
-					),
-				),
+				'activity' => $create_no_id,
 				'expected' => null, // Will use activity ID as fallback.
 			),
 			'nested object with id'          => array(
-				'activity' => array(
-					'type'   => 'Create',
-					'object' => array(
-						'type'   => 'Article',
-						'object' => array(
-							'type' => 'Note',
-							'id'   => 'https://example.com/note/123',
-						),
-					),
+				'activity' => Activity::init_from_array(
+					array(
+						'type'   => 'Announce',
+						'object' => $create_with_id,
+					)
 				),
 				'expected' => 'https://example.com/note/123',
 			),
 			'nested object without id'       => array(
-				'activity' => array(
-					'type'   => 'Create',
-					'object' => array(
-						'type'   => 'Article',
-						'object' => array(
-							'type'    => 'Note',
-							'content' => 'Test content',
-						),
-					),
+				'activity' => Activity::init_from_array(
+					array(
+						'type'   => 'Announce',
+						'object' => $create_no_id,
+					)
 				),
 				'expected' => null, // Will use activity ID as fallback.
 			),
 			'activity with no object'        => array(
-				'activity' => array(
-					'type'  => 'Delete',
-					'actor' => 'https://example.com/user/1',
+				'activity' => Activity::init_from_array(
+					array(
+						'type'  => 'Delete',
+						'actor' => 'https://example.com/user/1',
+					)
 				),
 				'expected' => 'https://example.com/user/1', // Will use actor as fallback.
 			),


### PR DESCRIPTION
While debugging the Outbox-Scheduler, I realized that the `Announce` Outbox Items had the wrong `_activitypub_object_id`. It was the `Activity` ID instead of the original `Object` ID of the post/comment/...

This PR checks recursively for the deepest nested ID possible. This way we always have the `Object` ID which is needed to invalidate Outbox-Activities.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Properly search for the ID in nested Activities/Objects

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Write a new Post
* Check the Outbox-Items

Before the PR, the `Announce` Activity would use the ID of the `Create` Activity instead of the `Object` ID of the Post.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Support multiple layers of nested Outbox activities when searching for the Object ID.

</details>
