### PR TITLE
Introduce user_can_activitypub

### DIFF
--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -125,13 +125,7 @@ class Comment {
 			$current_user = Actors::BLOG_USER_ID;
 		}
 
-		$is_user_disabled = is_user_disabled( $current_user );
-
-		if ( $is_user_disabled ) {
-			return false;
-		}
-
-		return true;
+		return user_can_activitypub( $current_user );
 	}
 
 	/**
@@ -235,10 +229,8 @@ class Comment {
 			$user_id = Actors::BLOG_USER_ID;
 		}
 
-		$is_user_disabled = is_user_disabled( $user_id );
-
-		// User is disabled for federation.
-		if ( $is_user_disabled ) {
+		// User is not allowed to federate comments.
+		if ( ! user_can_activitypub( $user_id ) ) {
 			return false;
 		}
 

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -761,11 +761,11 @@ class Migration {
 		}
 
 		// If the user is disabled, fall back to the blog user when available.
-		if ( is_user_disabled( $user_id ) ) {
-			if ( is_user_disabled( Actors::BLOG_USER_ID ) ) {
-				return;
-			} else {
+		if ( ! user_can_activitypub( $user_id ) ) {
+			if ( user_can_activitypub( Actors::BLOG_USER_ID ) ) {
 				$user_id = Actors::BLOG_USER_ID;
+			} else {
+				return;
 			}
 		}
 

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -17,8 +17,8 @@ use function Activitypub\object_to_uri;
 use function Activitypub\normalize_url;
 use function Activitypub\normalize_host;
 use function Activitypub\url_to_authorid;
-use function Activitypub\is_user_disabled;
 use function Activitypub\is_user_type_disabled;
+use function Activitypub\user_can_activitypub;
 
 /**
  * Actors collection.
@@ -50,7 +50,7 @@ class Actors {
 			$user_id = (int) $user_id;
 		}
 
-		if ( is_user_disabled( $user_id ) ) {
+		if ( ! user_can_activitypub( $user_id ) ) {
 			return new WP_Error(
 				'activitypub_user_not_found',
 				\__( 'Actor not found', 'activitypub' ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -327,57 +327,67 @@ function is_post_disabled( $post ) {
 }
 
 /**
+ * This function checks if a user is enabled for ActivityPub.
+ *
+ * @param int $user_id The user ID.
+ * @return boolean True if the user is enabled, false otherwise.
+ */
+function user_can_activitypub( $user_id ) {
+	switch ( $user_id ) {
+		case Actors::APPLICATION_USER_ID:
+			$enabled = true; // Application user is always enabled.
+			break;
+
+		case Actors::BLOG_USER_ID:
+			$enabled = ! is_user_type_disabled( 'blog' );
+			break;
+
+		default:
+			if ( ! \get_user_by( 'id', $user_id ) ) {
+				$enabled = false;
+				break;
+			}
+
+			if ( is_user_type_disabled( 'user' ) ) {
+				$enabled = false;
+				break;
+			}
+
+			$enabled = \user_can( $user_id, 'activitypub' );
+	}
+
+	/**
+	 * Allow plugins to disable users for ActivityPub.
+	 *
+	 * @deprecated unreleased Use the `activitypub_user_can_activitypub` filter instead.
+	 *
+	 * @param boolean $disabled True if the user is disabled, false otherwise.
+	 * @param int     $user_id  The user ID.
+	 */
+	$enabled = ! \apply_filters_deprecated( 'activitypub_is_user_disabled', array( ! $enabled, $user_id ), 'unreleased', 'activitypub_user_can_activitypub' );
+
+	/**
+	 * Allow plugins to enable/disable users for ActivityPub.
+	 *
+	 * @param boolean $enabled True if the user is enabled, false otherwise.
+	 * @param int     $user_id The user ID.
+	 */
+	return apply_filters( 'activitypub_user_can_activitypub', $enabled, $user_id );
+}
+
+/**
  * This function checks if a user is disabled for ActivityPub.
+ *
+ * @deprecated unreleased Use the `user_can_activitypub` function instead.
  *
  * @param int $user_id The user ID.
  *
  * @return boolean True if the user is disabled, false otherwise.
  */
 function is_user_disabled( $user_id ) {
-	$disabled = false;
+	_deprecated_function( __FUNCTION__, 'unreleased', 'user_can_activitypub' );
 
-	switch ( $user_id ) {
-		// if the user is the application user, it's always enabled.
-		case \Activitypub\Collection\Actors::APPLICATION_USER_ID:
-			$disabled = false;
-			break;
-		// if the user is the blog user, it's only enabled in single-user mode.
-		case \Activitypub\Collection\Actors::BLOG_USER_ID:
-			if ( is_user_type_disabled( 'blog' ) ) {
-				$disabled = true;
-				break;
-			}
-
-			$disabled = false;
-			break;
-		// if the user is any other user, it's enabled if it can publish posts.
-		default:
-			if ( ! \get_user_by( 'id', $user_id ) ) {
-				$disabled = true;
-				break;
-			}
-
-			if ( is_user_type_disabled( 'user' ) ) {
-				$disabled = true;
-				break;
-			}
-
-			if ( ! \user_can( $user_id, 'activitypub' ) ) {
-				$disabled = true;
-				break;
-			}
-
-			$disabled = false;
-			break;
-	}
-
-	/**
-	 * Allow plugins to disable users for ActivityPub.
-	 *
-	 * @param boolean $disabled True if the user is disabled, false otherwise.
-	 * @param int     $user_id  The User-ID.
-	 */
-	return apply_filters( 'activitypub_is_user_disabled', $disabled, $user_id );
+	return ! user_can_activitypub( $user_id );
 }
 
 /**
@@ -615,7 +625,7 @@ function get_active_users( $duration = 1 ) {
 	}
 
 	// If blog user is disabled.
-	if ( is_user_disabled( Actors::BLOG_USER_ID ) ) {
+	if ( ! user_can_activitypub( Actors::BLOG_USER_ID ) ) {
 		return (int) $count;
 	}
 
@@ -647,7 +657,7 @@ function get_total_users() {
 	}
 
 	// If blog user is disabled.
-	if ( is_user_disabled( Actors::BLOG_USER_ID ) ) {
+	if ( ! user_can_activitypub( Actors::BLOG_USER_ID ) ) {
 		return (int) $users;
 	}
 
@@ -1492,11 +1502,11 @@ function add_to_outbox( $data, $activity_type = null, $user_id = 0, $content_vis
 	}
 
 	// If the user is disabled, fall back to the blog user when available.
-	if ( is_user_disabled( $user_id ) ) {
-		if ( is_user_disabled( Actors::BLOG_USER_ID ) ) {
-			return false;
-		} else {
+	if ( ! user_can_activitypub( $user_id ) ) {
+		if ( user_can_activitypub( Actors::BLOG_USER_ID ) ) {
 			$user_id = Actors::BLOG_USER_ID;
+		} else {
+			return false;
 		}
 	}
 

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -13,9 +13,9 @@ use Activitypub\Activity\Actor;
 use Activitypub\Collection\Extra_Fields;
 
 use function Activitypub\is_blog_public;
-use function Activitypub\is_user_disabled;
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_attribution_domains;
+use function Activitypub\user_can_activitypub;
 
 /**
  * User class.
@@ -88,7 +88,7 @@ class User extends Actor {
 	 * @return WP_Error|User The User object or WP_Error if user not found.
 	 */
 	public static function from_wp_user( $user_id ) {
-		if ( is_user_disabled( $user_id ) ) {
+		if ( ! user_can_activitypub( $user_id ) ) {
 			return new WP_Error(
 				'activitypub_user_not_found',
 				\__( 'User not found', 'activitypub' ),

--- a/includes/transformer/class-factory.php
+++ b/includes/transformer/class-factory.php
@@ -11,8 +11,8 @@ use WP_Error;
 use Activitypub\Http;
 use Activitypub\Comment as Comment_Helper;
 
-use function Activitypub\is_user_disabled;
 use function Activitypub\is_post_disabled;
+use function Activitypub\user_can_activitypub;
 
 /**
  * Transformer Factory.
@@ -100,7 +100,7 @@ class Factory {
 				}
 				break;
 			case 'WP_User':
-				if ( ! is_user_disabled( $data->ID ) ) {
+				if ( user_can_activitypub( $data->ID ) ) {
 					return new User( $data );
 				}
 				break;

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -12,9 +12,9 @@ use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 use function Activitypub\count_followers;
 use function Activitypub\get_content_visibility;
-use function Activitypub\is_user_disabled;
 use function Activitypub\is_user_type_disabled;
 use function Activitypub\site_supports_blocks;
+use function Activitypub\user_can_activitypub;
 use function Activitypub\was_comment_received;
 
 /**
@@ -49,7 +49,7 @@ class Admin {
 		\add_filter( 'bulk_actions-users', array( self::class, 'user_bulk_options' ) );
 		\add_filter( 'handle_bulk_actions-users', array( self::class, 'handle_bulk_request' ), 10, 3 );
 
-		if ( ! is_user_disabled( get_current_user_id() ) ) {
+		if ( user_can_activitypub( \get_current_user_id() ) ) {
 			\add_action( 'show_user_profile', array( self::class, 'add_profile' ) );
 		}
 
@@ -112,7 +112,7 @@ class Admin {
 	 */
 	public static function followers_list_page() {
 		// User has to be able to publish posts.
-		if ( ! is_user_disabled( get_current_user_id() ) ) {
+		if ( user_can_activitypub( \get_current_user_id() ) ) {
 			\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/user-followers-list.php' );
 		}
 	}
@@ -510,7 +510,7 @@ class Admin {
 	public static function dashboard_glance_items( $items ) {
 		\add_filter( 'number_format_i18n', '\Activitypub\custom_large_numbers', 10, 3 );
 
-		if ( ! is_user_disabled( get_current_user_id() ) ) {
+		if ( user_can_activitypub( \get_current_user_id() ) ) {
 			$follower_count = sprintf(
 				// translators: %s: number of followers.
 				_n(

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -12,7 +12,7 @@ use Activitypub\Http;
 use Activitypub\Collection\Actors;
 use Activitypub\Sanitize;
 
-use function Activitypub\is_user_disabled;
+use function Activitypub\user_can_activitypub;
 
 /**
  * ActivityPub Health_Check Class.
@@ -37,7 +37,7 @@ class Health_Check {
 	 * @return array The filtered test array.
 	 */
 	public static function add_tests( $tests ) {
-		if ( ! is_user_disabled( get_current_user_id() ) ) {
+		if ( user_can_activitypub( \get_current_user_id() ) ) {
 			$tests['direct']['activitypub_test_author_url'] = array(
 				'label' => \__( 'Author URL test', 'activitypub' ),
 				'test'  => array( self::class, 'test_author_url' ),

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -7,7 +7,7 @@
 
 namespace Activitypub\WP_Admin;
 
-use function Activitypub\is_user_disabled;
+use function Activitypub\user_can_activitypub;
 
 /**
  * ActivityPub Menu Class.
@@ -29,7 +29,7 @@ class Menu {
 		\add_action( 'load-' . $settings_page, array( Settings::class, 'add_settings_help_tab' ) );
 
 		// User has to be able to publish posts.
-		if ( ! is_user_disabled( get_current_user_id() ) ) {
+		if ( user_can_activitypub( \get_current_user_id() ) ) {
 			$followers_list_page = \add_users_page(
 				\__( 'Followers ⁂', 'activitypub' ),
 				\__( 'Followers ⁂', 'activitypub' ),

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -10,7 +10,7 @@ namespace Activitypub\WP_Admin;
 use Activitypub\Collection\Actors;
 use Activitypub\Model\Blog;
 use Activitypub\Sanitize;
-use function Activitypub\is_user_disabled;
+use function Activitypub\user_can_activitypub;
 
 /**
  * ActivityPub Settings Class.
@@ -260,7 +260,7 @@ class Settings {
 			'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php',
 		);
 
-		if ( ! is_user_disabled( Actors::BLOG_USER_ID ) ) {
+		if ( user_can_activitypub( Actors::BLOG_USER_ID ) ) {
 			$settings_tabs['blog-profile'] = array(
 				'label'    => __( 'Blog Profile', 'activitypub' ),
 				'template' => ACTIVITYPUB_PLUGIN_DIR . 'templates/blog-settings.php',
@@ -322,7 +322,7 @@ class Settings {
 			),
 		);
 
-		if ( ! is_user_disabled( \get_current_user_id() ) ) {
+		if ( user_can_activitypub( \get_current_user_id() ) ) {
 			$webfinger = Actors::get_by_id( \get_current_user_id() )->get_webfinger();
 		} else {
 			$webfinger = ( new Blog() )->get_webfinger();

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -11,7 +11,7 @@ use Activitypub\Model\Blog;
 use Activitypub\Collection\Actors;
 
 use function Activitypub\get_reply_intent_js;
-use function Activitypub\is_user_disabled;
+use function Activitypub\user_can_activitypub;
 
 /**
  * Class Welcome_Fields.
@@ -43,7 +43,7 @@ class Welcome_Fields {
 			'activitypub_welcome'
 		);
 
-		if ( ! is_user_disabled( Actors::BLOG_USER_ID ) ) {
+		if ( user_can_activitypub( Actors::BLOG_USER_ID ) ) {
 			\add_settings_section(
 				'activitypub_blog_profile',
 				\__( 'Blog profile', 'activitypub' ),
@@ -52,7 +52,7 @@ class Welcome_Fields {
 			);
 		}
 
-		if ( ! is_user_disabled( get_current_user_id() ) ) {
+		if ( user_can_activitypub( \get_current_user_id() ) ) {
 			\add_settings_section(
 				'activitypub_author_profile',
 				\__( 'Author profile', 'activitypub' ),


### PR DESCRIPTION
Replaces `is_user_disabled()` to avoid double meaning.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduces `user_can_activitypub()` to determine whether the passed user_id is enabled.
* Deprecates `is_user_disabled()`.
* Replaces all uses of `is_user_disabled()` with `user_can_activitypub()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
