### PR TITLE
Fix: Clear Errors when a Follower update is successfull

### DIFF
--- a/.github/changelog/1668-from-description
+++ b/.github/changelog/1668-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent accidental follower removal by resetting errors properly.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -133,6 +133,8 @@ class Scheduler {
 			} else {
 				$follower->from_array( $meta );
 				$follower->update();
+
+				$follower->clear_errors();
 			}
 		}
 	}

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -480,4 +480,15 @@ class Followers {
 			$error_message
 		);
 	}
+
+	/**
+	 * Clear the errors for a Follower.
+	 *
+	 * @param int $post_id The ID of the WordPress Custom-Post-Type.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public static function clear_errors( $post_id ) {
+		return delete_post_meta( $post_id, '_activitypub_errors' );
+	}
 }

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -489,6 +489,6 @@ class Followers {
 	 * @return bool True on success, false on failure.
 	 */
 	public static function clear_errors( $post_id ) {
-		return delete_post_meta( $post_id, '_activitypub_errors' );
+		return \delete_post_meta( $post_id, '_activitypub_errors' );
 	}
 }

--- a/includes/model/class-follower.php
+++ b/includes/model/class-follower.php
@@ -58,11 +58,7 @@ class Follower extends Actor {
 	 */
 	public function clear_errors() {
 		if ( ! $this->_id ) {
-			\_doing_it_wrong(
-				__METHOD__,
-				__( 'Follower ID is not set.', 'activitypub' ),
-				'unreleased'
-			);
+			\_doing_it_wrong( __METHOD__, 'Follower ID is not set.', 'unreleased' );
 
 			return false;
 		}

--- a/includes/model/class-follower.php
+++ b/includes/model/class-follower.php
@@ -52,6 +52,25 @@ class Follower extends Actor {
 	}
 
 	/**
+	 * Clear the errors for the current Follower.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public function clear_errors() {
+		if ( ! $this->_id ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				__( 'Follower ID is not set.', 'activitypub' ),
+				'unreleased'
+			);
+
+			return false;
+		}
+
+		return Followers::clear_errors( $this->_id );
+	}
+
+	/**
 	 * Get the Summary.
 	 *
 	 * @return string The Summary.

--- a/tests/includes/collection/class-test-followers.php
+++ b/tests/includes/collection/class-test-followers.php
@@ -713,4 +713,61 @@ class Test_Followers extends \WP_UnitTestCase {
 			array( 'https://example.com', 'https://example.com' ),
 		);
 	}
+
+	/**
+	 * Tests clear_errors.
+	 *
+	 * @covers ::clear_errors
+	 */
+	public function test_clear_errors() {
+		$follower = 'https://example.com/author/jon';
+		$result = Followers::add_follower( 1, $follower );
+		$this->assertNotWPError( $result );
+
+		// Add some errors
+		Followers::add_error( $result->get__id(), 'Test error 1' );
+		Followers::add_error( $result->get__id(), 'Test error 2' );
+
+		// Verify errors were added
+		$errors = get_post_meta( $result->get__id(), '_activitypub_errors', false );
+		$this->assertCount( 2, $errors );
+
+		// Clear errors
+		$cleared = Followers::clear_errors( $result->get__id() );
+		$this->assertTrue( $cleared );
+
+		// Verify errors were cleared
+		$errors = get_post_meta( $result->get__id(), '_activitypub_errors', false );
+		$this->assertEmpty( $errors );
+	}
+
+	/**
+	 * Tests clear_errors with no errors.
+	 *
+	 * @covers ::clear_errors
+	 */
+	public function test_clear_errors_no_errors() {
+		$follower = 'https://example.com/author/jon';
+		$result = Followers::add_follower( 1, $follower );
+		$this->assertNotWPError( $result );
+
+		// Clear errors when none exist
+		$cleared = Followers::clear_errors( $result->get__id() );
+		$this->assertFalse( $cleared );
+
+		// Verify no errors exist
+		$errors = get_post_meta( $result->get__id(), '_activitypub_errors', false );
+		$this->assertEmpty( $errors );
+	}
+
+	/**
+	 * Tests clear_errors with invalid follower ID.
+	 *
+	 * @covers ::clear_errors
+	 */
+	public function test_clear_errors_invalid_id() {
+		// Try to clear errors for non-existent follower
+		$cleared = Followers::clear_errors( 99999 );
+		$this->assertFalse( $cleared );
+	}
 }

--- a/tests/includes/collection/class-test-followers.php
+++ b/tests/includes/collection/class-test-followers.php
@@ -721,22 +721,22 @@ class Test_Followers extends \WP_UnitTestCase {
 	 */
 	public function test_clear_errors() {
 		$follower = 'https://example.com/author/jon';
-		$result = Followers::add_follower( 1, $follower );
+		$result   = Followers::add_follower( 1, $follower );
 		$this->assertNotWPError( $result );
 
-		// Add some errors
+		// Add some errors.
 		Followers::add_error( $result->get__id(), 'Test error 1' );
 		Followers::add_error( $result->get__id(), 'Test error 2' );
 
-		// Verify errors were added
+		// Verify errors were added.
 		$errors = get_post_meta( $result->get__id(), '_activitypub_errors', false );
 		$this->assertCount( 2, $errors );
 
-		// Clear errors
+		// Clear errors.
 		$cleared = Followers::clear_errors( $result->get__id() );
 		$this->assertTrue( $cleared );
 
-		// Verify errors were cleared
+		// Verify errors were cleared.
 		$errors = get_post_meta( $result->get__id(), '_activitypub_errors', false );
 		$this->assertEmpty( $errors );
 	}
@@ -748,14 +748,14 @@ class Test_Followers extends \WP_UnitTestCase {
 	 */
 	public function test_clear_errors_no_errors() {
 		$follower = 'https://example.com/author/jon';
-		$result = Followers::add_follower( 1, $follower );
+		$result   = Followers::add_follower( 1, $follower );
 		$this->assertNotWPError( $result );
 
-		// Clear errors when none exist
+		// Clear errors when none exist.
 		$cleared = Followers::clear_errors( $result->get__id() );
 		$this->assertFalse( $cleared );
 
-		// Verify no errors exist
+		// Verify no errors exist.
 		$errors = get_post_meta( $result->get__id(), '_activitypub_errors', false );
 		$this->assertEmpty( $errors );
 	}
@@ -766,7 +766,7 @@ class Test_Followers extends \WP_UnitTestCase {
 	 * @covers ::clear_errors
 	 */
 	public function test_clear_errors_invalid_id() {
-		// Try to clear errors for non-existent follower
+		// Try to clear errors for non-existent follower.
 		$cleared = Followers::clear_errors( 99999 );
 		$this->assertFalse( $cleared );
 	}

--- a/tests/includes/model/class-test-follower.php
+++ b/tests/includes/model/class-test-follower.php
@@ -24,7 +24,6 @@ class Test_Follower extends \WP_UnitTestCase {
 	public function test_clear_errors() {
 		// Mock request
 
-
 		$follower = new Follower();
 		$follower->from_array(
 			array(

--- a/tests/includes/model/class-test-follower.php
+++ b/tests/includes/model/class-test-follower.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Test file for Activitypub Follower.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Model;
+
+use Activitypub\Model\Follower;
+use Activitypub\Collection\Followers;
+
+/**
+ * Tests the Follower class.
+ *
+ * @package Activitypub
+ */
+class Test_Follower extends \WP_UnitTestCase {
+	/**
+	 * Tests clear_errors.
+	 *
+	 * @covers ::clear_errors
+	 */
+	public function test_clear_errors() {
+		// Mock request
+
+
+		$follower = new Follower();
+		$follower->from_array(
+			array(
+				'id'                => 'https://example.com/author/jon',
+				'type'              => 'Person',
+				'name'              => 'Jon Doe',
+				'preferredUsername' => 'jon',
+				'inbox'             => 'https://example.com/author/jon/inbox',
+				'publicKey'         => 'publicKey',
+				'publicKeyPem'      => 'publicKeyPem',
+			)
+		);
+
+		$id = $follower->upsert();
+		$this->assertNotWPError( $id );
+
+		// Add some errors
+		Followers::add_error( $follower->get__id(), 'Test error 1' );
+		Followers::add_error( $follower->get__id(), 'Test error 2' );
+
+		// Verify errors were added
+		$errors = $follower->get_errors();
+		$this->assertCount( 2, $errors );
+
+		// Clear errors
+		$cleared = $follower->clear_errors();
+		$this->assertTrue( $cleared );
+
+		// Verify errors were cleared
+		$errors = $follower->get_errors();
+		$this->assertEmpty( $errors );
+	}
+
+	/**
+	 * Tests clear_errors with no errors.
+	 *
+	 * @covers ::clear_errors
+	 */
+	public function test_clear_errors_no_errors() {
+		$follower = new Follower();
+		$follower->from_array(
+			array(
+				'id'                => 'https://example.com/author/jon',
+				'type'              => 'Person',
+				'name'              => 'Jon Doe',
+				'preferredUsername' => 'jon',
+				'inbox'             => 'https://example.com/author/jon/inbox',
+				'publicKey'         => 'publicKey',
+				'publicKeyPem'      => 'publicKeyPem',
+			)
+		);
+		$id = $follower->upsert();
+		$this->assertNotWPError( $id );
+
+		// Clear errors when none exist
+		$cleared = $follower->clear_errors();
+		$this->assertFalse( $cleared );
+
+		// Verify no errors exist
+		$errors = $follower->get_errors();
+		$this->assertEmpty( $errors );
+	}
+
+	/**
+	 * Tests clear_errors triggers _doing_it_wrong when ID is not set.
+	 *
+	 * @covers ::clear_errors
+	 */
+	public function test_clear_errors_doing_it_wrong() {
+		$this->setExpectedIncorrectUsage( 'Activitypub\Model\Follower::clear_errors' );
+
+		$follower = new Follower();
+		$follower->clear_errors();
+	}
+}

--- a/tests/includes/model/class-test-follower.php
+++ b/tests/includes/model/class-test-follower.php
@@ -22,8 +22,7 @@ class Test_Follower extends \WP_UnitTestCase {
 	 * @covers ::clear_errors
 	 */
 	public function test_clear_errors() {
-		// Mock request
-
+		// Mock request.
 		$follower = new Follower();
 		$follower->from_array(
 			array(
@@ -40,19 +39,19 @@ class Test_Follower extends \WP_UnitTestCase {
 		$id = $follower->upsert();
 		$this->assertNotWPError( $id );
 
-		// Add some errors
+		// Add some errors.
 		Followers::add_error( $follower->get__id(), 'Test error 1' );
 		Followers::add_error( $follower->get__id(), 'Test error 2' );
 
-		// Verify errors were added
+		// Verify errors were added.
 		$errors = $follower->get_errors();
 		$this->assertCount( 2, $errors );
 
-		// Clear errors
+		// Clear errors.
 		$cleared = $follower->clear_errors();
 		$this->assertTrue( $cleared );
 
-		// Verify errors were cleared
+		// Verify errors were cleared.
 		$errors = $follower->get_errors();
 		$this->assertEmpty( $errors );
 	}
@@ -78,11 +77,11 @@ class Test_Follower extends \WP_UnitTestCase {
 		$id = $follower->upsert();
 		$this->assertNotWPError( $id );
 
-		// Clear errors when none exist
+		// Clear errors when none exist.
 		$cleared = $follower->clear_errors();
 		$this->assertFalse( $cleared );
 
-		// Verify no errors exist
+		// Verify no errors exist.
 		$errors = $follower->get_errors();
 		$this->assertEmpty( $errors );
 	}


### PR DESCRIPTION
Currently, the plugin increments error counters whenever a follower ID request fails. This behavior can inadvertently lead to the deletion of all followers over time, especially since webservers occasionally experience temporary errors due to maintenance or high traffic.

This PR improves this by resetting the error counter upon successful requests.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reset errors on successful requests

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See unittests

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Prevent accidental follower removal by resetting errors properly.

</details>
