### PR TITLE
Improve Mobile-View

### DIFF
--- a/.github/changelog/1684-from-description
+++ b/.github/changelog/1684-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Settings pages are now more mobile-friendly with more space and easier scrolling.

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -401,3 +401,10 @@ input.blog-user-identifier {
 		margin: 0 22px;
 	}
 }
+
+@media screen and (max-width: 782px) {
+	.activitypub-settings .row > div {
+		max-width: calc(100% - 36px);
+		width: 100%;
+	}
+}

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -45,6 +45,14 @@
 	padding-left: 0;
 }
 
+.activitypub-settings-tabs-scroller {
+	overflow-x: auto;
+	width: 100%;
+	padding-top: 2px;
+	-webkit-overflow-scrolling: touch;
+	scroll-behavior: smooth;
+}
+
 .activitypub-settings-tabs-wrapper {
 	display: inline-flex;
 	vertical-align: top;
@@ -64,6 +72,7 @@
 	padding: .5rem 1rem 1rem;
 	margin: 0 1rem;
 	transition: box-shadow .5s ease-in-out;
+	white-space: nowrap;
 }
 
 .activitypub-settings .row {
@@ -385,4 +394,10 @@ input.blog-user-identifier {
 	border-left: none;
 	border-right: 4px solid #3582c4;
 	padding: 16px 20px;
+}
+
+@media screen and (max-width: 844px) {
+	.activitypub-settings {
+		margin: 0 22px;
+	}
 }

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -396,13 +396,11 @@ input.blog-user-identifier {
 	padding: 16px 20px;
 }
 
-@media screen and (max-width: 844px) {
+@media screen and (max-width: 782px) {
 	.activitypub-settings {
 		margin: 0 22px;
 	}
-}
 
-@media screen and (max-width: 782px) {
 	.activitypub-settings .row > div {
 		max-width: calc(100% - 36px);
 		width: 100%;

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -13,22 +13,24 @@ $args = wp_parse_args( $args ?? array() );
 		<h1><?php \esc_html_e( 'ActivityPub', 'activitypub' ); ?></h1>
 	</div>
 
-	<nav class="activitypub-settings-tabs-wrapper" aria-label="<?php \esc_attr_e( 'Secondary menu', 'activitypub' ); ?>">
-		<?php
-		foreach ( $args['tabs'] as $slug => $label ) :
-			$url = add_query_arg(
-				array( 'tab' => 'welcome' !== $slug ? $slug : false ),
-				\admin_url( 'options-general.php?page=activitypub' )
-			);
-			?>
-
-			<a href="<?php echo \esc_url( $url ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args[ $slug ] ); ?>">
-				<?php echo \esc_html( $label ); ?>
-			</a>
-
+	<div class="activitypub-settings-tabs-scroller">
+		<nav class="activitypub-settings-tabs-wrapper" aria-label="<?php \esc_attr_e( 'Secondary menu', 'activitypub' ); ?>">
 			<?php
-		endforeach;
-		?>
-	</nav>
+			foreach ( $args['tabs'] as $slug => $label ) :
+				$url = add_query_arg(
+					array( 'tab' => 'welcome' !== $slug ? $slug : false ),
+					\admin_url( 'options-general.php?page=activitypub' )
+				);
+				?>
+
+				<a href="<?php echo \esc_url( $url ); ?>" class="activitypub-settings-tab <?php echo \esc_attr( $args[ $slug ] ); ?>">
+					<?php echo \esc_html( $label ); ?>
+				</a>
+
+				<?php
+			endforeach;
+			?>
+		</nav>
+	</div>
 </div>
 <hr class="wp-header-end">


### PR DESCRIPTION
Improve the mobile view of the Settings Screens.

<!--- Provide a general summary of your changes in the Title above -->

| Before   |      After    |
|----------|:-------------:|
| <img width="562" alt="Screenshot 2025-05-09 at 15 28 58" src="https://github.com/user-attachments/assets/cc0746de-49e5-4bde-84db-c44ce34cdf39" /> | <img width="562" alt="Screenshot 2025-05-09 at 15 29 16" src="https://github.com/user-attachments/assets/fbd7ff92-1eb7-43f3-a1a2-99280778340c" /> |


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added margins for content area
* Scrollable menu for mobile views

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Settings pages are now more mobile-friendly with more space and easier scrolling.

</details>
