### PR TITLE
Send the Vary header by default

### DIFF
--- a/.github/changelog/1638-from-description
+++ b/.github/changelog/1638-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Improve compatibility with third-party caching plugins by sending a `Vary` header.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -205,7 +205,7 @@ class Activitypub {
 		if ( ! headers_sent() ) {
 			\header( 'Link: <' . esc_url( $id ) . '>; title="ActivityPub (JSON)"; rel="alternate"; type="application/activity+json"', false );
 
-			if ( \get_option( 'activitypub_vary_header' ) ) {
+			if ( \get_option( 'activitypub_vary_header', '1' ) ) {
 				// Send Vary header for Accept header.
 				\header( 'Vary: Accept', false );
 			}

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -111,14 +111,14 @@ class Options {
 	/**
 	 * Disallow interactions if the constant is set.
 	 *
-	 * @param bool $pre_option The value of the option.
+	 * @param bool $pre The value of the option.
 	 * @return bool|string The value of the option.
 	 */
-	public static function maybe_disable_interactions( $pre_option ) {
+	public static function maybe_disable_interactions( $pre ) {
 		if ( ACTIVITYPUB_DISABLE_INCOMING_INTERACTIONS ) {
 			return '0';
 		}
 
-		return $pre_option;
+		return $pre;
 	}
 }

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -116,7 +116,7 @@ class Advanced_Settings_Fields {
 	 * Render vary header field.
 	 */
 	public static function render_vary_header_field() {
-		$value = \get_option( 'activitypub_vary_header', '0' );
+		$value = \get_option( 'activitypub_vary_header', '1' );
 		?>
 		<p>
 			<label>

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -328,7 +328,7 @@ class Health_Check {
 
 		$info['activitypub']['fields']['vary_header'] = array(
 			'label'   => \__( 'Vary Header', 'activitypub' ),
-			'value'   => \esc_attr( (int) \get_option( 'activitypub_vary_header', '0' ) ),
+			'value'   => \esc_attr( (int) \get_option( 'activitypub_vary_header', '1' ) ),
 			'private' => false,
 		);
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -184,7 +184,7 @@ class Settings {
 			array(
 				'type'        => 'boolean',
 				'description' => \__( 'Add the Vary header to the ActivityPub response.', 'activitypub' ),
-				'default'     => false,
+				'default'     => true,
 			)
 		);
 


### PR DESCRIPTION
This PR changes the default behaviour of the `Vary` header from opt-in to opt-out.

There are still way too many problems with caching plugins and the plugin should work out of the box without having to tweak too much.

/cc @snarfed

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set the default of the `Vary` header setting to `true`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Improve compatibility with third-party caching plugins by sending a `Vary` header.

</details>
