### PR TITLE
Import: Convert to blocks and add reply

### DIFF
--- a/.github/changelog/1591-from-description
+++ b/.github/changelog/1591-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Mastodon imports now support blocks, with automatic reply embedding for conversations.

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -27,6 +27,8 @@ class Blocks {
 		// Add editor plugin.
 		\add_action( 'enqueue_block_editor_assets', array( self::class, 'enqueue_editor_assets' ) );
 		\add_action( 'init', array( self::class, 'register_postmeta' ), 11 );
+
+		\add_filter( 'activitypub_import_mastodon_post_data', array( self::class, 'filter_import_mastodon_post_data' ), 10, 2 );
 	}
 
 	/**
@@ -411,5 +413,34 @@ class Blocks {
 			esc_html( $data['preferredUsername'] ),
 			$external_svg
 		);
+	}
+
+	/**
+	 * Converts content to blocks before saving to the database.
+	 *
+	 * @param array  $data The post data to be inserted.
+	 * @param object $post The Mastodon Create activity.
+	 *
+	 * @return array
+	 */
+	public static function filter_import_mastodon_post_data( $data, $post ) {
+		// Convert paragraphs to blocks.
+		preg_match_all( '#<p>.*?</p>#is', $data['post_content'], $matches );
+		$blocks = array_map(
+			function ( $paragraph ) {
+				return '<!-- wp:paragraph -->' . PHP_EOL . $paragraph . PHP_EOL . '<!-- /wp:paragraph -->';
+			},
+			$matches[0] ?? array()
+		);
+
+		$data['post_content'] = implode( PHP_EOL, $blocks );
+
+		// Add reply block if it's a reply.
+		if ( null !== $post->object->inReplyTo ) {
+			$reply_block          = sprintf( '<!-- wp:activitypub/reply {"url":"%1$s","embedPost":true} /-->' . PHP_EOL, esc_url( $post->object->inReplyTo ) );
+			$data['post_content'] = $reply_block . $data['post_content'];
+		}
+
+		return $data;
 	}
 }

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -425,19 +425,19 @@ class Blocks {
 	 */
 	public static function filter_import_mastodon_post_data( $data, $post ) {
 		// Convert paragraphs to blocks.
-		preg_match_all( '#<p>.*?</p>#is', $data['post_content'], $matches );
-		$blocks = array_map(
+		\preg_match_all( '#<p>.*?</p>#is', $data['post_content'], $matches );
+		$blocks = \array_map(
 			function ( $paragraph ) {
-				return '<!-- wp:paragraph -->' . PHP_EOL . $paragraph . PHP_EOL . '<!-- /wp:paragraph -->';
+				return '<!-- wp:paragraph -->' . PHP_EOL . $paragraph . PHP_EOL . '<!-- /wp:paragraph -->' . PHP_EOL;
 			},
 			$matches[0] ?? array()
 		);
 
-		$data['post_content'] = implode( PHP_EOL, $blocks );
+		$data['post_content'] = \rtrim( \implode( PHP_EOL, $blocks ), PHP_EOL );
 
 		// Add reply block if it's a reply.
 		if ( null !== $post->object->inReplyTo ) {
-			$reply_block          = sprintf( '<!-- wp:activitypub/reply {"url":"%1$s","embedPost":true} /-->' . PHP_EOL, esc_url( $post->object->inReplyTo ) );
+			$reply_block          = \sprintf( '<!-- wp:activitypub/reply {"url":"%1$s","embedPost":true} /-->' . PHP_EOL, \esc_url( $post->object->inReplyTo ) );
 			$data['post_content'] = $reply_block . $data['post_content'];
 		}
 

--- a/includes/wp-admin/import/class-mastodon.php
+++ b/includes/wp-admin/import/class-mastodon.php
@@ -312,9 +312,10 @@ class Mastodon {
 			/**
 			 * Filter the post data before inserting it into the database.
 			 *
-			 * @param array $post_data The post data to be inserted.
+			 * @param array  $post_data The post data to be inserted.
+			 * @param object $post      The Mastodon Create activity.
 			 */
-			$post_data = \apply_filters( 'activitypub_import_mastodon_post_data', $post_data );
+			$post_data = \apply_filters( 'activitypub_import_mastodon_post_data', $post_data, $post );
 
 			$post_exists = \post_exists( '', $post_data['post_content'], $post_data['post_date'], $post_data['post_type'] );
 

--- a/tests/includes/class-test-blocks.php
+++ b/tests/includes/class-test-blocks.php
@@ -152,7 +152,7 @@ class Test_Blocks extends \WP_UnitTestCase {
 
 		$result = Blocks::filter_import_mastodon_post_data( $data, $post );
 
-		$this->assertSame( "<!-- wp:paragraph -->\n<p>First paragraph</p>\n<!-- /wp:paragraph -->\n<!-- wp:paragraph -->\n<p>Second paragraph</p>\n<!-- /wp:paragraph -->", $result['post_content'] );
+		$this->assertSame( "<!-- wp:paragraph -->\n<p>First paragraph</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Second paragraph</p>\n<!-- /wp:paragraph -->", $result['post_content'] );
 	}
 
 	/**

--- a/tests/includes/class-test-blocks.php
+++ b/tests/includes/class-test-blocks.php
@@ -133,4 +133,48 @@ class Test_Blocks extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'u-in-reply-to', $output, 'Output should contain the reply link.' );
 		$this->assertStringContainsString( 'example.com/no-embed', $output, 'Output should contain the formatted URL.' );
 	}
+
+	/**
+	 * Test filter_import_mastodon_post_data with regular paragraphs.
+	 *
+	 * @covers ::filter_import_mastodon_post_data
+	 */
+	public function test_filter_import_mastodon_post_data_with_paragraphs() {
+		$data = array(
+			'post_content' => '<p>First paragraph</p><p>Second paragraph</p>',
+		);
+
+		$post = (object) array(
+			'object' => (object) array(
+				'inReplyTo' => null,
+			),
+		);
+
+		$result = Blocks::filter_import_mastodon_post_data( $data, $post );
+
+		$this->assertSame( "<!-- wp:paragraph -->\n<p>First paragraph</p>\n<!-- /wp:paragraph -->\n<!-- wp:paragraph -->\n<p>Second paragraph</p>\n<!-- /wp:paragraph -->", $result['post_content'] );
+	}
+
+	/**
+	 * Test filter_import_mastodon_post_data with a reply post.
+	 *
+	 * @covers ::filter_import_mastodon_post_data
+	 */
+	public function test_filter_import_mastodon_post_data_with_reply() {
+		$data = array(
+			'post_content' => '<p>This is a reply</p>',
+		);
+
+		$reply_url = 'https://mastodon.social/@user/123456';
+		$post      = (object) array(
+			'object' => (object) array(
+				'inReplyTo' => $reply_url,
+			),
+		);
+
+		$result = Blocks::filter_import_mastodon_post_data( $data, $post );
+
+		$this->assertStringContainsString( '<!-- wp:activitypub/reply {"url":"https://mastodon.social/@user/123456","embedPost":true} /-->', $result['post_content'] );
+		$this->assertStringContainsString( "<!-- wp:paragraph -->\n<p>This is a reply</p>\n<!-- /wp:paragraph -->", $result['post_content'] );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When the site supports blocks, this callback converts all paragraphs to valid blocks and, if the post is a reply, adds a reply block with embed enabled to the beginning.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds raw post object to `activitypub_import_mastodon_post_data` filter.
* Adds a callback that converts paragraphs to blocks and adds a reply block.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Mastodon imports now support blocks, with automatic reply embedding for conversations.

</details>
