### PR TITLE
Extra Fields: Don't send more than 20

### DIFF
--- a/.github/changelog/1660-from-description
+++ b/.github/changelog/1660-from-description
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Author profiles will cap the amount of extra fields they return to 100, to avoid response size errors in clients.
+Author profiles will cap the amount of extra fields they return to 20, to avoid response size errors in clients.

--- a/.github/changelog/1660-from-description
+++ b/.github/changelog/1660-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Author profiles will cap the amount of extra fields they return to 100, to avoid response size errors in clients.

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -39,7 +39,7 @@ class Extra_Fields {
 			$args['author'] = $user_id;
 		}
 
-		// Limit to 100 fields to prevent response size issues.
+		// Limit to 20 fields to prevent response size issues.
 		if ( ! is_admin() ) {
 			/**
 			 * Filters the number of extra fields to retrieve for an ActivityPub actor.

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -39,6 +39,12 @@ class Extra_Fields {
 			$args['author'] = $user_id;
 		}
 
+		// Limit to 100 fields to prevent response size issues.
+		if ( ! is_admin() ) {
+			$args['nopaging']       = false;
+			$args['posts_per_page'] = 100;
+		}
+
 		$query  = new \WP_Query( $args );
 		$fields = $query->posts ?? array();
 

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -41,8 +41,13 @@ class Extra_Fields {
 
 		// Limit to 100 fields to prevent response size issues.
 		if ( ! is_admin() ) {
+			/**
+			 * Filters the number of extra fields to retrieve for an ActivityPub actor.
+			 *
+			 * @param int $limit The number of extra fields to retrieve. Default 20.
+			 */
+			$args['posts_per_page'] = apply_filters( 'activitypub_actor_extra_fields_limit', 20 );
 			$args['nopaging']       = false;
-			$args['posts_per_page'] = 100;
 		}
 
 		$query  = new \WP_Query( $args );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Limits the amount of extra fields that get returned to 100, when outside of wp-admin to prevent response size errors in clients.

See https://mastodon.social/@manualdousuario/114461466878024369

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Limits the amount of extra fields that get returned to 100, when outside of wp-admin.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have more than one Extra Field in `/wp-admin/edit.php?post_type=ap_extrafield`.
* Manually change the limit of extra fields in this PR to 1.
* Call your author profile link and make sure it only shows one extra field, equalling two attachments.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Author profiles will cap the amount of extra fields they return to 100, to avoid response size errors in clients.

</details>
