### PR TITLE
Settings: Only initiate table that's needed

### DIFF
--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -108,6 +108,22 @@ class Admin {
 	}
 
 	/**
+	 * Creates the followers and following list tables in ActivityPub settings.
+	 */
+	public static function add_settings_list_tables() {
+		$tab = \sanitize_text_field( \wp_unslash( $_GET['tab'] ?? 'welcome' ) ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		switch ( $tab ) {
+			case 'followers':
+				self::add_followers_list_table();
+				break;
+			case 'following':
+				self::add_following_list_table();
+				break;
+		}
+	}
+
+	/**
 	 * Creates the followers list table.
 	 */
 	public static function add_followers_list_table() {

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -28,8 +28,7 @@ class Menu {
 
 		\add_action( 'load-' . $settings_page, array( Settings::class, 'add_settings_help_tab' ) );
 		\add_action( 'load-users.php', array( Settings::class, 'add_users_help_tab' ) );
-		\add_action( 'load-' . $settings_page, array( Admin::class, 'add_followers_list_table' ) );
-		\add_action( 'load-' . $settings_page, array( Admin::class, 'add_following_list_table' ) );
+		\add_action( 'load-' . $settings_page, array( Admin::class, 'add_settings_list_tables' ) );
 		\add_action( 'load-' . $settings_page, array( Screen_Options::class, 'add_settings_list_options' ) );
 
 		// User has to be able to publish posts.


### PR DESCRIPTION
Avoids both tables listening for the same admin notice arguments and displaying their messages.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Consolidate the addition of followers and following list tables into a single method, `Admin::add_settings_list_tables`, which selects the appropriate table based on the current tab. 
