### PR TITLE
Onboarding: Isolate profile settings during onboarding

### DIFF
--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -16,12 +16,12 @@ class Sanitize {
 	/**
 	 * Sanitize a list of URLs.
 	 *
-	 * @param string|array $value The value to sanitize.
+	 * @param string|array|null $value The value to sanitize.
 	 * @return array The sanitized list of URLs.
 	 */
 	public static function url_list( $value ) {
 		if ( ! \is_array( $value ) ) {
-			$value = \explode( PHP_EOL, $value );
+			$value = \explode( PHP_EOL, (string) $value );
 		}
 
 		$value = \array_filter( $value );
@@ -35,11 +35,11 @@ class Sanitize {
 	/**
 	 * Sanitize a list of hosts.
 	 *
-	 * @param string $value The value to sanitize.
+	 * @param string|null $value The value to sanitize.
 	 * @return string The sanitized list of hosts.
 	 */
 	public static function host_list( $value ) {
-		$value = \explode( PHP_EOL, $value );
+		$value = \explode( PHP_EOL, (string) $value );
 		$value = \array_map(
 			function ( $host ) {
 				$host = \trim( $host );

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -17,20 +17,41 @@ class Settings_Fields {
 	 * Initialize the settings fields.
 	 */
 	public static function init() {
-		add_action( 'load-settings_page_activitypub', array( self::class, 'register_settings_fields' ) );
+		// TODO: Update option name.
+		if ( \get_option( 'activitypub_launchpad_settings_visited', false ) ) {
+			\add_action( 'load-settings_page_activitypub', array( self::class, 'register_settings_fields' ) );
+		} else {
+			\add_action( 'load-settings_page_activitypub', array( self::class, 'register_profile_fields' ) );
+		}
+	}
+
+	/**
+	 * Registers profile settings fields.
+	 *
+	 * Separate from register_settings_fields() so it can be displayed on its own during onboarding.
+	 */
+	public static function register_profile_fields() {
+		\add_settings_section(
+			'activitypub_profiles',
+			\__( 'Profiles', 'activitypub' ),
+			'__return_empty_string',
+			'activitypub_settings'
+		);
+
+		\add_settings_field(
+			'activitypub_actor_mode',
+			\__( 'Enable profiles by type', 'activitypub' ),
+			array( self::class, 'render_actor_mode_field' ),
+			'activitypub_settings',
+			'activitypub_profiles'
+		);
 	}
 
 	/**
 	 * Register settings fields.
 	 */
 	public static function register_settings_fields() {
-		// Add settings sections.
-		add_settings_section(
-			'activitypub_profiles',
-			__( 'Profiles', 'activitypub' ),
-			'__return_empty_string',
-			'activitypub_settings'
-		);
+		self::register_profile_fields();
 
 		add_settings_section(
 			'activitypub_activities',
@@ -54,14 +75,6 @@ class Settings_Fields {
 		);
 
 		// Add settings fields.
-		add_settings_field(
-			'activitypub_actor_mode',
-			__( 'Enable profiles by type', 'activitypub' ),
-			array( self::class, 'render_actor_mode_field' ),
-			'activitypub_settings',
-			'activitypub_profiles'
-		);
-
 		add_settings_field(
 			'activitypub_object_type',
 			__( 'Activity-Object-Type', 'activitypub' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Depends on #1625.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Creates separate registration callback for profile section and setting.
* Hooks settings sections conditionally on onboarding task having been completed.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Activitypub.
* Without #1625 the onboarding option should not be set and it should only display the Profile setting.
* After testing #1625, the option should be set and the full settings screen should show.

#### After
<img width="1510" alt="Screenshot 2025-04-30 at 2 50 50 PM" src="https://github.com/user-attachments/assets/3554c5a6-67cc-4503-98ae-44106cdba395" />


