### PR TITLE
Scheduler: Pass guid so it can be queried later

### DIFF
--- a/.github/changelog/1915-from-description
+++ b/.github/changelog/1915-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+When deleting interactions for cleaned up actors, we use the actor's URL again to retrieve their information instead of our internal ID.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -198,12 +198,8 @@ class Scheduler {
 				\wp_delete_post( $actor->ID );
 			} elseif ( empty( $meta ) || ! is_array( $meta ) || is_wp_error( $meta ) ) {
 				if ( Actors::count_errors( $actor->ID ) >= 5 ) {
+					\wp_schedule_single_event( \time(), 'activitypub_delete_actor_interactions', array( $actor->guid ) );
 					\wp_delete_post( $actor->ID );
-					\wp_schedule_single_event(
-						\time(),
-						'activitypub_delete_actor_interactions',
-						array( $actor->ID )
-					);
 				} else {
 					Actors::add_error( $actor->ID, $meta );
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a fatal error when trying to delete interactions for a faulty actor:
```
PHP Fatal error:  Uncaught TypeError: array_is_list(): Argument #1 ($array) must be of type array, int given in /plugins/activitypub/includes/functions.php:700
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Pass guid instead of actor ID, as the actor gets deleted at the same time.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

When deleting interactions for cleaned up actors, we use the actor's URL again to retrieve their information instead of our internal ID.

</details>
