### PR TITLE
Add support for capability discovery

### DIFF
--- a/.github/changelog/1868-from-description
+++ b/.github/changelog/1868-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Documented support for FEP-844e.

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -19,6 +19,7 @@ The WordPress plugin largely follows ActivityPub's server-to-server specificatio
 - [FEP-fb2a: Actor metadata](https://codeberg.org/fediverse/fep/src/branch/main/fep/fb2a/fep-fb2a.md)
 - [FEP-b2b8: Long-form Text](https://codeberg.org/fediverse/fep/src/branch/main/fep/b2b8/fep-b2b8.md)
 - [FEP-7888: Demystifying the context property](https://codeberg.org/fediverse/fep/src/branch/main/fep/7888/fep-7888.md)
+- [FEP-844e: Capability discovery](https://codeberg.org/fediverse/fep/src/branch/main/fep/844e/fep-844e.md)
 
 Partially supported FEPs
 

--- a/includes/activity/class-actor.php
+++ b/includes/activity/class-actor.php
@@ -285,4 +285,13 @@ class Actor extends Base_Object {
 	 * @var boolean
 	 */
 	protected $posting_restricted_to_mods;
+
+	/**
+	 * Listing Implemented Specifications on the Application Actor
+	 *
+	 * @see https://codeberg.org/helge/fep/src/commit/e1b2a16707b542ea5ea0cfb390ac1abce89f05bb/fep/aaa3/fep-aaa3.md
+	 *
+	 * @var array
+	 */
+	protected $implemented;
 }

--- a/includes/activity/class-actor.php
+++ b/includes/activity/class-actor.php
@@ -23,6 +23,7 @@ class Actor extends Base_Object {
 		'https://www.w3.org/ns/activitystreams',
 		'https://w3id.org/security/v1',
 		'https://purl.archive.org/socialweb/webfinger',
+		'https://w3id.org/fep/844e',
 		array(
 			'schema'                    => 'http://schema.org#',
 			'toot'                      => 'http://joinmastodon.org/ns#',

--- a/includes/model/class-application.php
+++ b/includes/model/class-application.php
@@ -46,6 +46,20 @@ class Application extends Actor {
 	protected $indexable = false;
 
 	/**
+	 * List of software capabilities implemented by the Application.
+	 *
+	 * @see https://codeberg.org/silverpill/feps/src/branch/main/844e/fep-844e.md
+	 *
+	 * @var array
+	 */
+	protected $implements = array(
+		array(
+			'href' => 'https://datatracker.ietf.org/doc/html/rfc9421',
+			'name' => 'RFC-9421: HTTP Message Signatures',
+		),
+	);
+
+	/**
 	 * Returns the type of the object.
 	 *
 	 * @return string The type of the object.

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -31,6 +31,22 @@ class Blog extends Actor {
 	protected $_id = Actors::BLOG_USER_ID; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
+	 * The generator of the object.
+	 *
+	 * @see https://www.w3.org/TR/activitypub/#generator
+	 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/844e/fep-844e.md#discovery-through-an-actor
+	 *
+	 * @var array
+	 */
+	protected $generator = array(
+		'type'       => 'Application',
+		'implements' => array(
+			'href' => 'https://datatracker.ietf.org/doc/html/rfc9421',
+			'name' => 'RFC-9421: HTTP Message Signatures',
+		),
+	);
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -41,6 +41,22 @@ class User extends Actor {
 	protected $discoverable = true;
 
 	/**
+	 * The generator of the object.
+	 *
+	 * @see https://www.w3.org/TR/activitypub/#generator
+	 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/844e/fep-844e.md#discovery-through-an-actor
+	 *
+	 * @var array
+	 */
+	protected $generator = array(
+		'type'       => 'Application',
+		'implements' => array(
+			'href' => 'https://datatracker.ietf.org/doc/html/rfc9421',
+			'name' => 'RFC-9421: HTTP Message Signatures',
+		),
+	);
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int $user_id Optional. The WordPress user ID. Default null.

--- a/includes/rest/class-actors-controller.php
+++ b/includes/rest/class-actors-controller.php
@@ -357,17 +357,14 @@ class Actors_Controller extends \WP_REST_Controller {
 							'type' => 'string',
 						),
 						'implements' => array(
-							'type'  => 'array',
-							'items' => array(
-								'type'       => 'object',
-								'properties' => array(
-									'href' => array(
-										'type'   => 'string',
-										'format' => 'uri',
-									),
-									'name' => array(
-										'type' => 'string',
-									),
+							'type'       => 'object',
+							'properties' => array(
+								'href' => array(
+									'type'   => 'string',
+									'format' => 'uri',
+								),
+								'name' => array(
+									'type' => 'string',
 								),
 							),
 						),

--- a/includes/rest/class-actors-controller.php
+++ b/includes/rest/class-actors-controller.php
@@ -349,6 +349,31 @@ class Actors_Controller extends \WP_REST_Controller {
 					'type'        => 'boolean',
 					'readonly'    => true,
 				),
+				'generator'                 => array(
+					'description' => 'The generator of the object.',
+					'type'        => 'object',
+					'properties'  => array(
+						'type'       => array(
+							'type' => 'string',
+						),
+						'implements' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'href' => array(
+										'type'   => 'string',
+										'format' => 'uri',
+									),
+									'name' => array(
+										'type' => 'string',
+									),
+								),
+							),
+						),
+					),
+					'readonly'    => true,
+				),
 			),
 		);
 

--- a/includes/rest/class-application-controller.php
+++ b/includes/rest/class-application-controller.php
@@ -157,6 +157,21 @@ class Application_Controller extends \WP_REST_Controller {
 				'indexable'                 => array(
 					'type' => 'boolean',
 				),
+				'implements'                => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'href' => array(
+								'type'   => 'string',
+								'format' => 'uri',
+							),
+							'name' => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
 				'webfinger'                 => array(
 					'type' => 'string',
 				),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I came across FEP 844e during my research on RFC 9421. It's pretty fresh and I'm happy for us to determine this would not be a good fit for the plugin, but I thought supporting it seems pretty trivial and could help with making it clearer that we support RFC 9421 signatures.

See https://codeberg.org/fediverse/fep/src/branch/main/fep/844e/fep-844e.md

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds support for FEP 844e.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Documented support for FEP-844e.

</details>
