### PR TITLE
Update WP requirement to 6.5

### DIFF
--- a/.github/changelog/1703-from-description
+++ b/.github/changelog/1703-from-description
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Bumped minimum required WordPress version to 6.5.

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,7 +20,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         include:
           - wp-version: latest
-          - wp-version: '6.4'
+          - wp-version: '6.5'
             php-versions: '7.2'
           - wp-version: trunk
             php-versions: '8.4'

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -96,16 +96,3 @@ if ( ! function_exists( 'str_contains' ) ) {
 		return false !== strpos( $haystack, $needle );
 	}
 }
-
-if ( ! function_exists( 'wp_is_serving_rest_request' ) ) {
-	/**
-	 * Polyfill for `wp_is_serving_rest_request()` function added in WordPress 6.5.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/wp_is_serving_rest_request/
-	 *
-	 * @return bool True if it's a WordPress REST API request, false otherwise.
-	 */
-	function wp_is_serving_rest_request() {
-		return defined( 'REST_REQUEST' ) && REST_REQUEST;
-	}
-}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,7 +17,7 @@
 	<rule ref="PHPCompatibility"/>
 	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibilityWP"/>
-	<config name="minimum_supported_wp_version" value="6.4"/>
+	<config name="minimum_supported_wp_version" value="6.5"/>
 
 	<config name="text_domain" value="activitypub,default"/>
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === ActivityPub ===
 Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaformat, nuriapena, cavalierlife, andremenrath
 Tags: OStatus, fediverse, activitypub, activitystream
-Requires at least: 6.4
+Requires at least: 6.5
 Tested up to: 6.8
 Stable tag: 5.9.0
 Requires PHP: 7.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This will allow us to move our Blocks to using the Interactivity API.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates min required version in readme.
* Updates min version for unit tests.
* Removes unneeded compat function.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [x] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Bumped minimum required WordPress version to 6.5.

</details>
