### PR TITLE
Outbox: Properly handle username requests

### DIFF
--- a/.github/changelog/1559-from-description
+++ b/.github/changelog/1559-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Outbox endpoint bug where non-numeric usernames caused errors when querying Outbox data.

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -99,9 +99,9 @@ class Outbox_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$user_id = $request->get_param( 'user_id' );
 		$page    = $request->get_param( 'page' ) ?? 1;
-		$user    = Actors::get_by_various( $user_id );
+		$user    = Actors::get_by_various( $request->get_param( 'user_id' ) );
+		$user_id = $user->get__id();
 
 		/**
 		 * Action triggered prior to the ActivityPub profile being created and sent to the client.

--- a/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/includes/rest/class-test-outbox-controller.php
@@ -112,6 +112,19 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 	}
 
 	/**
+	 * Test getting items by passing the username instead of the user ID.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_with_username() {
+		$request  = new \WP_REST_Request( 'GET', sprintf( '/%s/actors/%s/outbox', ACTIVITYPUB_REST_NAMESPACE, get_userdata( self::$user_id )->user_nicename ) );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 10, $data['totalItems'] );
+	}
+
+	/**
 	 * Test schema.
 	 *
 	 * @covers ::get_collection_schema


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The Outbox endpoint accepts a string user_id and tests it with `Actors:get_by_various()`, suggesting that passing a username as the user_id should work. The endpoint however passes the user_id straight to `WP_Query`, which expects a true, numeric user_id, leading to errors.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Grabs user_id from the User object to make sure it's a numeric ID.
* Adds unit test.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Call the Outbox URL of an actor on your test and make sure it returns the correct content.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Outbox endpoint bug where non-numeric usernames caused errors when querying Outbox data.

</details>
