### PR TITLE
Remote Reply: Set script translations

### DIFF
--- a/.github/changelog/1595-from-description
+++ b/.github/changelog/1595-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reply links and popup modals are now properly translated for logged-out visitors.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -495,6 +495,7 @@ class Comment {
 				true
 			);
 			\wp_add_inline_script( $handle, $js, 'before' );
+			\wp_set_script_translations( $handle, 'activitypub' );
 
 			\wp_enqueue_style(
 				$handle,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1295.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds call to set script translations for remote reply for logged-out users.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to a test site that has a post with comments from the Fediverse.
* Set the site language to something other than English (preferably a language we have translations for).
* In incognito mode, or logged out, visit a post with comments from the Fediverse.
* Make sure the Reply link and popup modal are translated.

#### Before
<img width="1510" alt="Screenshot 2025-04-22 at 10 22 36 AM" src="https://github.com/user-attachments/assets/bf5a20fb-5af5-4713-a1ce-87daa63f2a36" />

#### After
<img width="1510" alt="Screenshot 2025-04-22 at 10 22 54 AM" src="https://github.com/user-attachments/assets/d6409b50-14f0-4a47-828f-a4718a275b77" />


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Reply links and popup modals are now properly translated for logged-out visitors.

</details>
