### PR TITLE
Changelogger: Don't run on branches of branches

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # Enforces the addition of a changelog entry (a file in the .github/changelog directory) every pull request.
   changelog:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'trunk'
     runs-on: ubuntu-latest
     steps:
       - name: "Check for Skip Changelog label"


### PR DESCRIPTION
When contributing to other PRs, the resulting child-PRs should not be required to have changelogs. The "Parent" PR will be the one that should take care of it.