### PR TITLE
Move the hooks of the HTML e-mails before the footer part

### DIFF
--- a/templates/emails/new-dm.php
+++ b/templates/emails/new-dm.php
@@ -38,12 +38,12 @@ require __DIR__ . '/parts/header.php';
 </div>
 
 <?php
-// Load footer.
-require __DIR__ . '/parts/footer.php';
-
 /**
  * Fires at the bottom of the new direct message emails.
  *
  * @param array $args The template arguments.
  */
 do_action( 'activitypub_new_dm_email', $args );
+
+// Load footer.
+require __DIR__ . '/parts/footer.php';

--- a/templates/emails/new-follower.php
+++ b/templates/emails/new-follower.php
@@ -148,12 +148,12 @@ require __DIR__ . '/parts/header.php';
 </p>
 
 <?php
-// Load footer.
-require __DIR__ . '/parts/footer.php';
-
 /**
  * Fires at the bottom of the new follower email.
  *
  * @param array $args The actor that followed the blog.
  */
 do_action( 'activitypub_new_follower_email', $args );
+
+// Load footer.
+require __DIR__ . '/parts/footer.php';

--- a/templates/emails/new-mention.php
+++ b/templates/emails/new-mention.php
@@ -53,12 +53,12 @@ require __DIR__ . '/parts/header.php';
 </p>
 
 <?php
-// Load footer.
-require __DIR__ . '/parts/footer.php';
-
 /**
  * Fires at the bottom of the new mention emails.
  *
  * @param array $args The template arguments.
  */
 do_action( 'activitypub_new_mention_email', $args );
+
+// Load footer.
+require __DIR__ . '/parts/footer.php';


### PR DESCRIPTION
With the new HTML e-mail the hooks trigger after the HTML footer end, thus adding text to the e-mail results in a broken visual appearance.

## Proposed changes:
* Move the hook in the new notification e-mails (#1577, #1581, #1582) before the footer

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the Friends Plugin alongside ActivityPub
* Turn on New Follower Notifications and follow the blog
* Alternatively trigger this from a wp shell: `$follow_activity = new \Activitypub\Activity\Activity();$follow_activity->set_type( 'Follow' );$follow_activity->set_object( /* insert followed user/blog URL */ );$follow_activity->set_actor(  /* insert follower URL */ ); do_action( 'activitypub_inbox_follow', $follow_activity->to_array() );`

## Screenshot Before

![Screenshot 2025-04-17 at 09 49 36](https://github.com/user-attachments/assets/d0cd97c0-0081-4cff-b965-978dd8e54a2a)


## Screenshot After
![Screenshot 2025-04-17 at 09 59 35](https://github.com/user-attachments/assets/b38b0b42-ca7c-4e35-8dd8-70d470a232fe)



(I took the opportunity to adjust the text in the Friends plugin in https://github.com/akirk/friends/pull/507)
