### PR TITLE
Interactions: Accept webfinger IDs

### DIFF
--- a/.github/changelog/1834-from-description
+++ b/.github/changelog/1834-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Interaction attempts that pass a webfinger ID instead of a URL will work again.

--- a/includes/rest/class-interaction-controller.php
+++ b/includes/rest/class-interaction-controller.php
@@ -60,6 +60,12 @@ class Interaction_Controller extends \WP_REST_Controller {
 	 * @return string Sanitized URI.
 	 */
 	public function sanitize_uri( $uri ) {
+		// Remove "acct:" prefix if present.
+		if ( str_starts_with( $uri, 'acct:' ) ) {
+			$uri = \substr( $uri, 5 );
+		}
+
+		// Remove "@" prefix if present.
 		$uri = \ltrim( $uri, '@' );
 
 		if ( is_email( $uri ) ) {

--- a/includes/rest/class-interaction-controller.php
+++ b/includes/rest/class-interaction-controller.php
@@ -41,15 +41,32 @@ class Interaction_Controller extends \WP_REST_Controller {
 					'permission_callback' => '__return_true',
 					'args'                => array(
 						'uri' => array(
-							'description' => 'The URI of the object to interact with.',
-							'type'        => 'string',
-							'format'      => 'uri',
-							'required'    => true,
+							'description'       => 'The URI or webfinger ID of the object to interact with.',
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => array( $this, 'sanitize_uri' ),
 						),
 					),
 				),
 			)
 		);
+	}
+
+	/**
+	 * Sanitize the URI parameter.
+	 *
+	 * @param string $uri The URI or webfinger ID of the object to interact with.
+	 *
+	 * @return string Sanitized URI.
+	 */
+	public function sanitize_uri( $uri ) {
+		$uri = \ltrim( $uri, '@' );
+
+		if ( is_email( $uri ) ) {
+			return \sanitize_text_field( $uri );
+		}
+
+		return \sanitize_url( $uri );
 	}
 
 	/**

--- a/tests/includes/rest/class-test-interaction-controller.php
+++ b/tests/includes/rest/class-test-interaction-controller.php
@@ -95,8 +95,15 @@ class Test_Interaction_Controller extends \Activitypub\Tests\Test_REST_Controlle
 					'response' => array( 'code' => 200 ),
 					'body'     => wp_json_encode(
 						array(
-							'type' => 'Person',
-							'url'  => 'https://example.org/person',
+							'type'  => 'Person',
+							'url'   => 'https://example.org/person',
+							'links' => array(
+								array(
+									'rel'  => 'self',
+									'type' => 'application/activity+json',
+									'href' => 'https://example.org/user/person',
+								),
+							),
 						)
 					),
 				);
@@ -112,6 +119,16 @@ class Test_Interaction_Controller extends \Activitypub\Tests\Test_REST_Controlle
 		$this->assertEquals( 302, $response->get_status() );
 		$this->assertArrayHasKey( 'Location', $response->get_headers() );
 		$this->assertEquals( $this->follow_or_reply_url(), $response->get_headers()['Location'] );
+
+		\remove_filter( 'activitypub_interactions_follow_url', array( $this, 'follow_or_reply_url' ) );
+
+		// Test with Webfinger.
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/interactions' );
+		$request->set_param( 'uri', 'activitypub.blog@activitypub.blog' );
+
+		$this->expectExceptionMessage( 'This Interaction type is not supported yet!' );
+
+		rest_get_server()->dispatch( $request );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1831.
Introduced in #1149.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replaces `uri` formatting from `uri` parameter with sanitization callback.
* Adds unit test for accepting webfinger IDs.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* When following the Steps to reproduce in #1831, make sure the request fails with `This Interaction type is not supported yet!` and not with `The URL is not supported!`.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Interaction attempts that pass a webfinger ID instead of a URL will work again.

</details>
