### PR TITLE
Signature: Always add Host header

### DIFF
--- a/includes/signature/class-draft-cavage-signature.php
+++ b/includes/signature/class-draft-cavage-signature.php
@@ -63,6 +63,7 @@ class Draft_Cavage_Signature implements Signature_Standard {
 		\openssl_sign( $signed_string, $signature, $args['private_key'], \OPENSSL_ALGO_SHA256 );
 		$signature = \base64_encode( $signature );
 
+		$args['headers']['Host']      = $host;
 		$args['headers']['Signature'] = \sprintf(
 			'keyId="%s",algorithm="rsa-sha256",headers="%s",signature="%s"',
 			$args['key_id'],

--- a/includes/signature/class-http-message-signature.php
+++ b/includes/signature/class-http-message-signature.php
@@ -31,11 +31,13 @@ class Http_Message_Signature implements Signature_Standard {
 	 * @return array Request arguments with signature headers.
 	 */
 	public function sign( $args, $url ) {
+		$host = \wp_parse_url( $url, \PHP_URL_HOST );
+
 		// Standard components to sign.
 		$components  = array(
 			'"@method"'     => \strtoupper( $args['method'] ),
 			'"@target-uri"' => $url,
-			'"@authority"'  => \wp_parse_url( $url, PHP_URL_HOST ),
+			'"@authority"'  => $host,
 			'"created"'     => \strtotime( $args['headers']['Date'] ), // Required by Mastodon. See https://github.com/mastodon/mastodon/pull/34814.
 		);
 		$identifiers = \array_keys( $components );
@@ -61,6 +63,7 @@ class Http_Message_Signature implements Signature_Standard {
 		\openssl_sign( $signature_base, $signature, $args['private_key'], \OPENSSL_ALGO_SHA256 );
 		$signature = \base64_encode( $signature );
 
+		$args['headers']['Host']            = $host;
 		$args['headers']['Signature-Input'] = 'wp=(' . \implode( ' ', $identifiers ) . ');created=' . $components['"created"'] . ';keyid="' . $args['key_id'] . '";alg="rsa-v1_5-sha256"';
 		$args['headers']['Signature']       = 'wp=:' . $signature . ':';
 


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wordpress-activitypub/pull/1858.

[Mitra looks for the Host header](https://codeberg.org/silverpill/mitra/src/branch/main/apx_core/src/http_signatures/verify.rs#L303-L308) when processing the `@authority` parameter.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The Host header is now explicitly set in both `Draft_Cavage_Signature` and `Http_Message_Signature` classes when signing requests.

