### PR TITLE
Re-Add ActivityPub CLI extension

### DIFF
--- a/.github/changelog/1878-from-description
+++ b/.github/changelog/1878-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The command-line interface extension, accidentally removed in a recent cleanup, has been restored.

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -57,6 +57,7 @@ jobs:
             {"path": "integration", "label": "[Focus] Compatibility"},
             {"path": "includes/class-mailer.php", "label": "[Feature] Notifications"},
             {"path": "includes/class-blocks.php", "label": "[Focus] Editor"},
+            {"path": "includes/class-cli.php", "label": "[Feature] CLI"},
             {"path": "includes/collection", "label": "[Feature] Collections"},
             {"path": "includes/rest", "label": "[Feature] REST API"},
             {"path": "includes/signature", "label": "[Feature] Signature"},

--- a/activitypub.php
+++ b/activitypub.php
@@ -150,3 +150,14 @@ function activation_redirect( $plugin ) {
 		'uninstall',
 	)
 );
+
+// Check for CLI env, to add the CLI commands.Add commentMore actions.
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	WP_CLI::add_command(
+		'activitypub',
+		'\Activitypub\Cli',
+		array(
+			'shortdesc' => 'ActivityPub related commands to manage plugin functionality and the federation of posts and comments.',
+		)
+	);
+}


### PR DESCRIPTION
The CLI extension was accidentally removed in one of the latest cleanups. This PR re-adds the CLI integration.

https://github.com/Automattic/wordpress-activitypub/commit/79b9b3533249eaf00d4382e24249c67de335abb4

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Re-add CLI extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

The command-line interface extension, accidentally removed in a recent cleanup, has been restored.

</details>
