### PR TITLE
Remove reactions from comment feed

### DIFF
--- a/.github/changelog/1877-from-description
+++ b/.github/changelog/1877-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Comment feeds now show only comments by default, with a new `type` filter (e.g., `like`, `all`) to customize which reactions appear.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -309,6 +309,7 @@ class Activitypub {
 		$vars[] = 'preview';
 		$vars[] = 'author';
 		$vars[] = 'actor';
+		$vars[] = 'type';
 		$vars[] = 'c';
 		$vars[] = 'p';
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -25,6 +25,7 @@ class Comment {
 
 		\add_filter( 'comment_reply_link', array( self::class, 'comment_reply_link' ), 10, 3 );
 		\add_filter( 'comment_class', array( self::class, 'comment_class' ), 10, 3 );
+		\add_filter( 'comment_feed_where', array( static::class, 'comment_feed_where' ) );
 		\add_filter( 'get_comment_link', array( self::class, 'remote_comment_link' ), 11, 2 );
 		\add_action( 'pre_get_comments', array( static::class, 'comment_query' ) );
 		\add_filter( 'pre_comment_approved', array( static::class, 'pre_comment_approved' ), 10, 2 );
@@ -338,6 +339,31 @@ class Comment {
 		}
 
 		return $classes;
+	}
+
+	/**
+	 * Filters the comment feed where clause to exclude ActivityPub comment types.
+	 *
+	 * @param string $where The WHERE clause for the comment feed query.
+	 *
+	 * @return string The modified WHERE clause.
+	 */
+	public static function comment_feed_where( $where ) {
+		$comment_type = get_query_var( 'type' );
+
+		if ( 'all' === $comment_type ) {
+			return $where;
+		}
+
+		$comment_types = self::get_comment_type_slugs();
+
+		if ( in_array( $comment_type, $comment_types, true ) ) {
+			$where .= " AND comment_type = '$comment_type'";
+		} else {
+			$where .= " AND comment_type = 'comment'";
+		}
+
+		return $where;
 	}
 
 	/**

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -342,7 +342,9 @@ class Comment {
 	}
 
 	/**
-	 * Filters the comment feed where clause to exclude ActivityPub comment types.
+	 * Makes the comment feed filterable by comment type.
+	 *
+	 * Also excludes ActivityPub comment types from the feed when no type is specified.
 	 *
 	 * @param string $where The WHERE clause for the comment feed query.
 	 *

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -359,10 +359,11 @@ class Comment {
 
 		$comment_types = self::get_comment_type_slugs();
 
-		if ( in_array( $comment_type, $comment_types, true ) ) {
-			$where .= sprintf( " AND comment_type = '%s'", esc_sql( $comment_type ) );
+		if ( \in_array( $comment_type, $comment_types, true ) ) {
+			$where .= \sprintf( " AND comment_type = '%s'", \esc_sql( $comment_type ) );
 		} else {
-			$where .= sprintf( " AND comment_type NOT IN ('%s')", esc_sql( implode( "', '", $comment_types ) ) );
+			$comment_types = \array_map( 'esc_sql', $comment_types );
+			$where        .= \sprintf( " AND comment_type NOT IN ('%s')", \implode( "', '", $comment_types ) );
 		}
 
 		return $where;

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -349,7 +349,7 @@ class Comment {
 	 * @return string The modified WHERE clause.
 	 */
 	public static function comment_feed_where( $where ) {
-		$comment_type = get_query_var( 'type' );
+		$comment_type = \get_query_var( 'type' );
 
 		if ( 'all' === $comment_type ) {
 			return $where;

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -358,7 +358,7 @@ class Comment {
 		$comment_types = self::get_comment_type_slugs();
 
 		if ( in_array( $comment_type, $comment_types, true ) ) {
-			$where .= " AND comment_type = '$comment_type'";
+			$where .= " AND comment_type = '" . esc_sql( $comment_type ) . "'";
 		} else {
 			$where .= " AND comment_type = 'comment'";
 		}

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -346,9 +346,9 @@ class Comment {
 	 *
 	 * Also excludes ActivityPub comment types from the feed when no type is specified.
 	 *
-	 * @param string $where The WHERE clause for the comment feed query.
+	 * @param string $where The `WHERE` clause for the comment feed query.
 	 *
-	 * @return string The modified WHERE clause.
+	 * @return string The modified `WHERE` clause.
 	 */
 	public static function comment_feed_where( $where ) {
 		$comment_type = \get_query_var( 'type' );
@@ -360,9 +360,9 @@ class Comment {
 		$comment_types = self::get_comment_type_slugs();
 
 		if ( in_array( $comment_type, $comment_types, true ) ) {
-			$where .= " AND comment_type = '" . esc_sql( $comment_type ) . "'";
+			$where .= sprintf( " AND comment_type = '%s'", esc_sql( $comment_type ) );
 		} else {
-			$where .= " AND comment_type = 'comment'";
+			$where .= sprintf( " AND comment_type NOT IN ('%s')", esc_sql( implode( "', '", $comment_types ) ) );
 		}
 
 		return $where;

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -351,6 +351,8 @@ class Comment {
 	 * @return string The modified `WHERE` clause.
 	 */
 	public static function comment_feed_where( $where ) {
+		global $wpdb;
+
 		$comment_type = \get_query_var( 'type' );
 
 		if ( 'all' === $comment_type ) {
@@ -360,13 +362,12 @@ class Comment {
 		$comment_types = self::get_comment_type_slugs();
 
 		if ( \in_array( $comment_type, $comment_types, true ) ) {
-			global $wpdb;
-			$where .= $wpdb->prepare( " AND comment_type = %s", $comment_type );
+			$where .= $wpdb->prepare( ' AND comment_type = %s', $comment_type );
 		} else {
 			$comment_types = \array_map( 'esc_sql', $comment_types );
-			global $wpdb;
-			$placeholders = implode( ', ', array_fill( 0, count( $comment_types ), '%s' ) );
-			$where       .= $wpdb->prepare( " AND comment_type NOT IN ($placeholders)", ...$comment_types );
+			$placeholders  = implode( ', ', array_fill( 0, count( $comment_types ), '%s' ) );
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.NotPrepared
+			$where .= $wpdb->prepare( sprintf( ' AND comment_type NOT IN (%s)', $placeholders ), ...$comment_types );
 		}
 
 		return $where;

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -360,10 +360,13 @@ class Comment {
 		$comment_types = self::get_comment_type_slugs();
 
 		if ( \in_array( $comment_type, $comment_types, true ) ) {
-			$where .= \sprintf( " AND comment_type = '%s'", \esc_sql( $comment_type ) );
+			global $wpdb;
+			$where .= $wpdb->prepare( " AND comment_type = %s", $comment_type );
 		} else {
 			$comment_types = \array_map( 'esc_sql', $comment_types );
-			$where        .= \sprintf( " AND comment_type NOT IN ('%s')", \implode( "', '", $comment_types ) );
+			global $wpdb;
+			$placeholders = implode( ', ', array_fill( 0, count( $comment_types ), '%s' ) );
+			$where       .= $wpdb->prepare( " AND comment_type NOT IN ($placeholders)", ...$comment_types );
 		}
 
 		return $where;

--- a/tests/includes/class-test-comment.php
+++ b/tests/includes/class-test-comment.php
@@ -607,4 +607,41 @@ class Test_Comment extends \WP_UnitTestCase {
 		\wp_delete_comment( $comment_id, true );
 		\wp_delete_post( $post_id, true );
 	}
+
+	/**
+	 * Test comment_feed_where.
+	 *
+	 * @covers ::comment_feed_where
+	 */
+	public function test_comment_feed_where() {
+		global $wp_query;
+		if ( ! isset( $wp_query ) ) {
+			$wp_query = new \WP_Query();
+		}
+
+		$original_where = 'WHERE 1=1';
+		$slugs          = \Activitypub\Comment::get_comment_type_slugs();
+
+		// 1. type = 'all'.
+		$wp_query->set( 'type', 'all' );
+		$this->assertEquals(
+			$original_where,
+			\Activitypub\Comment::comment_feed_where( $original_where )
+		);
+
+		// 2. type in allowed types (pick the first available).
+		$test_slug = $slugs[0];
+		$wp_query->set( 'type', $test_slug );
+		$this->assertEquals(
+			$original_where . " AND comment_type = '" . $test_slug . "'",
+			\Activitypub\Comment::comment_feed_where( $original_where )
+		);
+
+		// 3. type not in allowed types.
+		$wp_query->set( 'type', 'foo_bar_baz_not_a_real_type' );
+		$this->assertEquals(
+			$original_where . " AND comment_type = 'comment'",
+			\Activitypub\Comment::comment_feed_where( $original_where )
+		);
+	}
 }

--- a/tests/includes/class-test-comment.php
+++ b/tests/includes/class-test-comment.php
@@ -616,8 +616,15 @@ class Test_Comment extends \WP_UnitTestCase {
 	public function test_comment_feed_where() {
 		$post_id = self::factory()->post->create();
 
-		$comment_types   = Comment::get_comment_type_slugs();
-		$comment_types[] = 'comment';
+		$core_comment_types = array(
+			'comment',
+			'pingback',
+			'trackback',
+		);
+
+		$activitypub_comment_types = Comment::get_comment_type_slugs();
+
+		$comment_types = \array_merge( $activitypub_comment_types, $core_comment_types );
 
 		foreach ( $comment_types as $comment_type ) {
 			self::factory()->comment->create(
@@ -638,14 +645,14 @@ class Test_Comment extends \WP_UnitTestCase {
 		);
 		$query->get_posts();
 
-		$this->assertSame( 1, $query->comment_count );
-		$this->assertSame( 'comment', $query->comments[0]->comment_type );
+		$this->assertSame( count( $core_comment_types ), $query->comment_count );
+		$this->assertEqualSets( $core_comment_types, \wp_list_pluck( $query->comments, 'comment_type' ) );
 
 		// Test what would happen if we don't filter comment_feed_where.
 		\remove_filter( 'comment_feed_where', array( Comment::class, 'comment_feed_where' ) );
 		$query->get_posts();
 
-		$this->assertSame( 3, $query->comment_count ); // All comments are included.
+		$this->assertSame( count( $comment_types ), $query->comment_count ); // All comments are included.
 		$this->assertEqualSets( $comment_types, \wp_list_pluck( $query->comments, 'comment_type' ) );
 
 		// Restore the filter.
@@ -664,8 +671,8 @@ class Test_Comment extends \WP_UnitTestCase {
 		\set_query_var( 'type', 'foo_bar_baz_not_a_real_type' );
 		$query->get_posts();
 
-		$this->assertSame( 1, $query->comment_count );
-		$this->assertSame( 'comment', $query->comments[0]->comment_type );
+		$this->assertSame( count( $core_comment_types ), $query->comment_count );
+		$this->assertEqualSets( $core_comment_types, \wp_list_pluck( $query->comments, 'comment_type' ) );
 
 		// Clean up.
 		\wp_delete_post( $post_id, true );

--- a/tests/includes/class-test-comment.php
+++ b/tests/includes/class-test-comment.php
@@ -633,14 +633,14 @@ class Test_Comment extends \WP_UnitTestCase {
 		$test_slug = $slugs[0];
 		$wp_query->set( 'type', $test_slug );
 		$this->assertEquals(
-			$original_where . " AND comment_type = '" . $test_slug . "'",
+			$original_where . sprintf( " AND comment_type = '%s'", esc_sql( $test_slug ) ),
 			\Activitypub\Comment::comment_feed_where( $original_where )
 		);
 
 		// 3. type not in allowed types.
 		$wp_query->set( 'type', 'foo_bar_baz_not_a_real_type' );
 		$this->assertEquals(
-			$original_where . " AND comment_type = 'comment'",
+			$original_where . sprintf( " AND comment_type NOT IN ('%s')", esc_sql( implode( "', '", $slugs ) ) ),
 			\Activitypub\Comment::comment_feed_where( $original_where )
 		);
 	}

--- a/tests/includes/class-test-comment.php
+++ b/tests/includes/class-test-comment.php
@@ -614,34 +614,40 @@ class Test_Comment extends \WP_UnitTestCase {
 	 * @covers ::comment_feed_where
 	 */
 	public function test_comment_feed_where() {
-		global $wp_query;
-		if ( ! isset( $wp_query ) ) {
-			$wp_query = new \WP_Query();
+		$post_id = self::factory()->post->create();
+
+		$comment_types = array( 'repost', 'like', 'comment' );
+		foreach ( $comment_types as $comment_type ) {
+			self::factory()->comment->create(
+				array(
+					'comment_approved' => '1',
+					'comment_post_ID'  => $post_id,
+					'comment_type'     => $comment_type,
+					'comment_content'  => 'This is a comment.',
+				)
+			);
 		}
 
-		$original_where = 'WHERE 1=1';
-		$slugs          = \Activitypub\Comment::get_comment_type_slugs();
-
-		// 1. type = 'all'.
-		$wp_query->set( 'type', 'all' );
-		$this->assertEquals(
-			$original_where,
-			\Activitypub\Comment::comment_feed_where( $original_where )
+		$query = new \WP_Query(
+			array(
+				'feed'         => 'comments-rss2',
+				'withcomments' => true,
+			)
 		);
+		$query->get_posts();
 
-		// 2. type in allowed types (pick the first available).
-		$test_slug = $slugs[0];
-		$wp_query->set( 'type', $test_slug );
-		$this->assertEquals(
-			$original_where . sprintf( " AND comment_type = '%s'", esc_sql( $test_slug ) ),
-			\Activitypub\Comment::comment_feed_where( $original_where )
-		);
+		$this->assertSame( 1, $query->comment_count );
+		$this->assertSame( 'comment', $query->comments[0]->comment_type );
 
-		// 3. type not in allowed types.
-		$wp_query->set( 'type', 'foo_bar_baz_not_a_real_type' );
-		$this->assertEquals(
-			$original_where . sprintf( " AND comment_type NOT IN ('%s')", esc_sql( implode( "', '", $slugs ) ) ),
-			\Activitypub\Comment::comment_feed_where( $original_where )
-		);
+		// Test what would happen if we don't filter comment_feed_where.
+		\remove_filter( 'comment_feed_where', array( Comment::class, 'comment_feed_where' ) );
+		$query->get_posts();
+
+		$this->assertSame( 3, $query->comment_count ); // All comments are included.
+		$this->assertEqualSets( $comment_types, \wp_list_pluck( $query->comments, 'comment_type' ) );
+
+		// Clean up.
+		\add_filter( 'comment_feed_where', array( Comment::class, 'comment_feed_where' ) );
+		\wp_delete_post( $post_id, true );
 	}
 }

--- a/tests/includes/class-test-comment.php
+++ b/tests/includes/class-test-comment.php
@@ -659,7 +659,7 @@ class Test_Comment extends \WP_UnitTestCase {
 		\add_filter( 'comment_feed_where', array( Comment::class, 'comment_feed_where' ) );
 
 		// Test filtering by comment type.
-		foreach ( $comment_types as $comment_type ) {
+		foreach ( $activitypub_comment_types as $comment_type ) {
 			\set_query_var( 'type', $comment_type );
 			$query->get_posts();
 

--- a/tests/includes/class-test-comment.php
+++ b/tests/includes/class-test-comment.php
@@ -616,14 +616,16 @@ class Test_Comment extends \WP_UnitTestCase {
 	public function test_comment_feed_where() {
 		$post_id = self::factory()->post->create();
 
-		$comment_types = array( 'repost', 'like', 'comment' );
+		$comment_types   = Comment::get_comment_type_slugs();
+		$comment_types[] = 'comment';
+
 		foreach ( $comment_types as $comment_type ) {
 			self::factory()->comment->create(
 				array(
 					'comment_approved' => '1',
+					'comment_content'  => 'This is a comment.',
 					'comment_post_ID'  => $post_id,
 					'comment_type'     => $comment_type,
-					'comment_content'  => 'This is a comment.',
 				)
 			);
 		}
@@ -646,8 +648,27 @@ class Test_Comment extends \WP_UnitTestCase {
 		$this->assertSame( 3, $query->comment_count ); // All comments are included.
 		$this->assertEqualSets( $comment_types, \wp_list_pluck( $query->comments, 'comment_type' ) );
 
-		// Clean up.
+		// Restore the filter.
 		\add_filter( 'comment_feed_where', array( Comment::class, 'comment_feed_where' ) );
+
+		// Test filtering by comment type.
+		foreach ( $comment_types as $comment_type ) {
+			\set_query_var( 'type', $comment_type );
+			$query->get_posts();
+
+			$this->assertSame( 1, $query->comment_count );
+			$this->assertSame( $comment_type, $query->comments[0]->comment_type );
+		}
+
+		// Test filtering by comment type that doesn't exist.
+		\set_query_var( 'type', 'foo_bar_baz_not_a_real_type' );
+		$query->get_posts();
+
+		$this->assertSame( 1, $query->comment_count );
+		$this->assertSame( 'comment', $query->comments[0]->comment_type );
+
+		// Clean up.
 		\wp_delete_post( $post_id, true );
+		\set_query_var( 'type', null );
 	}
 }


### PR DESCRIPTION
The comment feed contains all reactions (like, repost), which can be very distracting.

<img width="744" alt="Screenshot 2025-07-01 at 11 41 01" src="https://github.com/user-attachments/assets/a491d4ef-bb93-42d4-9dee-f89b3cae73f5" />

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Exclude all comment type except `comment`.
* Add `type` query string, to have different feeds for different types (`/feed?type=like`).
* Add `type=all` to list all reactions to a post

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a posts feed and change the `type` query

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Comment feeds now show only comments by default, with a new `type` filter (e.g., `like`, `all`) to customize which reactions appear.

</details>
