### PR TITLE
Welcome: Only count internal callbacks as steps

### DIFF
--- a/.github/changelog/1942-from-description
+++ b/.github/changelog/1942-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Step counts for the Welcome checklist now only take into account steps that are added in the Welcome class.

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -139,7 +139,10 @@ class Welcome_Fields {
 		$count = 0;
 
 		if ( isset( $wp_filter['activitypub_onboarding_steps'] ) ) {
-			$count = \count( $wp_filter['activitypub_onboarding_steps']->callbacks );
+			foreach ( $wp_filter['activitypub_onboarding_steps']->callbacks as $callbacks ) {
+				$matching_keys = \preg_grep( '/^' . \preg_quote( self::class, '/' ) . '/', \array_keys( $callbacks ) );
+				$count        += \count( $matching_keys );
+			}
 		}
 
 		return $count;

--- a/includes/wp-admin/class-welcome-fields.php
+++ b/includes/wp-admin/class-welcome-fields.php
@@ -139,8 +139,9 @@ class Welcome_Fields {
 		$count = 0;
 
 		if ( isset( $wp_filter['activitypub_onboarding_steps'] ) ) {
+			$pattern = '/^' . \preg_quote( self::class, '/' ) . '/';
 			foreach ( $wp_filter['activitypub_onboarding_steps']->callbacks as $callbacks ) {
-				$matching_keys = \preg_grep( '/^' . \preg_quote( self::class, '/' ) . '/', \array_keys( $callbacks ) );
+				$matching_keys = \preg_grep( $pattern, \array_keys( $callbacks ) );
 				$count        += \count( $matching_keys );
 			}
 		}


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the logic to count only callbacks matching the Welcome_Fields class in the 'activitypub_onboarding_steps' filter. This ensures the count accurately reflects the number of relevant onboarding steps.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Activitypub and make sure the number of total steps in the counter is accurate.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Step counts for the Welcome checklist now only take into account steps that are added in the Welcome class.

</details>
