### PR TITLE
Welcome Page: Fix missing CSS when used as fallback

### DIFF
--- a/.github/changelog/1820-from-description
+++ b/.github/changelog/1820-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The Welcome screen now loads with proper styling when shown as a fallback.

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -25,6 +25,23 @@ if ( ! function_exists( 'str_starts_with' ) ) {
 	}
 }
 
+if ( ! function_exists( 'str_ends_with' ) ) {
+	/**
+	 * Polyfill for `str_ends_with()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if
+	 * the haystack ends with needle.
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the `$haystack`.
+	 *
+	 * @return bool True if `$haystack` ends with `$needle`, otherwise false.
+	 */
+	function str_ends_with( $haystack, $needle ) {
+		return strlen( $needle ) === 0 || substr( $haystack, - strlen( $needle ) ) === $needle;
+	}
+}
+
 if ( ! function_exists( 'is_countable' ) ) {
 	/**
 	 * Polyfill for `is_countable()` function added in PHP 7.3.

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -36,10 +36,10 @@ class Welcome_Fields {
 	 * Enqueue styles.
 	 */
 	public static function enqueue_styles() {
-		add_action(
+		\add_action(
 			'wp_after_load_template',
 			function ( $template ) {
-				if ( str_ends_with( $template, 'welcome.php' ) ) {
+				if ( \str_ends_with( $template, 'welcome.php' ) ) {
 					\wp_enqueue_style(
 						'activitypub-welcome',
 						\plugins_url( 'assets/css/activitypub-welcome.css', ACTIVITYPUB_PLUGIN_FILE ),

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -36,15 +36,12 @@ class Welcome_Fields {
 	 * Enqueue styles.
 	 */
 	public static function enqueue_styles() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( 'welcome' === ( isset( $_GET['tab'] ) ? \sanitize_key( $_GET['tab'] ) : 'welcome' ) ) {
-			\wp_enqueue_style(
-				'activitypub-welcome',
-				\plugins_url( 'assets/css/activitypub-welcome.css', ACTIVITYPUB_PLUGIN_FILE ),
-				array(),
-				ACTIVITYPUB_PLUGIN_VERSION
-			);
-		}
+		\wp_enqueue_style(
+			'activitypub-welcome',
+			\plugins_url( 'assets/css/activitypub-welcome.css', ACTIVITYPUB_PLUGIN_FILE ),
+			array(),
+			ACTIVITYPUB_PLUGIN_VERSION
+		);
 	}
 
 	/**

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -18,7 +18,6 @@ class Welcome_Fields {
 	 */
 	public static function init() {
 		\add_action( 'load-settings_page_activitypub', array( self::class, 'register_welcome_fields' ) );
-		\add_action( 'admin_print_styles-settings_page_activitypub', array( self::class, 'enqueue_styles' ) );
 
 		\add_action( 'add_option_activitypub_checklist_health_check_issues', array( self::class, 'resolve_checklist' ) );
 		\add_action( 'update_option_activitypub_checklist_health_check_issues', array( self::class, 'resolve_checklist' ) );
@@ -30,25 +29,6 @@ class Welcome_Fields {
 		\add_action( 'update_option_activitypub_checklist_profile_setup_visited', array( self::class, 'resolve_checklist' ) );
 		\add_action( 'add_option_activitypub_checklist_blocks_visited', array( self::class, 'resolve_checklist' ) );
 		\add_action( 'update_option_activitypub_checklist_blocks_visited', array( self::class, 'resolve_checklist' ) );
-	}
-
-	/**
-	 * Enqueue styles.
-	 */
-	public static function enqueue_styles() {
-		\add_action(
-			'wp_after_load_template',
-			function ( $template ) {
-				if ( \str_ends_with( $template, 'welcome.php' ) ) {
-					\wp_enqueue_style(
-						'activitypub-welcome',
-						\plugins_url( 'assets/css/activitypub-welcome.css', ACTIVITYPUB_PLUGIN_FILE ),
-						array(),
-						ACTIVITYPUB_PLUGIN_VERSION
-					);
-				}
-			}
-		);
 	}
 
 	/**

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -36,11 +36,18 @@ class Welcome_Fields {
 	 * Enqueue styles.
 	 */
 	public static function enqueue_styles() {
-		\wp_enqueue_style(
-			'activitypub-welcome',
-			\plugins_url( 'assets/css/activitypub-welcome.css', ACTIVITYPUB_PLUGIN_FILE ),
-			array(),
-			ACTIVITYPUB_PLUGIN_VERSION
+		add_action(
+			'wp_after_load_template',
+			function ( $template ) {
+				if ( str_ends_with( $template, 'welcome.php' ) ) {
+					\wp_enqueue_style(
+						'activitypub-welcome',
+						\plugins_url( 'assets/css/activitypub-welcome.css', ACTIVITYPUB_PLUGIN_FILE ),
+						array(),
+						ACTIVITYPUB_PLUGIN_VERSION
+					);
+				}
+			}
 		);
 	}
 

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -5,6 +5,12 @@
  * @package Activitypub
  */
 
+wp_enqueue_style(
+	'activitypub-welcome',
+	plugins_url( 'assets/css/activitypub-welcome.css', ACTIVITYPUB_PLUGIN_FILE ),
+	array(),
+	ACTIVITYPUB_PLUGIN_VERSION
+);
 ?>
 
 <div class="activitypub-settings activitypub-welcome-page hide-if-no-js">

--- a/tests/includes/class-test-compat.php
+++ b/tests/includes/class-test-compat.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Test file for Activitypub Compat.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+/**
+ * Test class for Activitypub Compat.
+ */
+class Test_Compat extends \WP_UnitTestCase {
+	/**
+	 * Test str_starts_with.
+	 *
+	 * @covers str_starts_with
+	 */
+	public function test_str_starts_with() {
+		$this->assertTrue( \str_starts_with( 'abc', 'ab' ) );
+		$this->assertFalse( \str_starts_with( 'abc', 'bc' ) );
+	}
+
+	/**
+	 * Test str_ends_with.
+	 *
+	 * @covers str_ends_with
+	 */
+	public function test_str_ends_with() {
+		$this->assertTrue( \str_ends_with( 'abc', 'bc' ) );
+		$this->assertFalse( \str_ends_with( 'abc', 'ab' ) );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

While testing #1802 and #1806 I experienced a bug, where the CSS was not shown for the Welcome page when used as fallback.

When the plugin is configured to use only `Actors` (no blog user), the plugin loads the Welcome page as fallback if you try to load `/wp-admin/options-general.php?page=activitypub&tab=blog-profile` (same with other potentially deactivated settings pages). In this case the `tab` query param is `blog-profile` but it loads the welcome screen and because we have this check in place:

`if ( 'welcome' === ( isset( $_GET['tab'] ) ? \sanitize_key( $_GET['tab'] ) : 'welcome' ) )`

the welcome screen will be loaded without CSS.

<img width="1516" alt="Screenshot 2025-06-16 at 10 18 26" src="https://github.com/user-attachments/assets/c9c65a8e-211b-44c5-8545-fdfe002586f5" />

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check for loaded template file instead of tab, to show the CSS

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout trunk
* Change User-Mode to "Actors only"
* Load `/wp-admin/options-general.php?page=activitypub&tab=blog-profile`
* You will see the page with the missing CSS
* Checkout this PR and re-do all the steps above

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

The Welcome screen now loads with proper styling when shown as a fallback.

</details>
