### PR TITLE
Fix: Properly save the "Receive reblogs (boosts)" setting

### DIFF
--- a/.github/changelog/1622-from-description
+++ b/.github/changelog/1622-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix issue preventing "Receive reblogs (boosts)" setting from being changed due to incorrect input field name.
+Issue preventing "Receive reblogs (boosts)" setting from being properly saved.

--- a/.github/changelog/1622-from-description
+++ b/.github/changelog/1622-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix issue preventing "Receive reblogs (boosts)" setting from being changed due to incorrect input field name.

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -342,7 +342,7 @@ class Settings_Fields {
 			</p>
 			<p>
 				<label>
-					<input type="checkbox" name="activitypub_allow_announces" value="1" <?php checked( '1', $allow_reposts ); ?> />
+					<input type="checkbox" name="activitypub_allow_reposts" value="1" <?php checked( '1', $allow_reposts ); ?> />
 					<?php esc_html_e( 'Receive reblogs (boosts)', 'activitypub' ); ?>
 				</label>
 			</p>


### PR DESCRIPTION
It was not possible to change the option "Receive reblogs (boosts)" because of a wrong input field name.

See: https://mastodon.social/@jansenspott@ruhr.social/114417563495334578

<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix issue preventing "Receive reblogs (boosts)" setting from being changed due to incorrect input field name.

</details>
