### PR TITLE
Settings: Make all tabs filterable

### DIFF
--- a/.github/changelog/1806-from-description
+++ b/.github/changelog/1806-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Plugins now have full control over which Settings tabs are shown in Settings > Activitypub.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Updates the `activitypub_admin_settings_tabs` filter to not only add tabs, but control the tabs that get displayed in general.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Passes all settings tabs to the filter.
* Adds doing it wrong notice if somehow we end up with 0 tabs and falls back to settings.
* Determines default tab based on the order in the settings_tabs array. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Activitypub and navigate through the settings tabs.
* Activate/deactivate Welcome and Advanced settings tab, make sure they still work.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Plugins now have full control over which Settings tabs are shown in Settings > Activitypub.

</details>
