### PR TITLE
Upgrades: Delete orphaned extra fields

### DIFF
--- a/.github/changelog/1566-from-description
+++ b/.github/changelog/1566-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Upgrade routine that removes any erroneously created extra field entries.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow-up to #1554.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds an upgrade routine that deletes any user extra fields where the post author is the blog user.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on a test site with user extra fields that were generated through the bug in #1554.
* Manually adjust the version constant to a higher version (5.6.1.1, for example) and use the same version in the version check.
* Load wp-admin.
* Check in phpmyadmin that those posts no longer exist.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Upgrade routine that removes any erroneously created extra field entries.
</details>
