### PR TITLE
Signature: Cache instances that don't support RFC 9421

### DIFF
--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -90,7 +90,7 @@ class Signature {
 			)
 		);
 
-		if ( '1' === \get_option( 'activitypub_rfc9421_signature' ) ) {
+		if ( '1' === \get_option( 'activitypub_rfc9421_signature' ) && ! self::rfc9421_is_unsupported( $url ) ) {
 			$signature = new Http_Message_Signature();
 			\add_filter( 'http_response', array( self::class, 'maybe_double_knock' ), 10, 3 );
 		} else {
@@ -208,12 +208,49 @@ class Signature {
 
 		if ( 401 === wp_remote_retrieve_response_code( $response ) ) {
 			unset( $parsed_args['headers']['Signature'], $parsed_args['headers']['Signature-Input'], $parsed_args['headers']['Content-Digest'] );
+			self::set_rfc9421_unsupported( $url );
 
 			$parsed_args = ( new Draft_Cavage_Signature() )->sign( $parsed_args, $url );
 			$response    = \wp_remote_request( $url, $parsed_args );
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Check if RFC-9421 signature is unsupported for a given host.
+	 *
+	 * @param string $url The URL to check.
+	 *
+	 * @return bool True, if unsupported, false otherwise.
+	 */
+	private static function rfc9421_is_unsupported( $url ) {
+		$host = \wp_parse_url( $url, \PHP_URL_HOST );
+		$list = \get_option( 'activitypub_rfc9421_unsupported', array() );
+
+		if ( isset( $list[ $host ] ) ) {
+			if ( $list[ $host ] > \time() ) {
+				return true;
+			}
+
+			unset( $list[ $host ] );
+			\update_option( 'activitypub_rfc9421_unsupported', $list );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Set RFC-9421 signature unsupported for a given host.
+	 *
+	 * @param string $url The URL to set.
+	 */
+	private static function set_rfc9421_unsupported( $url ) {
+		$list = \get_option( 'activitypub_rfc9421_unsupported', array() );
+		$host = \wp_parse_url( $url, \PHP_URL_HOST );
+
+		$list[ $host ] = \time() + MONTH_IN_SECONDS;
+		\update_option( 'activitypub_rfc9421_unsupported', $list, false );
 	}
 
 	/**

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -208,7 +208,7 @@ class Signature {
 
 		if ( 401 === wp_remote_retrieve_response_code( $response ) ) {
 			unset( $parsed_args['headers']['Signature'], $parsed_args['headers']['Signature-Input'], $parsed_args['headers']['Content-Digest'] );
-			self::set_rfc9421_unsupported( $url );
+			self::rfc9421_add_unsupported_host( $url );
 
 			$parsed_args = ( new Draft_Cavage_Signature() )->sign( $parsed_args, $url );
 			$response    = \wp_remote_request( $url, $parsed_args );
@@ -245,7 +245,7 @@ class Signature {
 	 *
 	 * @param string $url The URL to set.
 	 */
-	private static function set_rfc9421_unsupported( $url ) {
+	private static function rfc9421_add_unsupported_host( $url ) {
 		$list = \get_option( 'activitypub_rfc9421_unsupported', array() );
 		$host = \wp_parse_url( $url, \PHP_URL_HOST );
 

--- a/tests/includes/class-test-signature.php
+++ b/tests/includes/class-test-signature.php
@@ -687,15 +687,16 @@ class Test_Signature extends \WP_UnitTestCase {
 	/**
 	 * Test RFC-9421 signature verification when it is unsupported.
 	 *
-	 * @covers ::set_rfc9421_unsupported
+	 * @covers ::rfc9421_add_unsupported_host
 	 */
 	public function test_set_rfc9421_unsupported() {
 		\update_option( 'activitypub_rfc9421_signature', '1' );
+		$url = 'https://example.org/wp-json/activitypub/1.0/inbox';
 
 		// Test domain is not unsupported.
 		$rfc9421_is_unsupported = new \ReflectionMethod( Signature::class, 'rfc9421_is_unsupported' );
 		$rfc9421_is_unsupported->setAccessible( true );
-		$this->assertFalse( $rfc9421_is_unsupported->invoke( null, 'https://example.org' ) );
+		$this->assertFalse( $rfc9421_is_unsupported->invoke( null, $url ) );
 
 		\add_filter(
 			'pre_http_request',
@@ -722,10 +723,10 @@ class Test_Signature extends \WP_UnitTestCase {
 			3
 		);
 
-		Http::post( 'https://example.org/wp-json/activitypub/1.0/inbox', '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}', 1 );
+		Http::post( $url, '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}', 1 );
 
 		// Domain is set as unsupported.
-		$this->assertTrue( $rfc9421_is_unsupported->invoke( null, 'https://example.org' ) );
+		$this->assertTrue( $rfc9421_is_unsupported->invoke( null, $url ) );
 
 		// Cleanup.
 		\delete_option( 'activitypub_rfc9421_signature' );

--- a/tests/includes/class-test-signature.php
+++ b/tests/includes/class-test-signature.php
@@ -9,6 +9,7 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Http;
 use Activitypub\Signature;
 use Activitypub\Collection\Actors;
 
@@ -634,5 +635,100 @@ class Test_Signature extends \WP_UnitTestCase {
 		$this->assertTrue( Signature::verify_http_signature( $request ) );
 
 		\remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+	}
+
+	/**
+	 * Test RFC-9421 signature verification when it is unsupported.
+	 *
+	 * @covers ::rfc9421_is_unsupported
+	 */
+	public function test_rfc9421_is_unsupported() {
+		\add_option( 'activitypub_rfc9421_unsupported', array( 'sub.www.example.org' => \time() + MINUTE_IN_SECONDS ), '', false );
+		\update_option( 'activitypub_rfc9421_signature', '1' );
+
+		\add_filter( 'pre_http_request', '__return_null' );
+		\add_filter(
+			'http_request_args',
+			function ( $args ) {
+				$this->assertFalse( isset( $args['headers']['Signature-Input'] ) );
+				$this->assertStringContainsString( 'headers="(request-target) host date digest"', $args['headers']['Signature'] );
+
+				return $args;
+			}
+		);
+
+		Http::post( 'https://sub.www.example.org/wp-json/activitypub/1.0/inbox', '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}', 1 );
+
+		// Expired timestamp results in another try.
+		\update_option( 'activitypub_rfc9421_unsupported', array( 'sub.www.example.org' => \time() - MINUTE_IN_SECONDS ), '', false );
+		\remove_all_filters( 'http_request_args' );
+
+		\add_filter(
+			'http_request_args',
+			function ( $args ) {
+				$this->assertTrue( isset( $args['headers']['Signature-Input'] ) );
+				$this->assertStringStartsWith( 'wp=:', $args['headers']['Signature'] );
+
+				return $args;
+			}
+		);
+
+		Http::post( 'https://sub.www.example.org/wp-json/activitypub/1.0/inbox', '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}', 1 );
+
+		$this->assertEmpty( \get_option( 'activitypub_rfc9421_unsupported' ) );
+
+		// Cleanup.
+		\delete_option( 'activitypub_rfc9421_unsupported' );
+		\delete_option( 'activitypub_rfc9421_signature' );
+		\remove_all_filters( 'pre_http_request' );
+		\remove_all_filters( 'http_request_args' );
+	}
+
+	/**
+	 * Test RFC-9421 signature verification when it is unsupported.
+	 *
+	 * @covers ::set_rfc9421_unsupported
+	 */
+	public function test_set_rfc9421_unsupported() {
+		\update_option( 'activitypub_rfc9421_signature', '1' );
+
+		// Test domain is not unsupported.
+		$rfc9421_is_unsupported = new \ReflectionMethod( Signature::class, 'rfc9421_is_unsupported' );
+		$rfc9421_is_unsupported->setAccessible( true );
+		$this->assertFalse( $rfc9421_is_unsupported->invoke( null, 'https://example.org' ) );
+
+		\add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) {
+				$response = array(
+					'headers'  => array(),
+					'body'     => '',
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+				);
+
+				if ( isset( $args['headers']['Signature-Input'] ) ) {
+					$response['response'] = array(
+						'code'    => 401,
+						'message' => 'Unauthorized',
+					);
+				}
+
+				return \apply_filters( 'http_response', $response, $args, $url );
+			},
+			10,
+			3
+		);
+
+		Http::post( 'https://example.org/wp-json/activitypub/1.0/inbox', '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}', 1 );
+
+		// Domain is set as unsupported.
+		$this->assertTrue( $rfc9421_is_unsupported->invoke( null, 'https://example.org' ) );
+
+		// Cleanup.
+		\delete_option( 'activitypub_rfc9421_signature' );
+		\remove_all_filters( 'pre_http_request' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow-up to #1858.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check for known instances that don't support RFC 9421 signatures, before attempting to send them.
* Adds hosts who returned a 401 for an RFC 9421 signature to the list of unsupported hosts.
* Adds tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
