### PR TITLE
Fix: Site-Health WebFinger check

### DIFF
--- a/.github/changelog/1733-from-description
+++ b/.github/changelog/1733-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug in Site Health that caused a PHP warning and missing details for the WebFinger check.

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -211,17 +211,17 @@ class Webfinger {
 		$webfinger_url = sprintf(
 			'https://%s/.well-known/webfinger?resource=%s',
 			$host,
-			rawurlencode( $identifier )
+			\rawurlencode( $identifier )
 		);
 
-		$response = wp_safe_remote_get(
+		$response = \wp_safe_remote_get(
 			$webfinger_url,
 			array(
 				'headers' => array( 'Accept' => 'application/jrd+json' ),
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
+		if ( \is_wp_error( $response ) || \wp_remote_retrieve_response_code( $response ) >= 400 ) {
 			return new WP_Error(
 				'webfinger_url_not_accessible',
 				__( 'The WebFinger Resource is not accessible.', 'activitypub' ),
@@ -232,8 +232,8 @@ class Webfinger {
 			);
 		}
 
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
+		$body = \wp_remote_retrieve_body( $response );
+		$data = \json_decode( $body, true );
 
 		\set_transient( $transient_key, $data, WEEK_IN_SECONDS );
 

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -241,15 +241,21 @@ class Health_Check {
 				$allowed
 			);
 
+			$data       = $url->get_error_data();
+			$author_url = $resource;
+			if ( \is_string( $data['data'] ) ) {
+				$author_url = $data['data'];
+			}
+
 			$health_messages = array(
 				'webfinger_url_not_accessible'   => \sprintf(
 					$not_accessible,
-					$url->get_error_data()['data']
+					$author_url
 				),
 				'webfinger_url_invalid_response' => \sprintf(
 					// translators: %s: Author URL.
 					$invalid_response,
-					$url->get_error_data()['data']
+					$author_url
 				),
 			);
 			$message         = null;

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -243,7 +243,7 @@ class Health_Check {
 
 			$data       = $url->get_error_data();
 			$author_url = $resource;
-			if ( \is_string( $data['data'] ) ) {
+			if ( isset( $data['data'] ) && \is_string( $data['data'] ) ) {
 				$author_url = $data['data'];
 			}
 

--- a/tests/includes/class-test-webfinger.php
+++ b/tests/includes/class-test-webfinger.php
@@ -158,6 +158,8 @@ class Test_Webfinger extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the resolve method.
+	 *
 	 * @dataProvider the_resolve_provider
 	 * @covers ::resolve
 	 *

--- a/tests/includes/class-test-webfinger.php
+++ b/tests/includes/class-test-webfinger.php
@@ -44,4 +44,224 @@ class Test_Webfinger extends \WP_UnitTestCase {
 			array( 'https://example.org', md5( 'https://example.org' ) ),
 		);
 	}
+
+	/**
+	 * Test the get_identifier_and_host method.
+	 *
+	 * @dataProvider the_identifier_and_host_provider
+	 * @covers ::get_identifier_and_host
+	 *
+	 * @param string $uri        The URI to generate the identifier and host for.
+	 * @param string $identifier The expected identifier.
+	 * @param string $host       The expected host.
+	 */
+	public function test_get_identifier_and_host( $uri, $identifier, $host ) {
+		$this->assertEquals(
+			array( $identifier, $host ),
+			Webfinger::get_identifier_and_host( $uri )
+		);
+	}
+
+	/**
+	 * Identifier and host provider.
+	 *
+	 * @return array[]
+	 */
+	public function the_identifier_and_host_provider() {
+		return array(
+			array( 'author@example.org', 'acct:author@example.org', 'example.org' ),
+			array( 'acct:author@example.org', 'acct:author@example.org', 'example.org' ),
+			array( 'https://example.org/@pfefferle', 'https://example.org/@pfefferle', 'example.org' ),
+			array( 'mailto:pfefferle@example.org', 'mailto:pfefferle@example.org', 'example.org' ),
+			array( 'xmpp:pfefferle@example.com', 'xmpp:pfefferle@example.com', 'example.com' ),
+		);
+	}
+
+	/**
+	 * Test the get_data method.
+	 *
+	 * @dataProvider the_get_data_provider
+	 * @covers ::get_data
+	 *
+	 * @param string $uri      The URI to get data for.
+	 * @param array  $data     The data to return.
+	 * @param array  $expected The expected data.
+	 */
+	public function test_get_data( $uri, $data, $expected ) {
+		$filter = function () use ( $data ) {
+			return $data;
+		};
+		\add_filter( 'pre_http_request', $filter );
+
+		$data = Webfinger::get_data( $uri );
+
+		$this->assertEquals( $expected, $data );
+
+		\remove_filter( 'pre_http_request', $filter );
+	}
+
+	/**
+	 * Data provider for test_get_data.
+	 *
+	 * @return array[]
+	 */
+	public function the_get_data_provider() {
+		return array(
+			array(
+				'http://example.org/?author=1',
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => '{ "subject": "acct:pfefferle@example.org", "aliases": [ "https://example.org/?author=1" ] }',
+				),
+				array(
+					'subject' => 'acct:pfefferle@example.org',
+					'aliases' => array( 'https://example.org/?author=1' ),
+				),
+			),
+			array(
+				'http://example.org/?author=1',
+				array(
+					'response' => array(
+						'code' => 400,
+					),
+					'body'     => 'error',
+				),
+				new \WP_Error(
+					'webfinger_url_not_accessible',
+					__( 'The WebFinger Resource is not accessible.', 'activitypub' ),
+					array(
+						'status' => 400,
+						'data'   => 'https://example.org/.well-known/webfinger?resource=http%3A%2F%2Fexample.org%2F%3Fauthor%3D1',
+					)
+				),
+			),
+			array(
+				'test@example.org',
+				array(
+					'response' => array(
+						'code' => 404,
+					),
+					'body'     => '{"type":"about:blank","title":"activitypub_wrong_host","detail":"Der Ressourcen-Host stimmt nicht mit dem Blog-Host \u00fcberein","status":404,"metadata":{"code":"activitypub_wrong_host","message":"Der Ressourcen-Host stimmt nicht mit dem Blog-Host \u00fcberein","data":{"status":404}}}',
+				),
+				new \WP_Error(
+					'webfinger_url_not_accessible',
+					__( 'The WebFinger Resource is not accessible.', 'activitypub' ),
+					array(
+						'status' => 400,
+						'data'   => 'https://example.org/.well-known/webfinger?resource=acct%3Atest%40example.org',
+					)
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider the_resolve_provider
+	 * @covers ::resolve
+	 *
+	 * @param string $uri      The URI to resolve.
+	 * @param array  $data     The data to return.
+	 * @param mixed  $expected The expected result.
+	 */
+	public function test_resolve( $uri, $data, $expected ) {
+		$filter = function () use ( $data ) {
+			return $data;
+		};
+		\add_filter( 'pre_http_request', $filter );
+
+		$data = Webfinger::resolve( $uri );
+
+		$this->assertEquals( $expected, $data );
+
+		\remove_filter( 'pre_http_request', $filter );
+	}
+
+	/**
+	 * Data provider for test_resolve.
+	 *
+	 * @return array[]
+	 */
+	public function the_resolve_provider() {
+		return array(
+			array(
+				'http://example.org/?author=1',
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => '{ "subject": "acct:test@example.org", "aliases": [ "https://example.org/?author=1" ] }',
+				),
+				new \WP_Error(
+					'webfinger_missing_links',
+					__( 'No valid Link elements found.', 'activitypub' ),
+					array(
+						'status' => 400,
+						'data'   => array(
+							'subject' => 'acct:test@example.org',
+							'aliases' => array( 'https://example.org/?author=1' ),
+						),
+					)
+				),
+			),
+			array(
+				'http://example.org/?author=1',
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => '{ "subject": "acct:test@example.org", "aliases": [ "https://example.org/?author=1" ], "links": [] }',
+				),
+				new \WP_Error(
+					'webfinger_missing_links',
+					__( 'No valid Link elements found.', 'activitypub' ),
+					array(
+						'status' => 400,
+						'data'   => array(
+							'subject' => 'acct:test@example.org',
+							'aliases' => array( 'https://example.org/?author=1' ),
+							'links'   => array(),
+						),
+					)
+				),
+			),
+			array(
+				'http://example.org/?author=1',
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => '{ "subject": "acct:test@example.org", "aliases": [ "https://example.org/?author=1" ], "links": [ { "rel": "http://webfinger.net/rel/profile-page", "href": "https://example.org/?author=1" } ] }',
+				),
+				new \WP_Error(
+					'webfinger_url_no_activitypub',
+					__( 'The Site supports WebFinger but not ActivityPub', 'activitypub' ),
+					array(
+						'status' => 400,
+						'data'   => array(
+							'subject' => 'acct:test@example.org',
+							'aliases' => array( 'https://example.org/?author=1' ),
+							'links'   => array(
+								array(
+									'rel'  => 'http://webfinger.net/rel/profile-page',
+									'href' => 'https://example.org/?author=1',
+								),
+							),
+						),
+					)
+				),
+			),
+			array(
+				'http://example.org/?author=1',
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => '{ "subject": "acct:test@example.org", "aliases": [ "https://example.org/?author=1" ], "links": [ { "rel": "self", "type": "application/activity+json", "href": "https://example.org/?author=1" } ] }',
+				),
+				'https://example.org/?author=1',
+			),
+		);
+	}
 }


### PR DESCRIPTION
Fixes a bug in the Site-Health that causes a PHP error.

Bug Report:

> The site health check shows a critial issue “WebFinger endpoint is not accessible” but there are no details when opening the accordion item.
>
> Beside that, the Query Monitor Plugin shows two PHP warnings “Array to string conversion” at these locations:
>
> >   wp-content/plugins/activitypub/includes/wp-admin/class-health-check.php:245
>    sprintf()
>    wp-content/plugins/activitypub/includes/wp-admin/class-health-check.php:245
>    Activitypub\WP_Admin\Health_Check::is_webfinger_endpoint_accessible()
>    wp-content/plugins/activitypub/includes/wp-admin/class-health-check.php:169
>    Activitypub\WP_Admin\Health_Check::test_webfinger()
>    wp-admin/includes/class-wp-site-health.php:194
>    WP_Site_Health->perform_test()
>    wp-admin/includes/class-wp-site-health.php:145
>    WP_Site_Health->enqueue_scripts()
>    wp-includes/class-wp-hook.php:324
>    do_action('admin_enqueue_scripts')
>    wp-admin/admin-header.php:123
>
> How can I debug this? Webhoster Netcup can’t help.

https://wordpress.org/support/topic/webfinger-endpoint-is-not-accessible-php-warning/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check WP_Error `data` before processing it

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed a bug in Site Health that caused a PHP warning and missing details for the WebFinger check.

</details>
