### PR TITLE
Embed: Add Fediverse fallback to oembed attempts

### DIFF
--- a/.github/changelog/1576-from-description
+++ b/.github/changelog/1576-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Fallback embed support for Fediverse content that lacks native oEmbed responses.

--- a/includes/class-embed.php
+++ b/includes/class-embed.php
@@ -36,7 +36,7 @@ class Embed {
 		$oembed_result = \wp_oembed_get( $url, $args );
 
 		// Add our filter back.
-		\add_filter( 'pre_oembed_result', array( __CLASS__, 'maybe_use_activitypub_embed' ), 10, 3 );
+		\add_filter( 'pre_oembed_result', array( self::class, 'maybe_use_activitypub_embed' ), 10, 3 );
 
 		return false !== $oembed_result;
 	}

--- a/includes/class-embed.php
+++ b/includes/class-embed.php
@@ -7,8 +7,6 @@
 
 namespace Activitypub;
 
-use WP_REST_Response;
-
 /**
  * Class to handle embedding ActivityPub content
  */
@@ -18,8 +16,9 @@ class Embed {
 	 * Initialize the embed handler
 	 */
 	public static function init() {
-		add_filter( 'pre_oembed_result', array( __CLASS__, 'maybe_use_activitypub_embed' ), 10, 3 );
-		add_filter( 'oembed_dataparse', array( __CLASS__, 'handle_filtered_oembed_result' ), 11, 3 );
+		\add_filter( 'pre_oembed_result', array( self::class, 'maybe_use_activitypub_embed' ), 10, 3 );
+		\add_filter( 'oembed_dataparse', array( self::class, 'handle_filtered_oembed_result' ), 11, 3 );
+		\add_filter( 'oembed_request_post_id', array( self::class, 'register_fallback_hook' ) );
 	}
 
 	/**
@@ -31,13 +30,13 @@ class Embed {
 	 */
 	public static function has_real_oembed( $url, $args = array() ) {
 		// Temporarily remove our filter to avoid infinite loops.
-		remove_filter( 'pre_oembed_result', array( __CLASS__, 'maybe_use_activitypub_embed' ), 10, 3 );
+		\remove_filter( 'pre_oembed_result', array( self::class, 'maybe_use_activitypub_embed' ), 10, 3 );
 
 		// Try to get a "real" oEmbed result. If found, it'll be cached to avoid unnecessary HTTP requests in `wp_oembed_get`.
-		$oembed_result = wp_oembed_get( $url, $args );
+		$oembed_result = \wp_oembed_get( $url, $args );
 
 		// Add our filter back.
-		add_filter( 'pre_oembed_result', array( __CLASS__, 'maybe_use_activitypub_embed' ), 10, 3 );
+		\add_filter( 'pre_oembed_result', array( __CLASS__, 'maybe_use_activitypub_embed' ), 10, 3 );
 
 		return false !== $oembed_result;
 	}
@@ -92,12 +91,12 @@ class Embed {
 		}
 
 		// If this isn't a rich or video type, we can't help.
-		if ( ! isset( $data->type ) || ! in_array( $data->type, array( 'rich', 'video' ), true ) ) {
+		if ( ! isset( $data->type ) || ! \in_array( $data->type, array( 'rich', 'video' ), true ) ) {
 			return $html;
 		}
 
 		// If there's no HTML in the data, we can't help.
-		if ( empty( $data->html ) || ! is_string( $data->html ) ) {
+		if ( empty( $data->html ) || ! \is_string( $data->html ) ) {
 			return $html;
 		}
 
@@ -109,5 +108,55 @@ class Embed {
 
 		// Return our safer ActivityPub embed HTML.
 		return $activitypub_html;
+	}
+
+	/**
+	 * Register the fallback hook for oEmbed requests.
+	 *
+	 * Avoids filtering every single API request.
+	 *
+	 * @param int $post_id The post ID.
+	 * @return int The post ID.
+	 */
+	public static function register_fallback_hook( $post_id ) {
+		\add_filter( 'rest_request_after_callbacks', array( self::class, 'oembed_fediverse_fallback' ), 10, 3 );
+
+		return $post_id;
+	}
+
+	/**
+	 * Fallback for oEmbed requests to the Fediverse.
+	 *
+	 * @param \WP_REST_Response|\WP_Error $response Result to send to the client.
+	 * @param array                       $handler  Route handler used for the request.
+	 * @param \WP_REST_Request            $request  Request used to generate the response.
+	 *
+	 * @return \WP_REST_Response|\WP_Error The response to send to the client.
+	 */
+	public static function oembed_fediverse_fallback( $response, $handler, $request ) {
+		if ( is_wp_error( $response ) && 'oembed_invalid_url' === $response->get_error_code() ) {
+			$url  = $request->get_param( 'url' );
+			$html = get_embed_html( $request->get_param( 'url' ) );
+			if ( $html ) {
+				$args = $request->get_params();
+				$data = (object) array(
+					'provider_name' => 'Embed Handler',
+					'html'          => $html,
+					'scripts'       => array(),
+				);
+
+				/** This filter is documented in wp-includes/class-wp-oembed.php */
+				$data->html = apply_filters( 'oembed_result', $data->html, $url, $args );
+
+				/** This filter is documented in wp-includes/class-wp-oembed-controller.php */
+				$ttl = apply_filters( 'rest_oembed_ttl', DAY_IN_SECONDS, $url, $args );
+
+				set_transient( 'oembed_' . md5( serialize( $args ) ), $data, $ttl ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+
+				$response = new \WP_REST_Response( $data );
+			}
+		}
+
+		return $response;
 	}
 }

--- a/includes/class-embed.php
+++ b/includes/class-embed.php
@@ -136,7 +136,8 @@ class Embed {
 	public static function oembed_fediverse_fallback( $response, $handler, $request ) {
 		if ( is_wp_error( $response ) && 'oembed_invalid_url' === $response->get_error_code() ) {
 			$url  = $request->get_param( 'url' );
-			$html = get_embed_html( $request->get_param( 'url' ) );
+			$html = get_embed_html( $url );
+
 			if ( $html ) {
 				$args = $request->get_params();
 				$data = (object) array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Re-uses our custom embed fallback for Fediverse objects when oembed proxy request come back empty.
Registers the callback only when oembeds are processed in an API request.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds callback to build a custom embed response for Fediverse objects.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and paste a URL of a Fediverse resource.
* Make sure it gets displayed with our fallback markup.


#### Before
<img width="657" alt="Screenshot 2025-04-11 at 2 03 54 PM" src="https://github.com/user-attachments/assets/5a986c93-7e6d-4abb-b740-2e37be4b8180" />


#### After
<img width="678" alt="Screenshot 2025-04-11 at 2 02 37 PM" src="https://github.com/user-attachments/assets/d034d77d-6cc4-4e71-8196-f7deb0be9e85" />


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fallback embed support for Fediverse content that lacks native oEmbed responses.

</details>
