### PR TITLE
Fix deprecated notices in PHP 8

### DIFF
--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -24,8 +24,8 @@ class Sanitize {
 			$value = \explode( PHP_EOL, $value );
 		}
 
-		$value = \array_map( 'trim', $value );
 		$value = \array_filter( $value );
+		$value = \array_map( 'trim', $value );
 		$value = \array_map( 'sanitize_url', $value );
 		$value = \array_unique( $value );
 

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -610,8 +610,10 @@ class Test_Migration extends \WP_UnitTestCase {
 		$follower = new Follower();
 		$follower->from_array(
 			array(
-				'type'    => 'Person',
-				'summary' => '<p>unescaped backslash 04\2024</p>',
+				'type'               => 'Person',
+				'name'               => 'Test Follower',
+				'preferred_username' => 'Follower',
+				'summary'            => '<p>unescaped backslash 04\2024</p>',
 			)
 		);
 		$unslashed_json = $follower->to_json();

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -56,9 +56,15 @@ class Test_Scheduler extends \WP_UnitTestCase {
 	public function test_reprocess_outbox() {
 		// Create test activity objects.
 		$activity = new Activity();
-		$activity->set_object( array( 'content' => 'Test Content' ) );
 		$activity->set_type( 'Create' );
 		$activity->set_id( 'https://example.com/test-id' );
+		$activity->set_object(
+			array(
+				'id'      => 'https://example.com/test-id',
+				'type'    => 'Note',
+				'content' => 'Test Content',
+			)
+		);
 
 		// Add multiple pending activities.
 		$pending_ids = array();
@@ -149,9 +155,15 @@ class Test_Scheduler extends \WP_UnitTestCase {
 	public function test_reprocess_outbox_scheduling() {
 		// Create a test activity.
 		$activity = new Activity();
-		$activity->set_object( array( 'content' => 'Test Content' ) );
 		$activity->set_type( 'Create' );
 		$activity->set_id( 'https://example.com/test-id' );
+		$activity->set_object(
+			array(
+				'id'      => 'https://example.com/test-id',
+				'type'    => 'Note',
+				'content' => 'Test Content',
+			)
+		);
 
 		$pending_id = Outbox::add( $activity, self::$user_id );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes deprecated notices in PHP 8.* runs of unit tests.
See https://github.com/Automattic/wordpress-activitypub/actions/runs/14225062216/job/39862498346?pr=1530

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds more details to fixtures to avoid passing null values.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

