### PR TITLE
Introduce general namespace support, using `dcterms` as an example

### DIFF
--- a/.github/changelog/1893-from-description
+++ b/.github/changelog/1893-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added support for namespaced attributes and the dcterms:subject field (FEP-b2b8), as a first step toward phasing out summary-based content warnings.

--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -32,6 +32,7 @@ class Base_Object extends Generic_Object {
 		array(
 			'Hashtag'   => 'as:Hashtag',
 			'sensitive' => 'as:sensitive',
+			'dcterms'   => 'http://purl.org/dc/terms/',
 		),
 	);
 
@@ -415,6 +416,16 @@ class Base_Object extends Generic_Object {
 	 * @var boolean
 	 */
 	protected $sensitive;
+
+	/**
+	 * The dcterms namespace.
+	 *
+	 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/b2b8/fep-b2b8.md#sensitive
+	 * @see https://www.dublincore.org/specifications/dublin-core/dcmi-terms/
+	 *
+	 * @var array
+	 */
+	protected $dcterms;
 
 	/**
 	 * Generic getter.

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -297,8 +297,11 @@ class Generic_Object {
 				$value = $value->to_array( false );
 			}
 
-			// If value is still empty, ignore it for the array and continue.
-			if ( isset( $value ) ) {
+			if ( $this->is_namespaced( $key ) && is_array( $value ) ) {
+				foreach ( $value as $sub_key => $sub_value ) {
+					$array[ snake_to_camel_case( $key ) . ':' . snake_to_camel_case( $sub_key ) ] = $sub_value;
+				}
+			} elseif ( isset( $value ) ) {
 				$array[ snake_to_camel_case( $key ) ] = $value;
 			}
 		}
@@ -372,5 +375,24 @@ class Generic_Object {
 	 */
 	public function get_json_ld_context() {
 		return static::JSON_LD_CONTEXT;
+	}
+
+	/**
+	 * Checks if an attribute is in a namespace.
+	 *
+	 * @param string $attribute The attribute to check.
+	 *
+	 * @return bool Whether the attribute is namespaced.
+	 */
+	private function is_namespaced( $attribute ) {
+		$namespaces = array();
+
+		foreach ( static::JSON_LD_CONTEXT as $context ) {
+			if ( is_array( $context ) ) {
+				$namespaces = \array_merge( $namespaces, $context );
+			}
+		}
+
+		return isset( $namespaces[ $attribute ] ) && \wp_http_validate_url( $namespaces[ $attribute ] );
 	}
 }

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -297,7 +297,7 @@ class Generic_Object {
 				$value = $value->to_array( false );
 			}
 
-			if ( $this->is_namespaced( $key ) && is_array( $value ) ) {
+			if ( is_array( $value ) && $this->is_namespaced( $key ) ) {
 				foreach ( $value as $sub_key => $sub_value ) {
 					$array[ snake_to_camel_case( $key ) . ':' . snake_to_camel_case( $sub_key ) ] = $sub_value;
 				}

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -57,6 +57,7 @@ class Post extends Base {
 			$object->set_sensitive( true );
 			$object->set_summary( $content_warning );
 			$object->set_summary_map( null );
+			$object->set_dcterms( array( 'subject' => $content_warning ) );
 		}
 
 		return $object;

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -115,7 +115,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				1,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"actor":"http:\/\/example.org\/?author=1","id":"http:\/\/example.org\/?post_type=ap_outbox\u0026p=351","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/1","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive","dcterms":"http:\/\/purl.org\/dc\/terms\/"}],"actor":"http:\/\/example.org\/?author=1","id":"http:\/\/example.org\/?post_type=ap_outbox\u0026p=351","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/1","type":"Note","content":"\u003Cp\u003EThis is a note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is a note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
 			),
 			array(
 				array(
@@ -126,7 +126,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				),
 				'Create',
 				2,
-				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive"}],"actor":"http:\/\/example.org\/?author=0","id":"http:\/\/example.org\/?post_type=ap_outbox\u0026p=352","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
+				'{"@context":["https:\/\/www.w3.org\/ns\/activitystreams",{"Hashtag":"as:Hashtag","sensitive":"as:sensitive","dcterms":"http:\/\/purl.org\/dc\/terms\/"}],"actor":"http:\/\/example.org\/?author=0","id":"http:\/\/example.org\/?post_type=ap_outbox\u0026p=352","type":"Create","to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"object":{"id":"https:\/\/example.com\/2","type":"Note","content":"\u003Cp\u003EThis is another note\u003C\/p\u003E","contentMap":{"en":"\u003Cp\u003EThis is another note\u003C\/p\u003E"},"tag":[],"to":["https:\/\/www.w3.org\/ns\/activitystreams#Public"],"mediaType":"text\/html"}}',
 			),
 			array(
 				Event::init_from_array(


### PR DESCRIPTION
This implements general support for namespaced attributes and implements the `dcterms:subject` field, defined in [FEP-b2b8](https://codeberg.org/fediverse/fep/src/branch/main/fep/b2b8/fep-b2b8.md).

This is a first step to deprecate the usage of Summary as Content-Warning description. https://codeberg.org/fediverse/fep/src/branch/main/fep/b2b8/fep-b2b8.md#sensitive

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add support for namespaced attributes
* Implement `dcterms:subject` support as described in FEP-b2b8

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish a post with a Content-Warning
* Check the JSON output

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added support for namespaced attributes and the dcterms:subject field (FEP-b2b8), as a first step toward phasing out summary-based content warnings.

</details>
