### PR TITLE
Outbox: Skip posts that can't be prepared

### DIFF
--- a/.github/changelog/1627-from-description
+++ b/.github/changelog/1627-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+The Outbox now skips invalid items instead of trying to process them for output and encountering an error.

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -178,6 +178,20 @@ class Outbox_Controller extends \WP_REST_Controller {
 
 		\update_postmeta_cache( \wp_list_pluck( $query_result, 'ID' ) );
 		foreach ( $query_result as $outbox_item ) {
+			if ( ! $outbox_item instanceof \WP_Post ) {
+				/**
+				 * Action triggered when an outbox item is not a WP_Post.
+				 *
+				 * @param mixed            $outbox_item  The outbox item.
+				 * @param array            $args         The arguments used to query the outbox.
+				 * @param array            $query_result The result of the query.
+				 * @param \WP_REST_Request $request      The request object.
+				 */
+				do_action( 'activitypub_rest_outbox_item_error', $outbox_item, $args, $query_result, $request );
+
+				continue;
+			}
+
 			$response['orderedItems'][] = $this->prepare_item_for_response( $outbox_item, $request );
 		}
 


### PR DESCRIPTION
Occasionally we see type errors with outbox items that are not `WP_Post` objects. This change avoids these errors and allow enhanced logging and debugging to better understand instances where that happens.

See p1745934199587809-slack-C04TJ8P900J

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds WP_Post instance check to skip invalid outbox items from being rendered.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

The Outbox now skips invalid items instead of trying to process them for output and encountering an error.

</details>