### PR TITLE
Do not store `activitypub_max_image_attachments` if it uses the default value

### DIFF
--- a/.github/changelog/1821-from-description
+++ b/.github/changelog/1821-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+The image attachment setting is no longer saved to the database if it matches the default value.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -692,6 +692,13 @@ class Activitypub {
 		if ( 'activitypub_content_visibility' === $meta_key && empty( $meta_value ) ) {
 			\delete_post_meta( $object_id, 'activitypub_content_visibility' );
 		}
+
+		if (
+			'activitypub_max_image_attachments' === $meta_key &&
+			\get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) === (int) $meta_value
+		) {
+			\delete_post_meta( $object_id, 'activitypub_max_image_attachments' );
+		}
 	}
 
 	/**

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -695,7 +695,7 @@ class Activitypub {
 
 		if (
 			'activitypub_max_image_attachments' === $meta_key &&
-			\get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) === (int) $meta_value
+			(int) \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) === (int) $meta_value
 		) {
 			\delete_post_meta( $object_id, 'activitypub_max_image_attachments' );
 		}

--- a/tests/includes/class-test-activitypub.php
+++ b/tests/includes/class-test-activitypub.php
@@ -300,11 +300,11 @@ class Test_Activitypub extends \WP_UnitTestCase {
 			)
 		);
 
-		\add_post_meta( $post_id, 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
+		\update_post_meta( $post_id, 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
 		$this->assertEmpty( \get_post_meta( $post_id, 'activitypub_max_image_attachments', true ) );
 		\delete_post_meta( $post_id, 'activitypub_max_image_attachments' );
 
-		\add_post_meta( $post_id, 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS + 3 );
+		\update_post_meta( $post_id, 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS + 3 );
 		$this->assertEquals( ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS + 3, \get_post_meta( $post_id, 'activitypub_max_image_attachments', true ) );
 		\delete_post_meta( $post_id, 'activitypub_max_image_attachments' );
 

--- a/tests/includes/class-test-activitypub.php
+++ b/tests/includes/class-test-activitypub.php
@@ -287,4 +287,27 @@ class Test_Activitypub extends \WP_UnitTestCase {
 		// Clean up.
 		set_query_var( 'actor', null );
 	}
+
+	/**
+	 * Test updated_postmeta method.
+	 *
+	 * @covers ::updated_postmeta
+	 */
+	public function test_updated_postmeta() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => 1,
+			)
+		);
+
+		\add_post_meta( $post_id, 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
+		$this->assertEmpty( \get_post_meta( $post_id, 'activitypub_max_image_attachments', true ) );
+		\delete_post_meta( $post_id, 'activitypub_max_image_attachments' );
+
+		\add_post_meta( $post_id, 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS + 3 );
+		$this->assertEquals( ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS + 3, \get_post_meta( $post_id, 'activitypub_max_image_attachments', true ) );
+		\delete_post_meta( $post_id, 'activitypub_max_image_attachments' );
+
+		\wp_delete_post( $post_id, true );
+	}
 }


### PR DESCRIPTION
Do not store the `activitypub_max_image_attachments` Post-Meta, if it is the same as the default, to not spam the DB.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks if the `activitypub_max_image_attachments` setting from the block editor has the same value as the default, and remove it if so.

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See unittest

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

The image attachment setting is no longer saved to the database if it matches the default value.

</details>
