### PR TITLE
Directly link to a help tab.

### DIFF
--- a/.github/changelog/1598-from-description
+++ b/.github/changelog/1598-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable direct linking to Help Tabs.

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -612,21 +612,27 @@ class Admin {
 		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/toolbox.php' );
 	}
 
+	/**
+	 * Open the help tab.
+	 *
+	 * This function is used to open the help tab,
+	 * it is triggered by the hash in the URL.
+	 */
 	public static function open_help_tab() {
-	?>
-	<script type="text/javascript">
-	jQuery(document).ready(function($) {
-		var hash = window.location.hash;
-		if (hash) {
-			// Small delay to ensure the help tab is loaded
-			setTimeout(function() {
-				$('#contextual-help-link').click();
-				console.log(hash + ' a');
-				$(hash + ' a').click();
-			}, 500);
-		}
-	});
-	</script>
-	<?php
+		?>
+		<script type="text/javascript">
+		jQuery(document).ready(function($) {
+			var hash = window.location.hash;
+			if (hash) {
+				// Small delay to ensure the help tab is loaded
+				setTimeout(function() {
+					$('#contextual-help-link').click();
+					console.log(hash + ' a');
+					$(hash + ' a').click();
+				}, 500);
+			}
+		});
+		</script>
+		<?php
 	}
 }

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -619,11 +619,19 @@ class Admin {
 	 * it is triggered by the hash in the URL.
 	 */
 	public static function open_help_tab() {
+		// get all tabs registered for the ActivityPub settings page.
+		$tabs = \get_current_screen()->get_help_tabs();
+		$ids  = array_values( wp_list_pluck( $tabs, 'id' ) );
+		$ids  = array_map( function( $id ) {
+			return '#tab-link-' . $id;
+		}, $ids );
 		?>
 		<script type="text/javascript">
 		document.addEventListener('DOMContentLoaded', function() {
+			// add allowed ids to the hash.
 			const hash = window.location.hash;
-			if (hash) {
+			const allowed_ids = <?php echo wp_json_encode( $ids ); ?>;
+			if (allowed_ids.includes(hash)) {
 				// Small delay to ensure the help tab is loaded.
 				setTimeout(function() {
 					document.getElementById('contextual-help-link').click();

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -621,14 +621,13 @@ class Admin {
 	public static function open_help_tab() {
 		?>
 		<script type="text/javascript">
-		jQuery(document).ready(function($) {
-			var hash = window.location.hash;
+		document.addEventListener('DOMContentLoaded', function() {
+			const hash = window.location.hash;
 			if (hash) {
-				// Small delay to ensure the help tab is loaded
+				// Small delay to ensure the help tab is loaded.
 				setTimeout(function() {
-					$('#contextual-help-link').click();
-					console.log(hash + ' a');
-					$(hash + ' a').click();
+					document.getElementById('contextual-help-link').click();
+					document.querySelector(hash + ' a').click();
 				}, 500);
 			}
 		});

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -638,7 +638,7 @@ class Admin {
 				// Small delay to ensure the help tab is loaded.
 				setTimeout(function() {
 					document.getElementById('contextual-help-link').click();
-					document.querySelector(hash + ' a').click();
+					document.querySelector(hash + ' > a[href^="#tab-panel-"]').click();
 				}, 500);
 			}
 		});

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -60,6 +60,8 @@ class Admin {
 		if ( site_supports_blocks() ) {
 			\add_action( 'tool_box', array( self::class, 'tool_box' ) );
 		}
+
+		\add_action( 'admin_print_footer_scripts', array( self::class, 'open_help_tab' ) );
 	}
 
 	/**
@@ -608,5 +610,23 @@ class Admin {
 	 */
 	public static function tool_box() {
 		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/toolbox.php' );
+	}
+
+	public static function open_help_tab() {
+	?>
+	<script type="text/javascript">
+	jQuery(document).ready(function($) {
+		var hash = window.location.hash;
+		if (hash) {
+			// Small delay to ensure the help tab is loaded
+			setTimeout(function() {
+				$('#contextual-help-link').click();
+				console.log(hash + ' a');
+				$(hash + ' a').click();
+			}, 500);
+		}
+	});
+	</script>
+	<?php
 	}
 }

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -621,8 +621,8 @@ class Admin {
 	public static function open_help_tab() {
 		// get all tabs registered for the ActivityPub settings page.
 		$tabs = \get_current_screen()->get_help_tabs();
-		$ids  = array_values( wp_list_pluck( $tabs, 'id' ) );
-		$ids  = array_map(
+		$ids  = \array_values( \wp_list_pluck( $tabs, 'id' ) );
+		$ids  = \array_map(
 			function ( $id ) {
 				return '#tab-link-' . $id;
 			},
@@ -633,7 +633,7 @@ class Admin {
 		document.addEventListener('DOMContentLoaded', function() {
 			// add allowed ids to the hash.
 			const hash = window.location.hash;
-			const allowed_ids = <?php echo wp_json_encode( $ids ); ?>;
+			const allowed_ids = <?php echo \wp_json_encode( $ids ); ?>;
 			if (allowed_ids.includes(hash)) {
 				// Small delay to ensure the help tab is loaded.
 				setTimeout(function() {

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -622,9 +622,12 @@ class Admin {
 		// get all tabs registered for the ActivityPub settings page.
 		$tabs = \get_current_screen()->get_help_tabs();
 		$ids  = array_values( wp_list_pluck( $tabs, 'id' ) );
-		$ids  = array_map( function( $id ) {
-			return '#tab-link-' . $id;
-		}, $ids );
+		$ids  = array_map(
+			function ( $id ) {
+				return '#tab-link-' . $id;
+			},
+			$ids
+		);
 		?>
 		<script type="text/javascript">
 		document.addEventListener('DOMContentLoaded', function() {

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -61,7 +61,7 @@ class Admin {
 			\add_action( 'tool_box', array( self::class, 'tool_box' ) );
 		}
 
-		\add_action( 'admin_print_footer_scripts', array( self::class, 'open_help_tab' ) );
+		\add_action( 'admin_print_footer_scripts-settings_page_activitypub', array( self::class, 'open_help_tab' ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR allows you to directly link to help tabs. The idea is to use it for the Onboarding as part of a launchpad.

<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the ActivityPub admin page with the hash of the help tab you want to open. The link for the "Account Migration" help tab is `/wp-admin/options-general.php?page=activitypub#tab-link-account-migration` for example.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Enable direct linking to Help Tabs.

</details>
