### PR TITLE
Signature: Use lowercase key in Content-Digest

### DIFF
--- a/includes/signature/class-http-message-signature.php
+++ b/includes/signature/class-http-message-signature.php
@@ -23,6 +23,16 @@ use Activitypub\Collection\Actors;
 class Http_Message_Signature implements Signature_Standard {
 
 	/**
+	 * Digest algorithms.
+	 *
+	 * @var string[]
+	 */
+	private $digest_algorithms = array(
+		'sha-256' => 'sha256',
+		'sha-512' => 'sha512',
+	);
+
+	/**
 	 * Generate RFC-9421 compliant Signature-Input and Signature headers for an outgoing HTTP request.
 	 *
 	 * @param array  $args The request arguments.
@@ -216,16 +226,11 @@ class Http_Message_Signature implements Signature_Standard {
 			if ( \preg_match( '/^([a-z0-9-]+)=:(.+):$/i', $digest, $matches ) ) {
 				list( , $alg, $encoded ) = $matches;
 
-				$map = array(
-					'sha-256' => 'sha256',
-					'sha-512' => 'sha512',
-				);
-
-				if ( ! isset( $map[ $alg ] ) ) {
+				if ( ! isset( $this->digest_algorithms[ $alg ] ) ) {
 					return new \WP_Error( 'unsupported_digest', 'WordPress supports sha-256 and sha-512 in Digest header. Offered algorithm: ' . $alg );
 				}
 
-				if ( \hash_equals( $encoded, \base64_encode( \hash( $map[ $alg ], $body, true ) ) ) ) {
+				if ( \hash_equals( $encoded, \base64_encode( \hash( $this->digest_algorithms[ $alg ], $body, true ) ) ) ) {
 					return true;
 				}
 			}

--- a/includes/signature/class-http-message-signature.php
+++ b/includes/signature/class-http-message-signature.php
@@ -105,7 +105,7 @@ class Http_Message_Signature implements Signature_Standard {
 	 * @return string The digest.
 	 */
 	public function generate_digest( $body ) {
-		return 'SHA-256=:' . \base64_encode( \hash( 'sha256', $body, true ) ) . ':';
+		return 'sha-256=:' . \base64_encode( \hash( 'sha256', $body, true ) ) . ':';
 	}
 
 	/**
@@ -217,12 +217,12 @@ class Http_Message_Signature implements Signature_Standard {
 				list( , $alg, $encoded ) = $matches;
 
 				$map = array(
-					'SHA-256' => 'sha256',
-					'SHA-512' => 'sha512',
+					'sha-256' => 'sha256',
+					'sha-512' => 'sha512',
 				);
 
 				if ( ! isset( $map[ $alg ] ) ) {
-					return new \WP_Error( 'unsupported_digest', 'WordPress supports SHA-256 and SHA-512 in Digest header. Offered algorithm: ' . $alg );
+					return new \WP_Error( 'unsupported_digest', 'WordPress supports sha-256 and sha-512 in Digest header. Offered algorithm: ' . $alg );
 				}
 
 				if ( \hash_equals( $encoded, \base64_encode( \hash( $map[ $alg ], $body, true ) ) ) ) {

--- a/tests/includes/class-test-signature.php
+++ b/tests/includes/class-test-signature.php
@@ -571,7 +571,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		$body = '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}';
 
 		// Generate a digest for the body.
-		$digest = 'SHA-256=:' . \base64_encode( \hash( 'sha256', $body, true ) ) . ':';
+		$digest = 'sha-256=:' . \base64_encode( \hash( 'sha256', $body, true ) ) . ':';
 
 		// Create a date for the request.
 		$date = \gmdate( 'D, d M Y H:i:s T' );


### PR DESCRIPTION
This is the missing piece to make outgoing RFC 9421-based signatures work with Mastodon.
I initially did not pick up on the nuance that in RFC 9421 the digest algorithm identifier is lowercase, while in Draft Cavage it's uppercase with both still using a hyphen. See #1874 for the other side of it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use lowercase algorithm identifier in Content-Digest

### Other information:

- [x] Have you written new tests for your changes, if applicable?
