### PR TITLE
Following v1: Rest-API endpoint

### DIFF
--- a/.github/changelog/1916-from-description
+++ b/.github/changelog/1916-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+The `following` endpoint now returns the actual list of users being followed.

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -26,13 +26,6 @@ class Following_Controller extends Actors_Controller {
 	use Collection;
 
 	/**
-	 * Initialize the class, registering WordPress hooks.
-	 */
-	public function __construct() {
-		\add_filter( 'activitypub_rest_following', array( self::class, 'default_following' ), 10, 2 );
-	}
-
-	/**
 	 * Register routes.
 	 */
 	public function register_routes() {
@@ -138,29 +131,6 @@ class Following_Controller extends Actors_Controller {
 		$response->header( 'Content-Type', 'application/activity+json; charset=' . \get_option( 'blog_charset' ) );
 
 		return $response;
-	}
-
-	/**
-	 * Add the Blog Authors to the following list of the Blog Actor
-	 * if Blog not in single mode.
-	 *
-	 * @param array                   $follow_list The array of following urls.
-	 * @param \Activitypub\Model\User $user        The user object.
-	 *
-	 * @return array The array of following urls.
-	 */
-	public static function default_following( $follow_list, $user ) {
-		if ( 0 !== $user->get__id() || is_single_user() ) {
-			return $follow_list;
-		}
-
-		$users = Actors::get_collection();
-
-		foreach ( $users as $user ) {
-			$follow_list[] = $user->get_id();
-		}
-
-		return $follow_list;
 	}
 
 	/**

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Collection\Actors;
+use Activitypub\Collection\Following;
 
 use function Activitypub\get_context;
 use function Activitypub\is_single_user;
@@ -65,6 +66,18 @@ class Following_Controller extends Actors_Controller {
 							'minimum'     => 1,
 							'maximum'     => 100,
 						),
+						'order'    => array(
+							'description' => 'Order sort attribute ascending or descending.',
+							'type'        => 'string',
+							'default'     => 'desc',
+							'enum'        => array( 'asc', 'desc' ),
+						),
+						'context'  => array(
+							'description' => 'The context in which the request is made.',
+							'type'        => 'string',
+							'default'     => 'simple',
+							'enum'        => array( 'simple', 'full' ),
+						),
 					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
@@ -91,24 +104,30 @@ class Following_Controller extends Actors_Controller {
 		 */
 		\do_action( 'activitypub_rest_following_pre' );
 
+		$order    = $request->get_param( 'order' );
+		$per_page = $request->get_param( 'per_page' );
+		$page     = $request->get_param( 'page' ) ?? 1;
+		$context  = $request->get_param( 'context' );
+
+		$data = Following::get_following_with_count( $user_id, $per_page, $page, array( 'order' => \ucwords( $order ) ) );
+
 		$response = array(
-			'@context'  => get_context(),
-			'id'        => get_rest_url_by_path( \sprintf( 'actors/%d/following', $user->get__id() ) ),
-			'generator' => 'https://wordpress.org/?v=' . get_masked_wp_version(),
-			'actor'     => $user->get_id(),
-			'type'      => 'OrderedCollection',
+			'@context'     => get_context(),
+			'id'           => get_rest_url_by_path( \sprintf( 'actors/%d/following', $user->get__id() ) ),
+			'generator'    => 'https://wordpress.org/?v=' . get_masked_wp_version(),
+			'actor'        => $user->get_id(),
+			'type'         => 'OrderedCollection',
+			'totalItems'   => $data['total'],
+			'orderedItems' => array_map(
+				function ( $item ) use ( $context ) {
+					if ( 'full' === $context ) {
+						return Actors::get_actor( $item )->to_array( false );
+					}
+					return $item->guid;
+				},
+				$data['following']
+			),
 		);
-
-		/**
-		 * Filter the list of following urls.
-		 *
-		 * @param array                   $items The array of following urls.
-		 * @param \Activitypub\Model\User $user  The user object.
-		 */
-		$items = \apply_filters( 'activitypub_rest_following', array(), $user );
-
-		$response['totalItems']   = \is_countable( $items ) ? \count( $items ) : 0;
-		$response['orderedItems'] = $items;
 
 		$response = $this->prepare_collection_response( $response, $request );
 		if ( is_wp_error( $response ) ) {
@@ -154,9 +173,65 @@ class Following_Controller extends Actors_Controller {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
+		// Define the schema for items in the following collection.
 		$item_schema = array(
-			'type'   => 'string',
-			'format' => 'uri',
+			'oneOf' => array(
+				array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+				array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'                => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
+						'type'              => array(
+							'type' => 'string',
+						),
+						'name'              => array(
+							'type' => 'string',
+						),
+						'icon'              => array(
+							'type'       => 'object',
+							'properties' => array(
+								'type'      => array(
+									'type' => 'string',
+								),
+								'mediaType' => array(
+									'type' => 'string',
+								),
+								'url'       => array(
+									'type'   => 'string',
+									'format' => 'uri',
+								),
+							),
+						),
+						'published'         => array(
+							'type'   => 'string',
+							'format' => 'date-time',
+						),
+						'summary'           => array(
+							'type' => 'string',
+						),
+						'updated'           => array(
+							'type'   => 'string',
+							'format' => 'date-time',
+						),
+						'url'               => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
+						'streams'           => array(
+							'type' => 'array',
+						),
+						'preferredUsername' => array(
+							'type' => 'string',
+						),
+					),
+				),
+			),
 		);
 
 		$schema = $this->get_collection_schema( $item_schema );


### PR DESCRIPTION
Now that we support followings, the endpoints should return the real list of followers, the same way we do with followers.

<img width="1317" height="1067" alt="Screenshot 2025-07-11 at 09 59 59" src="https://github.com/user-attachments/assets/55b0973c-2d95-4e01-8385-15fadfaafe22" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR implements the following endpoint based on the already implemented followers endpoint.

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add followings
* Go to the API-Endpoint and check the result

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

The `following` endpoint now returns the actual list of users being followed.

</details>
