### PR TITLE
Editor: Show media in Preview for drafts

### DIFF
--- a/.github/changelog/1636-from-description
+++ b/.github/changelog/1636-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Fediverse Previews in the Block Editor now show media items, even if the post has not been published yet.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -297,7 +297,7 @@ class Post extends Base {
 		$id    = $this->item->ID;
 
 		// List post thumbnail first if this post has one.
-		if ( \function_exists( 'has_post_thumbnail' ) && \has_post_thumbnail( $id ) ) {
+		if ( \has_post_thumbnail( $id ) ) {
 			$media['image'][] = array( 'id' => \get_post_thumbnail_id( $id ) );
 		}
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -275,11 +275,6 @@ class Post extends Base {
 	 * @return array The Attachments.
 	 */
 	protected function get_attachment() {
-		// Remove attachments from drafts.
-		if ( 'draft' === \get_post_status( $this->item ) ) {
-			return array();
-		}
-
 		// phpcs:ignore Universal.Operators.DisallowShortTernary
 		$max_media = \get_post_meta( $this->item->ID, 'activitypub_max_image_attachments', true ) ?: \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -275,6 +275,14 @@ class Post extends Base {
 	 * @return array The Attachments.
 	 */
 	protected function get_attachment() {
+		/*
+		 * Remove attachments from the Fediverse if a post was federated and then set back to draft.
+		 * Except in preview mode, where we want to show attachments.
+		 */
+		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
+			return array();
+		}
+
 		// phpcs:ignore Universal.Operators.DisallowShortTernary
 		$max_media = \get_post_meta( $this->item->ID, 'activitypub_max_image_attachments', true ) ?: \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
 


### PR DESCRIPTION
While posts are in draft, any media included in the post will not show up in the Fediverse Preview. This PR changes that, so the post can be previewed with media, before publishing it.

Introduced in #780.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes post status check for Drafts when generating attachements list.
* Removes function exists check.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post in the block editor.
* Add a media item of your choice.
* Select Fediverse Preview and make sure it's being displayed there.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fediverse Previews in the Block Editor now show media items, even if the post has not been published yet.
</details>
