### PR TITLE
Fix: Delete Undone comments instead of trashing them

### DIFF
--- a/.github/changelog/1520-from-description
+++ b/.github/changelog/1520-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Permanently delete reactions that were `Undo` instead of trashing them.

--- a/includes/handler/class-undo.php
+++ b/includes/handler/class-undo.php
@@ -75,7 +75,7 @@ class Undo {
 				return;
 			}
 
-			$state = wp_trash_comment( $comment );
+			$state = wp_delete_comment( $comment, true );
 		}
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/Automattic/wordpress-activitypub/issues/1421#issuecomment-2760482568

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The Undo event now deletes reactions instead of trashing them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Like or Boost a WordPress post on Mastodon et. al.
* Undo this action
* Check the trash

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Permanently delete reactions that were `Undo` instead of trashing them.

</details>
