### PR TITLE
Delete: Avoid Warning when actor can't be found

### DIFF
--- a/includes/handler/class-delete.php
+++ b/includes/handler/class-delete.php
@@ -104,7 +104,7 @@ class Delete {
 		$follower = Actors::get_remote_by_uri( $activity['actor'] );
 
 		// Verify that Actor is deleted.
-		if ( $follower && Http::is_tombstone( $activity['actor'] ) ) {
+		if ( ! is_wp_error( $follower ) && Http::is_tombstone( $activity['actor'] ) ) {
 			Actors::delete( $follower->ID );
 			self::maybe_delete_interactions( $activity );
 		}


### PR DESCRIPTION
Replaces a truthy check on $follower with an explicit `is_wp_error()` check to ensure proper handling when retrieving remote actors. This prevents a PHP warning when `$follower` is a `WP_Error` object and we try to access the `ID` property.

Follow-up to #1759.

```
Warning: Undefined property: WP_Error::$ID in /wp-content/plugins/wordpress-activitypub/includes/handler/class-delete.php:108

Stack Trace
1. Activitypub\Handler\Delete::maybe_delete_follower(Array)
	/wp-content/plugins/wordpress-activitypub/includes/handler/class-delete.php:89
2. Activitypub\Handler\Delete::handle_delete(Array)
	/wp-includes/class-wp-hook.php:326
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks for `WP_Error` explicitly, rather than a truthy Follower.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Update a test site to latest trunk.
* Receive a Delete activity from a Person object.
* Don't find any PHP Warnings in php-errors.