### PR TITLE
Rerun `follower` migration

### DIFF
--- a/.github/changelog/1778-from-description
+++ b/.github/changelog/1778-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved follower migration: scheduler now more reliable and won't stop too early.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -1031,7 +1031,8 @@ class Migration {
 			\kses_init_filters();
 		}
 
-		if ( \count( $meta_values ) === $batch_size ) {
+		$tolerance = 20;
+		if ( abs( count( $meta_values ) - $batch_size ) <= $tolerance ) {
 			return array(
 				'batch_size' => $batch_size,
 				'offset'     => $offset + $batch_size,

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -1029,7 +1029,7 @@ class Migration {
 			\kses_init_filters();
 		}
 
-		if ( count( $meta_values ) === $batch_size ) {
+		if ( \count( $meta_values ) === $batch_size ) {
 			return array(
 				'batch_size' => $batch_size,
 			);

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -974,20 +974,18 @@ class Migration {
 	/**
 	 * Update _activitypub_actor_json meta values to ensure they are properly slashed.
 	 *
-	 * @param int $batch_size Optional. Number of meta values to process per batch. Default 200.
-	 * @param int $offset     Optional. Number of meta values to skip. Default 0.
+	 * @param int $batch_size Optional. Number of meta values to process per batch. Default 100.
 	 *
 	 * @return array|null Array with batch size and offset if there are more meta values to process, null otherwise.
 	 */
-	public static function update_actor_json_storage( $batch_size = 200, $offset = 0 ) {
+	public static function update_actor_json_storage( $batch_size = 100 ) {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$meta_values = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_activitypub_actor_json' ORDER BY post_id ASC LIMIT %d OFFSET %d",
-				$batch_size,
-				$offset
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_activitypub_actor_json' LIMIT %d",
+				$batch_size
 			)
 		);
 
@@ -1031,12 +1029,9 @@ class Migration {
 			\kses_init_filters();
 		}
 
-		$tolerance       = 20;
-		$processed_count = count( $meta_values );
-		if ( $processed_count > 0 && abs( $processed_count - $batch_size ) <= $tolerance ) {
+		if ( count( $meta_values ) === $batch_size ) {
 			return array(
 				'batch_size' => $batch_size,
-				'offset'     => $offset + $processed_count,
 			);
 		}
 

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -985,7 +985,7 @@ class Migration {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$meta_values = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_activitypub_actor_json' LIMIT %d OFFSET %d ORDER BY post_id ASC",
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_activitypub_actor_json' ORDER BY post_id ASC LIMIT %d OFFSET %d",
 				$batch_size,
 				$offset
 			)

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -985,7 +985,7 @@ class Migration {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$meta_values = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_activitypub_actor_json' LIMIT %d OFFSET %d",
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_activitypub_actor_json' LIMIT %d OFFSET %d ORDER BY post_id ASC",
 				$batch_size,
 				$offset
 			)
@@ -1031,11 +1031,12 @@ class Migration {
 			\kses_init_filters();
 		}
 
-		$tolerance = 20;
-		if ( abs( count( $meta_values ) - $batch_size ) <= $tolerance ) {
+		$tolerance       = 20;
+		$processed_count = count( $meta_values );
+		if ( $processed_count > 0 && abs( $processed_count - $batch_size ) <= $tolerance ) {
 			return array(
 				'batch_size' => $batch_size,
-				'offset'     => $offset + $batch_size,
+				'offset'     => $offset + $processed_count,
 			);
 		}
 

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -974,12 +974,12 @@ class Migration {
 	/**
 	 * Update _activitypub_actor_json meta values to ensure they are properly slashed.
 	 *
-	 * @param int $batch_size Optional. Number of meta values to process per batch. Default 100.
+	 * @param int $batch_size Optional. Number of meta values to process per batch. Default 200.
 	 * @param int $offset     Optional. Number of meta values to skip. Default 0.
 	 *
 	 * @return array|null Array with batch size and offset if there are more meta values to process, null otherwise.
 	 */
-	public static function update_actor_json_storage( $batch_size = 300, $offset = 0 ) {
+	public static function update_actor_json_storage( $batch_size = 200, $offset = 0 ) {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -185,6 +185,10 @@ class Migration {
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'update_actor_json_storage' ) );
 		}
 
+		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
+			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'update_actor_json_storage' ) );
+		}
+
 		/*
 		 * Add new update routines above this comment. ^
 		 *
@@ -975,7 +979,7 @@ class Migration {
 	 *
 	 * @return array|null Array with batch size and offset if there are more meta values to process, null otherwise.
 	 */
-	public static function update_actor_json_storage( $batch_size = 100, $offset = 0 ) {
+	public static function update_actor_json_storage( $batch_size = 300, $offset = 0 ) {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery


### PR DESCRIPTION
It seems that the update scheduler had issues with bigger follower lists, see #1776 

This PR adds a tolerance to the update scheduler, to not accidentally stop before running through all followers.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a small tolerance

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->
Improved follower migration: scheduler now more reliable and won't stop too early.

</details>
