### PR TITLE
Standards: Update heredoc to nowdoc

### DIFF
--- a/tests/includes/class-test-hashtag.php
+++ b/tests/includes/class-test-hashtag.php
@@ -44,14 +44,14 @@ class Test_Hashtag extends \WP_UnitTestCase {
 	 */
 	public function the_content_provider() {
 		$code     = '<code>text with some #object and <a> tag inside</code>';
-		$style    = <<<ENDSTYLE
+		$style    = <<<'ENDSTYLE'
 <style type="text/css">
 <![CDATA[
 color: #ccc;
 ]]>
 </style>
 ENDSTYLE;
-		$pre      = <<<ENDPRE
+		$pre      = <<<'ENDPRE'
 <pre>
 Please don't #touch
   this.

--- a/tests/includes/class-test-link.php
+++ b/tests/includes/class-test-link.php
@@ -35,14 +35,14 @@ class Test_Link extends \WP_UnitTestCase {
 	 */
 	public function the_content_provider() {
 		$code     = '<code>text with some https://test.de and <a> tag inside</code>';
-		$style    = <<<ENDSTYLE
+		$style    = <<<'ENDSTYLE'
 <style type="text/css">
 <![CDATA[
 color: #ccc;
 ]]>
 </style>
 ENDSTYLE;
-		$pre      = <<<ENDPRE
+		$pre      = <<<'ENDPRE'
 <pre>
 Please don't https://test.de
   this.

--- a/tests/includes/class-test-mention.php
+++ b/tests/includes/class-test-mention.php
@@ -67,7 +67,7 @@ class Test_Mention extends \WP_UnitTestCase {
 	 */
 	public function the_content_provider() {
 		$code = 'hallo <code>@username@example.org</code> test';
-		$pre  = <<<ENDPRE
+		$pre  = <<<'ENDPRE'
 <pre>
 Please don't mention @username@example.org
   here.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes failing phpcs runs.

```
FILE: tests/includes/class-test-mention.php
----------------------------------------------------------------------------------------------------------------------
 70 | WARNING | [x] Detected heredoc without interpolation or expressions. Use nowdoc syntax instead
    |         |     (Generic.Strings.UnnecessaryHeredoc.Found)
----------------------------------------------------------------------------------------------------------------------
```

See https://github.com/Automattic/wordpress-activitypub/actions/runs/15735873357/job/44348297528?pr=1812
See https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.nowdoc

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates heredoc without interpolation or expressions to nowdoc.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

