### PR TITLE
Follow: Make sure Actor doesn't already exist before saving

### DIFF
--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -239,6 +239,7 @@ class Cli extends \WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *    $ wp activitypub follow https://example.com/@user
+	 *    $ wp --user=pfefferle activitypub follow https://example.com/@user
 	 *
 	 * @synopsis <remote_user>
 	 *

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -432,6 +432,12 @@ class Actors {
 			$actor = Actor::init_from_array( $actor );
 		}
 
+		// Make sure the actor doesn't already exist.
+		$post = self::get_remote_by_uri( $actor->get_id() );
+		if ( ! \is_wp_error( $post ) ) {
+			return self::update( $post, $actor );
+		}
+
 		$args = self::prepare_custom_post_type( $actor );
 
 		if ( \is_wp_error( $args ) ) {

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -432,12 +432,6 @@ class Actors {
 			$actor = Actor::init_from_array( $actor );
 		}
 
-		// Make sure the actor doesn't already exist.
-		$post = self::get_remote_by_uri( $actor->get_id() );
-		if ( ! \is_wp_error( $post ) ) {
-			return self::update( $post, $actor );
-		}
-
 		$args = self::prepare_custom_post_type( $actor );
 
 		if ( \is_wp_error( $args ) ) {
@@ -567,7 +561,7 @@ class Actors {
 			return $object;
 		}
 
-		$post_id = self::create( $object );
+		$post_id = self::upsert( $object );
 
 		if ( \is_wp_error( $post_id ) ) {
 			return $post_id;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This allows for webfingers and actor URLs to be passed to `ActivityPub\follow()` and handles resolving them to actor IDs through `Actors::fetch_remote_by_uri()`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `upsert()` to add in another `get_remote_by_uri()` check before deciding whether to insert or update.
* Enhances the CLI documentation to show how to specify a different user with the `--user` flag.
