### PR TITLE
Tests: Convert timestamp to int for comparison

### DIFF
--- a/tests/includes/scheduler/class-test-actor.php
+++ b/tests/includes/scheduler/class-test-actor.php
@@ -318,7 +318,6 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$activity = \json_decode( $post->post_content, true );
 
 		// Verify the updated attribute is set and matches the post's modified date.
-		$expected_updated = gmdate( 'Y-m-d\TH:i:s\Z', strtotime( $post->post_modified ) );
-		$this->assertEqualsWithDelta( $expected_updated, $activity['updated'], 2, 'Updated attribute does not match post modified date.' );
+		$this->assertEqualsWithDelta( strtotime( $post->post_modified ), strtotime( $activity['updated'] ), 2, 'Updated attribute does not match post modified date.' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow-up to #1527. It looks like the equal with delta check still gets hung up on second differences.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Converts time strings to ints so they can be compared with delta.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
