### PR TITLE
Server: Remove redundant check

### DIFF
--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -77,12 +77,8 @@ class Server {
 			return true;
 		}
 
-		if (
-			// POST-Requests always have to be signed.
-			'GET' !== $request->get_method() ||
-			// GET-Requests only require a signature in secure mode.
-			( 'GET' === $request->get_method() && use_authorized_fetch() )
-		) {
+		// POST-Requests always have to be signed, GET-Requests only require a signature in secure mode.
+		if ( 'GET' !== $request->get_method() || use_authorized_fetch() ) {
 			$verified_request = Signature::verify_http_signature( $request );
 			if ( \is_wp_error( $verified_request ) ) {
 				return new WP_Error(

--- a/tests/includes/rest/class-test-server.php
+++ b/tests/includes/rest/class-test-server.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Test file for Server.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Rest;
+
+use Activitypub\Rest\Server;
+
+/**
+ * Test class for Server.
+ *
+ * @group rest
+ * @coversDefaultClass Server
+ */
+class Test_Server extends \WP_Test_REST_TestCase {
+	/**
+	 * Test verify_signature method.
+	 *
+	 * @covers ::verify_signature
+	 */
+	public function test_verify_signature() {
+		// HEAD requests are always bypassed.
+		$request = new \WP_REST_Request( 'HEAD', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$this->assertTrue( Server::verify_signature( $request ) );
+
+		// POST requests require a signature.
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$this->assertErrorResponse( 'activitypub_signature_verification', Server::verify_signature( $request ) );
+
+		// GET requests with secure mode enabled require a signature.
+		\add_filter( 'activitypub_use_authorized_fetch', '__return_true' );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$this->assertErrorResponse( 'activitypub_signature_verification', Server::verify_signature( $request ) );
+
+		// GET requests with secure mode disabled are bypassed.
+		\remove_filter( 'activitypub_use_authorized_fetch', '__return_true' );
+		$this->assertTrue( Server::verify_signature( $request ) );
+	}
+}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes redundant GET check. If `$request->get_method()` is not `GET` it can't also be `GET`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?