### PR TITLE
Import: Load on admin_init

### DIFF
--- a/.github/changelog/1561-from-description
+++ b/.github/changelog/1561-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Importers are loaded on admin-specific hook.

--- a/activitypub.php
+++ b/activitypub.php
@@ -109,7 +109,7 @@ function plugin_admin_init() {
 
 	if ( defined( 'WP_LOAD_IMPORTERS' ) && WP_LOAD_IMPORTERS ) {
 		require_once __DIR__ . '/includes/wp-admin/import/load.php';
-		\add_action( 'init', __NAMESPACE__ . '\WP_Admin\Import\load' );
+		\add_action( 'admin_init', __NAMESPACE__ . '\WP_Admin\Import\load' );
 	}
 }
 \add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_admin_init' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes load hook to admin_init for consistency

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Tools > Import and make sure the Mastodon Importer is still available.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Importers are loaded on admin-specific hook.

</details>
