### PR TITLE
Blog Settings: Don't show username error for empty identifier

### DIFF
--- a/.github/changelog/1805-from-description
+++ b/.github/changelog/1805-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Setting the blog identifier to empty will no longer trigger an error message about it being the same as an existing user name.

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -72,6 +72,10 @@ class Sanitize {
 		$sanitized = \array_map( 'sanitize_title', $parts );
 		$sanitized = \implode( '.', $sanitized );
 
+		if ( empty( $sanitized ) ) {
+			return Blog::get_default_username();
+		}
+
 		// Check for login or nicename.
 		$user = new \WP_User_Query(
 			array(

--- a/tests/includes/class-test-sanitize.php
+++ b/tests/includes/class-test-sanitize.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Model\Blog;
 use Activitypub\Sanitize;
 
 /**
@@ -136,7 +137,7 @@ class Test_Sanitize extends \WP_UnitTestCase {
 			'with_dots'     => array( 'test.blog', 'test.blog' ),
 			'special_chars' => array( 'test@#$%^&*blog', 'testblog' ),
 			'multiple_dots' => array( 'test.blog.name', 'test.blog.name' ),
-			'empty_string'  => array( '', 'example.org' ),
+			'empty_string'  => array( '', Blog::get_default_username() ),
 		);
 	}
 

--- a/tests/includes/class-test-sanitize.php
+++ b/tests/includes/class-test-sanitize.php
@@ -136,6 +136,7 @@ class Test_Sanitize extends \WP_UnitTestCase {
 			'with_dots'     => array( 'test.blog', 'test.blog' ),
 			'special_chars' => array( 'test@#$%^&*blog', 'testblog' ),
 			'multiple_dots' => array( 'test.blog.name', 'test.blog.name' ),
+			'empty_string'  => array( '', 'example.org' ),
 		);
 	}
 


### PR DESCRIPTION
When the Blog Identifier settings field gets removed the setting still updates with an empty value, leading to the error "You cannot use an existing author's name for the blog profile ID.'" to show up.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Short-circuits blog identifier sanitization when the identifier is empty.
* Adds unit test.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Activitypub > Blog Profile.
* Set an empty value for the blog user and Save Changes.
* Make sure the username error message doesn't appear and the blog user name is set to default.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Setting the blog identifier to empty will no longer trigger an error message about it being the same as an existing user name.

</details>
