### PR TITLE
Fix: Default value for empty `movedTo` field

### DIFF
--- a/.github/changelog/1539-from-description
+++ b/.github/changelog/1539-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+So not show `movedTo` attribute instead of setting it to `false` if empty.

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -576,6 +576,6 @@ class Blog extends Actor {
 	 * @return string The movedTo.
 	 */
 	public function get_moved_to() {
-		return \get_option( 'activitypub_blog_user_moved_to' );
+		return \get_option( 'activitypub_blog_user_moved_to' ) ?: null;
 	}
 }

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -576,6 +576,7 @@ class Blog extends Actor {
 	 * @return string The movedTo.
 	 */
 	public function get_moved_to() {
+		// phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 		return \get_option( 'activitypub_blog_user_moved_to' ) ?: null;
 	}
 }

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -446,6 +446,6 @@ class User extends Actor {
 	 * @return string The movedTo.
 	 */
 	public function get_moved_to() {
-		return \get_user_option( 'activitypub_moved_to', $this->_id );
+		return \get_user_option( 'activitypub_moved_to', $this->_id ) ?: null;
 	}
 }

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -446,6 +446,7 @@ class User extends Actor {
 	 * @return string The movedTo.
 	 */
 	public function get_moved_to() {
+		// phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 		return \get_user_option( 'activitypub_moved_to', $this->_id ) ?: null;
 	}
 }

--- a/tests/includes/model/class-test-user.php
+++ b/tests/includes/model/class-test-user.php
@@ -70,4 +70,24 @@ class Test_User extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'url', $icon );
 		$this->assertNotSame( wp_get_attachment_url( $attachment_id ), $icon['url'] );
 	}
+
+	/**
+	 * Tests the get_moved_to method.
+	 *
+	 * @covers ::get_moved_to
+	 */
+	public function test_get_moved_to() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user    = User::from_wp_user( $user_id );
+
+		// No value => should not even be set.
+		$this->assertArrayNotHasKey( 'movedTo', $user->to_array( false ) );
+
+		// Set movedTo.
+		\update_user_option( $user_id, 'activitypub_moved_to', 'https://example.com' );
+
+		$user = User::from_wp_user( $user_id )->to_array( false );
+		$this->assertArrayHasKey( 'movedTo', $user );
+		$this->assertSame( 'https://example.com', $user['movedTo'] );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`movedTo` returns `false` if it is not set, but the spec defines it as `@id` so it should be either empty or not existent instead: https://www.w3.org/TR/json-ld/#node-identifiers

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not show `movedTo` if not set.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

So not show `movedTo` attribute instead of setting it to `false` if empty.

</details>
