### PR TITLE
Comment: Redirect uneditable comments to the right list

### DIFF
--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -272,9 +272,25 @@ class Admin {
 		);
 
 		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( Comment::was_received( absint( $_GET['c'] ?? 0 ) ) ) {
-			// Redirect to the pending comments page.
-			\wp_safe_redirect( \admin_url( 'edit-comments.php?comment_status=moderated' ) );
+		if ( Comment::was_received( \absint( $_GET['c'] ?? 0 ) ) ) {
+			$path = 'edit-comments.php';
+
+			switch ( \wp_get_comment_status( \absint( $_GET['c'] ?? 0 ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				case 'spam':
+					$path = 'edit-comments.php?comment_status=spam';
+					break;
+
+				case 'trash':
+					$path = 'edit-comments.php?comment_status=trash';
+					break;
+
+				case 'unapproved':
+					$path = 'edit-comments.php?comment_status=moderated';
+					break;
+			}
+
+			// Redirect to the appropriate comments page.
+			\wp_safe_redirect( \admin_url( $path ) );
 			exit;
 		}
 	}

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -272,10 +272,11 @@ class Admin {
 		);
 
 		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( Comment::was_received( \absint( $_GET['c'] ?? 0 ) ) ) {
+		$comment_id = \absint( $_GET['c'] ?? 0 );
+		if ( Comment::was_received( $comment_id ) ) {
 			$path = 'edit-comments.php';
 
-			switch ( \wp_get_comment_status( \absint( $_GET['c'] ?? 0 ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			switch ( \wp_get_comment_status( $comment_id ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				case 'spam':
 					$path = 'edit-comments.php?comment_status=spam';
 					break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Follow-up to #1887.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We currently assume that all requests to edit pages for ActivityPub comments are moderation attempts—that might not always be the case. This update takes the comment status into account, and redirects to the appropriate list based on that.