### PR TITLE
Properly check if blog user is enabled before showing AP profile

### DIFF
--- a/.github/changelog/1661-from-description
+++ b/.github/changelog/1661-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-ActivityPub profiles are now hidden for disabled users to avoid confusion—profiles can no longer be found or followed if the user is not active.
+The blog profile can no longer be queried when the blog actor option is disabled.

--- a/.github/changelog/1661-from-description
+++ b/.github/changelog/1661-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+ActivityPub profiles are now hidden for disabled users to avoid confusion—profiles can no longer be found or followed if the user is not active.

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -88,11 +88,18 @@ class Actors {
 		}
 
 		// Check for blog user.
-		if ( Blog::get_default_username() === $username ) {
-			return new Blog();
-		}
+		if (
+			Blog::get_default_username() === $username ||
+			get_option( 'activitypub_blog_identifier' ) === $username
+		) {
+			if ( is_user_type_disabled( 'blog' ) ) {
+				return new WP_Error(
+					'activitypub_user_not_found',
+					\__( 'Actor not found', 'activitypub' ),
+					array( 'status' => 404 )
+				);
+			}
 
-		if ( get_option( 'activitypub_blog_identifier' ) === $username ) {
 			return new Blog();
 		}
 

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -90,7 +90,7 @@ class Actors {
 		// Check for blog user.
 		if (
 			Blog::get_default_username() === $username ||
-			get_option( 'activitypub_blog_identifier' ) === $username
+			\get_option( 'activitypub_blog_identifier' ) === $username
 		) {
 			if ( is_user_type_disabled( 'blog' ) ) {
 				return new WP_Error(

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -190,7 +190,14 @@ class Server {
 			return $response;
 		}
 
-		$data  = $response->get_data();
+		$data = $response->get_data();
+
+		// Ensure that `$data` was already converted to a response.
+		if ( \is_wp_error( $data ) ) {
+			$response = \rest_convert_error_to_response( $data );
+			$data     = $response->get_data();
+		}
+
 		$error = array(
 			'type'     => 'about:blank',
 			'title'    => $data['code'] ?? '',

--- a/tests/includes/collection/class-test-actors.php
+++ b/tests/includes/collection/class-test-actors.php
@@ -138,4 +138,21 @@ class Test_Actors extends \WP_UnitTestCase {
 		$this->assertSame( 'user', Actors::get_type_by_id( 1 ) );
 		$this->assertSame( 'user', Actors::get_type_by_id( 2 ) );
 	}
+
+	/**
+	 * Test if Actor mode will be respected properly
+	 *
+	 * @covers ::get_type_by_id
+	 */
+	public function test_disabled_blog_profile() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$resource = 'http://example.org/@blog';
+
+		$this->assertEquals( 'Activitypub\Model\Blog', get_class( Actors::get_by_resource( $resource ) ) );
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		$this->assertWPError( Actors::get_by_resource( $resource ) );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The `Actors::get_by_resource` does not properly check if the blog user is enabled or not. This returns the ActivityPub profile data even if the user is disabled and might be confusing and inconsistent, because others will be able to search for the profile, but not to follow it.

This PR adds a proper check and fixes that issue.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

ActivityPub profiles are now hidden for disabled users to avoid confusion—profiles can no longer be found or followed if the user is not active.

</details>
