### PR TITLE
Tests: Reduce chance of time offsets

### DIFF
--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -319,6 +319,6 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Verify the updated attribute is set and matches the post's modified date.
 		$expected_updated = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) );
-		$this->assertEquals( $expected_updated, $activity['updated'] );
+		$this->assertEqualsWithDelta( $expected_updated, $activity['updated'], 2, 'Updated attribute does not match post modified date.' );
 	}
 }


### PR DESCRIPTION
I noticed a couple of failed tests recently that showed a time difference in the updated test:
https://github.com/Automattic/wordpress-activitypub/actions/runs/14176817608/job/39713607394?pr=1521

```
There was 1 failure:

1) Activitypub\Tests\Scheduler\Test_Actor::test_actor_profile_update_sets_updated_attribute
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'2025-03-31 16:47:02'
+'2025-03-31 16:47:01'

/tests/includes/scheduler/class-test-actor.php:322
```

This should give us a bit more wiggle room.