### PR TITLE
Only show "Reply to the post" when using block-editor

### DIFF
--- a/.github/changelog/1643-from-description
+++ b/.github/changelog/1643-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hide interaction buttons in emails when the Classic Editor is used.

--- a/templates/emails/new-mention.php
+++ b/templates/emails/new-mention.php
@@ -62,7 +62,7 @@ require __DIR__ . '/parts/header.php';
  *
  * @param array $args The template arguments.
  */
-\do_action( 'activitypub_new_mention_email', $args );
+do_action( 'activitypub_new_mention_email', $args );
 
 // Load footer.
 require __DIR__ . '/parts/footer.php';

--- a/templates/emails/new-mention.php
+++ b/templates/emails/new-mention.php
@@ -11,7 +11,7 @@ use Activitypub\Embed;
 use function Activitypub\site_supports_blocks;
 
 /* @var array $args Template arguments. */
-$args = \wp_parse_args( $args ?? array() );
+$args = wp_parse_args( $args ?? array() );
 
 // Load header.
 require __DIR__ . '/parts/header.php';
@@ -20,9 +20,9 @@ require __DIR__ . '/parts/header.php';
 <h1>
 	<?php
 	if ( Actors::BLOG_USER_ID === $args['user_id'] ) :
-		\esc_html_e( 'Your blog was mentioned!', 'activitypub' );
+		esc_html_e( 'Your blog was mentioned!', 'activitypub' );
 	else :
-		\esc_html_e( 'You were mentioned!', 'activitypub' );
+		esc_html_e( 'You were mentioned!', 'activitypub' );
 	endif;
 	?>
 </h1>
@@ -31,13 +31,13 @@ require __DIR__ . '/parts/header.php';
 	<?php
 	if ( Actors::BLOG_USER_ID === $args['user_id'] ) :
 		/* translators: %s: The name of the person who mentioned the blog. */
-		$message = \__( 'Looks like someone&#8217;s talking about your blog! It was just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
+		$message = __( 'Looks like someone&#8217;s talking about your blog! It was just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
 	else :
 		/* translators: %s: The name of the person who mentioned the user. */
-		$message = \__( 'Looks like someone&#8217;s talking about you! You were just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
+		$message = __( 'Looks like someone&#8217;s talking about you! You were just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
 	endif;
 
-	\printf( \esc_html( $message ), '<a href="' . \esc_url( $args['actor']['url'] ) . '">' . \esc_html( $args['actor']['webfinger'] ) . '</a>' );
+	printf( qesc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
 	?>
 </p>
 
@@ -48,10 +48,10 @@ require __DIR__ . '/parts/header.php';
 	?>
 </div>
 
-<?php if ( site_supports_blocks() && ! \is_plugin_active( 'classic-editor/classic-editor.php' ) ) : ?>
+<?php if ( site_supports_blocks() && ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) : ?>
 <p>
-	<a class="button" href="<?php echo \esc_url( \admin_url( 'post-new.php?in_reply_to=' . $args['activity']['object']['id'] ) ); ?>">
-		<?php \esc_html_e( 'Reply to the post', 'activitypub' ); ?>
+	<a class="button" href="<?php echo esc_url( admin_url( 'post-new.php?in_reply_to=' . $args['activity']['object']['id'] ) ); ?>">
+		<?php esc_html_e( 'Reply to the post', 'activitypub' ); ?>
 	</a>
 </p>
 <?php endif; ?>

--- a/templates/emails/new-mention.php
+++ b/templates/emails/new-mention.php
@@ -37,7 +37,7 @@ require __DIR__ . '/parts/header.php';
 		$message = __( 'Looks like someone&#8217;s talking about you! You were just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
 	endif;
 
-	printf( qesc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
+	printf( esc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
 	?>
 </p>
 

--- a/templates/emails/new-mention.php
+++ b/templates/emails/new-mention.php
@@ -8,8 +8,10 @@
 use Activitypub\Collection\Actors;
 use Activitypub\Embed;
 
+use function Activitypub\site_supports_blocks;
+
 /* @var array $args Template arguments. */
-$args = wp_parse_args( $args ?? array() );
+$args = \wp_parse_args( $args ?? array() );
 
 // Load header.
 require __DIR__ . '/parts/header.php';
@@ -18,9 +20,9 @@ require __DIR__ . '/parts/header.php';
 <h1>
 	<?php
 	if ( Actors::BLOG_USER_ID === $args['user_id'] ) :
-		esc_html_e( 'Your blog was mentioned!', 'activitypub' );
+		\esc_html_e( 'Your blog was mentioned!', 'activitypub' );
 	else :
-		esc_html_e( 'You were mentioned!', 'activitypub' );
+		\esc_html_e( 'You were mentioned!', 'activitypub' );
 	endif;
 	?>
 </h1>
@@ -29,13 +31,13 @@ require __DIR__ . '/parts/header.php';
 	<?php
 	if ( Actors::BLOG_USER_ID === $args['user_id'] ) :
 		/* translators: %s: The name of the person who mentioned the blog. */
-		$message = __( 'Looks like someone&#8217;s talking about your blog! It was just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
+		$message = \__( 'Looks like someone&#8217;s talking about your blog! It was just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
 	else :
 		/* translators: %s: The name of the person who mentioned the user. */
-		$message = __( 'Looks like someone&#8217;s talking about you! You were just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
+		$message = \__( 'Looks like someone&#8217;s talking about you! You were just mentioned by %s in a post on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
 	endif;
 
-	printf( esc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
+	\printf( \esc_html( $message ), '<a href="' . \esc_url( $args['actor']['url'] ) . '">' . \esc_html( $args['actor']['webfinger'] ) . '</a>' );
 	?>
 </p>
 
@@ -46,11 +48,13 @@ require __DIR__ . '/parts/header.php';
 	?>
 </div>
 
+<?php if ( site_supports_blocks() && ! \is_plugin_active( 'classic-editor/classic-editor.php' ) ) : ?>
 <p>
-	<a class="button" href="<?php echo esc_url( admin_url( 'post-new.php?in_reply_to=' . $args['activity']['object']['id'] ) ); ?>">
-		<?php esc_html_e( 'Reply to the post', 'activitypub' ); ?>
+	<a class="button" href="<?php echo \esc_url( \admin_url( 'post-new.php?in_reply_to=' . $args['activity']['object']['id'] ) ); ?>">
+		<?php \esc_html_e( 'Reply to the post', 'activitypub' ); ?>
 	</a>
 </p>
+<?php endif; ?>
 
 <?php
 /**
@@ -58,7 +62,7 @@ require __DIR__ . '/parts/header.php';
  *
  * @param array $args The template arguments.
  */
-do_action( 'activitypub_new_mention_email', $args );
+\do_action( 'activitypub_new_mention_email', $args );
 
 // Load footer.
 require __DIR__ . '/parts/footer.php';


### PR DESCRIPTION
When user is not using the block editor the link would not work.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Hide interaction buttons in emails when the Classic Editor is used.

</details>
