### PR TITLE
Checklist: Update help tab checks

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -107,8 +107,6 @@ function plugin_admin_init() {
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Blog_Settings_Fields', 'init' ) );
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\User_Settings_Fields', 'init' ) );
 
-	\add_action( 'wp_ajax_activitypub_help_tab_visited', array( __NAMESPACE__ . '\WP_Admin\Welcome_Fields', 'help_tab_visited' ) );
-
 	if ( defined( 'WP_LOAD_IMPORTERS' ) && WP_LOAD_IMPORTERS ) {
 		require_once __DIR__ . '/includes/wp-admin/import/load.php';
 		\add_action( 'admin_init', __NAMESPACE__ . '\WP_Admin\Import\load' );

--- a/assets/js/activitypub-admin.js
+++ b/assets/js/activitypub-admin.js
@@ -17,22 +17,4 @@ jQuery( function( $ ) {
 			$( '.activate-now' ).removeClass( 'thickbox open-plugin-details-modal' );
 		}, 1200 );
 	} );
-
-	$( '#activitypub-welcome-checklist' ).on( 'click', 'a[href*="#tab-link-"]', function( event ) {
-		const match  = $( this ).attr( 'href' ).match( /#tab-link-([\w-]+)/ );
-		if ( match && match[1] && typeof wp !== 'undefined' && wp.ajax && typeof wp.ajax.post === 'function' ) {
-			wp.ajax.post( 'activitypub_help_tab_visited', {
-				tab: match[1],
-				_wpnonce: $( event.delegateTarget ).data( 'nonce' )
-			} )
-			.done( () => {
-				// Find the closest onboarding step
-				const $step = $( this ).closest( '.activitypub-onboarding-step' );
-				if ( $step.length ) {
-					$step.addClass( 'activitypub-step-completed' );
-					$step.find( '.step-icon' ).removeClass( 'dashicons-video-alt3 dashicons-info' ).addClass( 'dashicons-yes' );
-				}
-			} );
-		}
-	} );
 } );

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -364,7 +364,13 @@ class Settings {
 				\wp_enqueue_script( 'updates' );
 				break;
 			case 'settings':
-				\update_option( 'activitypub_checklist_settings_visited', true );
+				if ( isset( $_GET['help-tab'] ) && 'getting-started' === $_GET['help-tab'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+					\update_option( 'activitypub_checklist_fediverse_intro_visited', true );
+				} elseif ( isset( $_GET['help-tab'] ) && 'editor-blocks' === $_GET['help-tab'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+					\update_option( 'activitypub_checklist_blocks_visited', true );
+				} else {
+					\update_option( 'activitypub_checklist_settings_visited', true );
+				}
 				break;
 		}
 

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -81,7 +81,7 @@ class Welcome_Fields {
 		$total_steps         = self::get_total_steps_count();
 		$progress_percentage = \min( 100, \round( ( $completed_steps / $total_steps ) * 100 ) );
 		?>
-		<div id="activitypub-welcome-checklist" class="activitypub-welcome-container" data-nonce="<?php echo \esc_attr( \wp_create_nonce( 'activitypub_help_tab_visited' ) ); ?>">
+		<div id="activitypub-welcome-checklist" class="activitypub-welcome-container">
 		<div class="activitypub-welcome-header">
 			<div class="activitypub-progress-circle">
 				<div class="activitypub-progress-circle-content">
@@ -218,7 +218,7 @@ class Welcome_Fields {
 					<p><?php \esc_html_e( 'Learn what the Fediverse is and why it matters.', 'activitypub' ); ?></p>
 				</div>
 				<div class="step-action">
-					<a href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub#tab-link-getting-started' ) ); ?>" class="button <?php echo \esc_attr( $button_class ); ?>">
+					<a href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&tab=settings&help-tab=getting-started#tab-link-getting-started' ) ); ?>" class="button <?php echo \esc_attr( $button_class ); ?>">
 						<?php \esc_html_e( 'Watch now', 'activitypub' ); ?>
 					</a>
 				</div>
@@ -363,7 +363,7 @@ class Welcome_Fields {
 					<p><?php \esc_html_e( 'Discover blocks, privacy, and more.', 'activitypub' ); ?></p>
 				</div>
 				<div class="step-action">
-					<a href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub#tab-link-editor-blocks' ) ); ?>" class="button <?php echo \esc_attr( $button_class ); ?>">
+					<a href="<?php echo \esc_url( \admin_url( 'options-general.php?page=activitypub&tab=settings&help-tab=editor-blocks#tab-link-editor-blocks' ) ); ?>" class="button <?php echo \esc_attr( $button_class ); ?>">
 						<?php \esc_html_e( 'Explore features', 'activitypub' ); ?>
 					</a>
 				</div>
@@ -384,23 +384,5 @@ class Welcome_Fields {
 			</a>
 		</div>
 		<?php
-	}
-
-	/**
-	 * Mark checklist item as visited.
-	 */
-	public static function help_tab_visited() {
-		\check_ajax_referer( 'activitypub_help_tab_visited' );
-
-		$tab     = \sanitize_key( $_POST['tab'] ?? '' );
-		$options = array(
-			'getting-started' => 'activitypub_checklist_fediverse_intro_visited',
-			'editor-blocks'   => 'activitypub_checklist_blocks_visited',
-		);
-		if ( isset( $options[ $tab ] ) ) {
-			\update_option( $options[ $tab ], '1' );
-		}
-
-		\wp_send_json_success();
 	}
 }


### PR DESCRIPTION
In this PR the help tab links link to the settings tab, resulting in a new pageload and avoiding the flash of an updated checklist that #1655 struggled with in its initial iteration. It removes a lot of the brittleness of having to update the checklist through a JS listener and should also help with determining when a checklist is done and the welcome page can be hidden.

Supersedes https://github.com/Automattic/wordpress-activitypub/pull/1664 if we decide to go this route.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `help-tab` query arg that's used to identify which option to update.
* Removes the JS listener to update help tab options.
