### PR TITLE
NodeInfo: Make sure usage data has correct format

### DIFF
--- a/.github/changelog/1667-from-description
+++ b/.github/changelog/1667-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+NodeInfo endpoint response now correctly formats `localPosts` values.

--- a/includes/rest/class-nodeinfo-controller.php
+++ b/includes/rest/class-nodeinfo-controller.php
@@ -159,7 +159,7 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 					'activeHalfyear' => get_active_users( 6 ),
 					'activeMonth'    => get_active_users(),
 				),
-				'localPosts'    => $posts->publish,
+				'localPosts'    => (int) $posts->publish,
 				'localComments' => $comments->approved,
 			),
 			'metadata'          => array(

--- a/tests/includes/rest/class-test-nodeinfo-controller.php
+++ b/tests/includes/rest/class-test-nodeinfo-controller.php
@@ -73,6 +73,9 @@ class Test_Nodeinfo_Controller extends \Activitypub\Tests\Test_REST_Controller_T
 	 * @covers ::get_version_2_0
 	 */
 	public function test_get_item() {
+		self::factory()->post->create();
+		self::factory()->comment->create();
+
 		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/nodeinfo/2.0' );
 		$response = \rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -85,8 +88,9 @@ class Test_Nodeinfo_Controller extends \Activitypub\Tests\Test_REST_Controller_T
 		$this->assertEquals( array( 'activitypub' ), $data['protocols'] );
 		$this->assertArrayHasKey( 'services', $data );
 		$this->assertEquals( (bool) \get_option( 'users_can_register' ), $data['openRegistrations'] );
-		$this->assertArrayHasKey( 'usage', $data );
-		$this->assertArrayHasKey( 'metadata', $data );
+		$this->assertIsInt( $data['usage']['localPosts'] );
+		$this->assertIsInt( $data['usage']['localComments'] );
+		$this->assertSame( \get_bloginfo( 'name' ), $data['metadata']['nodeName'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Nodeinfo 2.0 schema defines localPosts as integer. We currently serve strings.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update tests to better test for types.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

NodeInfo endpoint response now correctly formats `localPosts` values.

</details>
