### PR TITLE
Signature: Fix server request formatting

### DIFF
--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -114,8 +114,8 @@ class Signature {
 		$headers = array();
 
 		foreach ( $server as $key => $value ) {
-			$header_key               = \str_replace( 'http_', '', \strtolower( $key ) );
-			$headers[ $header_key ][] = \wp_unslash( $value );
+			$key               = \str_replace( 'http_', '', \strtolower( $key ) );
+			$headers[ $key ][] = \wp_unslash( $value );
 
 		}
 

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -66,8 +66,7 @@ class Signature {
 			$headers                        = $request->get_headers();
 			$headers['(request-target)'][0] = strtolower( $request->get_method() ) . ' ' . self::get_route( $request );
 		} else {
-			$request                        = self::format_server_request( $request );
-			$headers                        = $request['headers']; // $_SERVER array
+			$headers                        = self::format_server_request( $request );
 			$headers['(request-target)'][0] = strtolower( $headers['request_method'][0] ) . ' ' . $headers['request_uri'][0];
 		}
 
@@ -112,21 +111,15 @@ class Signature {
 	 * @return array $request The formatted request array.
 	 */
 	public static function format_server_request( $server ) {
-		$request = array();
-		foreach ( $server as $param_key => $param_val ) {
-			$req_param = strtolower( $param_key );
-			if ( 'REQUEST_URI' === $req_param ) {
-				$request['headers']['route'][] = $param_val;
-			} else {
-				$header_key                          = str_replace(
-					'http_',
-					'',
-					$req_param
-				);
-				$request['headers'][ $header_key ][] = \wp_unslash( $param_val );
-			}
+		$headers = array();
+
+		foreach ( $server as $key => $value ) {
+			$header_key               = \str_replace( 'http_', '', \strtolower( $key ) );
+			$headers[ $header_key ][] = \wp_unslash( $value );
+
 		}
-		return $request;
+
+		return $headers;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow-up to #1885.

The `'REQUEST_URI' === $req_param` branch was always false and was never used. 
See https://github.com/Automattic/wordpress-activitypub/pull/1885#discussion_r2180393822 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes dead code branch in `format_server_request`.
* Simplifies the function to just return the headers, which is what this is actually looking for.

