### PR TITLE
Fix: Use specified time formatting for Outbox Activities

### DIFF
--- a/.github/changelog/1537-from-description
+++ b/.github/changelog/1537-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use specified date format for `updated` field in Outbox-Activites.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -223,7 +223,7 @@ class Outbox {
 		}
 
 		if ( 'Update' === $type ) {
-			$activity->set_updated( gmdate( 'Y-m-d H:i:s', strtotime( $outbox_item->post_modified ) ) );
+			$activity->set_updated( gmdate( 'Y-m-d\TH:i:s\Z', strtotime( $outbox_item->post_modified ) ) );
 		}
 
 		/**

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -223,7 +223,7 @@ class Outbox {
 		}
 
 		if ( 'Update' === $type ) {
-			$activity->set_updated( gmdate( 'Y-m-d\TH:i:s\Z', strtotime( $outbox_item->post_modified ) ) );
+			$activity->set_updated( gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, strtotime( $outbox_item->post_modified ) ) );
 		}
 
 		/**

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -64,6 +64,8 @@
 	)
 );
 
+\define( 'ACTIVITYPUB_DATE_TIME_RFC3339', 'Y-m-d\TH:i:s\Z' );
+
 // Define Actor-Modes for the plugin.
 \define( 'ACTIVITYPUB_ACTOR_MODE', 'actor' );
 \define( 'ACTIVITYPUB_BLOG_MODE', 'blog' );

--- a/includes/model/class-application.php
+++ b/includes/model/class-application.php
@@ -187,7 +187,7 @@ class Application extends Actor {
 			$time = \time();
 		}
 
-		return \gmdate( 'Y-m-d\TH:i:s\Z', $time );
+		return \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $time );
 	}
 
 	/**

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -311,7 +311,7 @@ class Blog extends Actor {
 			$time = \time();
 		}
 
-		return \gmdate( 'Y-m-d\TH:i:s\Z', $time );
+		return \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $time );
 	}
 
 	/**

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -226,7 +226,7 @@ class User extends Actor {
 	 * @return false|string The date the user was created.
 	 */
 	public function get_published() {
-		return \gmdate( 'Y-m-d\TH:i:s\Z', \strtotime( \get_the_author_meta( 'registered', $this->_id ) ) );
+		return \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, \strtotime( \get_the_author_meta( 'registered', $this->_id ) ) );
 	}
 
 	/**

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -139,7 +139,7 @@ class Actor {
 			return;
 		}
 
-		$actor->set_updated( gmdate( 'Y-m-d H:i:s', time() ) );
+		$actor->set_updated( gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, time() ) );
 
 		add_to_outbox( $actor, 'Update', $user_id );
 	}

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -49,11 +49,11 @@ class Comment extends Base {
 		$object->set_type( 'Note' );
 
 		$published = \strtotime( $comment->comment_date_gmt );
-		$object->set_published( \gmdate( 'Y-m-d\TH:i:s\Z', $published ) );
+		$object->set_published( \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $published ) );
 
 		$updated = \get_comment_meta( $comment->comment_ID, 'activitypub_comment_modified', true );
 		if ( $updated > $published ) {
-			$object->set_updated( \gmdate( 'Y-m-d\TH:i:s\Z', $updated ) );
+			$object->set_updated( \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $updated ) );
 		}
 
 		$object->set_content_map(
@@ -302,7 +302,7 @@ class Comment extends Base {
 		$published = \get_comment_meta( $this->item->comment_ID, 'activitypub_comment_published', true );
 
 		if ( $updated > $published ) {
-			return \gmdate( 'Y-m-d\TH:i:s\Z', $updated );
+			return \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $updated );
 		}
 
 		return null;
@@ -314,7 +314,7 @@ class Comment extends Base {
 	 * @return string The published date of the comment.
 	 */
 	public function get_published() {
-		return \gmdate( 'Y-m-d\TH:i:s\Z', \strtotime( $this->item->comment_date_gmt ) );
+		return \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, \strtotime( $this->item->comment_date_gmt ) );
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -573,7 +573,7 @@ class Post extends Base {
 	protected function get_published() {
 		$published = \strtotime( $this->item->post_date_gmt );
 
-		return \gmdate( 'Y-m-d\TH:i:s\Z', $published );
+		return \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $published );
 	}
 
 	/**
@@ -586,7 +586,7 @@ class Post extends Base {
 		$updated   = \strtotime( $this->item->post_modified_gmt );
 
 		if ( $updated > $published ) {
-			return \gmdate( 'Y-m-d\TH:i:s\Z', $updated );
+			return \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $updated );
 		}
 
 		return null;

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -454,7 +454,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Verify the updated attribute is set and matches the post's modified date.
 		$post             = get_post( $id );
-		$expected_updated = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) );
+		$expected_updated = gmdate( 'Y-m-d\TH:i:s\Z', strtotime( $post->post_modified ) );
 		$this->assertEquals( $expected_updated, $activity->get_updated() );
 
 		// Delete the Outbox item.

--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -318,7 +318,7 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$activity = \json_decode( $post->post_content, true );
 
 		// Verify the updated attribute is set and matches the post's modified date.
-		$expected_updated = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) );
+		$expected_updated = gmdate( 'Y-m-d\TH:i:s\Z', strtotime( $post->post_modified ) );
 		$this->assertEqualsWithDelta( $expected_updated, $activity['updated'], 2, 'Updated attribute does not match post modified date.' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes wrong timestamp formatting of the `updated` field for Outbox-Activities.

props @JohnONolan !

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use standardized date format

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Use specified date format for `updated` field in Outbox-Activites.

</details>
