### PR TITLE
Settings: Make screen options filterable

### DIFF
--- a/.github/changelog/1802-from-description
+++ b/.github/changelog/1802-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Screen options in the Activitypub settings page are now filterable.

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -539,38 +539,46 @@ class Settings {
 			}
 		}
 
-		if ( isset( $_POST['activitypub_show_welcome_tab'] ) ) {
-			$welcome         = \sanitize_text_field( \wp_unslash( $_POST['activitypub_show_welcome_tab'] ) );
-			$welcome_checked = empty( $welcome ) ? 0 : 1;
-			\update_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', $welcome_checked );
+		$screen_options = array(
+			'activitypub_show_welcome_tab'  => __( 'Welcome Page', 'activitypub' ),
+			'activitypub_show_advanced_tab' => __( 'Advanced Settings', 'activitypub' ),
+		);
+
+		/**
+		 * Filters Activitypub settings screen options.
+		 *
+		 * @param string[] $screen_options Screen options. An array of user meta keys and screen option labels.
+		 */
+		$screen_options = \apply_filters( 'activitypub_screen_options', $screen_options );
+		if ( empty( $screen_options ) ) {
+			return $screen_settings;
 		}
 
-		if ( isset( $_POST['activitypub_show_advanced_tab'] ) ) {
-			$advanced_settings         = \sanitize_text_field( \wp_unslash( $_POST['activitypub_show_advanced_tab'] ) );
-			$advanced_settings_checked = empty( $advanced_settings ) ? 0 : 1;
-			\update_user_meta( \get_current_user_id(), 'activitypub_show_advanced_tab', $advanced_settings_checked );
+		foreach ( $screen_options as $option => $label ) {
+			if ( isset( $_POST[ $option ] ) ) {
+				$value = \sanitize_text_field( \wp_unslash( $_POST[ $option ] ) );
+				\update_user_meta( \get_current_user_id(), $option, empty( $value ) ? 0 : 1 );
+			}
 		}
 
-		$screen_settings = '<fieldset>
-		<legend class="screen-layout">' . \esc_html__( 'Settings Pages', 'activitypub' ) . '</legend>
-		<p>
-			' . \esc_html__( 'Some settings pages can be shown or hidden by using the checkboxes.', 'activitypub' ) . '
-		</p>
-		<div class="metabox-prefs-container">
-			<label for="activitypub_show_welcome_tab">
-				<input name="activitypub_show_welcome_tab" type="hidden" value="0" />
-				<input name="activitypub_show_welcome_tab" type="checkbox" id="activitypub_show_welcome_tab" value="1" ' . \checked( 1, \get_user_meta( \get_current_user_id(), 'activitypub_show_welcome_tab', true ), false ) . ' />
-				' . \esc_html__( 'Welcome Page', 'activitypub' ) . '
-			</label>
-			<label for="activitypub_show_advanced_tab">
-				<input name="activitypub_show_advanced_tab" type="hidden" value="0" />
-				<input name="activitypub_show_advanced_tab" type="checkbox" id="activitypub_show_advanced_tab" value="1" ' . \checked( 1, \get_user_meta( \get_current_user_id(), 'activitypub_show_advanced_tab', true ), false ) . ' />
-				' . \esc_html__( 'Advanced Settings', 'activitypub' ) . '
-			</label>
-		</div>
-	</fieldset>';
+		ob_start();
+		?>
+		<fieldset>
+			<legend class="screen-layout"><?php \esc_html_e( 'Settings Pages', 'activitypub' ); ?></legend>
+			<p><?php \esc_html_e( 'Some settings pages can be shown or hidden by using the checkboxes.', 'activitypub' ); ?></p>
+			<div class="metabox-prefs-container">
+				<?php foreach ( $screen_options as $option => $label ) : ?>
+					<label for="<?php echo \esc_attr( $option ); ?>">
+						<input name="<?php echo \esc_attr( $option ); ?>" type="hidden" value="0" />
+						<input name="<?php echo \esc_attr( $option ); ?>" type="checkbox" id="<?php echo \esc_attr( $option ); ?>" value="1" <?php \checked( 1, \get_user_meta( \get_current_user_id(), $option, true ) ); ?> />
+						<?php echo \esc_html( $label ); ?>
+					</label>
+				<?php endforeach; ?>
+			</div>
+		</fieldset>
+		<?php
 
-		return $screen_settings;
+		return ob_get_clean();
 	}
 
 	/**


### PR DESCRIPTION
Making the screen options list filterable makes it possible to adjust it on WP.com, a step towards enabling the admin UI there.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Makes list of screen options filterable.
* Updates data handling and html display based on a list of screen options.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Activitypub.
* Find the screen options tab in the top right and open it.
* Experiment with different on/off settings and make sure they still work and save correctly.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Screen options in the Activitypub settings page are now filterable.

</details>
