### PR TITLE
Follow(ing|ers) Tables: Use CPT-ID instead of Actor-URI

### DIFF
--- a/.github/changelog/1946-from-description
+++ b/.github/changelog/1946-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Table actions are now faster by using the Custom Post Type ID instead of the remote user URI, thanks to the unified Actor Model.

--- a/includes/table/class-followers.php
+++ b/includes/table/class-followers.php
@@ -72,7 +72,7 @@ class Followers extends \WP_List_Table {
 							'action'  => 'deleted',
 						);
 
-						\wp_safe_redirect( \add_query_arg( $redirect_args ) );
+						\wp_safe_redirect( \add_query_arg( $redirect_args, \remove_query_arg( array( 'follower' ) ) ) );
 						exit;
 					}
 				}
@@ -93,7 +93,7 @@ class Followers extends \WP_List_Table {
 							'count'   => \count( $followers ),
 						);
 
-						\wp_safe_redirect( \add_query_arg( $redirect_args ) );
+						\wp_safe_redirect( \add_query_arg( $redirect_args, \remove_query_arg( array( 'followers' ) ) ) );
 						exit;
 					}
 				}

--- a/includes/table/class-followers.php
+++ b/includes/table/class-followers.php
@@ -82,7 +82,7 @@ class Followers extends \WP_List_Table {
 					$nonce = \sanitize_text_field( \wp_unslash( $_REQUEST['_wpnonce'] ) );
 
 					if ( \wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
-						$followers = \array_map( 'absint', $_REQUEST['followers'] );
+						$followers = \array_map( 'absint', \wp_unslash( $_REQUEST['followers'] ) );
 						foreach ( $followers as $follower ) {
 							Follower_Collection::remove( $follower, $this->user_id );
 						}

--- a/includes/table/class-followers.php
+++ b/includes/table/class-followers.php
@@ -61,7 +61,7 @@ class Followers extends \WP_List_Table {
 			case 'delete':
 				// Handle single follower deletion.
 				if ( isset( $_GET['follower'], $_GET['_wpnonce'] ) ) {
-					$follower = \esc_url_raw( \wp_unslash( $_GET['follower'] ) );
+					$follower = \absint( $_GET['follower'] );
 					$nonce    = \sanitize_text_field( \wp_unslash( $_GET['_wpnonce'] ) );
 
 					if ( \wp_verify_nonce( $nonce, 'delete-follower_' . $follower ) ) {
@@ -82,7 +82,7 @@ class Followers extends \WP_List_Table {
 					$nonce = \sanitize_text_field( \wp_unslash( $_REQUEST['_wpnonce'] ) );
 
 					if ( \wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
-						$followers = \array_map( 'esc_url_raw', \wp_unslash( $_REQUEST['followers'] ) );
+						$followers = \array_map( 'absint', $_REQUEST['followers'] );
 						foreach ( $followers as $follower ) {
 							Follower_Collection::remove( $follower, $this->user_id );
 						}
@@ -345,10 +345,10 @@ class Followers extends \WP_List_Table {
 					\add_query_arg(
 						array(
 							'action'   => 'delete',
-							'follower' => $item['identifier'],
+							'follower' => $item['id'],
 						)
 					),
-					'delete-follower_' . $item['identifier']
+					'delete-follower_' . $item['id']
 				),
 				/* translators: %s: username. */
 				\esc_attr( \sprintf( \__( 'Delete %s', 'activitypub' ), $item['username'] ) ),

--- a/includes/table/class-followers.php
+++ b/includes/table/class-followers.php
@@ -65,7 +65,7 @@ class Followers extends \WP_List_Table {
 					$nonce    = \sanitize_text_field( \wp_unslash( $_GET['_wpnonce'] ) );
 
 					if ( \wp_verify_nonce( $nonce, 'delete-follower_' . $follower ) ) {
-						Follower_Collection::remove_follower( $this->user_id, $follower );
+						Follower_Collection::remove( $follower, $this->user_id );
 
 						$redirect_args = array(
 							'updated' => 'true',
@@ -84,7 +84,7 @@ class Followers extends \WP_List_Table {
 					if ( \wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
 						$followers = \array_map( 'esc_url_raw', \wp_unslash( $_REQUEST['followers'] ) );
 						foreach ( $followers as $follower ) {
-							Follower_Collection::remove_follower( $this->user_id, $follower );
+							Follower_Collection::remove( $follower, $this->user_id );
 						}
 
 						$redirect_args = array(
@@ -284,7 +284,7 @@ class Followers extends \WP_List_Table {
 	 * @return string
 	 */
 	public function column_cb( $item ) {
-		return \sprintf( '<input type="checkbox" name="followers[]" value="%s" />', \esc_attr( $item['identifier'] ) );
+		return \sprintf( '<input type="checkbox" name="followers[]" value="%s" />', \esc_attr( $item['id'] ) );
 	}
 
 	/**

--- a/includes/table/class-following.php
+++ b/includes/table/class-following.php
@@ -82,7 +82,7 @@ class Following extends \WP_List_Table {
 					$nonce = \sanitize_text_field( \wp_unslash( $_REQUEST['_wpnonce'] ) );
 
 					if ( \wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
-						$following = array_map( 'absint', $_REQUEST['following'] );
+						$following = array_map( 'absint', \wp_unslash( $_REQUEST['following'] ) );
 
 						foreach ( $following as $post_id ) {
 							Following_Collection::unfollow( $post_id, $this->user_id );

--- a/includes/table/class-following.php
+++ b/includes/table/class-following.php
@@ -65,12 +65,7 @@ class Following extends \WP_List_Table {
 					$nonce    = \sanitize_text_field( \wp_unslash( $_GET['_wpnonce'] ) );
 
 					if ( \wp_verify_nonce( $nonce, 'delete-follower_' . $follower ) ) {
-						$actor = Actors::get_remote_by_uri( $follower );
-						if ( \is_wp_error( $actor ) ) {
-							break;
-						}
-
-						Following_Collection::unfollow( $actor, $this->user_id );
+						Following_Collection::unfollow( $follower, $this->user_id );
 
 						$redirect_args = array(
 							'updated' => 'true',
@@ -89,12 +84,8 @@ class Following extends \WP_List_Table {
 					if ( \wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
 						$following = array_map( 'esc_url_raw', \wp_unslash( $_REQUEST['following'] ) );
 
-						foreach ( $following as $actor_id ) {
-							$actor = Actors::get_remote_by_uri( $actor_id );
-							if ( \is_wp_error( $actor ) ) {
-								continue;
-							}
-							Following_Collection::unfollow( $actor, $this->user_id );
+						foreach ( $following as $post_id ) {
+							Following_Collection::unfollow( $post_id, $this->user_id );
 						}
 
 						$redirect_args = array(
@@ -343,7 +334,7 @@ class Following extends \WP_List_Table {
 	 * @return string
 	 */
 	public function column_cb( $item ) {
-		return \sprintf( '<input type="checkbox" name="following[]" value="%s" />', \esc_attr( $item['identifier'] ) );
+		return \sprintf( '<input type="checkbox" name="following[]" value="%s" />', \esc_attr( $item['id'] ) );
 	}
 
 	/**

--- a/includes/table/class-following.php
+++ b/includes/table/class-following.php
@@ -61,7 +61,7 @@ class Following extends \WP_List_Table {
 			case 'delete':
 				// Handle single follower deletion.
 				if ( isset( $_GET['follower'], $_GET['_wpnonce'] ) ) {
-					$follower = \esc_url_raw( \wp_unslash( $_GET['follower'] ) );
+					$follower = \absint( $_GET['follower'] );
 					$nonce    = \sanitize_text_field( \wp_unslash( $_GET['_wpnonce'] ) );
 
 					if ( \wp_verify_nonce( $nonce, 'delete-follower_' . $follower ) ) {
@@ -82,7 +82,7 @@ class Following extends \WP_List_Table {
 					$nonce = \sanitize_text_field( \wp_unslash( $_REQUEST['_wpnonce'] ) );
 
 					if ( \wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
-						$following = array_map( 'esc_url_raw', \wp_unslash( $_REQUEST['following'] ) );
+						$following = array_map( 'absint', $_REQUEST['following'] );
 
 						foreach ( $following as $post_id ) {
 							Following_Collection::unfollow( $post_id, $this->user_id );
@@ -419,10 +419,10 @@ class Following extends \WP_List_Table {
 					\add_query_arg(
 						array(
 							'action'   => 'delete',
-							'follower' => $item['identifier'],
+							'follower' => $item['id'],
 						)
 					),
-					'delete-follower_' . $item['identifier']
+					'delete-follower_' . $item['id']
 				),
 				/* translators: %s: username. */
 				\esc_attr( \sprintf( \__( 'Unfollow %s', 'activitypub' ), $item['username'] ) ),

--- a/includes/table/class-following.php
+++ b/includes/table/class-following.php
@@ -72,7 +72,7 @@ class Following extends \WP_List_Table {
 							'action'  => 'deleted',
 						);
 
-						\wp_safe_redirect( \add_query_arg( $redirect_args ) );
+						\wp_safe_redirect( \add_query_arg( $redirect_args, \remove_query_arg( array( 'follower' ) ) ) );
 						exit;
 					}
 				}
@@ -94,7 +94,7 @@ class Following extends \WP_List_Table {
 							'count'   => \count( $following ),
 						);
 
-						\wp_safe_redirect( \add_query_arg( $redirect_args ) );
+						\wp_safe_redirect( \add_query_arg( $redirect_args, \remove_query_arg( array( 'following' ) ) ) );
 						exit;
 					}
 				}

--- a/tests/includes/collection/class-test-followers.php
+++ b/tests/includes/collection/class-test-followers.php
@@ -227,6 +227,7 @@ class Test_Followers extends \WP_UnitTestCase {
 		$follower2 = Followers::get_follower( 2, 'https://example.com/author/jon' );
 		$this->assertEquals( 'https://example.com/author/jon', $follower2->guid );
 
+		$this->setExpectedDeprecated( 'Activitypub\Collection\Followers::remove_follower' );
 		Followers::remove_follower( 1, 'https://example.com/author/jon' );
 
 		$follower = Followers::get_follower( 1, 'https://example.com/author/jon' );
@@ -234,6 +235,36 @@ class Test_Followers extends \WP_UnitTestCase {
 
 		$follower2 = Followers::get_follower( 2, 'https://example.com/author/jon' );
 		$this->assertEquals( 'https://example.com/author/jon', $follower2->guid );
+
+		$followers = Followers::get_followers( 1 );
+		$this->assertEquals( 1, count( $followers ) );
+	}
+
+	/**
+	 * Tests remove_follower.
+	 *
+	 * @covers ::remove
+	 */
+	public function test_remove() {
+		$followers = array(
+			'https://example.com/author/jon',
+			'https://example.org/author/doe',
+		);
+
+		foreach ( $followers as $follower ) {
+			Followers::add_follower( 1, $follower );
+		}
+
+		$follower = Followers::get_follower( 1, 'https://example.com/author/jon' );
+		$this->assertEquals( 'https://example.com/author/jon', $follower->guid );
+
+		$followers = Followers::get_followers( 1 );
+		$this->assertEquals( 2, count( $followers ) );
+
+		Followers::remove( $followers[0]->ID, 1 );
+
+		$follower = Followers::get_follower( 1, $followers[0]->guid );
+		$this->assertWPError( $follower );
 
 		$followers = Followers::get_followers( 1 );
 		$this->assertEquals( 1, count( $followers ) );


### PR DESCRIPTION
There is no need to use the URI to identify a remote user any more. With the new rework and a unified Actor Model, we could simply work with the ID of the Custom-Post-Type. This makes all table actions way more effective and faster.

Bonus: The PR also removes the `following(s)` and `follower(s)` action query strings, otherwise it will stick to the action for all following actions.
Example: When you delete a single follower, the current code retains the follower query string after the redirect. As a result, if you immediately attempt a batch deletion, the query still matches follower and mistakenly triggers a reprocessing of the single deletion instead of executing the intended followers batch action.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change Table actions to use IDs instead of URIs
* Remove the `action` after is is done, to ensure that it does not stick with it

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test removing Followers
* Test unfollow Followings

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Table actions are now faster by using the Custom Post Type ID instead of the remote user URI, thanks to the unified Actor Model.

</details>
