### PR TITLE
Add .map files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,22 @@
-_site
-.sass-cache
-.jekyll-cache
-.jekyll-metadata
+# Directories
+/build/**/*.map
 /coverage/
 /node_modules/
 /vendor/
-package-lock.json
-composer.lock
-.DS_Store
-.cursor
+_site
 .idea/
+
+# Files
+.cursor
+.DS_Store
+.jekyll-cache
+.jekyll-metadata
 .php_cs.cache
 .phpunit.result.cache
+.sass-cache
 .vscode/settings.json
 .windsurf
 .windsurfrules
 .wp-env.override.json
+composer.lock
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,11 @@
-# Directories
 /build/**/*.map
 /coverage/
 /node_modules/
 /vendor/
 _site
 .idea/
-
-# Files
 .cursor
 .DS_Store
-.jekyll-cache
-.jekyll-metadata
 .php_cs.cache
 .phpunit.result.cache
 .sass-cache


### PR DESCRIPTION
@pfefferle noted a stray `.map` file in #1691. This change makes sure we'll never accidentally commit `.map` files again.

See https://github.com/Automattic/wordpress-activitypub/pull/1691#discussion_r2096125668

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `/build/**/*.map` to `.gitignore`.
* Sorts `.gitignore` alphabetically.

