### PR TITLE
Scheduler: Don't federate Deletes of unfederated posts.

### DIFF
--- a/.github/changelog/1528-from-description
+++ b/.github/changelog/1528-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+No longer federates `Delete` activities for posts that were not federated.

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Scheduler;
 
 use function Activitypub\add_to_outbox;
+use function Activitypub\get_wp_object_state;
 use function Activitypub\is_post_disabled;
 
 /**
@@ -62,7 +63,7 @@ class Post {
 				break;
 
 			case 'trash':
-				$type = 'Delete';
+				$type = 'federated' === get_wp_object_state( $post ) ? 'Delete' : false;
 				break;
 
 			default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Also see #1338.

While testing imports and deleting imported posts between test runs, I noticed that we create a Delete activity for every deleted post, even when it wasn't federated. These posts were not federated because they were created as part of an import. 

In actor & blog mode, it even added another Announcement activity for it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks federation status for a post before setting `$type` to `Delete`.
* Adds unit test.
* Update unit tests for a typo.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Import a few posts.
* Delete one of these posts.
* Make sure there's no Outbox item created for that Delete.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

No longer federates `Delete` activities for posts that were not federated.

</details>
