### PR TITLE
Scripts: Make plugin scripts available in all tabs

### DIFF
--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -225,6 +225,11 @@ class Admin {
 				ACTIVITYPUB_PLUGIN_VERSION,
 				false
 			);
+
+			// Plugin cards in help tab.
+			\wp_enqueue_script( 'plugin-install' );
+			\add_thickbox();
+			\wp_enqueue_script( 'updates' );
 		}
 
 		if ( 'index.php' === $hook_suffix ) {

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -358,11 +358,6 @@ class Settings {
 				\wp_enqueue_media();
 				\wp_enqueue_script( 'activitypub-header-image' );
 				break;
-			case 'welcome':
-				\wp_enqueue_script( 'plugin-install' );
-				\add_thickbox();
-				\wp_enqueue_script( 'updates' );
-				break;
 		}
 
 		if ( ! isset( $settings_tabs[ $tab ] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow up to #1599.

With plugin cards now living in the Help tab, they can be accessed from all tabs, not just the Welcome tab anymore.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves plugin scripts to general script enqueue callback.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Activitypub.
* Click on Help tab and look for Recommended Plugins.
* Click on "More Details" and make sure it opens in a modal.
* Install the plugin.
* Navigate to a different settings tab and repeat.

