### PR TITLE
Mention: Link to comment when it's a reply to a post

### DIFF
--- a/.github/changelog/1680-from-description
+++ b/.github/changelog/1680-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Mention notification emails now account for replies and link to the comment instead of the post editor.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -391,7 +391,7 @@ class Comment {
 	 * @return string $url
 	 */
 	public static function remote_comment_link( $comment_link, $comment ) {
-		if ( ! $comment || is_admin() ) {
+		if ( ! $comment || is_admin() || wp_is_serving_rest_request() ) {
 			return $comment_link;
 		}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -22,7 +22,7 @@ class Mailer {
 
 		\add_action( 'activitypub_inbox_follow', array( self::class, 'new_follower' ), 10, 2 );
 		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 10, 2 );
+		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 ); /** After @see \Activitypub\Handler\Create::handle_create() */
 	}
 
 	/**
@@ -292,10 +292,17 @@ class Mailer {
 
 		$actor = self::normalize_actor( $actor );
 
+		$reply_url = admin_url( 'post-new.php?in_reply_to=' . $activity['object']['id'] );
+		if ( is_activity_reply( $activity ) ) {
+			$comment   = object_id_to_comment( $activity['object']['id'] );
+			$reply_url = $comment ? \get_comment_link( $comment ) : $reply_url;
+		}
+
 		$template_args = array(
-			'activity' => $activity,
-			'actor'    => $actor,
-			'user_id'  => $user_id,
+			'activity'  => $activity,
+			'actor'     => $actor,
+			'user_id'   => $user_id,
+			'reply_url' => $reply_url,
 		);
 
 		/* translators: 1: Blog name, 2 Actor name */

--- a/templates/emails/new-mention.php
+++ b/templates/emails/new-mention.php
@@ -50,7 +50,7 @@ require __DIR__ . '/parts/header.php';
 
 <?php if ( site_supports_blocks() && ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) : ?>
 <p>
-	<a class="button" href="<?php echo esc_url( admin_url( 'post-new.php?in_reply_to=' . $args['activity']['object']['id'] ) ); ?>">
+	<a class="button" href="<?php echo esc_url( $args['reply_url'] ); ?>">
 		<?php esc_html_e( 'Reply to the post', 'activitypub' ); ?>
 	</a>
 </p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1678.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Skip rewriting federated comment URLs to their canonical URL in REST requests so we can link to their WP representations.
* Checks whether incoming mention is a reply and changes the reply URL to the comment, if any.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to a test site that can receive incoming requests from the Fediverse.
* Mention an actor of that test site from a remote instance.
* Make sure the "Reply to post" link in the notification email points to creating a new post in the Editor.
* Find a post from that test site and reply to it.
* Make sure the "Reply to post" link in the notification email points to the comment on your test site.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Mention notification emails now account for replies and link to the comment instead of the post editor.
</details>
