### PR TITLE
Signature: Examine public key when no algorithm passed

### DIFF
--- a/includes/signature/class-http-message-signature.php
+++ b/includes/signature/class-http-message-signature.php
@@ -23,7 +23,7 @@ use Activitypub\Collection\Actors;
 class Http_Message_Signature implements Signature_Standard {
 
 	/**
-	 * Supported algorithms.
+	 * Signature algorithms.
 	 *
 	 * @var int[][]
 	 */
@@ -72,7 +72,7 @@ class Http_Message_Signature implements Signature_Standard {
 	);
 
 	/**
-   * Digest algorithms.
+	 * Digest algorithms.
 	 *
 	 * @var string[]
 	 */

--- a/includes/signature/class-http-message-signature.php
+++ b/includes/signature/class-http-message-signature.php
@@ -23,6 +23,55 @@ use Activitypub\Collection\Actors;
 class Http_Message_Signature implements Signature_Standard {
 
 	/**
+	 * Supported algorithms.
+	 *
+	 * @var int[][]
+	 */
+	private $algorithms = array(
+		// RSA PKCS#1 v1.5.
+		'rsa-v1_5-sha256'   => array(
+			'type' => OPENSSL_KEYTYPE_RSA,
+			'algo' => OPENSSL_ALGO_SHA256,
+		),
+		'rsa-v1_5-sha384'   => array(
+			'type' => OPENSSL_KEYTYPE_RSA,
+			'algo' => OPENSSL_ALGO_SHA384,
+		),
+		'rsa-v1_5-sha512'   => array(
+			'type' => OPENSSL_KEYTYPE_RSA,
+			'algo' => OPENSSL_ALGO_SHA512,
+		),
+
+		// RSA PSS (note: not supported in openssl_verify() until PHP 8.1).
+		'rsa-pss-sha256'    => array(
+			'type' => OPENSSL_KEYTYPE_RSA,
+			'algo' => OPENSSL_ALGO_SHA256,
+		),
+		'rsa-pss-sha384'    => array(
+			'type' => OPENSSL_KEYTYPE_RSA,
+			'algo' => OPENSSL_ALGO_SHA384,
+		),
+		'rsa-pss-sha512'    => array(
+			'type' => OPENSSL_KEYTYPE_RSA,
+			'algo' => OPENSSL_ALGO_SHA512,
+		),
+
+		// ECDSA.
+		'ecdsa-p256-sha256' => array(
+			'type' => OPENSSL_KEYTYPE_EC,
+			'algo' => OPENSSL_ALGO_SHA256,
+		),
+		'ecdsa-p384-sha384' => array(
+			'type' => OPENSSL_KEYTYPE_EC,
+			'algo' => OPENSSL_ALGO_SHA384,
+		),
+		'ecdsa-p521-sha512' => array(
+			'type' => OPENSSL_KEYTYPE_EC,
+			'algo' => OPENSSL_ALGO_SHA512,
+		),
+	);
+
+	/**
 	 * Generate RFC-9421 compliant Signature-Input and Signature headers for an outgoing HTTP request.
 	 *
 	 * @param array  $args The request arguments.
@@ -243,69 +292,52 @@ class Http_Message_Signature implements Signature_Standard {
 	 * @return int|\WP_Error OpenSSL algorithm constant or WP_Error.
 	 */
 	private function verify_algorithm( $alg_string, $public_key ) {
-		$alg_string = \strtolower( $alg_string );
-		if ( \strpos( $alg_string, 'rsa-pss-' ) === 0 && \version_compare( PHP_VERSION, '8.1.0', '<' ) ) {
-			return new \WP_Error( 'unsupported_pss', 'RSA-PSS algorithms are not supported.' );
-		}
-
 		$details = \openssl_pkey_get_details( $public_key );
 		if ( ! isset( $details['type'] ) ) {
 			return new \WP_Error( 'invalid_key_details', 'Unable to read public key details.' );
 		}
 
-		$map = array(
-			// RSA PKCS#1 v1.5.
-			'rsa-v1_5-sha256'   => array(
-				'type' => OPENSSL_KEYTYPE_RSA,
-				'algo' => OPENSSL_ALGO_SHA256,
-			),
-			'rsa-v1_5-sha384'   => array(
-				'type' => OPENSSL_KEYTYPE_RSA,
-				'algo' => OPENSSL_ALGO_SHA384,
-			),
-			'rsa-v1_5-sha512'   => array(
-				'type' => OPENSSL_KEYTYPE_RSA,
-				'algo' => OPENSSL_ALGO_SHA512,
-			),
+		// If alg_string is empty, determine algorithm based on public key.
+		if ( empty( $alg_string ) ) {
+			switch ( $details['type'] ) {
+				case \OPENSSL_KEYTYPE_RSA:
+					$bits = $details['bits'] ?? 2048;
 
-			// RSA PSS (note: not supported in openssl_verify() until PHP 8.1).
-			'rsa-pss-sha256'    => array(
-				'type' => OPENSSL_KEYTYPE_RSA,
-				'algo' => OPENSSL_ALGO_SHA256,
-			),
-			'rsa-pss-sha384'    => array(
-				'type' => OPENSSL_KEYTYPE_RSA,
-				'algo' => OPENSSL_ALGO_SHA384,
-			),
-			'rsa-pss-sha512'    => array(
-				'type' => OPENSSL_KEYTYPE_RSA,
-				'algo' => OPENSSL_ALGO_SHA512,
-			),
+					if ( $bits >= 4 * KB_IN_BYTES ) {
+						return \OPENSSL_ALGO_SHA512;
+					} elseif ( $bits >= 3 * KB_IN_BYTES ) {
+						return \OPENSSL_ALGO_SHA384;
+					} else {
+						return \OPENSSL_ALGO_SHA256;
+					}
 
-			// ECDSA.
-			'ecdsa-p256-sha256' => array(
-				'type' => OPENSSL_KEYTYPE_EC,
-				'algo' => OPENSSL_ALGO_SHA256,
-			),
-			'ecdsa-p384-sha384' => array(
-				'type' => OPENSSL_KEYTYPE_EC,
-				'algo' => OPENSSL_ALGO_SHA384,
-			),
-			'ecdsa-p521-sha512' => array(
-				'type' => OPENSSL_KEYTYPE_EC,
-				'algo' => OPENSSL_ALGO_SHA512,
-			),
-		);
+				case \OPENSSL_KEYTYPE_EC:
+					switch ( $details['ec']['curve_name'] ?? '' ) {
+						case 'prime256v1':
+						case 'secp256r1':
+							return \OPENSSL_ALGO_SHA256;
+						case 'secp384r1':
+							return \OPENSSL_ALGO_SHA384;
+						case 'secp521r1':
+							return \OPENSSL_ALGO_SHA512;
+					}
+			}
+		}
 
-		if ( ! isset( $map[ $alg_string ] ) ) {
+		$alg_string = \strtolower( $alg_string );
+		if ( \strpos( $alg_string, 'rsa-pss-' ) === 0 && \version_compare( PHP_VERSION, '8.1.0', '<' ) ) {
+			return new \WP_Error( 'unsupported_pss', 'RSA-PSS algorithms are not supported.' );
+		}
+
+		if ( ! isset( $this->algorithms[ $alg_string ] ) ) {
 			return new \WP_Error( 'unsupported_alg', 'Unsupported or unknown alg parameter: ' . $alg_string );
 		}
 
-		if ( $map[ $alg_string ]['type'] !== $details['type'] ) {
+		if ( $this->algorithms[ $alg_string ]['type'] !== $details['type'] ) {
 			return new \WP_Error( 'alg_key_mismatch', 'Algorithm does not match public key type.' );
 		}
 
-		return $map[ $alg_string ]['algo'];
+		return $this->algorithms[ $alg_string ]['algo'];
 	}
 
 	/**

--- a/tests/includes/class-test-signature.php
+++ b/tests/includes/class-test-signature.php
@@ -540,6 +540,9 @@ class Test_Signature extends \WP_UnitTestCase {
 		$rsa_keys = self::$test_keys['rsa']['2048'];
 		$this->verify_rfc9421_signature_with_keys( $rsa_keys, 'rsa-v1_5-sha256' );
 
+		$rsa_keys = self::$test_keys['rsa']['2048'];
+		$this->verify_rfc9421_signature_with_keys( $rsa_keys, '' );
+
 		// Test with EC keys.
 		$ec_keys = self::$test_keys['ec']['prime256v1'];
 		$this->verify_rfc9421_signature_with_keys( $ec_keys, 'ecdsa-p256-sha256' );
@@ -579,11 +582,14 @@ class Test_Signature extends \WP_UnitTestCase {
 		// Create the signature input components.
 		$components    = array( '@method', '@target-uri', '@authority', 'content-digest', 'date' );
 		$params_string = \sprintf(
-			'(%s);created=%d;keyid="https://example.org/author/admin#main-key";alg="%s"',
+			'(%s);created=%d;keyid="https://example.org/author/admin#main-key"',
 			'"' . \implode( '" "', $components ) . '"',
-			\time(),
-			$algorithm
+			\time()
 		);
+
+		if ( ! empty( $algorithm ) ) {
+			$params_string .= ';alg="' . $algorithm . '"';
+		}
 
 		// Create the signature input header value (includes the label).
 		$signature_input = "sig1=$params_string";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The `alg` param is optional in RFC 9421, and when it's not provided we should examine the public key for its algorithm.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improved handling of empty algorithm strings by inferring the algorithm from the public key details.
* Moved supported algorithm definitions to a class property and updated verify_algorithm() to use this property instead of a local map.
* Added test.

### Other information:

- [x] Have you written new tests for your changes, if applicable?