### PR TITLE
Signature: Check for positive case in host support

### DIFF
--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -43,7 +43,7 @@ class Signature {
 			)
 		);
 
-		if ( '1' === \get_option( 'activitypub_rfc9421_signature' ) && ! self::rfc9421_is_unsupported( $url ) ) {
+		if ( '1' === \get_option( 'activitypub_rfc9421_signature' ) && self::could_support_rfc9421( $url ) ) {
 			$signature = new Http_Message_Signature();
 			\add_filter( 'http_response', array( self::class, 'maybe_double_knock' ), 10, 3 );
 		} else {
@@ -152,26 +152,26 @@ class Signature {
 	}
 
 	/**
-	 * Check if RFC-9421 signature is unsupported for a given host.
+	 * Check if RFC-9421 signature could be supported.
 	 *
 	 * @param string $url The URL to check.
 	 *
-	 * @return bool True, if unsupported, false otherwise.
+	 * @return bool True, if RFC-9421 signature could be supported, false otherwise.
 	 */
-	private static function rfc9421_is_unsupported( $url ) {
+	private static function could_support_rfc9421( $url ) {
 		$host = \wp_parse_url( $url, \PHP_URL_HOST );
 		$list = \get_option( 'activitypub_rfc9421_unsupported', array() );
 
 		if ( isset( $list[ $host ] ) ) {
 			if ( $list[ $host ] > \time() ) {
-				return true;
+				return false;
 			}
 
 			unset( $list[ $host ] );
 			\update_option( 'activitypub_rfc9421_unsupported', $list );
 		}
 
-		return false;
+		return true;
 	}
 
 	/**

--- a/tests/includes/class-test-signature.php
+++ b/tests/includes/class-test-signature.php
@@ -635,7 +635,7 @@ class Test_Signature extends \WP_UnitTestCase {
 	/**
 	 * Test RFC-9421 signature verification when it is unsupported.
 	 *
-	 * @covers ::rfc9421_is_unsupported
+	 * @covers ::could_support_rfc9421
 	 */
 	public function test_rfc9421_is_unsupported() {
 		\add_option( 'activitypub_rfc9421_unsupported', array( 'sub.www.example.org' => \time() + MINUTE_IN_SECONDS ), '', false );
@@ -689,9 +689,9 @@ class Test_Signature extends \WP_UnitTestCase {
 		$url = 'https://example.org/wp-json/activitypub/1.0/inbox';
 
 		// Test domain is not unsupported.
-		$rfc9421_is_unsupported = new \ReflectionMethod( Signature::class, 'rfc9421_is_unsupported' );
-		$rfc9421_is_unsupported->setAccessible( true );
-		$this->assertFalse( $rfc9421_is_unsupported->invoke( null, $url ) );
+		$could_support_rfc9421 = new \ReflectionMethod( Signature::class, 'could_support_rfc9421' );
+		$could_support_rfc9421->setAccessible( true );
+		$this->assertTrue( $could_support_rfc9421->invoke( null, $url ) );
 
 		\add_filter(
 			'pre_http_request',
@@ -721,7 +721,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		Http::post( $url, '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}', 1 );
 
 		// Domain is set as unsupported.
-		$this->assertTrue( $rfc9421_is_unsupported->invoke( null, $url ) );
+		$this->assertFalse( $could_support_rfc9421->invoke( null, $url ) );
 
 		// Cleanup.
 		\delete_option( 'activitypub_rfc9421_signature' );


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Renamed and inverted logic of `rfc9421_is_unsupported` to `could_support_rfc9421` in Signature class for clarity.
* Updated all usages and related tests to reflect the new method name and logic.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
