### PR TITLE
Functions: Fix fatal error in get_user_id

### DIFF
--- a/.github/changelog/1889-from-description
+++ b/.github/changelog/1889-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a potential error when getting an Activitypub ID based on a user ID.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1258,7 +1258,7 @@ function get_content_warning( $post_id ) {
 function get_user_id( $id ) {
 	$user = Actors::get_by_id( $id );
 
-	if ( ! $user ) {
+	if ( \is_wp_error( $user ) ) {
 		return false;
 	}
 

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -675,4 +675,18 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 			),
 		);
 	}
+
+	/**
+	 * Test get_user_id function.
+	 *
+	 * @covers \Activitypub\get_user_id
+	 */
+	public function test_get_user_id() {
+		$this->assertFalse( \Activitypub\get_user_id( 90210 ) );
+
+		$user = self::factory()->user->create_and_get();
+		$user->add_cap( 'activitypub' );
+
+		$this->assertIsString( \Activitypub\get_user_id( $user->ID ) );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1870.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds an WP_Error check to prevent a fatal error.
* Adds unit test.

### Other information:

- [x] Have you written new tests for your changes, if applicable?


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed a potential error when getting an Activitypub ID based on a user ID.
</details>
