### PR TITLE
Embed: Check it's an activity object before using it

### DIFF
--- a/.github/changelog/1642-from-description
+++ b/.github/changelog/1642-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a check to make sure we only attempt to embed activity objects, when processing fallback embeds.

--- a/includes/class-embed.php
+++ b/includes/class-embed.php
@@ -32,7 +32,8 @@ class Embed {
 	public static function get_html( $url, $inline_css = true ) {
 		// Try to get ActivityPub representation.
 		$object = Http::get_remote_object( $url );
-		if ( is_wp_error( $object ) ) {
+
+		if ( is_wp_error( $object ) || ! is_activity_object( $object ) ) {
 			return false;
 		}
 

--- a/includes/class-embed.php
+++ b/includes/class-embed.php
@@ -33,7 +33,7 @@ class Embed {
 		// Try to get ActivityPub representation.
 		$object = Http::get_remote_object( $url );
 
-		if ( is_wp_error( $object ) || ! is_activity_object( $object ) ) {
+		if ( \is_wp_error( $object ) || ! is_activity_object( $object ) ) {
 			return false;
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1547,19 +1547,27 @@ function is_activity( $data ) {
 	 */
 	$types = apply_filters( 'activitypub_activity_types', Activity::TYPES );
 
-	if ( is_string( $data ) ) {
-		return in_array( $data, $types, true );
-	}
+	return _is_type_of( $data, $types );
+}
 
-	if ( is_array( $data ) && isset( $data['type'] ) ) {
-		return in_array( $data['type'], $types, true );
-	}
+/**
+ * Check if an `$data` is an Activity Object.
+ *
+ * @see https://www.w3.org/TR/activitystreams-vocabulary/#object-types
+ *
+ * @param array|object|string $data The data to check.
+ *
+ * @return boolean True if the `$data` is an Activity Object, false otherwise.
+ */
+function is_activity_object( $data ) {
+	/**
+	 * Filters the activity object types.
+	 *
+	 * @param array $types The activity object types.
+	 */
+	$types = apply_filters( 'activitypub_activity_object_types', Base_Object::TYPES );
 
-	if ( is_object( $data ) && $data instanceof Base_Object ) {
-		return in_array( $data->get_type(), $types, true );
-	}
-
-	return false;
+	return _is_type_of( $data, $types );
 }
 
 /**
@@ -1579,6 +1587,17 @@ function is_actor( $data ) {
 	 */
 	$types = apply_filters( 'activitypub_actor_types', Actor::TYPES );
 
+	return _is_type_of( $data, $types );
+}
+
+/**
+ * Private helper to check if $data is of a given type set.
+ *
+ * @param array|object|string $data  The data to check.
+ * @param array               $types The types to check against.
+ * @return boolean True if $data is of one of the types, false otherwise.
+ */
+function _is_type_of( $data, $types ) {
 	if ( is_string( $data ) ) {
 		return in_array( $data, $types, true );
 	}
@@ -1587,7 +1606,7 @@ function is_actor( $data ) {
 		return in_array( $data['type'], $types, true );
 	}
 
-	if ( is_object( $data ) && $data instanceof Base_Object ) {
+	if ( $data instanceof Base_Object ) {
 		return in_array( $data->get_type(), $types, true );
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1565,7 +1565,7 @@ function is_activity_object( $data ) {
 	 *
 	 * @param array $types The activity object types.
 	 */
-	$types = apply_filters( 'activitypub_activity_object_types', Base_Object::TYPES );
+	$types = \apply_filters( 'activitypub_activity_object_types', Base_Object::TYPES );
 
 	return _is_type_of( $data, $types );
 }
@@ -1595,6 +1595,7 @@ function is_actor( $data ) {
  *
  * @param array|object|string $data  The data to check.
  * @param array               $types The types to check against.
+ *
  * @return boolean True if $data is of one of the types, false otherwise.
  */
 function _is_type_of( $data, $types ) {

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -278,6 +278,53 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
+	 * Test is_activity_object with array input.
+	 *
+	 * @covers \Activitypub\is_activity_object
+	 *
+	 * @dataProvider is_activity_object_data
+	 *
+	 * @param mixed $activity The activity object.
+	 * @param bool  $expected The expected result.
+	 */
+	public function test_is_activity_object( $activity, $expected ) {
+		$this->assertEquals( $expected, \Activitypub\is_activity_object( $activity ) );
+	}
+
+	/**
+	 * Data provider for test_is_activity_object.
+	 *
+	 * @return array[][]
+	 */
+	public function is_activity_object_data() {
+		// Test Activity object.
+		$create = new \Activitypub\Activity\Activity();
+		$create->set_type( 'Create' );
+
+		// Test Base_Object.
+		$note = new \Activitypub\Activity\Base_Object();
+		$note->set_type( 'Note' );
+
+		return array(
+			array( array( 'type' => 'Article' ), true ),
+			array( array( 'type' => 'Image' ), true ),
+			array( array( 'type' => 'Video' ), true ),
+			array( array( 'type' => 'Audio' ), true ),
+			array( array( 'type' => '' ), false ),
+			array( array( 'type' => null ), false ),
+			array( array(), false ),
+			array( $create, false ),
+			array( $note, true ),
+			array( 'string', false ),
+			array( 123, false ),
+			array( true, false ),
+			array( false, false ),
+			array( null, false ),
+			array( new \stdClass(), false ),
+		);
+	}
+
+	/**
 	 * Test is_activity with invalid input.
 	 *
 	 * @covers \Activitypub\is_activity


### PR DESCRIPTION
Fixes #1641.

I have not been able to reproduce the notice described in #1641. Adding a check to make sure we're dealing with an activity object before using it, should account for that scenario, though.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks whether the object returned is an activity object.
* Introduces `is_activity_object()`.
* Adds unit tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added a check to make sure we only attempt to embed activity objects, when processing fallback embeds.

</details>
