### PR TITLE
Fix `activitypub_max_image_attachments` check

### DIFF
--- a/.github/changelog/1822-from-description
+++ b/.github/changelog/1822-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The image attachment setting now correctly respects a value of 0, instead of falling back to the default.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -283,8 +283,11 @@ class Post extends Base {
 			return array();
 		}
 
-		// phpcs:ignore Universal.Operators.DisallowShortTernary
-		$max_media = \get_post_meta( $this->item->ID, 'activitypub_max_image_attachments', true ) ?: \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
+		$max_media = \get_post_meta( $this->item->ID, 'activitypub_max_image_attachments', true );
+
+		if ( ! is_numeric( $max_media ) ) {
+			$max_media = \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
+		}
 
 		/**
 		 * Filters the maximum number of media attachments allowed in a post.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -300,6 +300,10 @@ class Post extends Base {
 		 */
 		$max_media = (int) \apply_filters( 'activitypub_max_image_attachments', $max_media );
 
+		if ( 0 === $max_media ) {
+			return array();
+		}
+
 		$media = array(
 			'image' => array(),
 			'audio' => array(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The code currently uses the Ternary Operator (`?:`) to check if the `activitypub_max_image_attachments` meta is set and to fallback to the default `ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS` otherwise. The problem is, that the Ternary Operator sees `'0'` and `0` as negative/empty/null values and falls back to the default if the user sets `0` as the number of images in the block editor.

Fixes #1818 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check for `is_numberic` instead of using the Ternary Operator

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See #1818 or unittests

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

The image attachment setting now correctly respects a value of 0, instead of falling back to the default.

</details>
