### PR TITLE
Interactions: Don't (always) accept empty names

### DIFF
--- a/.github/changelog/1811-from-description
+++ b/.github/changelog/1811-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Likes, comments, and reposts from the Fediverse now require either a name or `preferredUsername` to be set when the Discussion option `require_name_email` is set to true. It falls back to "Anonymous", if not.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -235,11 +235,14 @@ class Interactions {
 		}
 
 		// Check Actor-Name.
+		$comment_author = null;
 		if ( ! empty( $actor['name'] ) ) {
 			$comment_author = $actor['name'];
 		} elseif ( ! empty( $actor['preferredUsername'] ) ) {
 			$comment_author = $actor['preferredUsername'];
-		} else {
+		}
+
+		if ( empty( $comment_author ) && \get_option( 'require_name_email' ) ) {
 			return false;
 		}
 
@@ -261,7 +264,7 @@ class Interactions {
 		}
 
 		$comment_data = array(
-			'comment_author'       => \esc_attr( $comment_author ),
+			'comment_author'       => $comment_author ?? __( 'Anonymous', 'activitypub' ),
 			'comment_author_url'   => \esc_url_raw( $url ),
 			'comment_content'      => $comment_content,
 			'comment_type'         => 'comment',

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -235,9 +235,9 @@ class Interactions {
 		}
 
 		// Check Actor-Name.
-		if ( isset( $actor['name'] ) ) {
+		if ( ! empty( $actor['name'] ) ) {
 			$comment_author = $actor['name'];
-		} elseif ( isset( $actor['preferredUsername'] ) ) {
+		} elseif ( ! empty( $actor['preferredUsername'] ) ) {
 			$comment_author = $actor['preferredUsername'];
 		} else {
 			return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="793" alt="image" src="https://github.com/user-attachments/assets/b5abc534-d457-4e7a-a967-bf6049cb5087" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Looks for an actual name or `preferredUsername`, rather than just the key being present.
* Checks `require_name_email` option before rejecting a likes, comments, or reposts.
* Falls back to "Anonymous" of no-name comments are allowed.
* Adds tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an external user without a name, like https://browser.pub/https://pixelfed.social/pfefferle
* React to a test post.
* Make sure that the `preferredUsername` shows up in the Reactions block's list of users.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Likes, comments, and reposts from the Fediverse now require either a name or `preferredUsername` to be set when the Discussion option `require_name_email` is set to true. It falls back to "Anonymous", if not.

</details>
