### PR TITLE
Add "Dismiss Welcome Page Welcome" section

### DIFF
--- a/.github/changelog/1600-from-description
+++ b/.github/changelog/1600-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use a dedicated hook for the "Dismiss Welcome Page Welcome" link.

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -31,6 +31,14 @@ class Welcome_Fields {
 	public static function register_welcome_fields() {
 		// Add settings sections.
 		\add_settings_section(
+			'activitypub_welcome_close',
+			'',
+			array( self::class, 'render_welcome_close_section' ),
+			'activitypub_welcome'
+		);
+
+		// Add settings sections.
+		\add_settings_section(
 			'activitypub_intro',
 			\__( 'Welcome', 'activitypub' ),
 			array( self::class, 'render_welcome_intro_section' ),
@@ -93,9 +101,17 @@ class Welcome_Fields {
 	/**
 	 * Render welcome intro section.
 	 */
-	public static function render_welcome_intro_section() {
+	public static function render_welcome_close_section() {
 		?>
 		<a class="welcome-tab-close" href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&welcome=0' ) ); ?>" aria-label="<?php \esc_attr_e( 'Dismiss the welcome page', 'activitypub' ); ?>"><?php \esc_html_e( 'Dismiss Welcome Page', 'activitypub' ); ?></a>
+		<?php
+	}
+
+	/**
+	 * Render welcome intro section.
+	 */
+	public static function render_welcome_intro_section() {
+		?>
 		<p><?php echo wp_kses( \__( 'Enter the fediverse with <strong>ActivityPub</strong>, broadcasting your blog to a wider audience. Attract followers, deliver updates, and receive comments from a diverse user base on <strong>Mastodon</strong>, <strong>Friendica</strong>, <strong>Pleroma</strong>, <strong>Pixelfed</strong>, and all <strong>ActivityPub</strong>-compliant platforms.', 'activitypub' ), array( 'strong' => array() ) ); ?></p>
 		<?php
 	}


### PR DESCRIPTION
Add a dedicated hook for the "Dismiss Welcome Page Welcome" to be able to unhook it independently from the "Welcome" section and vice verse.

This is only a structural change with no UI implications.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Use a dedicated hook for the "Dismiss Welcome Page Welcome" link.

</details>
