### PR TITLE
Blocks: Don't show contents in feeds

### DIFF
--- a/.github/changelog/1794-from-description
+++ b/.github/changelog/1794-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Blocks updated in 6.0.0 are back to not showing up in feeds and federated posts.

--- a/build/follow-me/render.php
+++ b/build/follow-me/render.php
@@ -8,6 +8,11 @@
 use Activitypub\Blocks;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use function Activitypub\is_activitypub_request;
+
+if ( is_activitypub_request() || is_feed() ) {
+	return;
+}
 
 /* @var array $attributes Block attributes. */
 $attributes = wp_parse_args( $attributes );

--- a/build/followers/render.php
+++ b/build/followers/render.php
@@ -8,7 +8,12 @@
 use Activitypub\Blocks;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use function Activitypub\is_activitypub_request;
 use function Activitypub\object_to_uri;
+
+if ( is_activitypub_request() || is_feed() ) {
+	return;
+}
 
 /* @var array $attributes Block attributes. */
 $attributes = wp_parse_args( $attributes );

--- a/build/reactions/render.php
+++ b/build/reactions/render.php
@@ -7,6 +7,11 @@
 
 use Activitypub\Comment;
 use Activitypub\Blocks;
+use function Activitypub\is_activitypub_request;
+
+if ( is_activitypub_request() || is_feed() ) {
+	return;
+}
 
 /* @var array $attributes Block attributes. */
 $attributes = wp_parse_args( $attributes, array( 'align' => null ) );

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -40,6 +40,9 @@ class Outbox {
 			$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
 		}
 
+		// Save activity in the context of an activitypub request.
+		\add_filter( 'activitypub_is_activitypub_request', '__return_true' );
+
 		$outbox_item = array(
 			'post_type'    => self::POST_TYPE,
 			'post_title'   => sprintf(
@@ -59,6 +62,8 @@ class Outbox {
 				'activitypub_content_visibility' => $visibility,
 			),
 		);
+
+		\remove_filter( 'activitypub_is_activitypub_request', '__return_true' );
 
 		$has_kses = false !== \has_filter( 'content_save_pre', 'wp_filter_post_kses' );
 		if ( $has_kses ) {

--- a/src/follow-me/render.php
+++ b/src/follow-me/render.php
@@ -8,6 +8,11 @@
 use Activitypub\Blocks;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use function Activitypub\is_activitypub_request;
+
+if ( is_activitypub_request() || is_feed() ) {
+	return;
+}
 
 /* @var array $attributes Block attributes. */
 $attributes = wp_parse_args( $attributes );

--- a/src/followers/render.php
+++ b/src/followers/render.php
@@ -11,7 +11,7 @@ use Activitypub\Collection\Followers;
 use function Activitypub\is_activitypub_request;
 use function Activitypub\object_to_uri;
 
-if ( is_activitypub_request() || is_feed() || wp_is_serving_rest_request() ) {
+if ( is_activitypub_request() || is_feed() ) {
 	return;
 }
 

--- a/src/followers/render.php
+++ b/src/followers/render.php
@@ -8,7 +8,12 @@
 use Activitypub\Blocks;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use function Activitypub\is_activitypub_request;
 use function Activitypub\object_to_uri;
+
+if ( is_activitypub_request() || is_feed() || wp_is_serving_rest_request() ) {
+	return;
+}
 
 /* @var array $attributes Block attributes. */
 $attributes = wp_parse_args( $attributes );

--- a/src/reactions/render.php
+++ b/src/reactions/render.php
@@ -7,6 +7,11 @@
 
 use Activitypub\Comment;
 use Activitypub\Blocks;
+use function Activitypub\is_activitypub_request;
+
+if ( is_activitypub_request() || is_feed() ) {
+	return;
+}
 
 /* @var array $attributes Block attributes. */
 $attributes = wp_parse_args( $attributes, array( 'align' => null ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1782.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bails in `render.php` when run in activitypub or feed context.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create or update a post with a Follow Me, Followers, or Reaction block.
* Inspect the post in the Outbox and make sure the block(s) don't show up in the output.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Blocks updated in 6.0.0 are back to not showing up in feeds and federated posts.
</details>
