### PR TITLE
Actors: Don't convert non-numeric strings to Blog user id

### DIFF
--- a/.github/changelog/1554-from-description
+++ b/.github/changelog/1554-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sites with comments from the Fediverse no longer create uncached extra fields posts that flood the Outbox.

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -46,7 +46,7 @@ class Actors {
 	 * @return User|Blog|Application|WP_Error The Actor or WP_Error if user not found.
 	 */
 	public static function get_by_id( $user_id ) {
-		if ( is_string( $user_id ) || is_numeric( $user_id ) ) {
+		if ( is_numeric( $user_id ) ) {
 			$user_id = (int) $user_id;
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -329,10 +329,14 @@ function is_post_disabled( $post ) {
 /**
  * This function checks if a user is enabled for ActivityPub.
  *
- * @param int $user_id The user ID.
+ * @param int|string $user_id The user ID.
  * @return boolean True if the user is enabled, false otherwise.
  */
 function user_can_activitypub( $user_id ) {
+	if ( ! is_numeric( $user_id ) ) {
+		return false;
+	}
+
 	switch ( $user_id ) {
 		case Actors::APPLICATION_USER_ID:
 			$enabled = true; // Application user is always enabled.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -333,27 +333,16 @@ function is_post_disabled( $post ) {
  * @return boolean True if the user is enabled, false otherwise.
  */
 function user_can_activitypub( $user_id ) {
-	switch ( $user_id ) {
-		case Actors::APPLICATION_USER_ID:
-			$enabled = true; // Application user is always enabled.
-			break;
-
-		case Actors::BLOG_USER_ID:
-			$enabled = ! is_user_type_disabled( 'blog' );
-			break;
-
-		default:
-			if ( ! \get_user_by( 'id', $user_id ) ) {
-				$enabled = false;
-				break;
-			}
-
-			if ( is_user_type_disabled( 'user' ) ) {
-				$enabled = false;
-				break;
-			}
-
-			$enabled = \user_can( $user_id, 'activitypub' );
+	if ( Actors::APPLICATION_USER_ID === $user_id ) {
+		$enabled = true; // Application user is always enabled.
+	} elseif ( Actors::BLOG_USER_ID === $user_id ) {
+		$enabled = ! is_user_type_disabled( 'blog' );
+	} elseif ( ! \get_user_by( 'id', $user_id ) ) {
+		$enabled = false;
+	} elseif ( is_user_type_disabled( 'user' ) ) {
+		$enabled = false;
+	} else {
+		$enabled = \user_can( $user_id, 'activitypub' );
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -333,16 +333,27 @@ function is_post_disabled( $post ) {
  * @return boolean True if the user is enabled, false otherwise.
  */
 function user_can_activitypub( $user_id ) {
-	if ( Actors::APPLICATION_USER_ID === $user_id ) {
-		$enabled = true; // Application user is always enabled.
-	} elseif ( Actors::BLOG_USER_ID === $user_id ) {
-		$enabled = ! is_user_type_disabled( 'blog' );
-	} elseif ( ! \get_user_by( 'id', $user_id ) ) {
-		$enabled = false;
-	} elseif ( is_user_type_disabled( 'user' ) ) {
-		$enabled = false;
-	} else {
-		$enabled = \user_can( $user_id, 'activitypub' );
+	switch ( $user_id ) {
+		case Actors::APPLICATION_USER_ID:
+			$enabled = true; // Application user is always enabled.
+			break;
+
+		case Actors::BLOG_USER_ID:
+			$enabled = ! is_user_type_disabled( 'blog' );
+			break;
+
+		default:
+			if ( ! \get_user_by( 'id', $user_id ) ) {
+				$enabled = false;
+				break;
+			}
+
+			if ( is_user_type_disabled( 'user' ) ) {
+				$enabled = false;
+				break;
+			}
+
+			$enabled = \user_can( $user_id, 'activitypub' );
 	}
 
 	/**

--- a/tests/includes/collection/class-test-actors.php
+++ b/tests/includes/collection/class-test-actors.php
@@ -28,6 +28,19 @@ class Test_Actors extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_by_id.
+	 *
+	 * @covers ::get_by_id
+	 */
+	public function test_get_by_id() {
+		// External user.
+		$user_id = 'obenland@mastodon.social';
+
+		$actor = Actors::get_by_id( $user_id );
+		$this->assertWPError( $actor );
+	}
+
+	/**
 	 * Test get_by_various.
 	 *
 	 * @dataProvider the_resource_provider


### PR DESCRIPTION
Fixes a bug in our Enable Mastodon Apps integration that can create hundreds of Outbox items.

The `mastodon_api_account` filter [passes a user_id or author_url as the second parameter](https://github.com/akirk/enable-mastodon-apps/blob/36707ccb7ce16b28d37c294f835df787f62ffed0/includes/class-comment-cpt.php#L245-L249), which [we currently don't account for in `Enable_Mastodon_Apps::api_account_internal()`](https://github.com/Automattic/wordpress-activitypub/blob/trunk/integration/class-enable-mastodon-apps.php#L274-L279).

Requests like the following end up creating two extra fields post for every comment from Activitypub commenters, which in turn create an Outbox item each:
```
Debugger [2025-04-06 14:31:22.067] 200 GET [/api/v1/timelines/public?only_media=false&since_id=8452](https://obietester.blog/api/v1/timelines/public?only_media=false&since_id=8452&_wpnonce=NONCE&_pretty=1)
params array (
  'limit' => 20,
  'only_media' => 'false',
  'since_id' => '8452',
)
current_user 0
user_agent 'Apache-HttpClient/4.5.13  Java/11.0.20 '
app \Enable_Mastodon_Apps\Mastodon_App::__set_state(array(
   'term' => 
  \WP_Term::__set_state(array(
     'term_id' => 1370,
     'name' => 'enable-mastodon-apps',
     'slug' => 'enable-mastodon-apps',
     'term_group' => 0,
     'term_taxonomy_id' => 16,
     'taxonomy' => 'mastodon-app',
     'description' => '',
     'parent' => 0,
     'count' => 0,
     'filter' => 'raw',
  )),
))
```

Stack trace:
```
require('wp-blog-header.php'), 
wp, 
WP->main, 
WP->parse_request, 
do_action_ref_array('parse_request'), 
WP_Hook->do_action, 
WP_Hook->apply_filters, 
rest_api_loaded, 
WP_REST_Server->serve_request, 
WP_REST_Server->dispatch, 
WP_REST_Server->respond_to_request, 
Enable_Mastodon_Apps\Mastodon_API->api_public_timeline, 
apply_filters('mastodon_api_public_timeline'), 
WP_Hook->apply_filters, 
Enable_Mastodon_Apps\Handler\Timeline->api_public_timeline, 
Enable_Mastodon_Apps\Handler\Handler->get_posts, 
apply_filters('mastodon_api_status'), 
WP_Hook->apply_filters, 
Enable_Mastodon_Apps\Comment_CPT->api_status, 
apply_filters('mastodon_api_account'), WP_Hook->apply_filters, Activitypub\Integration\Enable_Mastodon_Apps::api_account_internal, Activitypub\Integration\Enable_Mastodon_Apps::get_extra_fields, 
Activitypub\Collection\Extra_Fields::get_actor_fields, 
apply_filters('activitypub_get_actor_extra_fields'), 
WP_Hook->apply_filters, 
Activitypub\Collection\Extra_Fields::default_actor_extra_fields, 
wp_insert_post, 
wp_transition_post_status, 
do_action('transition_post_status'), 
WP_Hook->do_action, 
WP_Hook->apply_filters, 
Activitypub\Scheduler\Actor::schedule_post_activity, 
Activitypub\Scheduler\Actor::schedule_profile_update
```

The `author_url` we receive in `Enable_Mastodon_Apps::api_account_internal()` gets passed to `Actors::get_by_id()`, where [this check converts it to `0`](https://github.com/Automattic/wordpress-activitypub/blob/trunk/includes/collection/class-actors.php#L49-L51), clearing the `user_can_activitypub()` check on blogs with the blog user enabled.

Further down in `Enable_Mastodon_Apps::api_account_internal()` [it gets the extra fields for the user](https://github.com/Automattic/wordpress-activitypub/blob/trunk/integration/class-enable-mastodon-apps.php#L315), which in this case is still the author_url and not an internal user_id. This non-ID id gets passed down all the way to `Extra_Fields::default_actor_extra_fields()`, where [it can't find cached extra fields for it](https://github.com/Automattic/wordpress-activitypub/blob/trunk/includes/collection/class-extra-fields.php#L206-L212) and [fails to save the default extra fields it just created](https://github.com/Automattic/wordpress-activitypub/blob/trunk/includes/collection/class-extra-fields.php#L260-L262), since it doesn't have a valid user_id.

Every time an Extra Field post gets created, [it creates an Update activity for the blog user](https://github.com/Automattic/wordpress-activitypub/blob/trunk/includes/scheduler/class-actor.php#L117-L123).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the `is_string()` check that on its own was enough to continue with the process.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Sites with comments from the Fediverse no longer create uncached extra fields posts that flood the Outbox.

</details>
