### PR TITLE
Welcome: Make it possible to remove steps

### DIFF
--- a/.github/changelog/1809-from-description
+++ b/.github/changelog/1809-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Step completion tracking in the Welcome tab now even works when the number of steps gets reduced.

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -122,24 +122,24 @@ class Welcome_Fields {
 		$count = 1; // Plugin is already installed.
 
 		// We're looking for 0 issues.
-		if ( '0' === \get_option( 'activitypub_checklist_health_check_issues', (string) Health_Check::count_results( 'critical' ) ) ) {
+		if ( self::has_step( 'site_health' ) && '0' === \get_option( 'activitypub_checklist_health_check_issues', (string) Health_Check::count_results( 'critical' ) ) ) {
 			++$count;
 		}
 
 		// Check other completed steps.
-		if ( '1' === \get_option( 'activitypub_checklist_fediverse_intro_visited' ) ) {
+		if ( self::has_step( 'fediverse_intro' ) && '1' === \get_option( 'activitypub_checklist_fediverse_intro_visited' ) ) {
 			++$count;
 		}
 
-		if ( '1' === \get_option( 'activitypub_checklist_settings_visited' ) ) {
+		if ( self::has_step( 'profile_mode' ) && '1' === \get_option( 'activitypub_checklist_settings_visited' ) ) {
 			++$count;
 		}
 
-		if ( '1' === \get_option( 'activitypub_checklist_profile_setup_visited' ) ) {
+		if ( self::has_step( 'profile_setup' ) && '1' === \get_option( 'activitypub_checklist_profile_setup_visited' ) ) {
 			++$count;
 		}
 
-		if ( '1' === \get_option( 'activitypub_checklist_blocks_visited' ) ) {
+		if ( self::has_step( 'features' ) && '1' === \get_option( 'activitypub_checklist_blocks_visited' ) ) {
 			++$count;
 		}
 
@@ -165,27 +165,37 @@ class Welcome_Fields {
 	 * Get the next incomplete step.
 	 */
 	private static function get_next_incomplete_step() {
-		if ( '0' !== \get_option( 'activitypub_checklist_health_check_issues', (string) Health_Check::count_results( 'critical' ) ) ) {
+		if ( self::has_step( 'site_health' ) && '0' !== \get_option( 'activitypub_checklist_health_check_issues', (string) Health_Check::count_results( 'critical' ) ) ) {
 			return 'site_health';
 		}
 
-		if ( false === \get_option( 'activitypub_checklist_fediverse_intro_visited', false ) ) {
+		if ( self::has_step( 'fediverse_intro' ) && ! \get_option( 'activitypub_checklist_fediverse_intro_visited', false ) ) {
 			return 'fediverse_intro';
 		}
 
-		if ( false === \get_option( 'activitypub_checklist_settings_visited', false ) ) {
+		if ( self::has_step( 'profile_mode' ) && ! \get_option( 'activitypub_checklist_settings_visited', false ) ) {
 			return 'profile_mode';
 		}
 
-		if ( false === \get_option( 'activitypub_checklist_profile_setup_visited', false ) ) {
+		if ( self::has_step( 'profile_setup' ) && ! \get_option( 'activitypub_checklist_profile_setup_visited', false ) ) {
 			return 'profile_setup';
 		}
 
-		if ( false === \get_option( 'activitypub_checklist_blocks_visited', false ) ) {
+		if ( self::has_step( 'features' ) && ! \get_option( 'activitypub_checklist_blocks_visited', false ) ) {
 			return 'features';
 		}
 
 		return '';
+	}
+
+	/**
+	 * Check if a step exists.
+	 *
+	 * @param string $step Step slug.
+	 * @return bool
+	 */
+	private static function has_step( $step ) {
+		return \has_action( 'activitypub_onboarding_steps', array( self::class, 'render_step_' . $step ) );
 	}
 
 	/**

--- a/tests/includes/wp-admin/class-test-welcome-fields.php
+++ b/tests/includes/wp-admin/class-test-welcome-fields.php
@@ -16,10 +16,10 @@ use Activitypub\WP_Admin\Welcome_Fields;
  */
 class Test_Welcome_Fields extends \WP_UnitTestCase {
 	/**
-	 * Set up before class.
+	 * Set up.
 	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
+	public function set_up() {
+		parent::set_up();
 
 		Welcome_Fields::register_welcome_fields();
 	}

--- a/tests/includes/wp-admin/class-test-welcome-fields.php
+++ b/tests/includes/wp-admin/class-test-welcome-fields.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Test file for Welcome_Fields.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+use Activitypub\WP_Admin\Welcome_Fields;
+
+/**
+ * Test class for Welcome_Fields.
+ *
+ * @coversDefaultClass \Activitypub\WP_Admin\Welcome_Fields
+ */
+class Test_Welcome_Fields extends \WP_UnitTestCase {
+	/**
+	 * Set up before class.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		Welcome_Fields::register_welcome_fields();
+	}
+
+	/**
+	 * Test get_completed_steps_count.
+	 *
+	 * @throws \ReflectionException Reflection exception.
+	 * @covers ::get_completed_steps_count
+	 */
+	public function test_get_completed_steps_count() {
+		$get_completed_steps_count = new \ReflectionMethod( Welcome_Fields::class, 'get_completed_steps_count' );
+		$get_completed_steps_count->setAccessible( true );
+
+		$completed = 1; // Plugin is already installed.
+
+		$this->assertSame( $completed, $get_completed_steps_count->invoke( null ) ); // Null for static methods.
+
+		// Completed step.
+		\update_option( 'activitypub_checklist_settings_visited', '1' );
+		$this->assertSame( $completed + 1, $get_completed_steps_count->invoke( null ) );
+
+		// Remove the completed step.
+		\remove_action( 'activitypub_onboarding_steps', array( Welcome_Fields::class, 'render_step_profile_mode' ), 40 );
+
+		$this->assertSame( $completed, $get_completed_steps_count->invoke( null ) );
+
+		// Restore.
+		\add_action( 'activitypub_onboarding_steps', array( Welcome_Fields::class, 'render_step_profile_mode' ), 40 );
+		\delete_option( 'activitypub_checklist_settings_visited' );
+	}
+
+	/**
+	 * Test get_total_steps_count.
+	 *
+	 * @throws \ReflectionException Reflection exception.
+	 * @covers ::get_total_steps_count
+	 */
+	public function test_get_total_steps_count() {
+		$get_total_steps_count = new \ReflectionMethod( Welcome_Fields::class, 'get_total_steps_count' );
+		$get_total_steps_count->setAccessible( true );
+
+		$steps = 6;
+
+		$this->assertSame( $steps, $get_total_steps_count->invoke( null ) ); // Null for static methods.
+
+		// Remove a step.
+		\remove_action( 'activitypub_onboarding_steps', array( Welcome_Fields::class, 'render_step_site_health' ), 20 );
+
+		$this->assertSame( $steps - 1, $get_total_steps_count->invoke( null ) );
+
+		// Restore.
+		\add_action( 'activitypub_onboarding_steps', array( Welcome_Fields::class, 'render_step_site_health' ), 20 );
+	}
+
+	/**
+	 * Test get_next_incomplete_step.
+	 *
+	 * @throws \ReflectionException Reflection exception.
+	 * @covers ::get_next_incomplete_step
+	 */
+	public function test_get_next_incomplete_step() {
+		$get_next_incomplete_step = new \ReflectionMethod( Welcome_Fields::class, 'get_next_incomplete_step' );
+		$get_next_incomplete_step->setAccessible( true );
+
+		$this->assertSame( 'site_health', $get_next_incomplete_step->invoke( null ) ); // Null for static methods.
+
+		// Complete steps.
+		\add_filter( 'pre_option_activitypub_checklist_health_check_issues', array( $this, '__return_option_zero' ) );
+		\update_option( 'activitypub_checklist_fediverse_intro_visited', '1' );
+		$this->assertSame( 'profile_mode', $get_next_incomplete_step->invoke( null ) );
+
+		// Remove the next step.
+		\remove_action( 'activitypub_onboarding_steps', array( Welcome_Fields::class, 'render_step_profile_mode' ), 40 );
+
+		$this->assertSame( 'profile_setup', $get_next_incomplete_step->invoke( null ) );
+
+		// Restore.
+		\add_action( 'activitypub_onboarding_steps', array( Welcome_Fields::class, 'render_step_profile_mode' ), 40 );
+		\remove_filter( 'pre_option_activitypub_checklist_health_check_issues', array( $this, '__return_option_zero' ) );
+		\delete_option( 'activitypub_checklist_fediverse_intro_visited' );
+	}
+
+	/**
+	 * Return zero as a string.
+	 *
+	 * For when @see __return_zero() doesn't work because of how WordPress handles option values.
+	 *
+	 * @return string
+	 */
+	public function __return_option_zero() { // phpcs:ignore PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.MethodDoubleUnderscore
+		return '0';
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makes it possible to remove an onboarding step by removing the action that adds it, and the step tracking still keeping track correctly.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds tests.
* Makes sure a step is registered before counting it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a snippets plugin, or any other place, remove an onboarding step by removing the action that adds it. For example `\remove_action( 'activitypub_onboarding_steps', array( Activitypub\WP_Admin\Welcome_Fields::class, 'render_step_profile_mode' ), 40 );`
* Visit Settings > Activitypub and complete the remaining steps.
* Make sure the count and next-item highlight work as expected.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Step completion tracking in the Welcome tab now even works when the number of steps gets reduced.

</details>
