### PR TITLE
Fix a `Undefined array key "headers"` issue

### DIFF
--- a/.github/changelog/1594-from-description
+++ b/.github/changelog/1594-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Better check for an empty `headers` array key in the Signature class.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -276,9 +276,6 @@ class Signature {
 		}
 
 		$signed_headers = $signature_block['headers'];
-		if ( ! $signed_headers ) {
-			$signed_headers = array( 'date' );
-		}
 
 		$signed_data = self::get_signed_data( $signed_headers, $signature_block, $headers );
 		if ( ! $signed_data ) {
@@ -401,11 +398,7 @@ class Signature {
 			$parsed_header['signature'] = \base64_decode( preg_replace( '/\s+/', '', trim( $matches[1] ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		}
 
-		if (
-			! empty( $parsed_header['signature'] ) &&
-			! empty( $parsed_header['algorithm'] ) &&
-			empty( $parsed_header['headers'] )
-		) {
+		if ( empty( $parsed_header['headers'] ) ) {
 			$parsed_header['headers'] = array( 'date' );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Better check for an empty headers array key.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Better check for an empty `headers` array key in the Signature class.

</details>
