### PR TITLE
Help-Tab: Add ActivityPub capability help to users page

### DIFF
--- a/.github/changelog/1682-from-description
+++ b/.github/changelog/1682-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Help tab section explaining ActivityPub capabilities on the users page.

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -27,6 +27,7 @@ class Menu {
 		);
 
 		\add_action( 'load-' . $settings_page, array( Settings::class, 'add_settings_help_tab' ) );
+		\add_action( 'load-users.php', array( Settings::class, 'add_users_help_tab' ) );
 
 		// User has to be able to publish posts.
 		if ( user_can_activitypub( \get_current_user_id() ) ) {

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -480,6 +480,21 @@ class Settings {
 	}
 
 	/**
+	 * Adds the ActivityPub help tab to the users page.
+	 */
+	public static function add_users_help_tab() {
+		\get_current_screen()->add_help_tab(
+			array(
+				'id'       => 'activitypub',
+				'title'    => \__( 'ActivityPub', 'activitypub' ),
+				'content'  => self::get_help_tab_template( 'users' ),
+				// Add to the end of the list.
+				'priority' => 20,
+			)
+		);
+	}
+
+	/**
 	 * Handle 'welcome' query arg.
 	 */
 	public static function handle_welcome_query_arg() {

--- a/templates/help-tab/users.php
+++ b/templates/help-tab/users.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Users Help Tab template.
+ *
+ * @package Activitypub
+ */
+?>
+
+<h2><?php esc_html_e( 'Managing ActivityPub Capabilities', 'activitypub' ); ?></h2>
+
+<p><?php esc_html_e( 'Use the bulk actions on this page to control which users have access to ActivityPub features:', 'activitypub' ); ?></p>
+
+<ol>
+	<li><?php esc_html_e( 'Select the users you want to update by checking the boxes next to their names.', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'In the "Bulk Actions" dropdown, choose:', 'activitypub' ); ?>
+		<ul>
+			<li><?php esc_html_e( '"Enable for ActivityPub" to grant ActivityPub capabilities.', 'activitypub' ); ?></li>
+			<li><?php esc_html_e( '"Disable for ActivityPub" to remove ActivityPub capabilities.', 'activitypub' ); ?></li>
+		</ul>
+	</li>
+	<li><?php esc_html_e( 'Click "Apply" to save your changes.', 'activitypub' ); ?></li>
+</ol>
+
+<p><?php esc_html_e( 'The ActivityPub capability allows a user to:', 'activitypub' ); ?></p>
+
+<ul>
+	<li><?php esc_html_e( 'Have an individual ActivityPub profile', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'Publish content to the Fediverse', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'Manage followers', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'Access ActivityPub-specific features', 'activitypub' ); ?></li>
+</ul>
+
+<p><?php esc_html_e( 'By default, users who can publish posts are automatically granted this capability. You can override this using the bulk edit options above.', 'activitypub' ); ?></p>
+
+<p><em><?php esc_html_e( 'Note: If "Blog profile only" mode is enabled (where the site acts as a single ActivityPub profile), individual user capabilities do not affect ActivityPub functionality. All content is published under the blog\'s profile.', 'activitypub' ); ?></em></p>
+

--- a/templates/help-tab/users.php
+++ b/templates/help-tab/users.php
@@ -12,13 +12,13 @@
 
 <ol>
 	<li><?php esc_html_e( 'Select the users you want to update by checking the boxes next to their names.', 'activitypub' ); ?></li>
-	<li><?php esc_html_e( 'In the "Bulk Actions" dropdown, choose:', 'activitypub' ); ?>
+	<li><?php esc_html_e( 'In the &#8220;Bulk Actions&#8221; dropdown, choose:', 'activitypub' ); ?>
 		<ul>
-			<li><?php esc_html_e( '"Enable for ActivityPub" to grant ActivityPub capabilities.', 'activitypub' ); ?></li>
-			<li><?php esc_html_e( '"Disable for ActivityPub" to remove ActivityPub capabilities.', 'activitypub' ); ?></li>
+			<li><?php esc_html_e( '&#8220;Enable for ActivityPub&#8221; to grant ActivityPub capabilities.', 'activitypub' ); ?></li>
+			<li><?php esc_html_e( '&#8220;Disable for ActivityPub&#8221; to remove ActivityPub capabilities.', 'activitypub' ); ?></li>
 		</ul>
 	</li>
-	<li><?php esc_html_e( 'Click "Apply" to save your changes.', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'Click &#8220;Apply&#8221; to save your changes.', 'activitypub' ); ?></li>
 </ol>
 
 <p><?php esc_html_e( 'The ActivityPub capability allows a user to:', 'activitypub' ); ?></p>
@@ -32,4 +32,4 @@
 
 <p><?php esc_html_e( 'By default, users who can publish posts are automatically granted this capability. You can override this using the bulk edit options above.', 'activitypub' ); ?></p>
 
-<p><em><?php esc_html_e( 'Note: If "Blog profile only" mode is enabled (where the site acts as a single ActivityPub profile), individual user capabilities do not affect ActivityPub functionality. All content is published under the blog\'s profile.', 'activitypub' ); ?></em></p>
+<p><em><?php esc_html_e( 'Note: If &#8220;Blog profile only&#8221; mode is enabled (where the site acts as a single ActivityPub profile), individual user capabilities do not affect ActivityPub functionality. All content is published under the blog&#8217;s profile.', 'activitypub' ); ?></em></p>

--- a/templates/help-tab/users.php
+++ b/templates/help-tab/users.php
@@ -21,15 +21,30 @@
 	<li><?php esc_html_e( 'Click &#8220;Apply&#8221; to save your changes.', 'activitypub' ); ?></li>
 </ol>
 
+<h3><?php esc_html_e( 'What are ActivityPub Capabilities?', 'activitypub' ); ?></h3>
+
 <p><?php esc_html_e( 'The ActivityPub capability allows a user to:', 'activitypub' ); ?></p>
 
 <ul>
-	<li><?php esc_html_e( 'Have an individual ActivityPub profile', 'activitypub' ); ?></li>
-	<li><?php esc_html_e( 'Publish content to the Fediverse', 'activitypub' ); ?></li>
-	<li><?php esc_html_e( 'Manage followers', 'activitypub' ); ?></li>
-	<li><?php esc_html_e( 'Access ActivityPub-specific features', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'Have an individual ActivityPub profile that can be followed from other Fediverse platforms.', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'Publish content to the Fediverse automatically when posting on your WordPress site.', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'Manage followers and interactions from Fediverse users.', 'activitypub' ); ?></li>
+	<li><?php esc_html_e( 'Access ActivityPub-specific settings and features.', 'activitypub' ); ?></li>
 </ul>
 
-<p><?php esc_html_e( 'By default, users who can publish posts are automatically granted this capability. You can override this using the bulk edit options above.', 'activitypub' ); ?></p>
+<h3><?php esc_html_e( 'Default Behavior', 'activitypub' ); ?></h3>
 
-<p><em><?php esc_html_e( 'Note: If &#8220;Blog profile only&#8221; mode is enabled (where the site acts as a single ActivityPub profile), individual user capabilities do not affect ActivityPub functionality. All content is published under the blog&#8217;s profile.', 'activitypub' ); ?></em></p>
+<p><?php esc_html_e( 'By default, users who can publish posts are automatically granted ActivityPub capabilities. You can override this default behavior using the bulk edit options described above.', 'activitypub' ); ?></p>
+
+<p><em>
+<?php
+printf(
+	wp_kses(
+		/* translators: %s: URL to ActivityPub settings */
+		__( 'Note: If <a href="%s">&#8220;Blog profile only&#8221; mode</a> is enabled (where the site acts as a single ActivityPub profile), individual user capabilities do not affect ActivityPub functionality. All content is published under the blog&#8217;s profile.', 'activitypub' ),
+		array( 'a' => array( 'href' => true ) )
+	),
+	esc_url( admin_url( 'options-general.php?page=activitypub&tab=settings' ) )
+);
+?>
+</em></p>

--- a/templates/help-tab/users.php
+++ b/templates/help-tab/users.php
@@ -4,8 +4,8 @@
  *
  * @package Activitypub
  */
-?>
 
+?>
 <h2><?php esc_html_e( 'Managing ActivityPub Capabilities', 'activitypub' ); ?></h2>
 
 <p><?php esc_html_e( 'Use the bulk actions on this page to control which users have access to ActivityPub features:', 'activitypub' ); ?></p>
@@ -33,4 +33,3 @@
 <p><?php esc_html_e( 'By default, users who can publish posts are automatically granted this capability. You can override this using the bulk edit options above.', 'activitypub' ); ?></p>
 
 <p><em><?php esc_html_e( 'Note: If "Blog profile only" mode is enabled (where the site acts as a single ActivityPub profile), individual user capabilities do not affect ActivityPub functionality. All content is published under the blog\'s profile.', 'activitypub' ); ?></em></p>
-


### PR DESCRIPTION
Helps with guidance.

See #1671

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Help tab section explaining ActivityPub capabilities on the users page.

</details>
