### PR TITLE
Revert "Comments: Never allow edit of federated comments (#1895)"

### DIFF
--- a/.github/changelog/1895-from-description
+++ b/.github/changelog/1895-from-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Comments received from the Fediverse no longer show an Edit link in the comment list, despite not being editable.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -23,7 +23,6 @@ class Comment {
 	public static function init() {
 		self::register_comment_types();
 
-		\add_filter( 'map_meta_cap', array( self::class, 'map_meta_cap' ), 10, 4 );
 		\add_filter( 'comment_reply_link', array( self::class, 'comment_reply_link' ), 10, 3 );
 		\add_filter( 'comment_class', array( self::class, 'comment_class' ), 10, 3 );
 		\add_filter( 'comment_feed_where', array( static::class, 'comment_feed_where' ) );
@@ -34,24 +33,6 @@ class Comment {
 		\add_action( 'update_option_activitypub_allow_likes', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_action( 'update_option_activitypub_allow_reposts', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
-	}
-
-	/**
-	 * Remove edit capabilities for comments received via ActivityPub.
-	 *
-	 * @param array  $caps    Array of capabilities.
-	 * @param string $cap     Capability name.
-	 * @param int    $user_id User ID.
-	 * @param array  $args    Array of arguments.
-	 *
-	 * @return array Modified array of capabilities.
-	 */
-	public static function map_meta_cap( $caps, $cap, $user_id, $args ) {
-		if ( 'edit_comment' === $cap && self::was_received( $args[0] ) ) {
-			$caps[] = 'do_not_allow';
-		}
-
-		return $caps;
 	}
 
 	/**

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -270,6 +270,24 @@ class Admin {
 	 * Disables the edit_comment capability for federated comments.
 	 */
 	public static function edit_comment() {
+		// Disable the edit_comment capability for federated comments.
+		\add_filter(
+			'user_has_cap',
+			function ( $all_caps, $caps, $arg ) {
+				if ( 'edit_comment' !== $arg[0] ) {
+					return $all_caps;
+				}
+
+				if ( was_comment_received( $arg[2] ) ) {
+					return false;
+				}
+
+				return $all_caps;
+			},
+			1,
+			3
+		);
+
 		// phpcs:ignore WordPress.Security.NonceVerification
 		$comment_id = \absint( $_GET['c'] ?? 0 );
 		if ( Comment::was_received( $comment_id ) ) {


### PR DESCRIPTION
This reverts commit c95887644a9bec3dfb5e7fe6d5f5b38baebc071b.

This change made it impossible to run any action on a Comment, so it was no longer possible to moderate and/or delete a comment.

<img width="1119" alt="Screenshot 2025-07-09 at 11 08 28" src="https://github.com/user-attachments/assets/00fb94a4-3fb2-4c25-ad83-a95d6555573b" />

To be able to release a new version, I reverted the PR for now.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove c95887644a9bec3dfb5e7fe6d5f5b38baebc071b

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
