### PR TITLE
Outbox: Update hook names to follow convention

### DIFF
--- a/.github/changelog/1628-from-description
+++ b/.github/changelog/1628-from-description
@@ -1,0 +1,5 @@
+Significance: minor
+Type: deprecated
+
+Deprecated `rest_activitypub_outbox_query` filter in favor of `activitypub_rest_outbox_query`.
+Deprecated `activitypub_outbox_post` action in favor of `activitypub_rest_outbox_post`.

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -153,6 +153,8 @@ class Outbox_Controller extends \WP_REST_Controller {
 			);
 		}
 
+		$args = \apply_filters_deprecated( 'rest_activitypub_outbox_query', array( $args, $request ), 'unreleased', 'activitypub_rest_outbox_query' );
+
 		/**
 		 * Filters WP_Query arguments when querying Outbox items via the REST API.
 		 *
@@ -161,7 +163,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 		 * @param array            $args    Array of arguments for WP_Query.
 		 * @param \WP_REST_Request $request The REST API request.
 		 */
-		$args = apply_filters( 'rest_activitypub_outbox_query', $args, $request );
+		$args = \apply_filters( 'activitypub_rest_outbox_query', $args, $request );
 
 		$outbox_query = new \WP_Query();
 		$query_result = $outbox_query->query( $args );
@@ -194,12 +196,14 @@ class Outbox_Controller extends \WP_REST_Controller {
 		 */
 		$response = \apply_filters( 'activitypub_rest_outbox_array', $response, $request );
 
+		\do_action_deprecated( 'activitypub_outbox_post', array( $request ), 'unreleased', 'activitypub_rest_outbox_post' );
+
 		/**
 		 * Action triggered after the ActivityPub profile has been created and sent to the client.
 		 *
 		 * @param \WP_REST_Request $request The request object.
 		 */
-		\do_action( 'activitypub_outbox_post', $request );
+		\do_action( 'activitypub_rest_outbox_post', $request );
 
 		$response = \rest_ensure_response( $response );
 		$response->header( 'Content-Type', 'application/activity+json; charset=' . \get_option( 'blog_charset' ) );

--- a/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/includes/rest/class-test-outbox-controller.php
@@ -226,6 +226,14 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 		);
 
 		\add_action(
+			'activitypub_rest_outbox_post',
+			function () use ( &$post_called ) {
+				$post_called = true;
+			}
+		);
+
+		$this->setExpectedDeprecated( 'activitypub_outbox_post' );
+		\add_action(
 			'activitypub_outbox_post',
 			function () use ( &$post_called ) {
 				$post_called = true;
@@ -241,6 +249,7 @@ class Test_Outbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Tes
 
 		\remove_all_filters( 'activitypub_rest_outbox_array' );
 		\remove_all_actions( 'activitypub_rest_outbox_pre' );
+		\remove_all_actions( 'activitypub_rest_outbox_post' );
 		\remove_all_actions( 'activitypub_outbox_post' );
 	}
 


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates query arg filter to use `activitypub_rest_outbox_` namespace.
* Updates post action to use `activitypub_rest_outbox_` namespace.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [x] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Deprecated `rest_activitypub_outbox_query` filter in favor of `activitypub_rest_outbox_query`.
Deprecated `activitypub_outbox_post` action in favor of `activitypub_rest_outbox_post`.

</details>
