### PR TITLE
Fix: Post Interactions settings

### DIFF
--- a/.github/changelog/1540-from-description
+++ b/.github/changelog/1540-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+"Post Interactions" settings will now be saved to the options table.

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -506,7 +506,7 @@ class Settings_Fields {
 			</p>
 			<p>
 				<label>
-					<input type="checkbox" name="activitypub_allow_announces" value="1" <?php checked( '1', $allow_reposts ); ?> />
+					<input type="checkbox" name="activitypub_allow_reposts" value="1" <?php checked( '1', $allow_reposts ); ?> />
 					<?php esc_html_e( 'Receive reblogs (boosts)', 'activitypub' ); ?>
 				</label>
 			</p>

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -147,6 +147,28 @@ class Settings {
 
 		\register_setting(
 			'activitypub',
+			'activitypub_allow_likes',
+			array(
+				'type'              => 'integer',
+				'description'       => \__( 'Allow likes.', 'activitypub' ),
+				'default'           => '1',
+				'sanitize_callback' => 'absint',
+			)
+		);
+
+		\register_setting(
+			'activitypub',
+			'activitypub_allow_reposts',
+			array(
+				'type'              => 'integer',
+				'description'       => \__( 'Allow reposts.', 'activitypub' ),
+				'default'           => '1',
+				'sanitize_callback' => 'absint',
+			)
+		);
+
+		\register_setting(
+			'activitypub',
 			'activitypub_authorized_fetch',
 			array(
 				'type'        => 'boolean',


### PR DESCRIPTION
Fixes #1538

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Defined `register_setting` for `allow_likes` and `allow_reposts`, otherwise settings won't be stored in options table
* Fixed wrong naming in HTML form

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

"Post Interactions" settings will now be saved to the options table.

</details>
