### PR TITLE
Emails: Make sure actor URL is set correctly

### DIFF
--- a/.github/changelog/1677-from-description
+++ b/.github/changelog/1677-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email notifications for interactions with Brid.gy actors no longer trigger PHP Warnings.

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -346,6 +346,7 @@ class Mailer {
 		if ( empty( $actor['url'] ) ) {
 			$actor['url'] = $actor['id'];
 		}
+		$actor['url'] = object_to_uri( $actor['url'] );
 
 		if ( empty( $actor['webfinger'] ) ) {
 			$actor['webfinger'] = '@' . ( $actor['preferredUsername'] ?? $actor['name'] ) . '@' . \wp_parse_url( $actor['url'], PHP_URL_HOST );

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -471,7 +471,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		Mailer::direct_message( $activity, self::$user_id );
 
 		// Clean up.
-		remove_all_filters( 'wp_before_load_template' );// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
 		remove_all_filters( 'wp_mail' );
 	}

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -9,7 +9,6 @@ namespace Activitypub\Tests;
 
 use Activitypub\Mailer;
 use Activitypub\Collection\Actors;
-use Activitypub\Notification;
 use WP_UnitTestCase;
 
 /**
@@ -410,9 +409,8 @@ class Test_Mailer extends WP_UnitTestCase {
 		} else {
 			add_filter(
 				'wp_mail',
-				function ( $args ) {
+				function () {
 					$this->fail( 'Email should not be sent for public activity' );
-					return $args;
 				}
 			);
 
@@ -426,6 +424,56 @@ class Test_Mailer extends WP_UnitTestCase {
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
 		remove_all_filters( 'wp_mail' );
 		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test direct message notification from Bridgy.
+	 *
+	 * @covers ::direct_message
+	 */
+	public function test_direct_message_from_bridgy() {
+		$activity = array(
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'      => 'https://example.com/post/1',
+				'content' => 'Test direct message',
+			),
+			'to'     => array( Actors::get_by_id( self::$user_id )->get_id() ),
+		);
+
+		// Mock remote metadata.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function () {
+				return array(
+					'name' => 'Test Sender',
+					'url'  => array(
+						'https://fed.brid.gy/r/https://example.com/author',
+						'acct:author@example.com',
+					),
+				);
+			}
+		);
+
+		// Capture email.
+		add_filter(
+			'wp_mail',
+			function ( $args ) {
+				$this->assertStringContainsString(
+					'<a href="https://fed.brid.gy/r/https://example.com/author">@Test Sender@fed.brid.gy</a>',
+					$args['message']
+				);
+				return $args;
+			}
+		);
+
+		// Call the method.
+		Mailer::direct_message( $activity, self::$user_id );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );// Clean up.
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'wp_mail' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://wordpress.org/support/topic/stack-trace-when-attempting-to-send-email-on-direct-message/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Runs actor URL field through `object_to_uri()` before using it.
* Adds unit test.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Email notifications for interactions with Brid.gy actors no longer trigger PHP Warnings.

</details>
