### PR TITLE
Change default settings based on caching behaviour

### DIFF
--- a/.github/changelog/1640-from-description
+++ b/.github/changelog/1640-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adjusted the plugin's default behavior based on the caching plugins installed.

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -25,6 +25,9 @@ class Options {
 
 		\add_filter( 'pre_option_activitypub_allow_likes', array( self::class, 'maybe_disable_interactions' ) );
 		\add_filter( 'pre_option_activitypub_allow_replies', array( self::class, 'maybe_disable_interactions' ) );
+
+		\add_filter( 'default_option_activitypub_vary_header', array( self::class, 'default_option_activitypub_vary_header' ) );
+		\add_filter( 'default_option_activitypub_negotiate_content', array( self::class, 'default_option_activitypub_negotiate_content' ) );
 	}
 
 
@@ -112,6 +115,7 @@ class Options {
 	 * Disallow interactions if the constant is set.
 	 *
 	 * @param bool $pre_option The value of the option.
+	 *
 	 * @return bool|string The value of the option.
 	 */
 	public static function maybe_disable_interactions( $pre_option ) {
@@ -120,5 +124,56 @@ class Options {
 		}
 
 		return $pre_option;
+	}
+
+	/**
+	 * Default option filter for the Vary Header.
+	 *
+	 * @see https://github.com/Automattic/wordpress-activitypub/wiki/Caching
+	 *
+	 * @param string $default The default value of the option.
+	 *
+	 * @return string The default value of the option.
+	 */
+	public static function default_option_activitypub_vary_header( $default ) {
+		$enable_for_plugins = array(
+			// @see https://wordpress.org/support/topic/avoiding-caching-activitypub-content/
+			'litespeed-cache/litespeed-cache.php',
+		);
+
+		foreach ( $enable_for_plugins as $plugin ) {
+			if ( \is_plugin_active( $plugin ) ) {
+				return '1';
+			}
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Default option filter for the Content-Negotiation.
+	 *
+	 * @see https://github.com/Automattic/wordpress-activitypub/wiki/Caching
+	 *
+	 * @param string $default The default value of the option.
+	 *
+	 * @return string The default value of the option.
+	 */
+	public static function default_option_activitypub_negotiate_content( $default ) {
+		$disable_for_plugins = array(
+			'wp-optimize/wp-optimize.php',
+			'wp-rocket/wp-rocket.php',
+			'w3-total-cache/w3-total-cache.php',
+			'wp-fastest-cache/wp-fastest-cache.php',
+			'sg-cachepress/sg-cachepress.php',
+		);
+
+		foreach ( $disable_for_plugins as $plugin ) {
+			if ( \is_plugin_active( $plugin ) ) {
+				return '0';
+			}
+		}
+
+		return $default;
 	}
 }

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -26,7 +26,6 @@ class Options {
 		\add_filter( 'pre_option_activitypub_allow_likes', array( self::class, 'maybe_disable_interactions' ) );
 		\add_filter( 'pre_option_activitypub_allow_replies', array( self::class, 'maybe_disable_interactions' ) );
 
-		\add_filter( 'default_option_activitypub_vary_header', array( self::class, 'default_option_activitypub_vary_header' ) );
 		\add_filter( 'default_option_activitypub_negotiate_content', array( self::class, 'default_option_activitypub_negotiate_content' ) );
 	}
 
@@ -124,30 +123,6 @@ class Options {
 		}
 
 		return $pre_option;
-	}
-
-	/**
-	 * Default option filter for the Vary Header.
-	 *
-	 * @see https://github.com/Automattic/wordpress-activitypub/wiki/Caching
-	 *
-	 * @param string $default_value The default value of the option.
-	 *
-	 * @return string The default value of the option.
-	 */
-	public static function default_option_activitypub_vary_header( $default_value ) {
-		$enable_for_plugins = array(
-			// @see https://wordpress.org/support/topic/avoiding-caching-activitypub-content/
-			'litespeed-cache/litespeed-cache.php',
-		);
-
-		foreach ( $enable_for_plugins as $plugin ) {
-			if ( \is_plugin_active( $plugin ) ) {
-				return '1';
-			}
-		}
-
-		return $default_value;
 	}
 
 	/**

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -115,7 +115,7 @@ class Options {
 	 * Disallow interactions if the constant is set.
 	 *
 	 * @param bool $pre The value of the option.
-   *
+	 *
 	 * @return bool|string The value of the option.
 	 */
 	public static function maybe_disable_interactions( $pre ) {

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -131,11 +131,11 @@ class Options {
 	 *
 	 * @see https://github.com/Automattic/wordpress-activitypub/wiki/Caching
 	 *
-	 * @param string $default The default value of the option.
+	 * @param string $default_value The default value of the option.
 	 *
 	 * @return string The default value of the option.
 	 */
-	public static function default_option_activitypub_vary_header( $default ) {
+	public static function default_option_activitypub_vary_header( $default_value ) {
 		$enable_for_plugins = array(
 			// @see https://wordpress.org/support/topic/avoiding-caching-activitypub-content/
 			'litespeed-cache/litespeed-cache.php',
@@ -147,7 +147,7 @@ class Options {
 			}
 		}
 
-		return $default;
+		return $default_value;
 	}
 
 	/**
@@ -155,11 +155,11 @@ class Options {
 	 *
 	 * @see https://github.com/Automattic/wordpress-activitypub/wiki/Caching
 	 *
-	 * @param string $default The default value of the option.
+	 * @param string $default_value The default value of the option.
 	 *
 	 * @return string The default value of the option.
 	 */
-	public static function default_option_activitypub_negotiate_content( $default ) {
+	public static function default_option_activitypub_negotiate_content( $default_value ) {
 		$disable_for_plugins = array(
 			'wp-optimize/wp-optimize.php',
 			'wp-rocket/wp-rocket.php',
@@ -174,6 +174,6 @@ class Options {
 			}
 		}
 
-		return $default;
+		return $default_value;
 	}
 }


### PR DESCRIPTION
Change the default behaviour of the plugin based on the caching plugins that are installed.

This PR is an extension to #1639 and #1638

<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Have a list of plugins where the content negotiation is off by default:

* 'wp-optimize/wp-optimize.php',
* 'wp-rocket/wp-rocket.php',
* 'w3-total-cache/w3-total-cache.php',
* 'wp-fastest-cache/wp-fastest-cache.php',
* 'sg-cachepress/sg-cachepress.php',

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Adjusted the plugin's default behavior based on the caching plugins installed.

</details>
