### PR TITLE
Query: Don't double-query posts

### DIFF
--- a/.github/changelog/1907-from-description
+++ b/.github/changelog/1907-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Minor performance improvement when querying posts of various types, by avoiding double queries.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -48,6 +48,11 @@ class Comment {
 	 */
 	public static function map_meta_cap( $caps, $cap, $user_id, $args ) {
 		if ( 'edit_comment' === $cap && self::was_received( $args[0] ) ) {
+			// Allow quick links in comments list screen.
+			if ( \function_exists( 'get_current_screen' ) && 'edit-comments' === \get_current_screen()->id ) {
+				return $caps;
+			}
+
 			$caps[] = 'do_not_allow';
 		}
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -48,11 +48,6 @@ class Comment {
 	 */
 	public static function map_meta_cap( $caps, $cap, $user_id, $args ) {
 		if ( 'edit_comment' === $cap && self::was_received( $args[0] ) ) {
-			// Allow quick links in comments list screen.
-			if ( \function_exists( 'get_current_screen' ) && 'edit-comments' === \get_current_screen()->id ) {
-				return $caps;
-			}
-
 			$caps[] = 'do_not_allow';
 		}
 

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -662,8 +662,7 @@ class Actors {
 			),
 		);
 
-		$posts = new \WP_Query( $args );
-		return $posts->get_posts();
+		return ( new \WP_Query() )->query( $args );
 	}
 
 	/**
@@ -689,8 +688,7 @@ class Actors {
 			),
 		);
 
-		$posts = new \WP_Query( $args );
-		return $posts->get_posts();
+		return ( new \WP_Query() )->query( $args );
 	}
 
 	/**

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -197,7 +197,7 @@ class Followers {
 		$args      = \wp_parse_args( $args, $defaults );
 		$query     = new \WP_Query( $args );
 		$total     = $query->found_posts;
-		$followers = \array_filter( $query->get_posts() );
+		$followers = \array_filter( $query->posts );
 
 		return \compact( 'followers', 'total' );
 	}
@@ -301,9 +301,7 @@ class Followers {
 			)
 		);
 
-		$posts = $posts->get_posts();
-
-		if ( ! $posts ) {
+		if ( ! $posts->posts ) {
 			return array();
 		}
 
@@ -312,10 +310,10 @@ class Followers {
 		$results = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT DISTINCT meta_value FROM {$wpdb->postmeta}
-				WHERE post_id IN (" . implode( ', ', array_fill( 0, count( $posts ), '%d' ) ) . ")
+				WHERE post_id IN (" . \implode( ', ', \array_fill( 0, \esc_sql( $posts->found_posts ), '%d' ) ) . ")
 				AND meta_key = '_activitypub_inbox'
 				AND meta_value IS NOT NULL",
-				$posts
+				$posts->posts
 			)
 		);
 

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -310,7 +310,7 @@ class Followers {
 		$results = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT DISTINCT meta_value FROM {$wpdb->postmeta}
-				WHERE post_id IN (" . \implode( ', ', \array_fill( 0, \esc_sql( $posts->found_posts ), '%d' ) ) . ")
+				WHERE post_id IN (" . \implode( ', ', \array_fill( 0, \absint( $posts->post_count ), '%d' ) ) . ")
 				AND meta_key = '_activitypub_inbox'
 				AND meta_value IS NOT NULL",
 				$posts->posts

--- a/includes/collection/class-following.php
+++ b/includes/collection/class-following.php
@@ -148,10 +148,8 @@ class Following {
 			)
 		);
 
-		$post_ids = $post_id_query->get_posts();
-
-		if ( $post_ids ) {
-			Outbox::undo( $post_ids[0] );
+		if ( $post_id_query->posts ) {
+			Outbox::undo( $post_id_query->posts[0] );
 		}
 
 		return $post;
@@ -191,7 +189,7 @@ class Following {
 		$args      = \wp_parse_args( $args, $defaults );
 		$query     = new \WP_Query( $args );
 		$total     = $query->found_posts;
-		$following = \array_filter( $query->get_posts() );
+		$following = \array_filter( $query->posts );
 
 		return \compact( 'following', 'total' );
 	}

--- a/tests/includes/class-test-comment.php
+++ b/tests/includes/class-test-comment.php
@@ -643,7 +643,6 @@ class Test_Comment extends \WP_UnitTestCase {
 				'withcomments' => true,
 			)
 		);
-		$query->get_posts();
 
 		$this->assertSame( count( $core_comment_types ), $query->comment_count );
 		$this->assertEqualSets( $core_comment_types, \wp_list_pluck( $query->comments, 'comment_type' ) );


### PR DESCRIPTION
While testing Followers and Following I noticed that we run queries twice, between passing args to `WP_Query` and calling `get_posts()` on it. In reality it's probably cached, but still worth removing the overhead of running `get_posts()` twice.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replaces `get_posts()` with direct access to the posts property or the `query()` method in collection classes.
* Updates related test to remove unnecessary get_posts() call.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure lists of Followers and Following still show up as expected.
* When unfollowing someone, the Undo Outbox item should still be created.
* When processing followers for an outbox item, all inboxes should still be retrieved.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Minor performance improvement when querying posts of various types, by avoiding double queries.

</details>
