### PR TITLE
Re-add HTML handling for summaries/excerpts

### DIFF
--- a/.github/changelog/1731-from-description
+++ b/.github/changelog/1731-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Re-enabled HTML support in excerpts and summaries to properly display hashtags and @-replies, now that Mastodon supports it.

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -32,10 +32,7 @@ class Hashtag {
 	 * @return array The filtered activity object array.
 	 */
 	public static function filter_activity_object( $activity ) {
-		/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		Only changed it for Person and Group as long is not merged: https://github.com/mastodon/mastodon/pull/28629
-		*/
-		if ( ! empty( $activity['summary'] ) && in_array( $activity['type'], array( 'Person', 'Group' ), true ) ) {
+		if ( ! empty( $activity['summary'] ) ) {
 			$activity['summary'] = self::the_content( $activity['summary'] );
 		}
 

--- a/includes/class-link.php
+++ b/includes/class-link.php
@@ -28,10 +28,7 @@ class Link {
 	 * @return array Rhe activity object array.
 	 */
 	public static function filter_activity_object( $activity ) {
-		/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		Only changed it for Person and Group as long is not merged: https://github.com/mastodon/mastodon/pull/28629
-		*/
-		if ( ! empty( $activity['summary'] ) && in_array( $activity['type'], array( 'Person', 'Group' ), true ) ) {
+		if ( ! empty( $activity['summary'] ) ) {
 			$activity['summary'] = self::the_content( $activity['summary'] );
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1222,12 +1222,8 @@ function generate_post_summary( $post, $length = 500 ) {
 		$content = $content[0] . ' ' . $excerpt_more;
 	}
 
-	/*
-	Removed until this is merged: https://github.com/mastodon/mastodon/pull/28629
-	/** This filter is documented in wp-includes/post-template.php
+	// This filter is documented in `wp-includes/post-template.php`.
 	return \apply_filters( 'the_excerpt', $content );
-	*/
-	return $content;
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1222,7 +1222,7 @@ function generate_post_summary( $post, $length = 500 ) {
 		$content = $content[0] . ' ' . $excerpt_more;
 	}
 
-	// This filter is documented in `wp-includes/post-template.php`.
+	// This filter is documented in wp-includes/post-template.php.
 	return \apply_filters( 'the_excerpt', $content );
 }
 


### PR DESCRIPTION
We removed the HTML handling for `excerpts` and `summaries` because Mastodon has not supported it. Now that Mastodon has merged this PR https://github.com/mastodon/mastodon/pull/28629 I think it is fine to re-add the HTML handling.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Re-enabled HTML support in excerpts and summaries to properly display hashtags and @-replies, now that Mastodon supports it.

</details>
