### PR TITLE
Welcome: Account for blog mode in profile setup step

### DIFF
--- a/.github/changelog/1807-from-description
+++ b/.github/changelog/1807-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+The welcome page now links to the correct profile when Blog Only mode was selected in the profile mode step.

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -27,7 +27,7 @@ class Blog_Settings_Fields {
 	 */
 	public static function register_settings() {
 		// If we're in blog mode, and we're on the blog profile tab, mark the profile setup step as done.
-		if ( isset( $_GET['tab'] ) && 'blog-profile' === \sanitize_key( $_GET['tab'] && ACTIVITYPUB_BLOG_MODE === \get_option( 'activitypub_actor_mode' ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['tab'] ) && 'blog-profile' === \sanitize_key( $_GET['tab'] ) && ACTIVITYPUB_BLOG_MODE === \get_option( 'activitypub_actor_mode' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			\update_option( 'activitypub_checklist_profile_setup_visited', '1' );
 		}
 

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -26,8 +26,8 @@ class Blog_Settings_Fields {
 	 * Register all settings fields.
 	 */
 	public static function register_settings() {
-		if ( isset( $_GET['tab'] ) && 'blog-profile' === \sanitize_key( $_GET['tab'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			// Mark checklist item as done.
+		// If we're in blog mode, and we're on the blog profile tab, mark the profile setup step as done.
+		if ( isset( $_GET['tab'] ) && 'blog-profile' === \sanitize_key( $_GET['tab'] && ACTIVITYPUB_BLOG_MODE === \get_option( 'activitypub_actor_mode' ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			\update_option( 'activitypub_checklist_profile_setup_visited', '1' );
 		}
 

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -26,6 +26,11 @@ class Blog_Settings_Fields {
 	 * Register all settings fields.
 	 */
 	public static function register_settings() {
+		if ( isset( $_GET['tab'] ) && 'blog-profile' === \sanitize_key( $_GET['tab'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// Mark checklist item as done.
+			\update_option( 'activitypub_checklist_profile_setup_visited', '1' );
+		}
+
 		add_settings_section(
 			'activitypub_blog_profile',
 			__( 'Blog Profile', 'activitypub' ),

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -335,7 +335,7 @@ class Welcome_Fields {
 		$checked              = '1' === \get_option( 'activitypub_checklist_profile_setup_visited', false );
 		$step_class           = $checked ? 'activitypub-step-completed' : '';
 		$next_step            = self::get_next_incomplete_step();
-		$button_class         = ( 'profile_mode' === $next_step ) ? 'button-primary' : 'button-secondary';
+		$button_class         = ( 'profile_setup' === $next_step ) ? 'button-primary' : 'button-secondary';
 		?>
 		<div class="activitypub-onboarding-step <?php echo \esc_attr( $step_class ); ?>">
 			<div class="step-indicator">
@@ -353,6 +353,10 @@ class Welcome_Fields {
 				<div class="step-action">
 					<?php if ( true === $user_can_activitypub ) : ?>
 						<a href="<?php echo \esc_url( \admin_url( '/profile.php#activitypub' ) ); ?>" class="button <?php echo \esc_attr( $button_class ); ?>">
+							<?php \esc_html_e( 'Edit profile', 'activitypub' ); ?>
+						</a>
+					<?php elseif ( ACTIVITYPUB_BLOG_MODE === \get_option( 'activitypub_actor_mode' ) ) : ?>
+						<a href="<?php echo \esc_url( \admin_url( '/options-general.php?page=activitypub&tab=blog-profile' ) ); ?>" class="button <?php echo \esc_attr( $button_class ); ?>">
 							<?php \esc_html_e( 'Edit profile', 'activitypub' ); ?>
 						</a>
 					<?php else : ?>


### PR DESCRIPTION
Improves the experience for sites that picked Blog Only mode in the `profile_mode` step.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds step-completion option update to blog-profile tab.
* Adds a case for Blog Only sites to link the Profile setup button to the Blog Profile.
* Fixes a bug where the Blog Setup button was never made primary when it was the next button in the list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Activitypub to see the Welcome page. Re-enable it if needed.
* Click "Choose Mode", select "Blog profile only", and Save Changes.
* Go back to Welcome and click "Edit Profile"
* Make sure you end up on the Blog Profile tab.
*  Go back to Welcome and make sure the step is complete.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

The welcome page now links to the correct profile when Blog Only mode was selected in the profile mode step.

</details>
