### PR TITLE
Move: use `$from` for object in `Move::externally`

### DIFF
--- a/.github/changelog/1531-from-description
+++ b/.github/changelog/1531-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Use the $from account for the object in Move activity for external Moves

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -78,7 +78,7 @@ class Move {
 		$activity->set_type( 'Move' );
 		$activity->set_actor( $user->get_id() );
 		$activity->set_origin( $user->get_id() );
-		$activity->set_object( $target_actor->get_id() );
+		$activity->set_object( $user->get_id() );
 		$activity->set_target( $target_actor->get_id() );
 
 		// Add to outbox.


### PR DESCRIPTION
Following on from #1516 , we will also set the `object` to the `$from` value to conform to the spec.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `$from` for object in `Move::externally`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Use the $from account for the object in Move activity for external Moves

</details>
