### PR TITLE
Federation: Swap doc URLs

### DIFF
--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -5,8 +5,8 @@ The WordPress plugin largely follows ActivityPub's server-to-server specificatio
 ## Supported federation protocols and standards
 
 - [ActivityPub](https://www.w3.org/TR/activitypub/) (Server-to-Server)
-- [WebFinger](https://swicg.github.io/activitypub-http-signature/)
-- [HTTP Signatures](https://www.w3.org/community/reports/socialcg/CG-FINAL-apwf-20240608/)
+- [WebFinger](https://www.w3.org/community/reports/socialcg/CG-FINAL-apwf-20240608/)
+- [HTTP Signatures](https://swicg.github.io/activitypub-http-signature/)
 - [NodeInfo](https://nodeinfo.diaspora.software/)
 
 ## Supported FEPs


### PR DESCRIPTION
Looks like they were swapped when they were updated in f8cd515.
