### PR TITLE
Follow: Set local user as actor in Accept activities

### DIFF
--- a/includes/handler/class-follow.php
+++ b/includes/handler/class-follow.php
@@ -111,7 +111,7 @@ class Follow {
 
 		$activity = new Activity();
 		$activity->set_type( 'Accept' );
-		$activity->set_actor( $remote_actor->guid );
+		$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
 		$activity->set_object( $activity_object );
 		$activity->set_to( array( $actor ) );
 

--- a/tests/includes/handler/class-test-follow.php
+++ b/tests/includes/handler/class-test-follow.php
@@ -134,6 +134,7 @@ class Test_Follow extends \WP_UnitTestCase {
 
 		// Clean up.
 		wp_delete_post( $outbox_post->ID, true );
+		wp_delete_post( $remote_actor->ID, true );
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
 	}
 }

--- a/tests/includes/handler/class-test-follow.php
+++ b/tests/includes/handler/class-test-follow.php
@@ -7,8 +7,10 @@
 
 namespace Activitypub\Tests\Handler;
 
-use Activitypub\Handler\Follow;
+use Activitypub\Collection\Actors;
+use Activitypub\Collection\Followers;
 use Activitypub\Collection\Outbox;
+use Activitypub\Handler\Follow;
 
 /**
  * Test class for Follow handler.
@@ -26,7 +28,7 @@ class Test_Follow extends \WP_UnitTestCase {
 	/**
 	 * Create fake data before tests run.
 	 *
-	 * @param WP_UnitTest_Factory $factory Helper that creates fake data.
+	 * @param \WP_UnitTest_Factory $factory Helper that creates fake data.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$user_id = $factory->user->create(
@@ -49,12 +51,13 @@ class Test_Follow extends \WP_UnitTestCase {
 	 * @covers ::queue_accept
 	 */
 	public function test_queue_accept() {
+		$local_actor     = Actors::get_by_id( self::$user_id );
 		$actor           = 'https://example.com/actor';
 		$activity_object = array(
 			'id'     => 'https://example.com/activity/123',
 			'type'   => 'Follow',
 			'actor'  => $actor,
-			'object' => 'https://example.com/user/1',
+			'object' => $local_actor->get_id(),
 		);
 
 		// Test with WP_Error follower - should not create outbox entry.
@@ -77,11 +80,23 @@ class Test_Follow extends \WP_UnitTestCase {
 		);
 		$this->assertEmpty( $outbox_posts, 'No outbox entry should be created for WP_Error follower' );
 
-		$remote_actor        = new \stdClass();
-		$remote_actor->actor = $actor;
-		$remote_actor->type  = 'Person';
-		$remote_actor->inbox = 'https://example.com/inbox';
-		$remote_actor        = new \WP_Post( $remote_actor );
+		\add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function () use ( $actor ) {
+				return array(
+					'id'    => $actor,
+					'actor' => $actor,
+					'type'  => 'Person',
+					'inbox' => 'https://example.com/inbox',
+				);
+			}
+		);
+
+		$remote_actor = Followers::add_follower(
+			self::$user_id,
+			$activity_object['actor']
+		);
+		$remote_actor = \get_post( $remote_actor );
 
 		Follow::queue_accept( $actor, $activity_object, self::$user_id, $remote_actor );
 
@@ -112,11 +127,13 @@ class Test_Follow extends \WP_UnitTestCase {
 		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility );
 
 		$this->assertEquals( 'Follow', $activity_json['object']['type'] );
-		$this->assertEquals( 'https://example.com/user/1', $activity_json['object']['object'] );
+		$this->assertEquals( $local_actor->get_id(), $activity_json['object']['object'] );
 		$this->assertEquals( array( $actor ), $activity_json['to'] );
 		$this->assertEquals( $actor, $activity_json['object']['actor'] );
+		$this->assertEquals( $local_actor->get_id(), $activity_json['actor'] );
 
 		// Clean up.
 		wp_delete_post( $outbox_post->ID, true );
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
 	}
 }


### PR DESCRIPTION
Follow up to #1759.

I noticed `Accept` activities getting rejected by Ghost, with the message `The signer and the actor do not match.`. This PR restores setting the actor for the `Accept` activity to the local user that's being followed.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reverts changes to `actor` property in #1759.
* Updates unit test to cover that case.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to a test site that's accessible from the internet.
* From another instance, send a new Follow request to your test site.
* Make sure the Follow is successful.
