### PR TITLE
Show the upgrade notice on the Welcome Screen

### DIFF
--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -616,8 +616,11 @@ class Admin {
 	 */
 	public static function plugin_update_message( $data, $update ) {
 		if ( ! isset( $update->upgrade_notice ) ) {
+			\delete_option( 'activitypub_upgrade_notice' );
 			return;
 		}
+
+		\update_option( 'activitypub_upgrade_notice', wp_strip_all_tags( $update->upgrade_notice ) );
 
 		echo '<br>' . wp_strip_all_tags( $update->upgrade_notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -45,6 +45,17 @@ class Welcome_Fields {
 			'activitypub_welcome'
 		);
 
+		// Check if upgrade notice is set
+		$upgrade_notice = \get_option( 'activitypub_upgrade_notice' );
+		if ( $upgrade_notice ) {
+			\add_settings_section(
+				'activitypub_welcome_changelog',
+				\sprintf( \esc_html__( 'New in version %s', 'activitypub' ), ACTIVITYPUB_PLUGIN_VERSION ),
+				array( self::class, 'render_welcome_changelog_section' ),
+				'activitypub_welcome'
+			);
+		}
+
 		\add_settings_section(
 			'activitypub_bookmarklet',
 			\__( 'Bookmarklet', 'activitypub' ),
@@ -113,6 +124,16 @@ class Welcome_Fields {
 	public static function render_welcome_intro_section() {
 		?>
 		<p><?php echo wp_kses( \__( 'Enter the fediverse with <strong>ActivityPub</strong>, broadcasting your blog to a wider audience. Attract followers, deliver updates, and receive comments from a diverse user base on <strong>Mastodon</strong>, <strong>Friendica</strong>, <strong>Pleroma</strong>, <strong>Pixelfed</strong>, and all <strong>ActivityPub</strong>-compliant platforms.', 'activitypub' ), array( 'strong' => array() ) ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Render welcome changelog section.
+	 */
+	public static function render_welcome_changelog_section() {
+		?>
+		<p><?php echo \wp_kses( \get_option( 'activitypub_upgrade_notice' ), array( 'br' => array() ) ); ?></p>
+		<p><?php echo \wp_kses( \__( 'Read the full changelog <a href="https://github.com/Automattic/wordpress-activitypub/releases/tag/' . ACTIVITYPUB_PLUGIN_VERSION . '" target="_blank">here</a>.', 'activitypub' ), array( 'a' => array( 'href' => true, 'target' => true ) ) ); ?></p>
 		<?php
 	}
 


### PR DESCRIPTION
If we want to rely on upgrade messages, we maybe should also show them on the welcome screen.

Related #1609

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
