### PR TITLE
Max Image Attachments: Default to integer

### DIFF
--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -25,6 +25,8 @@ class Options {
 
 		\add_filter( 'pre_option_activitypub_allow_likes', array( self::class, 'maybe_disable_interactions' ) );
 		\add_filter( 'pre_option_activitypub_allow_replies', array( self::class, 'maybe_disable_interactions' ) );
+
+		\add_filter( 'option_activitypub_max_image_attachments', array( self::class, 'default_max_image_attachments' ) );
 	}
 
 
@@ -120,5 +122,19 @@ class Options {
 		}
 
 		return $pre_option;
+	}
+
+	/**
+	 * Default max image attachments.
+	 *
+	 * @param string $value The value of the option.
+	 * @return string|int
+	 */
+	public static function default_max_image_attachments( $value ) {
+		if ( ! \is_numeric( $value ) ) {
+			$value = ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS;
+		}
+
+		return $value;
 	}
 }

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -119,15 +119,4 @@ class Sanitize {
 
 		return $value;
 	}
-
-	/**
-	 * Sanitize the max image attachments.
-	 *
-	 * @param string $value The value to sanitize.
-	 *
-	 * @return int The sanitized value.
-	 */
-	public static function max_image_attachments( $value ) {
-		return \is_numeric( $value ) ? \absint( $value ) : ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS;
-	}
 }

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -119,4 +119,15 @@ class Sanitize {
 
 		return $value;
 	}
+
+	/**
+	 * Sanitize the max image attachments.
+	 *
+	 * @param string $value The value to sanitize.
+	 *
+	 * @return int The sanitized value.
+	 */
+	public static function max_image_attachments( $value ) {
+		return \is_numeric( $value ) ? \absint( $value ) : ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS;
+	}
 }

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -280,7 +280,7 @@ class Settings_Fields {
 	public static function render_max_image_attachments_field() {
 		$value = get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
 		?>
-		<input id="activitypub_max_image_attachments" value="<?php echo esc_attr( $value ); ?>" name="activitypub_max_image_attachments" type="number" min="0" class="small-text" />
+		<input id="activitypub_max_image_attachments" value="<?php echo esc_attr( $value ); ?>" name="activitypub_max_image_attachments" type="number" min="0" max="10" class="small-text" />
 		<p class="description">
 			<?php
 			echo wp_kses(

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -65,7 +65,9 @@ class Settings {
 				'type'              => 'integer',
 				'description'       => \__( 'Number of images to attach to posts.', 'activitypub' ),
 				'default'           => ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS,
-				'sanitize_callback' => array( Sanitize::class, 'max_image_attachments' ),
+				'sanitize_callback' => function ( $value ) {
+					return \is_numeric( $value ) ? \absint( $value ) : ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS;
+				},
 			)
 		);
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -62,9 +62,10 @@ class Settings {
 			'activitypub',
 			'activitypub_max_image_attachments',
 			array(
-				'type'        => 'integer',
-				'description' => \__( 'Number of images to attach to posts.', 'activitypub' ),
-				'default'     => ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS,
+				'type'              => 'integer',
+				'description'       => \__( 'Number of images to attach to posts.', 'activitypub' ),
+				'default'           => ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS,
+				'sanitize_callback' => array( Sanitize::class, 'max_image_attachments' ),
 			)
 		);
 

--- a/tests/includes/class-test-blocks.php
+++ b/tests/includes/class-test-blocks.php
@@ -38,6 +38,7 @@ class Test_Blocks extends \WP_UnitTestCase {
 		);
 
 		$this->expectedDeprecated();
+		$this->assertSame( ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS, \get_option( 'activitypub_max_image_attachments' ) );
 	}
 
 	/**

--- a/tests/includes/class-test-blocks.php
+++ b/tests/includes/class-test-blocks.php
@@ -16,6 +16,29 @@ use WP_UnitTestCase;
  * @coversDefaultClass \Activitypub\Blocks
  */
 class Test_Blocks extends \WP_UnitTestCase {
+	/**
+	 * Test register_post_meta.
+	 *
+	 * @covers ::register_postmeta
+	 */
+	public function test_register_post_meta() {
+		// Empty option should not trigger _doing_it_wrong() notice.
+		\update_option( 'activitypub_max_image_attachments', '' );
+
+		\register_post_meta(
+			'post',
+			'activitypub_max_image_attachments',
+			array(
+				'type'              => 'integer',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'default'           => \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ),
+				'sanitize_callback' => 'absint',
+			)
+		);
+
+		$this->expectedDeprecated();
+	}
 
 	/**
 	 * Test the reply block with a valid URL attribute.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It's possible for the `register_post_meta` call to trigger a `_doing_it_wrong()` notice, when the default value is not of type integer.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds unit test.
* Adds option callback to make sure it always returns an integer.
* Tightens sanitization to make sure it never saves an empty string.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* While on trunk, activate Classic Editor plugin to make the setting show up.
* Delete the number in the max image attachments setting and save.
* Make sure the input field is empty and a `_doing_it_wrong()` notice appears (DEBUG enabled).
* Switch to this branch. The notice should no longer appear.
