### PR TITLE
Make notification settings user-specific

### DIFF
--- a/.github/changelog/1586-from-description
+++ b/.github/changelog/1586-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated notification settings to be user-specific for more personalization.

--- a/assets/css/activitypub-embed.css
+++ b/assets/css/activitypub-embed.css
@@ -95,7 +95,7 @@
 	gap: 5px;
 }
 @media only screen and (max-width: 399px) {
-	.activitypub-embed-meta .ap-stat {
+	.activitypub-embed-meta span.ap-stat {
 		display: none !important;
 	}
 }

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -831,7 +831,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		add_filter( 'get_user_option_activitypub_mailer_new_dm', array( self::class, 'user_options_default' ), 10, 2 );
+		\add_filter( 'get_user_option_activitypub_mailer_new_dm', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -843,7 +843,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		add_filter( 'get_user_option_activitypub_mailer_new_follower', array( self::class, 'user_options_default' ), 10, 2 );
+		\add_filter( 'get_user_option_activitypub_mailer_new_follower', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -855,7 +855,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		add_filter( 'get_user_option_activitypub_mailer_new_mention', array( self::class, 'user_options_default' ), 10, 2 );
+		\add_filter( 'get_user_option_activitypub_mailer_new_mention', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -892,9 +892,9 @@ class Activitypub {
 	public static function user_options_default( $value, $option ) {
 		if ( false === $value ) {
 			if ( 'activitypub_mailer_new_dm' === $option ) {
-				$value = (int) get_option( 'activitypub_mailer_new_dm', 1 );
+				$value = (int) \get_option( 'activitypub_mailer_new_dm', 1 );
 			} elseif ( 'activitypub_mailer_new_follower' === $option ) {
-				$value = (int) get_option( 'activitypub_mailer_new_follower', 1 );
+				$value = (int) \get_option( 'activitypub_mailer_new_follower', 1 );
 			} elseif ( 'activitypub_mailer_new_mention' === $option ) {
 				$value = 1;
 			}

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -831,6 +831,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
+		\add_filter( 'get_user_option_activitypub_mailer_new_dm', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -842,6 +843,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
+		\add_filter( 'get_user_option_activitypub_mailer_new_follower', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -853,6 +855,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
+		\add_filter( 'get_user_option_activitypub_mailer_new_mention', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -877,5 +880,28 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
+	}
+
+	/**
+	 * Set default values for user options.
+	 *
+	 * @param bool|string $value  Option value.
+	 * @param string      $option Option name.
+	 * @return string|int
+	 */
+	public static function user_options_default( $value, $option ) {
+		if ( false === $value ) {
+			$options_with_default = array(
+				'activitypub_mailer_new_dm',
+				'activitypub_mailer_new_follower',
+				'activitypub_mailer_new_mention',
+			);
+
+			if ( \in_array( $option, $options_with_default, true ) ) {
+			//	return '1';
+			}
+		}
+
+		return $value;
 	}
 }

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -98,6 +98,9 @@ class Activitypub {
 		\delete_option( 'activitypub_application_user_private_key' );
 		\delete_option( 'activitypub_application_user_public_key' );
 		\delete_option( 'activitypub_blog_user_also_known_as' );
+		\delete_option( 'activitypub_blog_user_mailer_new_dm' );
+		\delete_option( 'activitypub_blog_user_mailer_new_follower' );
+		\delete_option( 'activitypub_blog_user_mailer_new_mention' );
 		\delete_option( 'activitypub_blog_user_moved_to' );
 		\delete_option( 'activitypub_blog_user_private_key' );
 		\delete_option( 'activitypub_blog_user_public_key' );
@@ -110,9 +113,6 @@ class Activitypub {
 		\delete_option( 'activitypub_enable_users' );
 		\delete_option( 'activitypub_header_image' );
 		\delete_option( 'activitypub_last_post_with_permalink_as_id' );
-		\delete_option( 'activitypub_mailer_new_dm' );
-		\delete_option( 'activitypub_mailer_new_follower' );
-		\delete_option( 'activitypub_mailer_new_mention' );
 		\delete_option( 'activitypub_max_image_attachments' );
 		\delete_option( 'activitypub_migration_lock' );
 		\delete_option( 'activitypub_object_type' );
@@ -831,7 +831,6 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		\add_filter( 'get_user_option_activitypub_mailer_new_dm', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -843,7 +842,6 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		\add_filter( 'get_user_option_activitypub_mailer_new_follower', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -855,7 +853,6 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		\add_filter( 'get_user_option_activitypub_mailer_new_mention', array( self::class, 'user_options_default' ), 10, 2 );
 
 		\register_meta(
 			'user',
@@ -880,26 +877,5 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-	}
-
-	/**
-	 * Set default values for user options.
-	 *
-	 * @param bool|int $value  Option value.
-	 * @param string   $option Option name.
-	 * @return bool|int
-	 */
-	public static function user_options_default( $value, $option ) {
-		if ( false === $value ) {
-			if ( 'activitypub_mailer_new_dm' === $option ) {
-				$value = (int) \get_option( 'activitypub_mailer_new_dm', 1 );
-			} elseif ( 'activitypub_mailer_new_follower' === $option ) {
-				$value = (int) \get_option( 'activitypub_mailer_new_follower', 1 );
-			} elseif ( 'activitypub_mailer_new_mention' === $option ) {
-				$value = 1;
-			}
-		}
-
-		return $value;
 	}
 }

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -831,7 +831,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		\add_filter( 'get_user_option_activitypub_mailer_new_dm', array( self::class, 'user_options_default' ), 10, 2 );
+		\add_filter( 'get_user_option_activitypub_mailer_new_dm', array( self::class, 'user_options_default' ) );
 
 		\register_meta(
 			'user',
@@ -843,7 +843,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		\add_filter( 'get_user_option_activitypub_mailer_new_follower', array( self::class, 'user_options_default' ), 10, 2 );
+		\add_filter( 'get_user_option_activitypub_mailer_new_follower', array( self::class, 'user_options_default' ) );
 
 		\register_meta(
 			'user',
@@ -855,7 +855,7 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
-		\add_filter( 'get_user_option_activitypub_mailer_new_mention', array( self::class, 'user_options_default' ), 10, 2 );
+		\add_filter( 'get_user_option_activitypub_mailer_new_mention', array( self::class, 'user_options_default' ) );
 
 		\register_meta(
 			'user',
@@ -886,20 +886,11 @@ class Activitypub {
 	 * Set default values for user options.
 	 *
 	 * @param bool|string $value  Option value.
-	 * @param string      $option Option name.
-	 * @return string|int
+	 * @return bool|string
 	 */
-	public static function user_options_default( $value, $option ) {
+	public static function user_options_default( $value ) {
 		if ( false === $value ) {
-			$options_with_default = array(
-				'activitypub_mailer_new_dm',
-				'activitypub_mailer_new_follower',
-				'activitypub_mailer_new_mention',
-			);
-
-			if ( \in_array( $option, $options_with_default, true ) ) {
-				return '1';
-			}
+			return '1';
 		}
 
 		return $value;

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -823,6 +823,42 @@ class Activitypub {
 
 		\register_meta(
 			'user',
+			$blog_prefix . 'activitypub_mailer_new_dm',
+			array(
+				'type'              => 'integer',
+				'description'       => 'Send a notification when someone sends this user a direct message.',
+				'single'            => true,
+				'sanitize_callback' => 'absint',
+			)
+		);
+		add_filter( 'get_user_option_activitypub_mailer_new_dm', array( self::class, 'user_options_default' ), 10, 2 );
+
+		\register_meta(
+			'user',
+			$blog_prefix . 'activitypub_mailer_new_follower',
+			array(
+				'type'              => 'integer',
+				'description'       => 'Send a notification when someone starts to follow this user.',
+				'single'            => true,
+				'sanitize_callback' => 'absint',
+			)
+		);
+		add_filter( 'get_user_option_activitypub_mailer_new_follower', array( self::class, 'user_options_default' ), 10, 2 );
+
+		\register_meta(
+			'user',
+			$blog_prefix . 'activitypub_mailer_new_mention',
+			array(
+				'type'              => 'integer',
+				'description'       => 'Send a notification when someone mentions this user.',
+				'single'            => true,
+				'sanitize_callback' => 'absint',
+			)
+		);
+		add_filter( 'get_user_option_activitypub_mailer_new_mention', array( self::class, 'user_options_default' ), 10, 2 );
+
+		\register_meta(
+			'user',
 			'activitypub_show_welcome_tab',
 			array(
 				'type'              => 'integer',
@@ -844,5 +880,26 @@ class Activitypub {
 				'sanitize_callback' => 'absint',
 			)
 		);
+	}
+
+	/**
+	 * Set default values for user options.
+	 *
+	 * @param bool|int $value  Option value.
+	 * @param string   $option Option name.
+	 * @return bool|int
+	 */
+	public static function user_options_default( $value, $option ) {
+		if ( false === $value ) {
+			if ( 'activitypub_mailer_new_dm' === $option ) {
+				$value = (int) get_option( 'activitypub_mailer_new_dm', 1 );
+			} elseif ( 'activitypub_mailer_new_follower' === $option ) {
+				$value = (int) get_option( 'activitypub_mailer_new_follower', 1 );
+			} elseif ( 'activitypub_mailer_new_mention' === $option ) {
+				$value = 1;
+			}
+		}
+
+		return $value;
 	}
 }

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -898,7 +898,7 @@ class Activitypub {
 			);
 
 			if ( \in_array( $option, $options_with_default, true ) ) {
-			//	return '1';
+				return '1';
 			}
 		}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -282,7 +282,7 @@ class Mailer {
 
 			$email = \get_userdata( $user_id )->user_email;
 		} else {
-			if ( '1' !== \get_option( 'activitypub_mailer_new_mention', '0' ) ) {
+			if ( '1' !== \get_option( 'activitypub_mailer_new_mention', '1' ) ) {
 				return;
 			}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -116,7 +116,7 @@ class Mailer {
 			$email     = \get_userdata( $user_id )->user_email;
 			$admin_url = '/users.php?page=activitypub-followers-list';
 		} else {
-			if ( '1' !== \get_option( 'activitypub_blog_user_mailer_new_follower', '0' ) ) {
+			if ( '1' !== \get_option( 'activitypub_blog_user_mailer_new_follower', '1' ) ) {
 				return;
 			}
 
@@ -206,7 +206,7 @@ class Mailer {
 
 			$email = \get_userdata( $user_id )->user_email;
 		} else {
-			if ( '1' !== \get_option( 'activitypub_blog_user_mailer_new_dm', '0' ) ) {
+			if ( '1' !== \get_option( 'activitypub_blog_user_mailer_new_dm', '1' ) ) {
 				return;
 			}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -116,7 +116,7 @@ class Mailer {
 			$email     = \get_userdata( $user_id )->user_email;
 			$admin_url = '/users.php?page=activitypub-followers-list';
 		} else {
-			if ( '1' !== \get_option( 'activitypub_mailer_new_follower', '0' ) ) {
+			if ( '1' !== \get_option( 'activitypub_blog_user_mailer_new_follower', '0' ) ) {
 				return;
 			}
 
@@ -206,7 +206,7 @@ class Mailer {
 
 			$email = \get_userdata( $user_id )->user_email;
 		} else {
-			if ( '1' !== \get_option( 'activitypub_mailer_new_dm', '0' ) ) {
+			if ( '1' !== \get_option( 'activitypub_blog_user_mailer_new_dm', '0' ) ) {
 				return;
 			}
 
@@ -282,7 +282,7 @@ class Mailer {
 
 			$email = \get_userdata( $user_id )->user_email;
 		} else {
-			if ( '1' !== \get_option( 'activitypub_mailer_new_mention', '1' ) ) {
+			if ( '1' !== \get_option( 'activitypub_blog_user_mailer_new_mention', '1' ) ) {
 				return;
 			}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -113,7 +113,7 @@ class Mailer {
 				return;
 			}
 
-			$email     = get_userdata( $user_id )->user_email;
+			$email     = \get_userdata( $user_id )->user_email;
 			$admin_url = '/users.php?page=activitypub-followers-list';
 		} else {
 			if ( '1' !== \get_option( 'activitypub_mailer_new_follower', '0' ) ) {
@@ -130,7 +130,7 @@ class Mailer {
 		}
 
 		if ( empty( $actor['webfinger'] ) ) {
-			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . wp_parse_url( $actor['url'], PHP_URL_HOST );
+			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . \wp_parse_url( $actor['url'], PHP_URL_HOST );
 		}
 
 		$template_args = array_merge(
@@ -152,8 +152,8 @@ class Mailer {
 			}
 
 			$result = Http::get( $actor[ $field ], true );
-			if ( 200 === wp_remote_retrieve_response_code( $result ) ) {
-				$body = \json_decode( wp_remote_retrieve_body( $result ), true );
+			if ( 200 === \wp_remote_retrieve_response_code( $result ) ) {
+				$body = \json_decode( \wp_remote_retrieve_body( $result ), true );
 				if ( isset( $body['totalItems'] ) ) {
 					$template_args['stats'][ $field ] = $body['totalItems'];
 				}
@@ -161,7 +161,7 @@ class Mailer {
 		}
 
 		/* translators: 1: Blog name, 2: Follower name */
-		$subject = \sprintf( \__( '[%1$s] New Follower: %2$s', 'activitypub' ), get_option( 'blogname' ), $actor['name'] );
+		$subject = \sprintf( \__( '[%1$s] New Follower: %2$s', 'activitypub' ), \get_option( 'blogname' ), $actor['name'] );
 
 		\ob_start();
 		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/emails/new-follower.php', false, $template_args );
@@ -204,7 +204,7 @@ class Mailer {
 				return;
 			}
 
-			$email = get_userdata( $user_id )->user_email;
+			$email = \get_userdata( $user_id )->user_email;
 		} else {
 			if ( '1' !== \get_option( 'activitypub_mailer_new_dm', '0' ) ) {
 				return;
@@ -220,7 +220,7 @@ class Mailer {
 		}
 
 		if ( empty( $actor['webfinger'] ) ) {
-			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . wp_parse_url( $actor['url'], PHP_URL_HOST );
+			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . \wp_parse_url( $actor['url'], PHP_URL_HOST );
 		}
 
 		$template_args = array(
@@ -230,7 +230,7 @@ class Mailer {
 		);
 
 		/* translators: 1: Blog name, 2 Actor name */
-		$subject = \sprintf( \esc_html__( '[%1$s] Direct Message from: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \esc_html( $actor['name'] ) );
+		$subject = \sprintf( \esc_html__( '[%1$s] Direct Message from: %2$s', 'activitypub' ), \esc_html( \get_option( 'blogname' ) ), \esc_html( $actor['name'] ) );
 
 		\ob_start();
 		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/emails/new-dm.php', false, $template_args );
@@ -280,7 +280,7 @@ class Mailer {
 				return;
 			}
 
-			$email = get_userdata( $user_id )->user_email;
+			$email = \get_userdata( $user_id )->user_email;
 		} else {
 			if ( '1' !== \get_option( 'activitypub_mailer_new_mention', '0' ) ) {
 				return;
@@ -295,7 +295,7 @@ class Mailer {
 		}
 
 		if ( empty( $actor['webfinger'] ) ) {
-			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . wp_parse_url( $actor['url'], PHP_URL_HOST );
+			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . \wp_parse_url( $actor['url'], PHP_URL_HOST );
 		}
 
 		$template_args = array(
@@ -305,7 +305,7 @@ class Mailer {
 		);
 
 		/* translators: 1: Blog name, 2 Actor name */
-		$subject = \sprintf( \esc_html__( '[%1$s] Mention from: %2$s', 'activitypub' ), \esc_html( get_option( 'blogname' ) ), \esc_html( $actor['name'] ) );
+		$subject = \sprintf( \esc_html__( '[%1$s] Mention from: %2$s', 'activitypub' ), \esc_html( \get_option( 'blogname' ) ), \esc_html( $actor['name'] ) );
 
 		\ob_start();
 		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/emails/new-mention.php', false, $template_args );

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -137,7 +137,7 @@ class Mailer {
 			$actor,
 			array(
 				'admin_url' => $admin_url,
-				'target'    => $activity['target'],
+				'user_id'   => $user_id,
 				'stats'     => array(
 					'outbox'    => null,
 					'followers' => null,

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -20,20 +20,9 @@ class Mailer {
 		\add_filter( 'comment_notification_subject', array( self::class, 'comment_notification_subject' ), 10, 2 );
 		\add_filter( 'comment_notification_text', array( self::class, 'comment_notification_text' ), 10, 2 );
 
-		// New follower notification.
-		if ( '1' === \get_option( 'activitypub_mailer_new_follower', '0' ) ) {
-			\add_action( 'activitypub_notification_follow', array( self::class, 'new_follower' ) );
-		}
-
-		// Direct message notification.
-		if ( '1' === \get_option( 'activitypub_mailer_new_dm', '0' ) ) {
-			\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		}
-
-		// Direct message notification.
-		if ( '1' === \get_option( 'activitypub_mailer_new_mention', '1' ) ) {
-			\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 10, 2 );
-		}
+		\add_action( 'activitypub_inbox_follow', array( self::class, 'new_follower' ), 10, 2 );
+		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
+		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 10, 2 );
 	}
 
 	/**
@@ -115,11 +104,27 @@ class Mailer {
 	/**
 	 * Send a notification email for every new follower.
 	 *
-	 * @param Notification $notification The notification object.
+	 * @param array $activity The activity object.
+	 * @param int   $user_id  The id of the local blog-user.
 	 */
-	public static function new_follower( $notification ) {
-		$actor = get_remote_metadata_by_actor( $notification->actor );
+	public static function new_follower( $activity, $user_id ) {
+		if ( $user_id > Actors::BLOG_USER_ID ) {
+			if ( ! \get_user_option( 'activitypub_mailer_new_follower', $user_id ) ) {
+				return;
+			}
 
+			$email     = get_userdata( $user_id )->user_email;
+			$admin_url = '/users.php?page=activitypub-followers-list';
+		} else {
+			if ( '1' !== \get_option( 'activitypub_mailer_new_follower', '0' ) ) {
+				return;
+			}
+
+			$email     = \get_option( 'admin_email' );
+			$admin_url = '/options-general.php?page=activitypub&tab=followers';
+		}
+
+		$actor = get_remote_metadata_by_actor( $activity['actor'] );
 		if ( ! $actor || \is_wp_error( $actor ) ) {
 			return;
 		}
@@ -128,25 +133,11 @@ class Mailer {
 			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . wp_parse_url( $actor['url'], PHP_URL_HOST );
 		}
 
-		$email     = \get_option( 'admin_email' );
-		$admin_url = '/options-general.php?page=activitypub&tab=followers';
-
-		if ( $notification->target > Actors::BLOG_USER_ID ) {
-			$user = \get_user_by( 'id', $notification->target );
-
-			if ( ! $user ) {
-				return;
-			}
-
-			$email     = $user->user_email;
-			$admin_url = '/users.php?page=activitypub-followers-list';
-		}
-
 		$template_args = array_merge(
 			$actor,
 			array(
 				'admin_url' => $admin_url,
-				'target'    => $notification->target,
+				'target'    => $activity['target'],
 				'stats'     => array(
 					'outbox'    => null,
 					'followers' => null,
@@ -208,6 +199,20 @@ class Mailer {
 			return;
 		}
 
+		if ( $user_id > Actors::BLOG_USER_ID ) {
+			if ( ! \get_user_option( 'activitypub_mailer_new_follower', $user_id ) ) {
+				return;
+			}
+
+			$email = get_userdata( $user_id )->user_email;
+		} else {
+			if ( '1' !== \get_option( 'activitypub_mailer_new_follower', '0' ) ) {
+				return;
+			}
+
+			$email = \get_option( 'admin_email' );
+		}
+
 		$actor = get_remote_metadata_by_actor( $activity['actor'] );
 
 		if ( ! $actor || \is_wp_error( $actor ) || empty( $activity['object']['content'] ) ) {
@@ -216,18 +221,6 @@ class Mailer {
 
 		if ( empty( $actor['webfinger'] ) ) {
 			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . wp_parse_url( $actor['url'], PHP_URL_HOST );
-		}
-
-		$email = \get_option( 'admin_email' );
-
-		if ( (int) $user_id > Actors::BLOG_USER_ID ) {
-			$user = \get_user_by( 'id', $user_id );
-
-			if ( ! $user ) {
-				return;
-			}
-
-			$email = $user->user_email;
 		}
 
 		$template_args = array(
@@ -282,6 +275,20 @@ class Mailer {
 			return;
 		}
 
+		if ( $user_id > Actors::BLOG_USER_ID ) {
+			if ( ! \get_user_option( 'activitypub_mailer_new_follower', $user_id ) ) {
+				return;
+			}
+
+			$email = get_userdata( $user_id )->user_email;
+		} else {
+			if ( '1' !== \get_option( 'activitypub_mailer_new_follower', '0' ) ) {
+				return;
+			}
+
+			$email = \get_option( 'admin_email' );
+		}
+
 		$actor = get_remote_metadata_by_actor( $activity['actor'] );
 		if ( \is_wp_error( $actor ) ) {
 			return;
@@ -289,18 +296,6 @@ class Mailer {
 
 		if ( empty( $actor['webfinger'] ) ) {
 			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . wp_parse_url( $actor['url'], PHP_URL_HOST );
-		}
-
-		$email = \get_option( 'admin_email' );
-
-		if ( (int) $user_id > Actors::BLOG_USER_ID ) {
-			$user = \get_user_by( 'id', $user_id );
-
-			if ( ! $user ) {
-				return;
-			}
-
-			$email = $user->user_email;
 		}
 
 		$template_args = array(

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -200,13 +200,13 @@ class Mailer {
 		}
 
 		if ( $user_id > Actors::BLOG_USER_ID ) {
-			if ( ! \get_user_option( 'activitypub_mailer_new_follower', $user_id ) ) {
+			if ( ! \get_user_option( 'activitypub_mailer_new_dm', $user_id ) ) {
 				return;
 			}
 
 			$email = get_userdata( $user_id )->user_email;
 		} else {
-			if ( '1' !== \get_option( 'activitypub_mailer_new_follower', '0' ) ) {
+			if ( '1' !== \get_option( 'activitypub_mailer_new_dm', '0' ) ) {
 				return;
 			}
 
@@ -276,13 +276,13 @@ class Mailer {
 		}
 
 		if ( $user_id > Actors::BLOG_USER_ID ) {
-			if ( ! \get_user_option( 'activitypub_mailer_new_follower', $user_id ) ) {
+			if ( ! \get_user_option( 'activitypub_mailer_new_mention', $user_id ) ) {
 				return;
 			}
 
 			$email = get_userdata( $user_id )->user_email;
 		} else {
-			if ( '1' !== \get_option( 'activitypub_mailer_new_follower', '0' ) ) {
+			if ( '1' !== \get_option( 'activitypub_mailer_new_mention', '0' ) ) {
 				return;
 			}
 

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -942,14 +942,9 @@ class Migration {
 
 		// Add the actor notification options.
 		foreach ( Actors::get_collection() as $actor ) {
-			\update_user_option( $actor->get__id(), 'activitypub_mailer_new_mention', 1 );
-
-			if ( '1' === $new_dm ) {
-				\update_user_option( $actor->get__id(), 'activitypub_mailer_new_dm', 1 );
-			}
-			if ( '1' === $new_follower ) {
-				\update_user_option( $actor->get__id(), 'activitypub_mailer_new_dm', 1 );
-			}
+			\update_user_option( $actor->get__id(), 'activitypub_mailer_new_dm', $new_dm );
+			\update_user_option( $actor->get__id(), 'activitypub_mailer_new_follower', $new_follower );
+			\update_user_option( $actor->get__id(), 'activitypub_mailer_new_mention', '1' );
 		}
 
 		// Delete the old notification options.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -743,7 +743,6 @@ class Migration {
 	 */
 	public static function add_default_settings() {
 		self::add_activitypub_capability();
-		self::add_notification_defaults();
 		self::add_default_extra_field();
 	}
 
@@ -796,15 +795,6 @@ class Migration {
 		foreach ( $users as $user ) {
 			$user->add_cap( 'activitypub' );
 		}
-	}
-
-	/**
-	 * Add default notification settings.
-	 */
-	private static function add_notification_defaults() {
-		\add_option( 'activitypub_blog_user_mailer_new_follower', '1' );
-		\add_option( 'activitypub_blog_user_mailer_new_dm', '1' );
-		\add_option( 'activitypub_blog_user_mailer_new_mention', '1' );
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -929,7 +929,7 @@ class Migration {
 	}
 
 	/**
-	 * Add the new mention notification option.
+	 * Update notification options.
 	 */
 	public static function update_notification_options() {
 		$new_dm       = \get_option( 'activitypub_mailer_new_dm', '1' );

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -192,7 +192,7 @@ class Migration {
 			self::delete_mastodon_api_orphaned_extra_fields();
 		}
 		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
-			self::add_mention_notification_option();
+			self::update_notification_options();
 		}
 
 		/*
@@ -802,9 +802,9 @@ class Migration {
 	 * Add default notification settings.
 	 */
 	private static function add_notification_defaults() {
-		\add_option( 'activitypub_mailer_new_follower', '1' );
-		\add_option( 'activitypub_mailer_new_dm', '1' );
-		\add_option( 'activitypub_mailer_new_mention', '1' );
+		\add_option( 'activitypub_blog_user_mailer_new_follower', '1' );
+		\add_option( 'activitypub_blog_user_mailer_new_dm', '1' );
+		\add_option( 'activitypub_blog_user_mailer_new_mention', '1' );
 	}
 
 	/**
@@ -931,7 +931,29 @@ class Migration {
 	/**
 	 * Add the new mention notification option.
 	 */
-	public static function add_mention_notification_option() {
-		\add_option( 'activitypub_mailer_new_mention', '1' );
+	public static function update_notification_options() {
+		$new_dm       = \get_option( 'activitypub_mailer_new_dm', '1' );
+		$new_follower = \get_option( 'activitypub_mailer_new_follower', '1' );
+
+		// Add the blog user notification options.
+		\add_option( 'activitypub_blog_user_mailer_new_dm', $new_dm );
+		\add_option( 'activitypub_blog_user_mailer_new_follower', $new_follower );
+		\add_option( 'activitypub_blog_user_mailer_new_mention', '1' );
+
+		// Add the actor notification options.
+		foreach ( Actors::get_collection() as $actor ) {
+			\update_user_option( $actor->get__id(), 'activitypub_mailer_new_mention', 1 );
+
+			if ( '1' === $new_dm ) {
+				\update_user_option( $actor->get__id(), 'activitypub_mailer_new_dm', 1 );
+			}
+			if ( '1' === $new_follower ) {
+				\update_user_option( $actor->get__id(), 'activitypub_mailer_new_dm', 1 );
+			}
+		}
+
+		// Delete the old notification options.
+		\delete_option( 'activitypub_mailer_new_dm' );
+		\delete_option( 'activitypub_mailer_new_follower' );
 	}
 }

--- a/includes/class-notification.php
+++ b/includes/class-notification.php
@@ -9,8 +9,6 @@ namespace Activitypub;
 
 /**
  * Notification class.
- *
- * @deprecated unreleased.
  */
 class Notification {
 	/**
@@ -44,16 +42,12 @@ class Notification {
 	/**
 	 * Notification constructor.
 	 *
-	 * @deprecated unreleased.
-	 *
 	 * @param string $type     The type of the notification.
 	 * @param string $actor    The actor URL.
 	 * @param array  $activity The Activity object.
 	 * @param int    $target   The WordPress User-Id.
 	 */
 	public function __construct( $type, $actor, $activity, $target ) {
-		_deprecated_class( __CLASS__, 'unreleased' );
-
 		$this->type   = $type;
 		$this->actor  = $actor;
 		$this->object = $activity;
@@ -62,12 +56,8 @@ class Notification {
 
 	/**
 	 * Send the notification.
-	 *
-	 * @deprecated unreleased.
 	 */
 	public function send() {
-		_deprecated_function( __METHOD__, 'unreleased' );
-
 		$type = \strtolower( $this->type );
 
 		/**
@@ -75,13 +65,13 @@ class Notification {
 		 *
 		 * @param Notification $instance The notification object.
 		 */
-		do_action_deprecated( 'activitypub_notification', array( $this ), 'unreleased', 'activitypub_inbox' );
+		do_action( 'activitypub_notification', $this );
 
 		/**
 		 * Type-specific action to send ActivityPub notifications.
 		 *
 		 * @param Notification $instance The notification object.
 		 */
-		do_action_deprecated( "activitypub_notification_{$type}", array( $this ), 'unreleased', 'activitypub_inbox_' . $type );
+		do_action( "activitypub_notification_{$type}", $this );
 	}
 }

--- a/includes/class-notification.php
+++ b/includes/class-notification.php
@@ -9,6 +9,8 @@ namespace Activitypub;
 
 /**
  * Notification class.
+ *
+ * @deprecated unreleased.
  */
 class Notification {
 	/**
@@ -42,12 +44,16 @@ class Notification {
 	/**
 	 * Notification constructor.
 	 *
+	 * @deprecated unreleased.
+	 *
 	 * @param string $type     The type of the notification.
 	 * @param string $actor    The actor URL.
 	 * @param array  $activity The Activity object.
 	 * @param int    $target   The WordPress User-Id.
 	 */
 	public function __construct( $type, $actor, $activity, $target ) {
+		_deprecated_class( __CLASS__, 'unreleased' );
+
 		$this->type   = $type;
 		$this->actor  = $actor;
 		$this->object = $activity;
@@ -56,8 +62,12 @@ class Notification {
 
 	/**
 	 * Send the notification.
+	 *
+	 * @deprecated unreleased.
 	 */
 	public function send() {
+		_deprecated_function( __METHOD__, 'unreleased' );
+
 		$type = \strtolower( $this->type );
 
 		/**
@@ -65,13 +75,13 @@ class Notification {
 		 *
 		 * @param Notification $instance The notification object.
 		 */
-		do_action( 'activitypub_notification', $this );
+		do_action_deprecated( 'activitypub_notification', array( $this ), 'unreleased', 'activitypub_inbox' );
 
 		/**
 		 * Type-specific action to send ActivityPub notifications.
 		 *
 		 * @param Notification $instance The notification object.
 		 */
-		do_action( "activitypub_notification_{$type}", $this );
+		do_action_deprecated( "activitypub_notification_{$type}", array( $this ), 'unreleased', 'activitypub_inbox_' . $type );
 	}
 }

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -145,25 +145,34 @@ class Admin {
 			return;
 		}
 
-		$description = ! empty( $_POST['activitypub_description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['activitypub_description'] ) ) : false;
-		if ( $description ) {
-			\update_user_option( $user_id, 'activitypub_description', $description );
-		} else {
-			\delete_user_option( $user_id, 'activitypub_description' );
+		// User options that should be processed with `sanitize_textarea_field()`.
+		$textarea_field_user_options = array(
+			'activitypub_blog_user_also_known_as',
+			'activitypub_description',
+		);
+
+		foreach ( $textarea_field_user_options as $option ) {
+			if ( ! empty( $_POST[ $option ] ) ) {
+				\update_user_option( $user_id, $option, sanitize_textarea_field( wp_unslash( $_POST[ $option ] ) ) );
+			} else {
+				\delete_user_option( $user_id, $option );
+			}
 		}
 
-		$header_image = ! empty( $_POST['activitypub_header_image'] ) ? sanitize_text_field( wp_unslash( $_POST['activitypub_header_image'] ) ) : false;
-		if ( $header_image && \wp_attachment_is_image( $header_image ) ) {
-			\update_user_option( $user_id, 'activitypub_header_image', $header_image );
-		} else {
-			\delete_user_option( $user_id, 'activitypub_header_image' );
-		}
+		// User options that should be processed with `sanitize_text_field()`.
+		$text_field_user_options = array(
+			'activitypub_header_image',
+			'activitypub_mailer_new_dm',
+			'activitypub_mailer_new_follower',
+			'activitypub_mailer_new_mention',
+		);
 
-		$also_known_as = ! empty( $_POST['activitypub_blog_user_also_known_as'] ) ? \sanitize_textarea_field( wp_unslash( $_POST['activitypub_blog_user_also_known_as'] ) ) : false;
-		if ( $also_known_as ) {
-			\update_user_option( $user_id, 'activitypub_also_known_as', $also_known_as );
-		} else {
-			\delete_user_option( $user_id, 'activitypub_also_known_as' );
+		foreach ( $text_field_user_options as $option ) {
+			if ( ! empty( $_POST[ $option ] ) ) {
+				\update_user_option( $user_id, $option, sanitize_text_field( wp_unslash( $_POST[ $option ] ) ) );
+			} else {
+				\delete_user_option( $user_id, $option );
+			}
 		}
 	}
 

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -491,6 +491,10 @@ class Admin {
 			$user = new \WP_User( $user_id );
 			if ( 'add_activitypub_cap' === $action ) {
 				$user->add_cap( 'activitypub' );
+
+				\update_user_option( $user_id, 'activitypub_mailer_new_dm', 1 );
+				\update_user_option( $user_id, 'activitypub_mailer_new_follower', 1 );
+				\update_user_option( $user_id, 'activitypub_mailer_new_mention', 1 );
 			} elseif ( 'remove_activitypub_cap' === $action ) {
 				$user->remove_cap( 'activitypub' );
 			}

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -162,9 +162,6 @@ class Admin {
 		// User options that should be processed with `sanitize_text_field()`.
 		$text_field_user_options = array(
 			'activitypub_header_image',
-			'activitypub_mailer_new_dm',
-			'activitypub_mailer_new_follower',
-			'activitypub_mailer_new_mention',
 		);
 
 		foreach ( $text_field_user_options as $option ) {
@@ -173,6 +170,17 @@ class Admin {
 			} else {
 				\delete_user_option( $user_id, $option );
 			}
+		}
+
+		// User options that have a default value and therefore can't be empty (Empty triggers the default value).
+		$required_user_options = array(
+			'activitypub_mailer_new_dm',
+			'activitypub_mailer_new_follower',
+			'activitypub_mailer_new_mention',
+		);
+
+		foreach ( $required_user_options as $option ) {
+			\update_user_option( $user_id, $option, sanitize_text_field( wp_unslash( $_POST[ $option ] ?? 0 ) ) );
 		}
 	}
 
@@ -491,10 +499,6 @@ class Admin {
 			$user = new \WP_User( $user_id );
 			if ( 'add_activitypub_cap' === $action ) {
 				$user->add_cap( 'activitypub' );
-
-				\update_user_option( $user_id, 'activitypub_mailer_new_dm', 1 );
-				\update_user_option( $user_id, 'activitypub_mailer_new_follower', 1 );
-				\update_user_option( $user_id, 'activitypub_mailer_new_mention', 1 );
 			} elseif ( 'remove_activitypub_cap' === $action ) {
 				$user->remove_cap( 'activitypub' );
 			}

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -204,7 +204,7 @@ class Blog_Settings_Fields {
 			<p>
 				<label>
 					<input type="checkbox" name="activitypub_mailer_new_follower" id="activitypub_mailer_new_follower" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_follower', '0' ) ); ?> />
-					<?php \esc_html_e( 'New followers', 'activitypub' ); ?>
+					<?php \esc_html_e( 'New Followers', 'activitypub' ); ?>
 				</label>
 			</p>
 			<p>

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -203,13 +203,13 @@ class Blog_Settings_Fields {
 		<fieldset id="activitypub-notifications">
 			<p>
 				<label>
-					<input type="checkbox" name="activitypub_blog_user_mailer_new_follower" id="activitypub_blog_user_mailer_new_follower" value="1" <?php \checked( '1', \get_option( 'activitypub_blog_user_mailer_new_follower', '0' ) ); ?> />
+					<input type="checkbox" name="activitypub_blog_user_mailer_new_follower" id="activitypub_blog_user_mailer_new_follower" value="1" <?php \checked( '1', \get_option( 'activitypub_blog_user_mailer_new_follower', '1' ) ); ?> />
 					<?php \esc_html_e( 'New Followers', 'activitypub' ); ?>
 				</label>
 			</p>
 			<p>
 				<label>
-					<input type="checkbox" name="activitypub_blog_user_mailer_new_dm" id="activitypub_blog_user_mailer_new_dm" value="1" <?php \checked( '1', \get_option( 'activitypub_blog_user_mailer_new_dm', '0' ) ); ?> />
+					<input type="checkbox" name="activitypub_blog_user_mailer_new_dm" id="activitypub_blog_user_mailer_new_dm" value="1" <?php \checked( '1', \get_option( 'activitypub_blog_user_mailer_new_dm', '1' ) ); ?> />
 					<?php \esc_html_e( 'Direct Messages', 'activitypub' ); ?>
 				</label>
 			</p>

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -63,6 +63,14 @@ class Blog_Settings_Fields {
 			array( 'label_for' => 'activitypub_blog_description' )
 		);
 
+		\add_settings_field(
+			'activitypub_notifications',
+			\esc_html__( 'Email Notifications', 'activitypub' ),
+			array( self::class, 'notifications_callback' ),
+			'activitypub_blog_settings',
+			'activitypub_blog_profile'
+		);
+
 		add_settings_field(
 			'activitypub_extra_fields',
 			__( 'Extra Fields', 'activitypub' ),
@@ -184,6 +192,34 @@ class Blog_Settings_Fields {
 		<p class="description">
 			<?php esc_html_e( 'By default the ActivityPub plugin uses the WordPress tagline as a description for the blog profile.', 'activitypub' ); ?>
 		</p>
+		<?php
+	}
+
+	/**
+	 * Notifications field callback.
+	 */
+	public static function notifications_callback() {
+		?>
+		<fieldset id="activitypub-notifications">
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_mailer_new_follower" id="activitypub_mailer_new_follower" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_follower', '0' ) ); ?> />
+					<?php \esc_html_e( 'New followers', 'activitypub' ); ?>
+				</label>
+			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_mailer_new_dm" id="activitypub_mailer_new_dm" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_dm', '0' ) ); ?> />
+					<?php \esc_html_e( 'Direct Messages', 'activitypub' ); ?>
+				</label>
+			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_mailer_new_mention" id="activitypub_mailer_new_mention" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_mention', '1' ) ); ?> />
+					<?php \esc_html_e( 'New Mentions', 'activitypub' ); ?>
+				</label>
+			</p>
+		</fieldset>
 		<?php
 	}
 

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -203,19 +203,19 @@ class Blog_Settings_Fields {
 		<fieldset id="activitypub-notifications">
 			<p>
 				<label>
-					<input type="checkbox" name="activitypub_mailer_new_follower" id="activitypub_mailer_new_follower" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_follower', '0' ) ); ?> />
+					<input type="checkbox" name="activitypub_blog_user_mailer_new_follower" id="activitypub_blog_user_mailer_new_follower" value="1" <?php \checked( '1', \get_option( 'activitypub_blog_user_mailer_new_follower', '0' ) ); ?> />
 					<?php \esc_html_e( 'New Followers', 'activitypub' ); ?>
 				</label>
 			</p>
 			<p>
 				<label>
-					<input type="checkbox" name="activitypub_mailer_new_dm" id="activitypub_mailer_new_dm" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_dm', '0' ) ); ?> />
+					<input type="checkbox" name="activitypub_blog_user_mailer_new_dm" id="activitypub_blog_user_mailer_new_dm" value="1" <?php \checked( '1', \get_option( 'activitypub_blog_user_mailer_new_dm', '0' ) ); ?> />
 					<?php \esc_html_e( 'Direct Messages', 'activitypub' ); ?>
 				</label>
 			</p>
 			<p>
 				<label>
-					<input type="checkbox" name="activitypub_mailer_new_mention" id="activitypub_mailer_new_mention" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_mention', '1' ) ); ?> />
+					<input type="checkbox" name="activitypub_blog_user_mailer_new_mention" id="activitypub_blog_user_mailer_new_mention" value="1" <?php \checked( '1', \get_option( 'activitypub_blog_user_mailer_new_mention', '1' ) ); ?> />
 					<?php \esc_html_e( 'New Mentions', 'activitypub' ); ?>
 				</label>
 			</p>

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -38,13 +38,6 @@ class Settings_Fields {
 		);
 
 		add_settings_section(
-			'activitypub_notifications',
-			__( 'Notifications', 'activitypub' ),
-			array( self::class, 'render_notifications_section' ),
-			'activitypub_settings'
-		);
-
-		add_settings_section(
 			'activitypub_general',
 			__( 'General', 'activitypub' ),
 			'__return_empty_string',
@@ -155,59 +148,6 @@ class Settings_Fields {
 			'activitypub_server',
 			array( 'label_for' => 'activitypub_relays' )
 		);
-	}
-
-	/**
-	 * Render notifications section.
-	 */
-	public static function render_notifications_section() {
-		?>
-		<p>
-			<?php \esc_html_e( 'Choose which notifications you want to receive. The plugin currently only supports e-mail notifications, but we will add more options in the future.', 'activitypub' ); ?>
-		</p>
-		<table class="form-table">
-			<tbody>
-			<tr>
-				<th scope="col">
-					<?php \esc_html_e( 'Type', 'activitypub' ); ?>
-				</th>
-				<th scope="col">
-					<?php \esc_html_e( 'E-Mail', 'activitypub' ); ?>
-				</th>
-			</tr>
-			<tr>
-				<td>
-					<?php \esc_html_e( 'New followers', 'activitypub' ); ?>
-				</td>
-				<td>
-					<label>
-						<input type="checkbox" name="activitypub_mailer_new_follower" id="activitypub_mailer_new_follower" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_follower', '0' ) ); ?> />
-					</label>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<?php \esc_html_e( 'Direct Messages', 'activitypub' ); ?>
-				</td>
-				<td>
-					<label>
-						<input type="checkbox" name="activitypub_mailer_new_dm" id="activitypub_mailer_new_dm" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_dm', '0' ) ); ?> />
-					</label>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<?php \esc_html_e( 'New Mentions', 'activitypub' ); ?>
-				</td>
-				<td>
-					<label>
-						<input type="checkbox" name="activitypub_mailer_new_mention" id="activitypub_mailer_new_mention" value="1" <?php \checked( '1', \get_option( 'activitypub_mailer_new_mention', '1' ) ); ?> />
-					</label>
-				</td>
-			</tr>
-			</tbody>
-		</table>
-		<?php
 	}
 
 	/**

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -244,31 +244,31 @@ class Settings {
 
 		\register_setting(
 			'activitypub_blog',
-			'activitypub_mailer_new_dm',
+			'activitypub_blog_user_mailer_new_dm',
 			array(
-				'type'        => 'boolean',
+				'type'        => 'integer',
 				'description' => 'Send a notification when someone sends a user of the blog a direct message.',
-				'default'     => false,
+				'default'     => 1,
 			)
 		);
 
 		\register_setting(
 			'activitypub_blog',
-			'activitypub_mailer_new_follower',
+			'activitypub_blog_user_mailer_new_follower',
 			array(
-				'type'        => 'boolean',
+				'type'        => 'integer',
 				'description' => 'Send a notification when someone starts to follow a user of the blog.',
-				'default'     => false,
+				'default'     => 1,
 			)
 		);
 
 		\register_setting(
 			'activitypub_blog',
-			'activitypub_mailer_new_mention',
+			'activitypub_blog_user_mailer_new_mention',
 			array(
-				'type'        => 'boolean',
+				'type'        => 'integer',
 				'description' => 'Send a notification when someone mentions a user of the blog.',
-				'default'     => false,
+				'default'     => 1,
 			)
 		);
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -95,36 +95,6 @@ class Settings {
 
 		\register_setting(
 			'activitypub',
-			'activitypub_mailer_new_dm',
-			array(
-				'type'        => 'boolean',
-				'description' => 'Send a notification when someone sends a user of the blog a direct message.',
-				'default'     => false,
-			)
-		);
-
-		\register_setting(
-			'activitypub',
-			'activitypub_mailer_new_follower',
-			array(
-				'type'        => 'boolean',
-				'description' => 'Send a notification when someone starts to follow a user of the blog.',
-				'default'     => false,
-			)
-		);
-
-		\register_setting(
-			'activitypub',
-			'activitypub_mailer_new_mention',
-			array(
-				'type'        => 'boolean',
-				'description' => 'Send a notification when someone mentions a user of the blog.',
-				'default'     => false,
-			)
-		);
-
-		\register_setting(
-			'activitypub',
 			'activitypub_use_opengraph',
 			array(
 				'type'        => 'boolean',
@@ -188,6 +158,17 @@ class Settings {
 		);
 
 		\register_setting(
+			'activitypub',
+			'activitypub_relays',
+			array(
+				'type'              => 'array',
+				'description'       => \__( 'Relays', 'activitypub' ),
+				'default'           => array(),
+				'sanitize_callback' => array( Sanitize::class, 'url_list' ),
+			)
+		);
+
+		\register_setting(
 			'activitypub_advanced',
 			'activitypub_outbox_purge_days',
 			array(
@@ -227,17 +208,6 @@ class Settings {
 			)
 		);
 
-		\register_setting(
-			'activitypub',
-			'activitypub_relays',
-			array(
-				'type'              => 'array',
-				'description'       => \__( 'Relays', 'activitypub' ),
-				'default'           => array(),
-				'sanitize_callback' => array( Sanitize::class, 'url_list' ),
-			)
-		);
-
 		// Blog-User Settings.
 		\register_setting(
 			'activitypub_blog',
@@ -269,6 +239,36 @@ class Settings {
 				'type'        => 'integer',
 				'description' => \__( 'The Attachment-ID of the Sites Header-Image', 'activitypub' ),
 				'default'     => null,
+			)
+		);
+
+		\register_setting(
+			'activitypub_blog',
+			'activitypub_mailer_new_dm',
+			array(
+				'type'        => 'boolean',
+				'description' => 'Send a notification when someone sends a user of the blog a direct message.',
+				'default'     => false,
+			)
+		);
+
+		\register_setting(
+			'activitypub_blog',
+			'activitypub_mailer_new_follower',
+			array(
+				'type'        => 'boolean',
+				'description' => 'Send a notification when someone starts to follow a user of the blog.',
+				'default'     => false,
+			)
+		);
+
+		\register_setting(
+			'activitypub_blog',
+			'activitypub_mailer_new_mention',
+			array(
+				'type'        => 'boolean',
+				'description' => 'Send a notification when someone mentions a user of the blog.',
+				'default'     => false,
 			)
 		);
 

--- a/includes/wp-admin/class-user-settings-fields.php
+++ b/includes/wp-admin/class-user-settings-fields.php
@@ -188,19 +188,19 @@ class User_Settings_Fields {
 			<p>
 				<label>
 					<input type="checkbox" name="activitypub_mailer_new_follower" id="activitypub_mailer_new_follower" value="1" <?php \checked( 1, \get_user_option( 'activitypub_mailer_new_follower' ) ); ?> />
-					<?php esc_html_e( 'New followers', 'activitypub' ); ?>
+					<?php \esc_html_e( 'New followers', 'activitypub' ); ?>
 				</label>
 			</p>
 			<p>
 				<label>
 					<input type="checkbox" name="activitypub_mailer_new_dm" id="activitypub_mailer_new_dm" value="1" <?php \checked( 1, \get_user_option( 'activitypub_mailer_new_dm' ) ); ?> />
-					<?php esc_html_e( 'Direct Messages', 'activitypub' ); ?>
+					<?php \esc_html_e( 'Direct Messages', 'activitypub' ); ?>
 				</label>
 			</p>
 			<p>
 				<label>
 					<input type="checkbox" name="activitypub_mailer_new_mention" id="activitypub_mailer_new_mention" value="1" <?php \checked( 1, \get_user_option( 'activitypub_mailer_new_mention' ) ); ?> />
-					<?php esc_html_e( 'New Mentions', 'activitypub' ); ?>
+					<?php \esc_html_e( 'New Mentions', 'activitypub' ); ?>
 				</label>
 			</p>
 		</fieldset>

--- a/includes/wp-admin/class-user-settings-fields.php
+++ b/includes/wp-admin/class-user-settings-fields.php
@@ -188,7 +188,7 @@ class User_Settings_Fields {
 			<p>
 				<label>
 					<input type="checkbox" name="activitypub_mailer_new_follower" id="activitypub_mailer_new_follower" value="1" <?php \checked( 1, \get_user_option( 'activitypub_mailer_new_follower' ) ); ?> />
-					<?php \esc_html_e( 'New followers', 'activitypub' ); ?>
+					<?php \esc_html_e( 'New Followers', 'activitypub' ); ?>
 				</label>
 			</p>
 			<p>

--- a/includes/wp-admin/class-user-settings-fields.php
+++ b/includes/wp-admin/class-user-settings-fields.php
@@ -56,6 +56,14 @@ class User_Settings_Fields {
 		);
 
 		\add_settings_field(
+			'activitypub_notifications',
+			\esc_html__( 'Email Notifications', 'activitypub' ),
+			array( self::class, 'notifications_callback' ),
+			'activitypub_user_settings',
+			'activitypub_user_profile'
+		);
+
+		\add_settings_field(
 			'activitypub_extra_fields',
 			\esc_html__( 'Extra Fields', 'activitypub' ),
 			array( self::class, 'extra_fields_callback' ),
@@ -168,6 +176,34 @@ class User_Settings_Fields {
 			<?php \esc_html_e( 'Remove Header Image', 'activitypub' ); ?>
 		</button>
 		<input type="hidden" name="activitypub_header_image" id="activitypub_header_image" value="<?php echo \esc_attr( $header_image ); ?>">
+		<?php
+	}
+
+	/**
+	 * Notifications field callback.
+	 */
+	public static function notifications_callback() {
+		?>
+		<fieldset id="activitypub-notifications">
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_mailer_new_follower" id="activitypub_mailer_new_follower" value="1" <?php \checked( 1, \get_user_option( 'activitypub_mailer_new_follower' ) ); ?> />
+					<?php esc_html_e( 'New followers', 'activitypub' ); ?>
+				</label>
+			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_mailer_new_dm" id="activitypub_mailer_new_dm" value="1" <?php \checked( 1, \get_user_option( 'activitypub_mailer_new_dm' ) ); ?> />
+					<?php esc_html_e( 'Direct Messages', 'activitypub' ); ?>
+				</label>
+			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_mailer_new_mention" id="activitypub_mailer_new_mention" value="1" <?php \checked( 1, \get_user_option( 'activitypub_mailer_new_mention' ) ); ?> />
+					<?php esc_html_e( 'New Mentions', 'activitypub' ); ?>
+				</label>
+			</p>
+		</fieldset>
 		<?php
 	}
 

--- a/templates/emails/new-follower.php
+++ b/templates/emails/new-follower.php
@@ -52,7 +52,7 @@ require __DIR__ . '/parts/header.php';
 </style>
 <h1>
 	<?php
-	if ( Actors::BLOG_USER_ID === $args['target'] ) :
+	if ( Actors::BLOG_USER_ID === $args['user_id'] ) :
 		esc_html_e( 'Your blog has a new follower!', 'activitypub' );
 	else :
 		esc_html_e( 'You have a new follower!', 'activitypub' );
@@ -62,7 +62,7 @@ require __DIR__ . '/parts/header.php';
 
 <p>
 	<?php
-	if ( Actors::BLOG_USER_ID === $args['target'] ) :
+	if ( Actors::BLOG_USER_ID === $args['user_id'] ) :
 		/* translators: %s: The name of the person who mentioned the blog. */
 		$message = __( 'Meet your blog&#8217;s newest follower, %s. Here&#8217;s a quick look at their profile:', 'activitypub' );
 	else :

--- a/templates/emails/parts/footer.php
+++ b/templates/emails/parts/footer.php
@@ -5,11 +5,22 @@
  * @package Activitypub
  */
 
+/* @var array $args Template arguments. */
+
+use Activitypub\Collection\Actors;
+
+/* @var array $args Template arguments. */
+$args = wp_parse_args( $args ?? array() );
+
+$settings_path = 'profile.php#activitypub-notifications';
+if ( Actors::BLOG_USER_ID === $args['user_id'] ) {
+	$settings_path = 'options-general.php?page=activitypub&tab=blog-profile#activitypub-notifications';
+}
 ?>
 	<div class="footer">
 		<p><?php esc_html_e( 'You are receiving this emails because of your ActivityPub plugin settings.', 'activitypub' ); ?></p>
 		<p>
-			<a href="<?php echo esc_url( admin_url( 'options-general.php?page=activitypub&tab=settings' ) ); ?>">
+			<a href="<?php echo esc_url( admin_url( $settings_path ) ); ?>">
 				<?php esc_html_e( 'Manage notification settings', 'activitypub' ); ?>
 			</a>
 		</p>

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -35,12 +35,19 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Create fake data before tests run.
 	 *
-	 * @param WP_UnitTest_Factory $factory Helper that creates fake data.
+	 * @param \WP_UnitTest_Factory $factory Helper that creates fake data.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
+		$blog_prefix = $GLOBALS['wpdb']->get_blog_prefix();
+
 		self::$user_id = $factory->user->create(
 			array(
-				'role' => 'author',
+				'role'       => 'author',
+				'meta_input' => array(
+					$blog_prefix . 'activitypub_mailer_new_dm'       => 1,
+					$blog_prefix . 'activitypub_mailer_new_follower' => 1,
+					$blog_prefix . 'activitypub_mailer_new_mention'  => 1,
+				),
 			)
 		);
 
@@ -553,7 +560,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	 */
 	public function test_blog_new_follower_with_disabled_option() {
 		// Set blog option to false (0).
-		update_option( 'activitypub_mailer_new_follower', '0' );
+		update_option( 'activitypub_blog_user_mailer_new_follower', '0' );
 		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
 		$activity = array(
@@ -574,7 +581,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		// Clean up.
 		remove_all_filters( 'wp_before_load_template' );
-		delete_option( 'activitypub_mailer_new_follower' );
+		delete_option( 'activitypub_blog_user_mailer_new_follower' );
 		delete_option( 'activitypub_actor_mode' );
 	}
 
@@ -585,7 +592,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	 */
 	public function test_blog_direct_message_with_disabled_option() {
 		// Set blog option to false (0).
-		update_option( 'activitypub_mailer_new_dm', '0' );
+		update_option( 'activitypub_blog_user_mailer_new_dm', '0' );
 		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
 		$activity = array(
@@ -609,7 +616,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		// Clean up.
 		remove_all_filters( 'wp_before_load_template' );
-		delete_option( 'activitypub_mailer_new_dm' );
+		delete_option( 'activitypub_blog_user_mailer_new_dm' );
 		delete_option( 'activitypub_actor_mode' );
 	}
 
@@ -620,7 +627,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	 */
 	public function test_blog_mention_with_disabled_option() {
 		// Set blog option to false (0).
-		update_option( 'activitypub_mailer_new_mention', '0' );
+		update_option( 'activitypub_blog_user_mailer_new_mention', '0' );
 		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
 		$activity = array(
@@ -644,7 +651,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		// Clean up.
 		remove_all_filters( 'wp_before_load_template' );
-		delete_option( 'activitypub_mailer_new_mention' );
+		delete_option( 'activitypub_blog_user_mailer_new_mention' );
 		delete_option( 'activitypub_actor_mode' );
 	}
 }

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -160,13 +160,10 @@ class Test_Mailer extends WP_UnitTestCase {
 	 * @covers ::new_follower
 	 */
 	public function test_new_follower() {
-		$notification = new Notification(
-			'follow',
-			'https://example.com/author',
-			array(
-				'object' => 'https://example.com/follow/1',
-			),
-			self::$user_id
+		$activity = array(
+			'type'   => 'Follow',
+			'actor'  => 'https://example.com/author',
+			'object' => 'https://example.com/follow/1',
 		);
 
 		// Mock remote metadata.
@@ -192,7 +189,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			}
 		);
 
-		Mailer::new_follower( $notification );
+		Mailer::new_follower( $activity, self::$user_id );
 
 		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
@@ -205,26 +202,13 @@ class Test_Mailer extends WP_UnitTestCase {
 	 * @covers ::init
 	 */
 	public function test_init() {
-		\delete_option( 'activitypub_mailer_new_follower' );
-		\delete_option( 'activitypub_mailer_new_dm' );
-
 		Mailer::init();
 
 		$this->assertEquals( 10, \has_filter( 'comment_notification_subject', array( Mailer::class, 'comment_notification_subject' ) ) );
 		$this->assertEquals( 10, \has_filter( 'comment_notification_text', array( Mailer::class, 'comment_notification_text' ) ) );
-		$this->assertEquals( 10, \has_action( 'activitypub_notification_follow', array( Mailer::class, 'new_follower' ) ) );
+		$this->assertEquals( 10, \has_action( 'activitypub_inbox_follow', array( Mailer::class, 'new_follower' ) ) );
 		$this->assertEquals( 10, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'direct_message' ) ) );
-
-		\remove_action( 'activitypub_notification_follow', array( Mailer::class, 'new_follower' ) );
-		\remove_action( 'activitypub_inbox_create', array( Mailer::class, 'direct_message' ) );
-
-		\update_option( 'activitypub_mailer_new_follower', '0' );
-		\update_option( 'activitypub_mailer_new_dm', '0' );
-
-		Mailer::init();
-
-		$this->assertEquals( false, \has_action( 'activitypub_notification_follow', array( Mailer::class, 'new_follower' ) ) );
-		$this->assertEquals( false, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'direct_message' ) ) );
+		$this->assertEquals( 10, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'mention' ) ) );
 	}
 
 	/**

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -448,4 +448,203 @@ class Test_Mailer extends WP_UnitTestCase {
 		remove_all_filters( 'wp_mail' );
 		wp_delete_user( $user_id );
 	}
+
+	/**
+	 * Test new follower notification when user option is disabled.
+	 *
+	 * @covers ::new_follower
+	 */
+	public function test_new_follower_with_disabled_option() {
+		$activity = array(
+			'type'   => 'Follow',
+			'actor'  => 'https://example.com/author',
+			'object' => 'https://example.com/follow/1',
+		);
+
+		// Set user option to false.
+		update_user_option( self::$user_id, 'activitypub_mailer_new_follower', false );
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call the method.
+		Mailer::new_follower( $activity, self::$user_id );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'wp_mail' );
+		delete_user_option( self::$user_id, 'activitypub_mailer_new_follower' );
+	}
+
+	/**
+	 * Test direct message notification when user option is disabled.
+	 *
+	 * @covers ::direct_message
+	 */
+	public function test_direct_message_with_disabled_option() {
+		$activity = array(
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'      => 'https://example.com/post/1',
+				'content' => 'Test direct message',
+			),
+			'to'     => array( Actors::get_by_id( self::$user_id )->get_id() ),
+		);
+
+		// Set user option to false.
+		update_user_option( self::$user_id, 'activitypub_mailer_new_dm', false );
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call the method.
+		Mailer::direct_message( $activity, self::$user_id );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
+		delete_user_option( self::$user_id, 'activitypub_mailer_new_dm' );
+	}
+
+	/**
+	 * Test mention notification when user option is disabled.
+	 *
+	 * @covers ::mention
+	 */
+	public function test_mention_with_disabled_option() {
+		$activity = array(
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'      => 'https://example.com/post/1',
+				'content' => 'Test mention',
+			),
+			'cc'     => array( Actors::get_by_id( self::$user_id )->get_id() ),
+		);
+
+		// Set user option to false.
+		update_user_option( self::$user_id, 'activitypub_mailer_new_mention', false );
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call the method.
+		Mailer::mention( $activity, self::$user_id );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
+		delete_user_option( self::$user_id, 'activitypub_mailer_new_mention' );
+	}
+
+	/**
+	 * Test new follower notification for blog user when option is disabled.
+	 *
+	 * @covers ::new_follower
+	 */
+	public function test_blog_new_follower_with_disabled_option() {
+		// Set blog option to false (0).
+		update_option( 'activitypub_mailer_new_follower', '0' );
+		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$activity = array(
+			'type'   => 'Follow',
+			'actor'  => 'https://example.com/author',
+			'object' => 'https://example.com/follow/1',
+		);
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call the method with blog user ID.
+		Mailer::new_follower( $activity, Actors::BLOG_USER_ID );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
+		delete_option( 'activitypub_mailer_new_follower' );
+		delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * Test direct message notification for blog user when option is disabled.
+	 *
+	 * @covers ::direct_message
+	 */
+	public function test_blog_direct_message_with_disabled_option() {
+		// Set blog option to false (0).
+		update_option( 'activitypub_mailer_new_dm', '0' );
+		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$activity = array(
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'      => 'https://example.com/post/1',
+				'content' => 'Test direct message',
+			),
+			'to'     => array( Actors::get_by_id( Actors::BLOG_USER_ID )->get_id() ),
+		);
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call the method with blog user ID.
+		Mailer::direct_message( $activity, Actors::BLOG_USER_ID );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
+		delete_option( 'activitypub_mailer_new_dm' );
+		delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * Test mention notification for blog user when option is disabled.
+	 *
+	 * @covers ::mention
+	 */
+	public function test_blog_mention_with_disabled_option() {
+		// Set blog option to false (0).
+		update_option( 'activitypub_mailer_new_mention', '0' );
+		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$activity = array(
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'      => 'https://example.com/post/1',
+				'content' => 'Test mention',
+			),
+			'cc'     => array( Actors::get_by_id( Actors::BLOG_USER_ID )->get_id() ),
+		);
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call the method with blog user ID.
+		Mailer::mention( $activity, Actors::BLOG_USER_ID );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
+		delete_option( 'activitypub_mailer_new_mention' );
+		delete_option( 'activitypub_actor_mode' );
+	}
 }


### PR DESCRIPTION
The updated emails link to notification settings to make it easier to update them when receiving these notifications.
This PR makes them user-specific, with the default being the current global settings.
The global settings become the settings for the blog user.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves global notification settings to blog settings.
* Adds user profile settings fields.
* Adds user options to manage notification options.
* Update Mailer to check for user and blog options.
* Updates existing unit tests and adds new ones.
* Deprecates Notification class.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* While still in trunk, set a few notification settings.
* Switch to this branch and make sure the setting values for the blog and your user are the same.
* Send a DM, a new follow, and/or a mention from a remote test user.
* Make sure notification settings are being respected.
* Update notification settings and keep testing them.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Updated notification settings to be user-specific for more personalization.

</details>

Fixes #1435.