### PR TITLE
Enable/disable content negotiation

### DIFF
--- a/.github/changelog/1639-from-description
+++ b/.github/changelog/1639-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add setting to enable or disable how content is tailored for browsers and Fediverse services.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -140,7 +140,7 @@ class Activitypub {
 
 		self::add_headers();
 
-		if ( ! is_activitypub_request() || ! negotiate_content() ) {
+		if ( ! is_activitypub_request() || ! should_negotiate_content() ) {
 			return $template;
 		}
 

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -106,6 +106,7 @@ class Activitypub {
 		\delete_option( 'activitypub_blog_user_public_key' );
 		\delete_option( 'activitypub_blog_description' );
 		\delete_option( 'activitypub_blog_identifier' );
+		\delete_option( 'activitypub_content_negotiation' );
 		\delete_option( 'activitypub_custom_post_content' );
 		\delete_option( 'activitypub_db_version' );
 		\delete_option( 'activitypub_default_extra_fields' );
@@ -139,7 +140,7 @@ class Activitypub {
 
 		self::add_headers();
 
-		if ( ! is_activitypub_request() ) {
+		if ( ! is_activitypub_request() || ! negotiate_content() ) {
 			return $template;
 		}
 

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -319,21 +319,11 @@ class Query {
 	 * @return bool True if content negotiation is allowed, false otherwise.
 	 */
 	public function negotiate_content() {
-		$return = false;
-
-		/**
-		 * Filters the query parameters that should always be negotiated.
-		 *
-		 * @param array $always_negotiate The query parameters that should always be negotiated.
-		 */
-		$always_negotiate = apply_filters(
-			'activitypub_content_negotiation_query_vars',
-			array( 'p', 'c', 'author', 'actor', 'preview', 'activitypub' )
-		);
-
-		$url   = $this->get_request_url();
-		$url   = \wp_parse_url( $url, PHP_URL_QUERY );
-		$query = array();
+		$return           = false;
+		$always_negotiate = array( 'p', 'c', 'author', 'actor', 'preview', 'activitypub' );
+		$url              = $this->get_request_url();
+		$url              = \wp_parse_url( $url, PHP_URL_QUERY );
+		$query            = array();
 		\wp_parse_str( $url, $query );
 		// check if any of the query params are in the `$always_negotiate` array.
 		if ( array_intersect( array_keys( $query ), $always_negotiate ) ) {
@@ -346,6 +336,11 @@ class Query {
 			$return = true;
 		}
 
+		/**
+		 * Filters whether content negotiation should be forced.
+		 *
+		 * @param bool $return Whether content negotiation should be forced.
+		 */
 		return apply_filters( 'activitypub_negotiate_content', $return );
 	}
 

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -318,7 +318,7 @@ class Query {
 	 *
 	 * @return bool True if content negotiation is allowed, false otherwise.
 	 */
-	public function negotiate_content() {
+	public function should_negotiate_content() {
 		$return           = false;
 		$always_negotiate = array( 'p', 'c', 'author', 'actor', 'preview', 'activitypub' );
 		$url              = \wp_parse_url( $this->get_request_url(), PHP_URL_QUERY );
@@ -339,7 +339,7 @@ class Query {
 		 *
 		 * @param bool $return Whether content negotiation should be forced.
 		 */
-		return \apply_filters( 'activitypub_negotiate_content', $return );
+		return \apply_filters( 'activitypub_should_negotiate_content', $return );
 	}
 
 	/**

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -314,6 +314,42 @@ class Query {
 	}
 
 	/**
+	 * Check if content negotiation is allowed for a request.
+	 *
+	 * @return bool True if content negotiation is allowed, false otherwise.
+	 */
+	public function negotiate_content() {
+		$return = false;
+
+		/**
+		 * Filters the query parameters that should always be negotiated.
+		 *
+		 * @param array $always_negotiate The query parameters that should always be negotiated.
+		 */
+		$always_negotiate = apply_filters(
+			'activitypub_content_negotiation_query_vars',
+			array( 'p', 'c', 'author', 'actor', 'preview', 'activitypub' )
+		);
+
+		$url   = $this->get_request_url();
+		$url   = \wp_parse_url( $url, PHP_URL_QUERY );
+		$query = array();
+		\wp_parse_str( $url, $query );
+		// check if any of the query params are in the `$always_negotiate` array.
+		if ( array_intersect( array_keys( $query ), $always_negotiate ) ) {
+			$return = true;
+		}
+
+		$option = \get_option( 'activitypub_content_negotiation', '1' );
+
+		if ( $option ) {
+			$return = true;
+		}
+
+		return apply_filters( 'activitypub_negotiate_content', $return );
+	}
+
+	/**
 	 * Check if the current request is from the old host.
 	 *
 	 * @return bool True if the request is from the old host, false otherwise.

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -340,7 +340,7 @@ class Query {
 		 *
 		 * @param bool $return Whether content negotiation should be forced.
 		 */
-		return apply_filters( 'activitypub_negotiate_content', $return );
+		return \apply_filters( 'activitypub_negotiate_content', $return );
 	}
 
 	/**

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -321,8 +321,7 @@ class Query {
 	public function negotiate_content() {
 		$return           = false;
 		$always_negotiate = array( 'p', 'c', 'author', 'actor', 'preview', 'activitypub' );
-		$url              = $this->get_request_url();
-		$url              = \wp_parse_url( $url, PHP_URL_QUERY );
+		$url              = \wp_parse_url( $this->get_request_url(), PHP_URL_QUERY );
 		$query            = array();
 		\wp_parse_str( $url, $query );
 		// check if any of the query params are in the `$always_negotiate` array.

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -329,9 +329,7 @@ class Query {
 			$return = true;
 		}
 
-		$option = \get_option( 'activitypub_content_negotiation', '1' );
-
-		if ( $option ) {
+		if ( \get_option( 'activitypub_content_negotiation', '1' ) ) {
 			$return = true;
 		}
 

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -324,8 +324,9 @@ class Query {
 		$url              = \wp_parse_url( $this->get_request_url(), PHP_URL_QUERY );
 		$query            = array();
 		\wp_parse_str( $url, $query );
-		// check if any of the query params are in the `$always_negotiate` array.
-		if ( array_intersect( array_keys( $query ), $always_negotiate ) ) {
+
+		// Check if any of the query params are in the `$always_negotiate` array.
+		if ( \array_intersect( \array_keys( $query ), $always_negotiate ) ) {
 			$return = true;
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -294,8 +294,8 @@ function is_activitypub_request() {
  *
  * @return bool True if content negotiation is allowed, false otherwise.
  */
-function negotiate_content() {
-	return Query::get_instance()->negotiate_content();
+function should_negotiate_content() {
+	return Query::get_instance()->should_negotiate_content();
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -290,6 +290,15 @@ function is_activitypub_request() {
 }
 
 /**
+ * Check if content negotiation is allowed for a request.
+ *
+ * @return bool True if content negotiation is allowed, false otherwise.
+ */
+function negotiate_content() {
+	return Query::get_instance()->negotiate_content();
+}
+
+/**
  * Check if a post is disabled for ActivityPub.
  *
  * This function checks if the post type supports ActivityPub and if the post is set to be local.

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -152,7 +152,7 @@ class Advanced_Settings_Fields {
 			</label>
 		</p>
 		<p class="description">
-			<?php \esc_html_e( 'Disable this if your site starts displaying raw technical data instead of normal pages, or if ActivityPub connections become unstable. This setting helps ensure your site serves the correct content format to browsers.', 'activitypub' ); ?>
+			<?php \esc_html_e( 'Content negotiation ensures your site displays regular web pages to browsers and machine-readable data to Fediverse services. Disable this if your site shows raw technical data to visitors or if ActivityPub connections have issues.', 'activitypub' ); ?>
 		</p>
 		<?php
 	}

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -50,6 +50,15 @@ class Advanced_Settings_Fields {
 			);
 		}
 
+		\add_settings_field(
+			'activitypub_content_negotiation',
+			\__( 'Content Negotiation', 'activitypub' ),
+			array( self::class, 'render_content_negotiation_field' ),
+			'activitypub_advanced_settings',
+			'activitypub_advanced_settings',
+			array( 'label_for' => 'activitypub_content_negotiation' )
+		);
+
 		if ( ! defined( 'ACTIVITYPUB_AUTHORIZED_FETCH' ) ) {
 			\add_settings_field(
 				'activitypub_authorized_fetch',
@@ -126,6 +135,24 @@ class Advanced_Settings_Fields {
 		</p>
 		<p class="description">
 			<?php \esc_html_e( 'Enable this if you notice your site showing technical content instead of normal web pages, or if your ActivityPub connections seem unreliable. This setting helps your site deliver the right format of content to different services automatically.', 'activitypub' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render content negotiation field.
+	 */
+	public static function render_content_negotiation_field() {
+		$value = \get_option( 'activitypub_content_negotiation', '1' );
+		?>
+		<p>
+			<label>
+				<input type="checkbox" id="activitypub_content_negotiation" name="activitypub_content_negotiation" value="1" <?php checked( '1', $value ); ?> />
+				<?php \esc_html_e( 'Differentiates how content is shown to browsers versus Fediverse services.', 'activitypub' ); ?>
+			</label>
+		</p>
+		<p class="description">
+			<?php \esc_html_e( 'Disable this if your site starts displaying raw technical data instead of normal pages, or if ActivityPub connections become unstable. This setting helps ensure your site serves the correct content format to browsers.', 'activitypub' ); ?>
 		</p>
 		<?php
 	}

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -148,7 +148,7 @@ class Advanced_Settings_Fields {
 		<p>
 			<label>
 				<input type="checkbox" id="activitypub_content_negotiation" name="activitypub_content_negotiation" value="1" <?php checked( '1', $value ); ?> />
-				<?php \esc_html_e( 'Differentiates how content is shown to browsers versus Fediverse services.', 'activitypub' ); ?>
+				<?php \esc_html_e( 'Enable content negotiation for browsers and Fediverse services.', 'activitypub' ); ?>
 			</label>
 		</p>
 		<p class="description">

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -196,7 +196,7 @@ class Settings {
 			'activitypub_content_negotiation',
 			array(
 				'type'        => 'boolean',
-				'description' => \__( 'Enable content negotiation.', 'activitypub' ),
+				'description' => 'Enable content negotiation.',
 				'default'     => true,
 			)
 		);

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -190,6 +190,16 @@ class Settings {
 
 		\register_setting(
 			'activitypub_advanced',
+			'activitypub_content_negotiation',
+			array(
+				'type'        => 'boolean',
+				'description' => \__( 'Enable content negotiation.', 'activitypub' ),
+				'default'     => true,
+			)
+		);
+
+		\register_setting(
+			'activitypub_advanced',
 			'activitypub_authorized_fetch',
 			array(
 				'type'        => 'boolean',

--- a/tests/includes/class-test-query.php
+++ b/tests/includes/class-test-query.php
@@ -369,30 +369,30 @@ class Test_Query extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test negotiate_content method.
+	 * Test should_negotiate_content method.
 	 *
-	 * @covers ::negotiate_content
+	 * @covers ::should_negotiate_content
 	 */
-	public function test_negotiate_content() {
+	public function test_should_negotiate_content() {
 		\add_option( 'permalink_structure', '/%postname%/' );
 
-		$this->assertTrue( Query::get_instance()->negotiate_content() );
+		$this->assertTrue( Query::get_instance()->should_negotiate_content() );
 
 		\update_option( 'activitypub_content_negotiation', '0' );
 		$_SERVER['REQUEST_URI'] = get_permalink( self::$post_id );
-		$this->assertFalse( Query::get_instance()->negotiate_content() );
+		$this->assertFalse( Query::get_instance()->should_negotiate_content() );
 
 		\update_option( 'activitypub_content_negotiation', '1' );
 
 		$_SERVER['REQUEST_URI'] = home_url( '/?p=' . self::$post_id );
-		$this->assertTrue( Query::get_instance()->negotiate_content() );
+		$this->assertTrue( Query::get_instance()->should_negotiate_content() );
 
 		unset( $_SERVER['REQUEST_URI'] );
 
 		\update_option( 'activitypub_content_negotiation', '0' );
 
 		$_SERVER['REQUEST_URI'] = home_url( '/?author=' . self::$user_id );
-		$this->assertTrue( Query::get_instance()->negotiate_content() );
+		$this->assertTrue( Query::get_instance()->should_negotiate_content() );
 
 		unset( $_SERVER['REQUEST_URI'] );
 

--- a/tests/includes/class-test-query.php
+++ b/tests/includes/class-test-query.php
@@ -374,9 +374,12 @@ class Test_Query extends \WP_UnitTestCase {
 	 * @covers ::negotiate_content
 	 */
 	public function test_negotiate_content() {
+		\add_option( 'permalink_structure', '/%postname%/' );
+
 		$this->assertTrue( Query::get_instance()->negotiate_content() );
 
 		\update_option( 'activitypub_content_negotiation', '0' );
+		$_SERVER['REQUEST_URI'] = get_permalink( self::$post_id );
 		$this->assertFalse( Query::get_instance()->negotiate_content() );
 
 		\update_option( 'activitypub_content_negotiation', '1' );
@@ -394,5 +397,6 @@ class Test_Query extends \WP_UnitTestCase {
 		unset( $_SERVER['REQUEST_URI'] );
 
 		\delete_option( 'activitypub_content_negotiation' );
+		\delete_option( 'permalink_structure' );
 	}
 }

--- a/tests/includes/class-test-query.php
+++ b/tests/includes/class-test-query.php
@@ -367,4 +367,32 @@ class Test_Query extends \WP_UnitTestCase {
 
 		\wp_delete_post( $post_id, true );
 	}
+
+	/**
+	 * Test negotiate_content method.
+	 *
+	 * @covers ::negotiate_content
+	 */
+	public function test_negotiate_content() {
+		$this->assertTrue( Query::get_instance()->negotiate_content() );
+
+		\update_option( 'activitypub_content_negotiation', '0' );
+		$this->assertFalse( Query::get_instance()->negotiate_content() );
+
+		\update_option( 'activitypub_content_negotiation', '1' );
+
+		$_SERVER['REQUEST_URI'] = home_url( '/?p=' . self::$post_id );
+		$this->assertTrue( Query::get_instance()->negotiate_content() );
+
+		unset( $_SERVER['REQUEST_URI'] );
+
+		\update_option( 'activitypub_content_negotiation', '0' );
+
+		$_SERVER['REQUEST_URI'] = home_url( '/?author=' . self::$user_id );
+		$this->assertTrue( Query::get_instance()->negotiate_content() );
+
+		unset( $_SERVER['REQUEST_URI'] );
+
+		\delete_option( 'activitypub_content_negotiation' );
+	}
 }


### PR DESCRIPTION
This PR allows users to enable or disable content negotiation for user facing permalinks. It should help with current caching issues.

I am not yet sure what the default setting should be. I would keep the current default and run some tests when released.

<!--- Provide a general summary of your changes in the Title above -->

Fixes nearly all caching issues.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Setting to enable/disable content negotiation for user facing sites.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable Content-Negotiation
* Call a posts permalink with the `application/json+activitypub` Accept header
* Site should render HTML
* Call a post with `?p=<post_id>` and `application/json+activitypub` Accept header
* Site should still render JSON

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add setting to enable or disable how content is tailored for browsers and Fediverse services.

</details>
