### PR TITLE
Ensure that Actor is always a URL

### DIFF
--- a/.github/changelog/1920-from-description
+++ b/.github/changelog/1920-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure that the Actor-ID is always a URL.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Collection;
 
 use Activitypub\Scheduler;
+use Activitypub\Webfinger;
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
 

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -39,6 +39,14 @@ class Outbox {
 			$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
 		}
 
+		if ( ! \filter_var( $object_id, FILTER_VALIDATE_URL ) ) {
+			$object_id = Webfinger::resolve( $object_id );
+		}
+
+		if ( \is_wp_error( $object_id ) ) {
+			return $object_id;
+		}
+
 		// Save activity in the context of an activitypub request.
 		\add_filter( 'activitypub_is_activitypub_request', '__return_true' );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1529,12 +1529,20 @@ function add_to_outbox( $data, $activity_type = null, $user_id = 0, $content_vis
 /**
  * Follow a user.
  *
- * @param string $remote_actor The Actor URL.
+ * @param string $remote_actor The Actor URL or WebFinger Resource.
  * @param int    $user_id      The ID of the WordPress User.
  *
  * @return int|\WP_Error The ID of the Outbox item or a WP_Error.
  */
 function follow( $remote_actor, $user_id ) {
+	if ( ! \filter_var( $remote_actor, FILTER_VALIDATE_URL ) ) {
+		$remote_actor = Webfinger::resolve( $remote_actor );
+	}
+
+	if ( \is_wp_error( $remote_actor ) ) {
+		return $remote_actor;
+	}
+
 	$remote_actor_post = Actors::fetch_remote_by_uri( $remote_actor );
 
 	if ( \is_wp_error( $remote_actor_post ) ) {


### PR DESCRIPTION
While working on Starter Kits #1919 I realized that we do not always ensure that an Actor-ID is a URL.

<img width="901" height="117" alt="Screenshot 2025-07-11 at 12 47 38" src="https://github.com/user-attachments/assets/ca627621-30ec-46fc-8fe9-b07b257deac6" />
(see the `_activitypub_object_id`)

This PR checks for a URL in the Follow and the Outbox process, to run a WebFinger lookup then.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that Actor-ID is a URL

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow a WebFinger resource and check the outbox meta data in the db then.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Ensure that the Actor-ID is always a URL.

</details>
