### PR TITLE
Follower: Fix missing ID warnings

### DIFF
--- a/includes/table/class-followers.php
+++ b/includes/table/class-followers.php
@@ -207,6 +207,7 @@ class Followers extends \WP_List_Table {
 		foreach ( $followers as $follower ) {
 			$actor         = Actors::get_actor( $follower );
 			$this->items[] = array(
+				'id'         => $follower->ID,
 				'icon'       => $actor->get_icon()['url'] ?? '',
 				'post_title' => $actor->get_name(),
 				'username'   => $actor->get_preferred_username(),

--- a/includes/table/class-following.php
+++ b/includes/table/class-following.php
@@ -218,7 +218,7 @@ class Following extends \WP_List_Table {
 		);
 
 		foreach ( $followings as $following ) {
-			$actor = Actors::get_actor( $following->ID );
+			$actor = Actors::get_actor( $following );
 
 			$this->items[] = array(
 				'id'         => $following->ID,


### PR DESCRIPTION
```
Warning: Undefined array key "id" in /var/www/html/wp-content/plugins/wordpress-activitypub/includes/table/class-followers.php on line 287
Warning: Undefined array key "id" in /var/www/html/wp-content/plugins/wordpress-activitypub/includes/table/class-followers.php on line 348
Warning: Undefined array key "id" in /var/www/html/wp-content/plugins/wordpress-activitypub/includes/table/class-followers.php on line 351
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In Followers, the follower ID is now included in the items array, fixing undefined index warnings.
* In Following, the full object is passed to Actors::get_actor, avoiding a get_post() lookup.
