### PR TITLE
Fix: Add user context to global inbox

### DIFF
--- a/.github/changelog/1603-from-description
+++ b/.github/changelog/1603-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Include user context in Global-Inbox actions.

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -8,7 +8,11 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Activity\Activity;
+use Activitypub\Collection\Actors;
 use Activitypub\Debug;
+
+use function Activitypub\is_same_domain;
+use function Activitypub\extract_recipients_from_activity;
 
 /**
  * Inbox_Controller class.
@@ -134,24 +138,38 @@ class Inbox_Controller extends \WP_REST_Controller {
 		if ( \wp_check_comment_disallowed_list( $activity->to_json( false ), '', '', '', $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT'] ?? '' ) ) {
 			Debug::write_log( 'Blocked activity from: ' . $activity->get_actor() );
 		} else {
-			/**
-			 * ActivityPub inbox action.
-			 *
-			 * @param array              $data     The data array.
-			 * @param int|null           $user_id  The user ID.
-			 * @param string             $type     The type of the activity.
-			 * @param Activity|\WP_Error $activity The Activity object.
-			 */
-			\do_action( 'activitypub_inbox', $data, null, $type, $activity );
+			$recipients = extract_recipients_from_activity( $data );
 
-			/**
-			 * ActivityPub inbox action for specific activity types.
-			 *
-			 * @param array              $data     The data array.
-			 * @param int|null           $user_id  The user ID.
-			 * @param Activity|\WP_Error $activity The Activity object.
-			 */
-			\do_action( 'activitypub_inbox_' . $type, $data, null, $activity );
+			foreach ( $recipients as $recipient ) {
+				if ( ! is_same_domain( $recipient ) ) {
+					continue;
+				}
+
+				$actor = Actors::get_by_various( $recipient );
+
+				if ( ! $actor || is_wp_error( $actor ) ) {
+					continue;
+				}
+
+				/**
+				 * ActivityPub inbox action.
+				 *
+				 * @param array              $data     The data array.
+				 * @param int                $user_id  The user ID.
+				 * @param string             $type     The type of the activity.
+				 * @param Activity|\WP_Error $activity The Activity object.
+				 */
+				\do_action( 'activitypub_inbox', $data, $actor->get__id(), $type, $activity );
+
+				/**
+				 * ActivityPub inbox action for specific activity types.
+				 *
+				 * @param array              $data     The data array.
+				 * @param int                $user_id  The user ID.
+				 * @param Activity|\WP_Error $activity The Activity object.
+				 */
+				\do_action( 'activitypub_inbox_' . $type, $data, $actor->get__id(), $activity );
+			}
 		}
 
 		$response = \rest_ensure_response( array() );

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -147,7 +147,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 
 				$actor = Actors::get_by_various( $recipient );
 
