### PR TITLE
Improve Post-Meta handling

### DIFF
--- a/.github/changelog/1829-from-description
+++ b/.github/changelog/1829-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent storage of empty or default post meta values.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -48,8 +48,8 @@ class Activitypub {
 
 		\add_filter( 'activitypub_get_actor_extra_fields', array( Extra_Fields::class, 'default_actor_extra_fields' ), 10, 2 );
 
-		\add_action( 'updated_postmeta', array( self::class, 'updated_postmeta' ), 10, 4 );
-		\add_action( 'added_post_meta', array( self::class, 'updated_postmeta' ), 10, 4 );
+		\add_filter( 'add_post_metadata', array( self::class, 'add_post_metadata' ), 10, 4 );
+		\add_filter( 'update_post_metadata', array( self::class, 'update_post_metadata' ), 10, 4 );
 
 		\add_action( 'init', array( self::class, 'register_user_meta' ), 11 );
 
@@ -680,25 +680,53 @@ class Activitypub {
 	}
 
 	/**
-	 * Delete `activitypub_content_visibility` when updated to an empty value.
+	 * Do not add meta in certain cases.
 	 *
-	 * @param int    $meta_id    ID of updated metadata entry.
-	 * @param int    $object_id  Post ID.
-	 * @param string $meta_key   Metadata key.
-	 * @param mixed  $meta_value Metadata value. This will be a PHP-serialized string representation of the value
-	 *                           if the value is an array, an object, or itself a PHP-serialized string.
+	 * @param null|bool $check      Whether to allow adding metadata for the given type.
+	 * @param int       $object_id  ID of the object metadata is for.
+	 * @param string    $meta_key   Metadata key.
+	 * @param mixed     $meta_value Metadata value. Must be serializable if non-scalar.
 	 */
-	public static function updated_postmeta( $meta_id, $object_id, $meta_key, $meta_value ) {
-		if ( 'activitypub_content_visibility' === $meta_key && empty( $meta_value ) ) {
-			\delete_post_meta( $object_id, 'activitypub_content_visibility' );
+	public static function add_post_metadata( $check, $object_id, $meta_key, $meta_value ) {
+		if ( \in_array( $meta_key, array( 'activitypub_content_visibility', 'activitypub_content_warning' ), true ) && empty( $meta_value ) ) {
+			return true;
 		}
 
 		if (
 			'activitypub_max_image_attachments' === $meta_key &&
 			(int) \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) === (int) $meta_value
 		) {
-			\delete_post_meta( $object_id, 'activitypub_max_image_attachments' );
+			return true;
 		}
+
+		return null;
+	}
+
+	/**
+	 * Do not add meta and delete meta when updated in certain cases.
+	 *
+	 * @param null|bool $check      Whether to allow updating metadata for the given type.
+	 * @param int       $object_id  ID of the object metadata is for.
+	 * @param string    $meta_key   Metadata key.
+	 * @param mixed     $meta_value Metadata value. Must be serializable if non-scalar.
+	 */
+	public static function update_post_metadata( $check, $object_id, $meta_key, $meta_value ) {
+		if ( \in_array( $meta_key, array( 'activitypub_content_visibility', 'activitypub_content_warning' ), true ) && empty( $meta_value ) ) {
+			\delete_post_meta( $object_id, $meta_key );
+
+			return true;
+		}
+
+		if (
+			'activitypub_max_image_attachments' === $meta_key &&
+			(int) \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) === (int) $meta_value
+		) {
+			\delete_post_meta( $object_id, $meta_key );
+
+			return true;
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -48,8 +48,8 @@ class Activitypub {
 
 		\add_filter( 'activitypub_get_actor_extra_fields', array( Extra_Fields::class, 'default_actor_extra_fields' ), 10, 2 );
 
-		\add_filter( 'add_post_metadata', array( self::class, 'add_post_metadata' ), 10, 4 );
-		\add_filter( 'update_post_metadata', array( self::class, 'update_post_metadata' ), 10, 4 );
+		\add_filter( 'add_post_metadata', array( self::class, 'prevent_empty_post_meta' ), 10, 4 );
+		\add_filter( 'update_post_metadata', array( self::class, 'prevent_empty_post_meta' ), 10, 4 );
 
 		\add_action( 'init', array( self::class, 'register_user_meta' ), 11 );
 
@@ -680,53 +680,29 @@ class Activitypub {
 	}
 
 	/**
-	 * Do not add meta in certain cases.
-	 *
-	 * @param null|bool $check      Whether to allow adding metadata for the given type.
-	 * @param int       $object_id  ID of the object metadata is for.
-	 * @param string    $meta_key   Metadata key.
-	 * @param mixed     $meta_value Metadata value. Must be serializable if non-scalar.
-	 */
-	public static function add_post_metadata( $check, $object_id, $meta_key, $meta_value ) {
-		if ( \in_array( $meta_key, array( 'activitypub_content_visibility', 'activitypub_content_warning' ), true ) && empty( $meta_value ) ) {
-			return true;
-		}
-
-		if (
-			'activitypub_max_image_attachments' === $meta_key &&
-			(int) \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) === (int) $meta_value
-		) {
-			return true;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Do not add meta and delete meta when updated in certain cases.
+	 * Prevent empty or default meta values.
 	 *
 	 * @param null|bool $check      Whether to allow updating metadata for the given type.
 	 * @param int       $object_id  ID of the object metadata is for.
 	 * @param string    $meta_key   Metadata key.
 	 * @param mixed     $meta_value Metadata value. Must be serializable if non-scalar.
 	 */
-	public static function update_post_metadata( $check, $object_id, $meta_key, $meta_value ) {
-		if ( \in_array( $meta_key, array( 'activitypub_content_visibility', 'activitypub_content_warning' ), true ) && empty( $meta_value ) ) {
-			\delete_post_meta( $object_id, $meta_key );
+	public static function prevent_empty_post_meta( $check, $object_id, $meta_key, $meta_value ) {
+		$post_metas = array(
+			'activitypub_content_visibility'    => '',
+			'activitypub_content_warning'       => '',
+			'activitypub_max_image_attachments' => (string) \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ),
+		);
 
-			return true;
+		if ( isset( $post_metas[ $meta_key ] ) && $post_metas[ $meta_key ] === (string) $meta_value ) {
+			if ( 'update_post_metadata' === current_action() ) {
+				\delete_post_meta( $object_id, $meta_key );
+			}
+
+			$check = true;
 		}
 
-		if (
-			'activitypub_max_image_attachments' === $meta_key &&
-			(int) \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) === (int) $meta_value
-		) {
-			\delete_post_meta( $object_id, $meta_key );
-
-			return true;
-		}
-
-		return null;
+		return $check;
 	}
 
 	/**

--- a/tests/includes/class-test-hashtag.php
+++ b/tests/includes/class-test-hashtag.php
@@ -44,14 +44,14 @@ class Test_Hashtag extends \WP_UnitTestCase {
 	 */
 	public function the_content_provider() {
 		$code     = '<code>text with some #object and <a> tag inside</code>';
-		$style    = <<<ENDSTYLE
+		$style    = <<<'ENDSTYLE'
 <style type="text/css">
 <![CDATA[
 color: #ccc;
 ]]>
 </style>
 ENDSTYLE;
-		$pre      = <<<ENDPRE
+		$pre      = <<<'ENDPRE'
 <pre>
 Please don't #touch
   this.

--- a/tests/includes/class-test-link.php
+++ b/tests/includes/class-test-link.php
@@ -35,14 +35,14 @@ class Test_Link extends \WP_UnitTestCase {
 	 */
 	public function the_content_provider() {
 		$code     = '<code>text with some https://test.de and <a> tag inside</code>';
-		$style    = <<<ENDSTYLE
+		$style    = <<<'ENDSTYLE'
 <style type="text/css">
 <![CDATA[
 color: #ccc;
 ]]>
 </style>
 ENDSTYLE;
-		$pre      = <<<ENDPRE
+		$pre      = <<<'ENDPRE'
 <pre>
 Please don't https://test.de
   this.

--- a/tests/includes/class-test-mention.php
+++ b/tests/includes/class-test-mention.php
@@ -67,7 +67,7 @@ class Test_Mention extends \WP_UnitTestCase {
 	 */
 	public function the_content_provider() {
 		$code = 'hallo <code>@username@example.org</code> test';
-		$pre  = <<<ENDPRE
+		$pre  = <<<'ENDPRE'
 <pre>
 Please don't mention @username@example.org
   here.


### PR DESCRIPTION
this is a follow up of #1821

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not store post-meta if empty or has the default value

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Prevent storage of empty or default post meta values.

</details>
