### PR TITLE
Remove Hashcats

### DIFF
--- a/.github/changelog/1873-from-description
+++ b/.github/changelog/1873-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Using categories as hashtags has been removed to prevent conflicts with tags of the same name.

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -312,32 +312,12 @@ class Shortcodes {
 	/**
 	 * Generates output for the 'ap_hashcats' Shortcode.
 	 *
+	 * @deprecated unreleased
+	 *
 	 * @return string The post categories as hashtags.
 	 */
 	public static function hashcats() {
-		$item = self::get_item();
-
-		if ( ! $item ) {
-			return '';
-		}
-
-		$categories = \get_the_category( $item->ID );
-
-		if ( ! $categories ) {
-			return '';
-		}
-
-		$hash_tags = array();
-
-		foreach ( $categories as $category ) {
-			$hash_tags[] = \sprintf(
-				'<a rel="tag" class="hashtag u-tag u-category" href="%s">%s</a>',
-				\esc_url( \get_category_link( $category ) ),
-				esc_hashtag( $category->name )
-			);
-		}
-
-		return \implode( ' ', $hash_tags );
+		return '';
 	}
 
 	/**

--- a/templates/help-tab/template-tags.php
+++ b/templates/help-tab/template-tags.php
@@ -41,8 +41,6 @@ $anchor_html = array(
 <dl>
 	<dt><code>[ap_hashtags]</code></dt>
 	<dd><?php esc_html_e( 'The post&#8217;s tags as hashtags.', 'activitypub' ); ?></dd>
-	<dt><code>[ap_hashcats]</code></dt>
-	<dd><?php esc_html_e( 'The post&#8217;s categories as hashtags.', 'activitypub' ); ?></dd>
 	<dt><code>[ap_author]</code></dt>
 	<dd><?php esc_html_e( 'The author&#8217;s name.', 'activitypub' ); ?></dd>
 	<dt><code>[ap_authorurl]</code></dt>

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -276,7 +276,7 @@ class Test_Migration extends \WP_UnitTestCase {
 		$this->assertEquals( "[ap_content]\n\n[ap_permalink type=\"html\"]\n\n[ap_hashtags]", $template );
 		$this->assertFalse( $content_type );
 
-		$custom = '[ap_title] [ap_content] [ap_hashcats] [ap_authorurl]';
+		$custom = '[ap_title] [ap_content] [ap_authorurl]';
 
 		\update_option( 'activitypub_post_content_type', 'custom' );
 		\update_option( 'activitypub_custom_post_content', $custom );


### PR DESCRIPTION
Categories can cause issues, when set as hashtags, because there is no proper collision detection that prevents the duplicate usage of a category and a tag with the same name.

Fixes #1783

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed hashcats shortcode

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See #1783

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Using categories as hashtags has been removed to prevent conflicts with tags of the same name.

</details>