-				if ( ! $actor || is_wp_error( $actor ) ) {
+				if ( ! $actor || \is_wp_error( $actor ) ) {
 					continue;
 				}
 

--- a/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/includes/rest/class-test-inbox-controller.php
@@ -29,6 +29,13 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 	}
 
 	/**
+	 * Delete fake data after tests run.
+	 */
+	public static function tear_down_after_class() {
+		\wp_delete_user( self::$user_id );
+	}
+
+	/**
 	 * Test follow request global inbox.
 	 *
 	 * @covers ::get_items

--- a/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/includes/rest/class-test-inbox-controller.php
@@ -15,6 +15,20 @@ namespace Activitypub\Tests\Rest;
  */
 class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Testcase {
 	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Create fake data before tests run.
+	 */
+	public static function set_up_before_class() {
+		self::$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+	}
+
+	/**
 	 * Test follow request global inbox.
 	 *
 	 * @covers ::get_items
@@ -273,6 +287,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$this->assertEquals( 1, $inbox_action->get_call_count() );
 
 		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\delete_option( 'activitypub_actor_mode' );
 	}
 
 	/**
@@ -285,8 +300,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
-		$user_id    = self::factory()->user->create( array( 'role' => 'author' ) );
-		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$user_actor = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
 		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
 
 		// Set up mock action.
@@ -318,6 +332,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$this->assertEquals( 2, $inbox_action->get_call_count() );
 
 		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\delete_option( 'activitypub_actor_mode' );
 	}
 
 	/**
@@ -330,8 +345,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
-		$user_id    = self::factory()->user->create( array( 'role' => 'author' ) );
-		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$user_actor = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
 		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
 
 		// Set up mock action.
@@ -363,6 +377,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$this->assertEquals( 2, $inbox_action->get_call_count() );
 
 		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\delete_option( 'activitypub_actor_mode' );
 	}
 
 	/**
@@ -375,8 +390,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
-		$user_id    = self::factory()->user->create( array( 'role' => 'author' ) );
-		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$user_actor = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
 		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
 
 		// Set up mock action.
@@ -410,6 +424,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$this->assertEquals( 1, $inbox_action->get_call_count() );
 
 		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\delete_option( 'activitypub_actor_mode' );
 	}
 
 	/**
@@ -422,8 +437,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
 
-		$user_id        = self::factory()->user->create( array( 'role' => 'author' ) );
-		$user_actor     = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$user_actor     = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
 		$activity_types = array( 'Update', 'Delete', 'Follow', 'Accept', 'Reject', 'Announce', 'Like' );
 
 		foreach ( $activity_types as $type ) {
@@ -457,6 +471,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		}
 
 		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\delete_option( 'activitypub_actor_mode' );
 	}
 
 	/**

--- a/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/includes/rest/class-test-inbox-controller.php
@@ -259,7 +259,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 				'to'        => array( $blog_actor->get_id() ),
 				'published' => '2020-01-01T00:00:00Z',
 			),
-			'to' => array( $blog_actor->get_id() ),
+			'to'     => array( $blog_actor->get_id() ),
 		);
 
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
@@ -285,7 +285,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
-		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user_id    = self::factory()->user->create( array( 'role' => 'author' ) );
 		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
 		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
 
@@ -304,7 +304,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 				'to'        => array( $user_actor->get_id(), $blog_actor->get_id() ),
 				'published' => '2020-01-01T00:00:00Z',
 			),
-			'to' => array( $user_actor->get_id(), $blog_actor->get_id() ),
+			'to'     => array( $user_actor->get_id(), $blog_actor->get_id() ),
 		);
 
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
@@ -330,7 +330,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
-		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user_id    = self::factory()->user->create( array( 'role' => 'author' ) );
 		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
 		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
 
@@ -349,7 +349,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 				'to'        => array( $user_actor->get_id(), $blog_actor->get_id() ),
 				'published' => '2020-01-01T00:00:00Z',
 			),
-			'to' => array( $user_actor->get_id(), $blog_actor->get_id(), 'https://invalid.example/@test' ),
+			'to'     => array( $user_actor->get_id(), $blog_actor->get_id(), 'https://invalid.example/@test' ),
 		);
 
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
@@ -375,7 +375,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
-		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user_id    = self::factory()->user->create( array( 'role' => 'author' ) );
 		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
 		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
 
@@ -394,7 +394,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 				'to'        => array( $user_actor->get_id(), $blog_actor->get_id() ),
 				'published' => '2020-01-01T00:00:00Z',
 			),
-			'to' => array( $user_actor->get_id(), $blog_actor->get_id() ),
+			'to'     => array( $user_actor->get_id(), $blog_actor->get_id() ),
 		);
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
@@ -422,8 +422,8 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
 
-		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
-		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$user_id        = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user_actor     = \Activitypub\Collection\Actors::get_by_id( $user_id );
 		$activity_types = array( 'Update', 'Delete', 'Follow', 'Accept', 'Reject', 'Announce', 'Like' );
 
 		foreach ( $activity_types as $type ) {
@@ -442,7 +442,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 					'to'        => array( $user_actor->get_id() ),
 					'published' => '2020-01-01T00:00:00Z',
 				),
-				'to' => array( $user_actor->get_id() ),
+				'to'     => array( $user_actor->get_id() ),
 			);
 
 			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
@@ -467,7 +467,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 	public function test_create_item_with_invalid_request() {
 		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
-		// Test with missing required fields
+		// Test with missing required fields.
 		$json = array(
 			'type' => 'Create',
 		);
@@ -479,7 +479,7 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$response = \rest_do_request( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
-		// Test with invalid content type
+		// Test with invalid content type.
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body( \wp_json_encode( $json ) );

--- a/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/includes/rest/class-test-inbox-controller.php
@@ -231,4 +231,262 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 	public function test_get_item_schema() {
 		// Controller does not implement get_item_schema().
 	}
+
+	/**
+	 * Test creating an inbox item with blog user context.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_with_blog_user() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+
+		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
+
+		// Set up mock action.
+		$inbox_action = new \MockAction();
+		\add_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+
+		$json = array(
+			'id'     => 'https://remote.example/@id',
+			'type'   => 'Create',
+			'actor'  => 'https://remote.example/@test',
+			'object' => array(
+				'id'        => 'https://remote.example/post/test',
+				'type'      => 'Note',
+				'content'   => 'Hello, World!',
+				'to'        => array( $blog_actor->get_id() ),
+				'published' => '2020-01-01T00:00:00Z',
+			),
+			'to' => array( $blog_actor->get_id() ),
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+		$this->assertEquals( 202, $response->get_status() );
+
+		// Verify the action was triggered exactly once for a single recipient.
+		$this->assertEquals( 1, $inbox_action->get_call_count() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+	}
+
+	/**
+	 * Test creating an inbox item with multiple recipients.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_with_multiple_recipients() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
+
+		// Set up mock action.
+		$inbox_action = new \MockAction();
+		\add_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+
+		$json = array(
+			'id'     => 'https://remote.example/@id',
+			'type'   => 'Create',
+			'actor'  => 'https://remote.example/@test',
+			'object' => array(
+				'id'        => 'https://remote.example/post/test',
+				'type'      => 'Note',
+				'content'   => 'Hello, World!',
+				'to'        => array( $user_actor->get_id(), $blog_actor->get_id() ),
+				'published' => '2020-01-01T00:00:00Z',
+			),
+			'to' => array( $user_actor->get_id(), $blog_actor->get_id() ),
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+		$this->assertEquals( 202, $response->get_status() );
+
+		// Verify the action was triggered exactly once for each recipient.
+		$this->assertEquals( 2, $inbox_action->get_call_count() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+	}
+
+	/**
+	 * Test creating an inbox item with multiple recipients and invalid recipient.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_with_multiple_recipients_and_invalid_recipient() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
+
+		// Set up mock action.
+		$inbox_action = new \MockAction();
+		\add_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+
+		$json = array(
+			'id'     => 'https://remote.example/@id',
+			'type'   => 'Create',
+			'actor'  => 'https://remote.example/@test',
+			'object' => array(
+				'id'        => 'https://remote.example/post/test',
+				'type'      => 'Note',
+				'content'   => 'Hello, World!',
+				'to'        => array( $user_actor->get_id(), $blog_actor->get_id() ),
+				'published' => '2020-01-01T00:00:00Z',
+			),
+			'to' => array( $user_actor->get_id(), $blog_actor->get_id(), 'https://invalid.example/@test' ),
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+		$this->assertEquals( 202, $response->get_status() );
+
+		// Verify the action was triggered exactly once for each recipient.
+		$this->assertEquals( 2, $inbox_action->get_call_count() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+	}
+
+	/**
+	 * Test creating an inbox item with multiple recipients and inactive recipient.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_with_multiple_recipients_and_inactive_recipient() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$blog_actor = \Activitypub\Collection\Actors::get_by_id( \Activitypub\Collection\Actors::BLOG_USER_ID );
+
+		// Set up mock action.
+		$inbox_action = new \MockAction();
+		\add_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+
+		$json = array(
+			'id'     => 'https://remote.example/@id',
+			'type'   => 'Create',
+			'actor'  => 'https://remote.example/@test',
+			'object' => array(
+				'id'        => 'https://remote.example/post/test',
+				'type'      => 'Note',
+				'content'   => 'Hello, World!',
+				'to'        => array( $user_actor->get_id(), $blog_actor->get_id() ),
+				'published' => '2020-01-01T00:00:00Z',
+			),
+			'to' => array( $user_actor->get_id(), $blog_actor->get_id() ),
+		);
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+		$this->assertEquals( 202, $response->get_status() );
+
+		// Verify the action was triggered exactly once for each recipient.
+		$this->assertEquals( 1, $inbox_action->get_call_count() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+	}
+
+	/**
+	 * Test creating an inbox item with different activity types.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_with_different_activity_types() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user_actor = \Activitypub\Collection\Actors::get_by_id( $user_id );
+		$activity_types = array( 'Update', 'Delete', 'Follow', 'Accept', 'Reject', 'Announce', 'Like' );
+
+		foreach ( $activity_types as $type ) {
+			// Set up mock action.
+			$inbox_action = new \MockAction();
+			\add_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+
+			$json = array(
+				'id'     => 'https://remote.example/@id',
+				'type'   => $type,
+				'actor'  => 'https://remote.example/@test',
+				'object' => array(
+					'id'        => 'https://remote.example/post/test',
+					'type'      => 'Note',
+					'content'   => 'Hello, World!',
+					'to'        => array( $user_actor->get_id() ),
+					'published' => '2020-01-01T00:00:00Z',
+				),
+				'to' => array( $user_actor->get_id() ),
+			);
+
+			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+			$request->set_header( 'Content-Type', 'application/activity+json' );
+			$request->set_body( \wp_json_encode( $json ) );
+
+			$response = \rest_do_request( $request );
+			$this->assertEquals( 202, $response->get_status(), "Failed for activity type: {$type}" );
+
+			// Verify the action was triggered exactly once for a single recipient.
+			$this->assertEquals( 1, $inbox_action->get_call_count() );
+		}
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+	}
+
+	/**
+	 * Test creating an inbox item with invalid request.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_with_invalid_request() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		// Test with missing required fields
+		$json = array(
+			'type' => 'Create',
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
+		// Test with invalid content type
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+	}
 }


### PR DESCRIPTION
There was no need to have a user context for quite some time, so we skipped the audience check. With Mailings that changed, so we have to check the audience and call the filters with the corresponding user ids, to match the user-inbox hooks.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add user-id to actions

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Include user context in Global-Inbox actions.

</details>
