### PR TITLE
Remove duplicate `nonce` fields

### DIFF
--- a/templates/followers-list.php
+++ b/templates/followers-list.php
@@ -45,7 +45,6 @@ $followers_list_table->prepare_items();
 	<form method="post">
 		<input type="hidden" name="page" value="<?php echo esc_attr( $_page ); ?>" />
 		<input type="hidden" name="tab" value="<?php echo esc_attr( $_tab ); ?>" />
-		<?php wp_nonce_field( 'bulk-' . $followers_list_table->_args['plural'] ); ?>
 		<?php $followers_list_table->display(); ?>
 	</form>
 </div>

--- a/templates/following-list.php
+++ b/templates/following-list.php
@@ -46,7 +46,6 @@ $following_list_table->prepare_items();
 	<form method="post">
 		<input type="hidden" name="page" value="<?php echo esc_attr( $_page ); ?>" />
 		<input type="hidden" name="tab" value="<?php echo esc_attr( $_tab ); ?>" />
-		<?php wp_nonce_field( 'bulk-' . $following_list_table->_args['plural'] ); ?>
 		<?php $following_list_table->display(); ?>
 	</form>
 	<div class="form-wrap edit-term-notes">


### PR DESCRIPTION
There is no need to add a nonce, because this is automatically done by `WP_List_Table::display()`

<img width="1059" height="167" alt="Screenshot 2025-07-17 at 11 50 22" src="https://github.com/user-attachments/assets/589cf93b-f83a-42a2-b45c-0586d7a30332" />

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove `wp_nonce_field`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
