### PR TITLE
Docs: Move method docs to most basic class

### DIFF
--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -20,49 +20,6 @@ namespace Activitypub\Activity;
  * 'Base_' for this reason.
  *
  * @see https://www.w3.org/TR/activitystreams-core/#object
- *
- * @method string|null             get_actor()         Gets one or more entities that performed or are expected to perform the activity.
- * @method string|null             get_attributed_to() Gets the entity attributed as the original author.
- * @method array|null              get_attachment()    Gets the attachment property of the object.
- * @method array|null              get_cc()            Gets the secondary recipients of the object.
- * @method string|null             get_content()       Gets the content property of the object.
- * @method array|null              get_icon()          Gets the icon property of the object.
- * @method string|null             get_id()            Gets the object's unique global identifier.
- * @method array|null              get_image()         Gets the image property of the object.
- * @method array|string|null       get_in_reply_to()   Gets the objects this object is in reply to.
- * @method string|null             get_name()          Gets the natural language name of the object.
- * @method Base_Object|string|null get_object()        Gets the direct object of the activity.
- * @method string|null             get_published()     Gets the date and time the object was published in ISO 8601 format.
- * @method string|null             get_summary()       Gets the natural language summary of the object.
- * @method array|null              get_tag()           Gets the tag property of the object.
- * @method array|string|null       get_to()            Gets the primary recipients of the object.
- * @method string                  get_type()          Gets the type of the object.
- * @method string|null             get_updated()       Gets the date and time the object was updated in ISO 8601 format.
- * @method string|null             get_url()           Gets the URL of the object.
- *
- * @method string|array add_cc( string|array $cc ) Adds one or more entities to the secondary audience of the object.
- * @method string|array add_to( string|array $to ) Adds one or more entities to the primary audience of the object.
- *
- * @method Base_Object set_actor( string|array $actor )           Sets one or more entities that performed the activity.
- * @method Base_Object set_attachment( array $attachment )        Sets the attachment property of the object.
- * @method Base_Object set_attributed_to( string $attributed_to ) Sets the entity attributed as the original author.
- * @method Base_Object set_cc( array|string $cc )                 Sets the secondary recipients of the object.
- * @method Base_Object set_content( string $content )             Sets the content property of the object.
- * @method Base_Object set_content_map( array $content_map )      Sets the content property of the object.
- * @method Base_Object set_icon( array $icon )                    Sets the icon property of the object.
- * @method Base_Object set_id( string $id )                       Sets the object's unique global identifier.
- * @method Base_Object set_image( array $image )                  Sets the image property of the object.
- * @method Base_Object set_name( string $name )                   Sets the natural language name of the object.
- * @method Base_Object set_origin( string $origin )               Sets the origin property of the object.
- * @method Base_Object set_published( string $published )         Sets the date and time the object was published in ISO 8601 format.
- * @method Base_Object set_sensitive( bool $sensitive )           Sets the sensitive property of the object.
- * @method Base_Object set_summary( string $summary )             Sets the natural language summary of the object.
- * @method Base_Object set_summary_map( array|null $summary_map ) Sets the summary property of the object.
- * @method Base_Object set_target( string $target )               Sets the target property of the object.
- * @method Base_Object set_to( array|string $to )                 Sets the primary recipients of the object.
- * @method Base_Object set_type( string $type )                   Sets the type of the object.
- * @method Base_Object set_updated( string $updated )             Sets the date and time the object was updated in ISO 8601 format.
- * @method Base_Object set_url( string $url )                     Sets the URL of the object.
  */
 class Base_Object extends Generic_Object {
 	/**

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -18,6 +18,49 @@ use function Activitypub\snake_to_camel_case;
  * conform to the ActivityStreams vocabulary.
  *
  * @since 5.3.0
+ *
+ * @method string|null             get_actor()         Gets one or more entities that performed or are expected to perform the activity.
+ * @method string|null             get_attributed_to() Gets the entity attributed as the original author.
+ * @method array|null              get_attachment()    Gets the attachment property of the object.
+ * @method array|null              get_cc()            Gets the secondary recipients of the object.
+ * @method string|null             get_content()       Gets the content property of the object.
+ * @method array|null              get_icon()          Gets the icon property of the object.
+ * @method string|null             get_id()            Gets the object's unique global identifier.
+ * @method array|null              get_image()         Gets the image property of the object.
+ * @method array|string|null       get_in_reply_to()   Gets the objects this object is in reply to.
+ * @method string|null             get_name()          Gets the natural language name of the object.
+ * @method Base_Object|string|null get_object()        Gets the direct object of the activity.
+ * @method string|null             get_published()     Gets the date and time the object was published in ISO 8601 format.
+ * @method string|null             get_summary()       Gets the natural language summary of the object.
+ * @method array|null              get_tag()           Gets the tag property of the object.
+ * @method array|string|null       get_to()            Gets the primary recipients of the object.
+ * @method string                  get_type()          Gets the type of the object.
+ * @method string|null             get_updated()       Gets the date and time the object was updated in ISO 8601 format.
+ * @method string|null             get_url()           Gets the URL of the object.
+ *
+ * @method string|array add_cc( string|array $cc ) Adds one or more entities to the secondary audience of the object.
+ * @method string|array add_to( string|array $to ) Adds one or more entities to the primary audience of the object.
+ *
+ * @method Base_Object set_actor( string|array $actor )           Sets one or more entities that performed the activity.
+ * @method Base_Object set_attachment( array $attachment )        Sets the attachment property of the object.
+ * @method Base_Object set_attributed_to( string $attributed_to ) Sets the entity attributed as the original author.
+ * @method Base_Object set_cc( array|string $cc )                 Sets the secondary recipients of the object.
+ * @method Base_Object set_content( string $content )             Sets the content property of the object.
+ * @method Base_Object set_content_map( array $content_map )      Sets the content property of the object.
+ * @method Base_Object set_icon( array $icon )                    Sets the icon property of the object.
+ * @method Base_Object set_id( string $id )                       Sets the object's unique global identifier.
+ * @method Base_Object set_image( array $image )                  Sets the image property of the object.
+ * @method Base_Object set_name( string $name )                   Sets the natural language name of the object.
+ * @method Base_Object set_origin( string $origin )               Sets the origin property of the object.
+ * @method Base_Object set_published( string $published )         Sets the date and time the object was published in ISO 8601 format.
+ * @method Base_Object set_sensitive( bool $sensitive )           Sets the sensitive property of the object.
+ * @method Base_Object set_summary( string $summary )             Sets the natural language summary of the object.
+ * @method Base_Object set_summary_map( array|null $summary_map ) Sets the summary property of the object.
+ * @method Base_Object set_target( string $target )               Sets the target property of the object.
+ * @method Base_Object set_to( array|string $to )                 Sets the primary recipients of the object.
+ * @method Base_Object set_type( string $type )                   Sets the type of the object.
+ * @method Base_Object set_updated( string $updated )             Sets the date and time the object was updated in ISO 8601 format.
+ * @method Base_Object set_url( string $url )                     Sets the URL of the object.
  */
 #[\AllowDynamicProperties]
 class Generic_Object {

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -22,25 +22,25 @@ use function Activitypub\snake_to_camel_case;
  * @method string|null             get_actor()         Gets one or more entities that performed or are expected to perform the activity.
  * @method string[]|null           get_also_known_as() Gets the also known as property of the object.
  * @method string|null             get_attributed_to() Gets the entity attributed as the original author.
- * @method array|null              get_attachment()    Gets the attachment property of the object.
- * @method array|null              get_cc()            Gets the secondary recipients of the object.
+ * @method array[]|null            get_attachment()    Gets the attachment property of the object.
+ * @method string[]|null           get_cc()            Gets the secondary recipients of the object.
  * @method string|null             get_content()       Gets the content property of the object.
- * @method array|null              get_icon()          Gets the icon property of the object.
+ * @method string[]|null           get_icon()          Gets the icon property of the object.
  * @method string|null             get_id()            Gets the object's unique global identifier.
- * @method array|null              get_image()         Gets the image property of the object.
- * @method array|string|null       get_in_reply_to()   Gets the objects this object is in reply to.
+ * @method string[]|null           get_image()         Gets the image property of the object.
+ * @method string[]|string|null    get_in_reply_to()   Gets the objects this object is in reply to.
  * @method string|null             get_name()          Gets the natural language name of the object.
  * @method Base_Object|string|null get_object()        Gets the direct object of the activity.
  * @method string|null             get_published()     Gets the date and time the object was published in ISO 8601 format.
  * @method string|null             get_summary()       Gets the natural language summary of the object.
- * @method array|null              get_tag()           Gets the tag property of the object.
- * @method array|string|null       get_to()            Gets the primary recipients of the object.
+ * @method array[]|null            get_tag()           Gets the tag property of the object.
+ * @method string[]|string|null    get_to()            Gets the primary recipients of the object.
  * @method string                  get_type()          Gets the type of the object.
  * @method string|null             get_updated()       Gets the date and time the object was updated in ISO 8601 format.
  * @method string|null             get_url()           Gets the URL of the object.
  *
- * @method string|array add_cc( string|array $cc ) Adds one or more entities to the secondary audience of the object.
- * @method string|array add_to( string|array $to ) Adds one or more entities to the primary audience of the object.
+ * @method string|string[] add_cc( string|array $cc ) Adds one or more entities to the secondary audience of the object.
+ * @method string|string[] add_to( string|array $to ) Adds one or more entities to the primary audience of the object.
  *
  * @method Base_Object set_actor( string|array $actor )           Sets one or more entities that performed the activity.
  * @method Base_Object set_attachment( array $attachment )        Sets the attachment property of the object.

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -20,6 +20,7 @@ use function Activitypub\snake_to_camel_case;
  * @since 5.3.0
  *
  * @method string|null             get_actor()         Gets one or more entities that performed or are expected to perform the activity.
+ * @method string[]|null           get_also_known_as() Gets the also known as property of the object.
  * @method string|null             get_attributed_to() Gets the entity attributed as the original author.
  * @method array|null              get_attachment()    Gets the attachment property of the object.
  * @method array|null              get_cc()            Gets the secondary recipients of the object.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves method docs to `Generic_Object` so all classes inheriting from it get those annotations.

#### Before
<img width="936" alt="Screenshot 2025-05-01 at 7 54 01 AM" src="https://github.com/user-attachments/assets/bb686604-4a4e-4649-849c-8191ba456353" />
<img width="556" alt="Screenshot 2025-05-01 at 7 54 29 AM" src="https://github.com/user-attachments/assets/a60d58e4-a082-41e8-9909-f5b833d150ef" />

