### PR TITLE
Admin: Fix aka saving

### DIFF
--- a/.github/changelog/1798-from-description
+++ b/.github/changelog/1798-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+"Account Aliases" for get saved correctly again and no longer return empty.

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -153,7 +153,7 @@ class Admin {
 
 		// User options that should be processed with `sanitize_textarea_field()`.
 		$textarea_field_user_options = array(
-			'activitypub_blog_user_also_known_as',
+			'activitypub_also_known_as',
 			'activitypub_description',
 		);
 

--- a/includes/wp-admin/class-user-settings-fields.php
+++ b/includes/wp-admin/class-user-settings-fields.php
@@ -87,7 +87,7 @@ class User_Settings_Fields {
 			array( self::class, 'also_known_as_callback' ),
 			'activitypub_user_settings',
 			'activitypub_user_profile',
-			array( 'label_for' => 'activitypub_blog_user_also_known_as' )
+			array( 'label_for' => 'activitypub_also_known_as' )
 		);
 	}
 
@@ -262,8 +262,8 @@ class User_Settings_Fields {
 		?>
 		<textarea
 			class="large-text"
-			name="activitypub_blog_user_also_known_as"
-			id="activitypub_blog_user_also_known_as"
+			name="activitypub_also_known_as"
+			id="activitypub_also_known_as"
 			rows="5"
 		><?php echo \esc_textarea( implode( PHP_EOL, (array) $also_known_as ) ); ?></textarea>
 		<p class="description">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

See https://wordpress.org/support/topic/transferring-followers-to-wordpress/#post-18505816

It looks like a c/p error led to `also_known_as` values not saving for individual users in `/wp-admin/profile.php`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes errand `_blog_user` prefix from user option.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/profile.php`.
* Add a url to the "Account Aliases" textarea and submit.
* Make sure the url still shows up in the text area.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

"Account Aliases" for get saved correctly again and no longer return empty.

</details>
