### PR TITLE
Signature: Double-knock on any 400 response

### DIFF
--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -206,7 +206,8 @@ class Signature {
 		// Remove this filter to prevent infinite recursion.
 		\remove_filter( 'http_response', array( self::class, 'maybe_double_knock' ) );
 
-		if ( 401 === wp_remote_retrieve_response_code( $response ) ) {
+		$response_code = \wp_remote_retrieve_response_code( $response );
+		if ( 400 <= $response_code && 500 > $response_code ) {
 			unset( $parsed_args['headers']['Signature'], $parsed_args['headers']['Signature-Input'], $parsed_args['headers']['Content-Digest'] );
 			self::rfc9421_add_unsupported_host( $url );
 

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -207,7 +207,9 @@ class Signature {
 		\remove_filter( 'http_response', array( self::class, 'maybe_double_knock' ) );
 
 		$response_code = \wp_remote_retrieve_response_code( $response );
-		if ( 400 <= $response_code && 500 > $response_code ) {
+
+		// Fall back to Draft Cavage signature for any 4xx responses.
+		if ( 400 <= $response_code && $response_code < 500 ) {
 			unset( $parsed_args['headers']['Signature'], $parsed_args['headers']['Signature-Input'], $parsed_args['headers']['Content-Digest'] );
 			self::rfc9421_add_unsupported_host( $url );
 

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -209,7 +209,7 @@ class Signature {
 		$response_code = \wp_remote_retrieve_response_code( $response );
 
 		// Fall back to Draft Cavage signature for any 4xx responses.
-		if ( 400 <= $response_code && $response_code < 500 ) {
+		if ( $response_code >= 400 && $response_code < 500 ) {
 			unset( $parsed_args['headers']['Signature'], $parsed_args['headers']['Signature-Input'], $parsed_args['headers']['Content-Digest'] );
 			self::rfc9421_add_unsupported_host( $url );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Lemmy processes content digest first and fails it with a `400` response. We'll need to expand the status code check to also send a second knock in that case.

Follow-up to #1858.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sends a second knock on any 4xx response code.
