### PR TITLE
Reactions: Decode html entities in reactor names

### DIFF
--- a/.github/changelog/1810-from-description
+++ b/.github/changelog/1810-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Names containing HTML entities now get displayed correctly in the Reactions block's list of users.

--- a/build/reactions/render.php
+++ b/build/reactions/render.php
@@ -72,8 +72,7 @@ foreach ( Comment::get_comment_types() as $_type => $type_object ) {
 		'items' => array_map(
 			function ( $comment ) {
 				return array(
-					'id'     => $comment->comment_ID,
-					'name'   => $comment->comment_author,
+					'name'   => html_entity_decode( $comment->comment_author ),
 					'url'    => $comment->comment_author_url,
 					'avatar' => get_comment_meta( $comment->comment_ID, 'avatar_url', true ),
 				);

--- a/includes/rest/class-post-controller.php
+++ b/includes/rest/class-post-controller.php
@@ -124,7 +124,7 @@ class Post_Controller extends \WP_REST_Controller {
 				'items' => \array_map(
 					function ( $comment ) {
 						return array(
-							'name'   => $comment->comment_author,
+							'name'   => html_entity_decode( $comment->comment_author ),
 							'url'    => $comment->comment_author_url,
 							'avatar' => \get_comment_meta( $comment->comment_ID, 'avatar_url', true ),
 						);

--- a/src/reactions/render.php
+++ b/src/reactions/render.php
@@ -72,8 +72,7 @@ foreach ( Comment::get_comment_types() as $_type => $type_object ) {
 		'items' => array_map(
 			function ( $comment ) {
 				return array(
-					'id'     => $comment->comment_ID,
-					'name'   => $comment->comment_author,
+					'name'   => html_entity_decode( $comment->comment_author ),
 					'url'    => $comment->comment_author_url,
 					'avatar' => get_comment_meta( $comment->comment_ID, 'avatar_url', true ),
 				);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="783" alt="image" src="https://github.com/user-attachments/assets/39437d34-472d-4bb3-9a23-da8e5d57e53b" />

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Decode html entities in reactor names.
* Removes unused comment Id.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a remote profile, add an apostrophe to your name.
* Like a post.
* Make sure the name shows up correctly in the Reactions block.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Names containing HTML entities now get displayed correctly in the Reactions block's list of users.

</details>
