### PR TITLE
Remove "Followed" date

### DIFF
--- a/.github/changelog/1928-from-description
+++ b/.github/changelog/1928-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Removed follower dates to avoid confusion, as they may not have accurately reflected the actual follow time.

--- a/includes/table/class-followers.php
+++ b/includes/table/class-followers.php
@@ -56,7 +56,6 @@ class Followers extends \WP_List_Table {
 			'cb'         => '<input type="checkbox" />',
 			'username'   => \esc_html__( 'Username', 'activitypub' ),
 			'post_title' => \esc_html__( 'Name', 'activitypub' ),
-			'published'  => \esc_html__( 'Followed', 'activitypub' ),
 			'modified'   => \esc_html__( 'Last updated', 'activitypub' ),
 		);
 	}
@@ -71,7 +70,6 @@ class Followers extends \WP_List_Table {
 			'username'   => array( 'username', true ),
 			'post_title' => array( 'post_title', true ),
 			'modified'   => array( 'modified', false ),
-			'published'  => array( 'published', false ),
 		);
 	}
 
@@ -124,7 +122,6 @@ class Followers extends \WP_List_Table {
 				'username'   => $actor->get_preferred_username(),
 				'url'        => object_to_uri( $actor->get_url() ),
 				'identifier' => $actor->get_id(),
-				'published'  => $follower->post_date_gmt,
 				'modified'   => $follower->post_modified_gmt,
 			);
 		}
@@ -213,21 +210,6 @@ class Followers extends \WP_List_Table {
 			\esc_attr( $item['username'] ),
 			\esc_url( $item['url'] ),
 			\esc_html( $item['username'] )
-		);
-	}
-
-	/**
-	 * Column published.
-	 *
-	 * @param array $item Item.
-	 * @return string
-	 */
-	public function column_published( $item ) {
-		$published = \strtotime( $item['published'] );
-		return \sprintf(
-			'<time datetime="%1$s">%2$s</time>',
-			\esc_attr( \gmdate( 'c', $published ) ),
-			\esc_html( \gmdate( \get_option( 'date_format' ), $published ) )
 		);
 	}
 

--- a/templates/followers-list.php
+++ b/templates/followers-list.php
@@ -16,7 +16,7 @@ $table->prepare_items();
 ?>
 <div class="wrap">
 	<?php if ( ! $_tab ) : ?>
-	<h1 class="wp-heading-inline"><?php esc_html_e( 'Author Followers', 'activitypub' ); ?></h1>
+	<h1 class="wp-heading-inline"><?php esc_html_e( 'Followers', 'activitypub' ); ?></h1>
 	<?php endif; ?>
 
 	<?php


### PR DESCRIPTION
Now that we use the persistence for following and followers, we can not say for sure if that date is the date of following or followed or simply the date when they were imported through an @-reply.

This PR removes it as quick fix. If we want to have that information, we would need to have it in a separate PR, using a post-meta for example.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #1927 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove "Followed" date

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Removed follower dates to avoid confusion, as they may not have accurately reflected the actual follow time.

</details>
