### PR TITLE
Add missing "Advanced Settings" to the `debug_information`

### DIFF
--- a/.github/changelog/1846-from-description
+++ b/.github/changelog/1846-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added missing "Advanced Settings" details to Site Health debug information.

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -326,15 +326,27 @@ class Health_Check {
 			'private' => false,
 		);
 
-		$info['activitypub']['fields']['authorized_fetch'] = array(
-			'label'   => \__( 'Authorized Fetch', 'activitypub' ),
-			'value'   => \esc_attr( (int) \get_option( 'activitypub_authorized_fetch', '0' ) ),
+		$info['activitypub']['fields']['activitypub_outbox_purge_days'] = array(
+			'label'   => \__( 'Outbox Retention Period', 'activitypub' ),
+			'value'   => \esc_attr( (int) \get_option( 'activitypub_outbox_purge_days', 180 ) ),
 			'private' => false,
 		);
 
 		$info['activitypub']['fields']['vary_header'] = array(
 			'label'   => \__( 'Vary Header', 'activitypub' ),
 			'value'   => \esc_attr( (int) \get_option( 'activitypub_vary_header', '1' ) ),
+			'private' => false,
+		);
+
+		$info['activitypub']['fields']['content_negotiation'] = array(
+			'label'   => \__( 'Content Negotiation', 'activitypub' ),
+			'value'   => \esc_attr( (int) \get_option( 'activitypub_content_negotiation', '1' ) ),
+			'private' => false,
+		);
+
+		$info['activitypub']['fields']['authorized_fetch'] = array(
+			'label'   => \__( 'Authorized Fetch', 'activitypub' ),
+			'value'   => \esc_attr( (int) \get_option( 'activitypub_authorized_fetch', '0' ) ),
 			'private' => false,
 		);
 


### PR DESCRIPTION
Add missing "Advanced Settings" to the Site-Health `debug_information`. Especially `Content-Negotiation` is usefull when it comes to debugging on caching issues.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `activitypub_outbox_purge_days` and `activitypub_content_negotiation` to `debug_information`
* Re-order to use the same order as on the settings site (to please @obenlands monk)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'Tools' -> 'Site Health' -> 'Info'
* Check if "Outbox Retention Period" and "Content Negotiation" are visible

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added missing "Advanced Settings" details to Site Health debug information.

</details>
