### PR TITLE
Comments: Never allow edit of federated comments

### DIFF
--- a/.github/changelog/1895-from-description
+++ b/.github/changelog/1895-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Comments received from the Fediverse no longer show an Edit link in the comment list, despite not being editable.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -23,6 +23,7 @@ class Comment {
 	public static function init() {
 		self::register_comment_types();
 
+		add_filter( 'map_meta_cap', array( self::class, 'map_meta_cap' ), 10, 4 );
 		\add_filter( 'comment_reply_link', array( self::class, 'comment_reply_link' ), 10, 3 );
 		\add_filter( 'comment_class', array( self::class, 'comment_class' ), 10, 3 );
 		\add_filter( 'comment_feed_where', array( static::class, 'comment_feed_where' ) );
@@ -33,6 +34,24 @@ class Comment {
 		\add_action( 'update_option_activitypub_allow_likes', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_action( 'update_option_activitypub_allow_reposts', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
+	}
+
+	/**
+	 * Remove edit capabilities for comments received via ActivityPub.
+	 *
+	 * @param array  $caps    Array of capabilities.
+	 * @param string $cap     Capability name.
+	 * @param int    $user_id User ID.
+	 * @param array  $args    Array of arguments.
+	 *
+	 * @return array Modified array of capabilities.
+	 */
+	public static function map_meta_cap( $caps, $cap, $user_id, $args ) {
+		if ( 'edit_comment' === $cap && self::was_received( $args[0] ) ) {
+			$caps[] = 'do_not_allow';
+		}
+
+		return $caps;
 	}
 
 	/**

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -23,7 +23,7 @@ class Comment {
 	public static function init() {
 		self::register_comment_types();
 
-		add_filter( 'map_meta_cap', array( self::class, 'map_meta_cap' ), 10, 4 );
+		\add_filter( 'map_meta_cap', array( self::class, 'map_meta_cap' ), 10, 4 );
 		\add_filter( 'comment_reply_link', array( self::class, 'comment_reply_link' ), 10, 3 );
 		\add_filter( 'comment_class', array( self::class, 'comment_class' ), 10, 3 );
 		\add_filter( 'comment_feed_where', array( static::class, 'comment_feed_where' ) );

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -253,24 +253,6 @@ class Admin {
 	 * Disables the edit_comment capability for federated comments.
 	 */
 	public static function edit_comment() {
-		// Disable the edit_comment capability for federated comments.
-		\add_filter(
-			'user_has_cap',
-			function ( $all_caps, $caps, $arg ) {
-				if ( 'edit_comment' !== $arg[0] ) {
-					return $all_caps;
-				}
-
-				if ( was_comment_received( $arg[2] ) ) {
-					return false;
-				}
-
-				return $all_caps;
-			},
-			1,
-			3
-		);
-
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( Comment::was_received( absint( $_GET['c'] ?? 0 ) ) ) {
 			// Redirect to the pending comments page.


### PR DESCRIPTION
Fixes #1894.

Hides Edit comment link in the front-end comment list, when a comment was received through ActivityPub.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves edit_comment check to apply globally.
* Uses `map_meta_cap` simplify conditionals.

I'm not too sure about the difference between `map_meta_cap` and `user_has_cap`. I guess in this case we're making a decision about the primitive capabilities based on parameters of an object, so `map_meta_cap` is technically where that's supposed to happen? Not sure.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to a test site that has received comments from the Fediverse.
* View a comment from the Fediverse on the front-end of the site.
* Make sure it does not display an Edit link.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Comments received from the Fediverse no longer show an Edit link in the comment list, despite not being editable.
</details>
