### PR TITLE
Signature: Don't use param as component

### DIFF
--- a/includes/signature/class-http-message-signature.php
+++ b/includes/signature/class-http-message-signature.php
@@ -60,7 +60,7 @@ class Http_Message_Signature implements Signature_Standard {
 		\openssl_sign( $signature_base, $signature, $args['private_key'], \OPENSSL_ALGO_SHA256 );
 		$signature = \base64_encode( $signature );
 
-		$args['headers']['Signature-Input'] = vsprintf( 'wp=(' . \implode( ' ', $identifiers ) . ');created=%1$d;keyid="%2$s";alg="%3$s"', $params );
+		$args['headers']['Signature-Input'] = 'wp=(' . \implode( ' ', $identifiers ) . ')' . $this->get_params_string( $params );
 		$args['headers']['Signature']       = 'wp=:' . $signature . ':';
 
 		return $args;
@@ -324,17 +324,32 @@ class Http_Message_Signature implements Signature_Standard {
 		}
 
 		$signature_base .= '"@signature-params": (' . \implode( ' ', \array_keys( $components ) ) . ')';
+		$signature_base .= $this->get_params_string( $params );
+
+		return $signature_base;
+	}
+
+	/**
+	 * Returns the signature params in a string format.
+	 *
+	 * @param array $params Signature params.
+	 *
+	 * @return string Signature params.
+	 */
+	private function get_params_string( $params ) {
+		$signature_params = '';
+
 		foreach ( $params as $key => $value ) {
 			if ( \is_numeric( $value ) ) {
-				$signature_base .= ';' . $key . '=' . $value; // No quotes.
+				$signature_params .= ';' . $key . '=' . $value; // No quotes.
 			} else {
 				// Escape backslashes and double quotes per RFC-9421.
-				$value           = \str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $value );
-				$signature_base .= ';' . $key . '="' . $value . '"'; // Double quotes.
+				$value             = \str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $value );
+				$signature_params .= ';' . $key . '="' . $value . '"'; // Double quotes.
 			}
 		}
 
-		return $signature_base;
+		return $signature_params;
 	}
 
 	/**

--- a/includes/signature/class-http-message-signature.php
+++ b/includes/signature/class-http-message-signature.php
@@ -36,7 +36,6 @@ class Http_Message_Signature implements Signature_Standard {
 			'"@method"'     => \strtoupper( $args['method'] ),
 			'"@target-uri"' => $url,
 			'"@authority"'  => \wp_parse_url( $url, PHP_URL_HOST ),
-			'"created"'     => \strtotime( $args['headers']['Date'] ), // Required by Mastodon. See https://github.com/mastodon/mastodon/pull/34814.
 		);
 		$identifiers = \array_keys( $components );
 
@@ -49,7 +48,7 @@ class Http_Message_Signature implements Signature_Standard {
 		}
 
 		$params = array(
-			'created' => $components['"created"'],
+			'created' => \strtotime( $args['headers']['Date'] ),
 			'keyid'   => $args['key_id'],
 			'alg'     => 'rsa-v1_5-sha256',
 		);
@@ -61,7 +60,7 @@ class Http_Message_Signature implements Signature_Standard {
 		\openssl_sign( $signature_base, $signature, $args['private_key'], \OPENSSL_ALGO_SHA256 );
 		$signature = \base64_encode( $signature );
 
-		$args['headers']['Signature-Input'] = 'wp=(' . \implode( ' ', $identifiers ) . ');created=' . $components['"created"'] . ';keyid="' . $args['key_id'] . '";alg="rsa-v1_5-sha256"';
+		$args['headers']['Signature-Input'] = vsprintf( 'wp=(' . \implode( ' ', $identifiers ) . ');created=%1$d;keyid="%2$s";alg="%3$s"', $params );
 		$args['headers']['Signature']       = 'wp=:' . $signature . ':';
 
 		return $args;
@@ -188,7 +187,8 @@ class Http_Message_Signature implements Signature_Standard {
 			return $result;
 		}
 
-		$signature_base = $this->get_signature_base_string( $data['components'], $params, $headers );
+		$components     = $this->get_component_values( $data['components'], $headers );
+		$signature_base = $this->get_signature_base_string( $components, $params );
 
 		$verified = \openssl_verify( $signature_base, $data['signature'], $public_key, $algorithm ) > 0;
 		if ( ! $verified ) {
@@ -313,17 +313,11 @@ class Http_Message_Signature implements Signature_Standard {
 	 *
 	 * @param array $components Signature components.
 	 * @param array $params     Signature params.
-	 * @param array $headers    Optional. The HTTP headers. Default: empty array.
 	 *
 	 * @return string Base string to compare signature with.
 	 */
-	private function get_signature_base_string( $components, $params, $headers = array() ) {
+	private function get_signature_base_string( $components, $params ) {
 		$signature_base = '';
-
-		// We only get component names when we verify a signature and have to get their values.
-		if ( \array_is_list( $components ) ) {
-			$components = $this->get_component_values( $components, \array_merge( $params, $headers ) );
-		}
 
 		foreach ( $components as $component => $value ) {
 			$signature_base .= $component . ': ' . $value . "\n";
@@ -359,11 +353,6 @@ class Http_Message_Signature implements Signature_Standard {
 			$key = \strtolower( \trim( $key, '"' ) );
 
 			switch ( $key ) {
-				case 'created':
-				case 'expires':
-					$value = (int) $headers[ $key ] ?? 0;
-					break;
-
 				case '@method':
 					$value = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 					break;


### PR DESCRIPTION
Mastodon requires the `created` param to be signer in RFC 9421, but I may have misunderstood what exactly that means. It appears like having it in the param string is enough and it doesn't need to be added to the components list as well.

This change also brings compatibility with Fedify.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes `created` from components array.
* Simplifies Signature-Input creation by parsing in the `$params` array.
* Removes support for `created` and `expires` params as header components on the receiving end.
* Separates concerns of getting component values and creating the signature base on the receiving end.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In Advanced settings, activate the "Modern Signatures" option.
* Create a Ghost site and activate ActivityPub.
* Follow your test site with the PR active.
* Send a create or update activity to your Ghost follower.
* Make sure the request succeeds.

I use this in Snippets to verify success:
```php
function snippet_http_response( $response, $parsed_args, $url ) {
	if ( isset($parsed_args['headers']['Signature'])) {
		if ( isset($parsed_args['headers']['Signature-Input'])) {
			error_log( 'RFC 9421: ' . print_r( wp_remote_retrieve_response_code( $response ), 1 ) );
			error_log($url);
			if (200 !==wp_remote_retrieve_response_code( $response ) || 202 !== wp_remote_retrieve_response_code( $response ) ) {
				error_log(print_r($parsed_args,1));
				error_log(print_r($response,1));
			}
		} else {
			error_log( 'Draft Cavage: ' . print_r( wp_remote_retrieve_response_code( $response ), 1 ) );
		//	error_log(print_r($parsed_args,1));
		//	error_log(print_r($response,1));
			error_log($url);
			
			if (200 !==wp_remote_retrieve_response_code( $response ) || 202 !== wp_remote_retrieve_response_code( $response ) ) {
				error_log(print_r($parsed_args,1));
				error_log(print_r($response,1));
			}
		}
	}
	return $response;
}
add_filter( 'http_response', 'snippet_http_response', 9, 3 );

```
