### PR TITLE
Actors: Extend collection method

### DIFF
--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -205,7 +205,7 @@ class Move {
 	 */
 	public static function change_domain( $from, $to ) {
 		// Get all actors that need to be migrated.
-		$actors = Actors::get_all();
+		$actors = Actors::get_collection( 'all' );
 
 		$results   = array();
 		$to_host   = \wp_parse_url( $to, \PHP_URL_HOST );

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -291,29 +291,35 @@ class Actors {
 	/**
 	 * Get the Actor collection.
 	 *
+	 * @param string $type Optional. The type of Actor to get. Can be 'user' or 'all'. Default is 'user'.
 	 * @return array The Actor collection.
 	 */
-	public static function get_collection() {
-		if ( is_user_type_disabled( 'user' ) ) {
-			return array();
-		}
-
-		$users = \get_users(
-			array(
-				'capability__in' => array( 'activitypub' ),
-			)
-		);
-
+	public static function get_collection( $type = 'user' ) {
 		$return = array();
 
-		foreach ( $users as $user ) {
-			$actor = User::from_wp_user( $user->ID );
+		if ( ! is_user_type_disabled( 'user' ) ) {
+			$user_ids = \get_users(
+				array(
+					'capability__in' => array( 'activitypub' ),
+					'fields'         => 'ID',
+				)
+			);
 
-			if ( \is_wp_error( $actor ) ) {
-				continue;
+			foreach ( $user_ids as $user_id ) {
+				$actor = User::from_wp_user( $user_id );
+
+				if ( ! \is_wp_error( $actor ) ) {
+					$return[] = $actor;
+				}
 			}
+		}
 
-			$return[] = $actor;
+		// Also include the blog actor if requested.
+		if ( 'all' === $type && ! is_user_type_disabled( 'blog' ) ) {
+			$blog_actor = self::get_by_id( self::BLOG_USER_ID );
+			if ( ! \is_wp_error( $blog_actor ) ) {
+				$return[] = $blog_actor;
+			}
 		}
 
 		return $return;

--- a/includes/collection/class-users.php
+++ b/includes/collection/class-users.php
@@ -68,11 +68,13 @@ class Users extends Actors {
 	/**
 	 * Get the User collection.
 	 *
+	 * @param string $type Optional. The type of Actor to get. Can be 'user' or 'all'. Default is 'user'.
+	 *
 	 * @return array The User collection.
 	 */
-	public static function get_collection() {
+	public static function get_collection( $type = 'user' ) {
 		_deprecated_function( __METHOD__, '4.2.0', 'Activitypub\Collection\Actors::get_collection' );
 
-		return parent::get_collection();
+		return parent::get_collection( $type );
 	}
 }

--- a/tests/includes/collection/class-test-actors.php
+++ b/tests/includes/collection/class-test-actors.php
@@ -128,6 +128,32 @@ class Test_Actors extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_collection.
+	 *
+	 * @covers ::get_collection
+	 */
+	public function test_get_collection() {
+		$users = Actors::get_collection();
+
+		foreach ( $users as $user ) {
+			$this->assertInstanceOf( 'Activitypub\Model\User', $user );
+		}
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		$all = Actors::get_collection( 'all' );
+
+		$blog = array_filter(
+			$all,
+			function ( $item ) {
+				return $item instanceof \Activitypub\Model\Blog;
+			}
+		);
+		$this->assertSame( 1, count( $blog ) );
+
+		\delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
 	 * Test get_type_by_id()
 	 *
 	 * @covers ::get_type_by_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow-up to #1530, proposing an extended `Actors::get_collection()` method instead of a separate one.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Extends get_collection to optionally include the Blog user
* Removes `Actors:all()`
* Updates function call in `Move::change_domain`
* Makes extending User class compatible
* Adds unit test

### Other information:

- [x] Have you written new tests for your changes, if applicable?
