### PR TITLE
Federated Reactions: Redirect edit requests

### DIFF
--- a/.github/changelog/1887-from-description
+++ b/.github/changelog/1887-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Notification emails for new reactions received from the Fediverse now link to the moderation page instead of the edit page, preventing errors and making comment management smoother.

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -270,6 +270,13 @@ class Admin {
 			1,
 			3
 		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( Comment::was_received( absint( $_GET['c'] ?? 0 ) ) ) {
+			// Redirect to the pending comments page.
+			\wp_safe_redirect( \admin_url( 'edit-comments.php?comment_status=moderated' ) );
+			exit;
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Some of our notification email templates — which inform users when they receive a new comment — include links to the edit page. However, since we don’t allow editing of remote posts, users currently encounter an error message when following these links:

<img width="609" alt="Screenshot 2025-07-03 at 10 54 19" src="https://github.com/user-attachments/assets/218c5eb7-24e6-422a-ab1a-729c8b0e8810" />

This results in a poor and potentially confusing user experience. To improve this, this PR redirects all attempts to access the edit page for received reactions to the moderation page instead. This way, users can still approve or delete the comments without confusion.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Redirect edit-page requests for reactions, received from the fediverse, to the moderation page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Notification emails for new reactions received from the Fediverse now link to the moderation page instead of the edit page, preventing errors and making comment management smoother.

</details>
