### PR TITLE
Move remaining screen options logic to Screen_Options class

### DIFF
--- a/.github/changelog/1802-from-description
+++ b/.github/changelog/1802-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Screen options in the Activitypub settings page are now filterable.

--- a/.github/changelog/1802-from-description
+++ b/.github/changelog/1802-from-description
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Screen options in the Activitypub settings page are now filterable.

--- a/includes/wp-admin/class-screen-options.php
+++ b/includes/wp-admin/class-screen-options.php
@@ -139,11 +139,11 @@ class Screen_Options {
 			<legend class="screen-layout"><?php \esc_html_e( 'Settings Pages', 'activitypub' ); ?></legend>
 			<div class="metabox-prefs-container">
 				<?php foreach ( $screen_options as $option => $label ) : ?>
-					<label for="<?php echo \esc_attr( $option ); ?>">
-						<input name="<?php echo \esc_attr( $option ); ?>" type="hidden" value="0" />
-						<input name="<?php echo \esc_attr( $option ); ?>" type="checkbox" id="<?php echo \esc_attr( $option ); ?>" value="1" <?php \checked( 1, \get_user_meta( \get_current_user_id(), $option, true ) ); ?> />
-						<?php echo \esc_html( $label ); ?>
-					</label>
+				<label for="<?php echo \esc_attr( $option ); ?>">
+					<input name="<?php echo \esc_attr( $option ); ?>" type="hidden" value="0" />
+					<input name="<?php echo \esc_attr( $option ); ?>" type="checkbox" id="<?php echo \esc_attr( $option ); ?>" value="1" <?php \checked( 1, \get_user_meta( \get_current_user_id(), $option, true ) ); ?> />
+					<?php echo \esc_html( $label ); ?>
+				</label>
 				<?php endforeach; ?>
 			</div>
 		</fieldset>

--- a/includes/wp-admin/class-screen-options.php
+++ b/includes/wp-admin/class-screen-options.php
@@ -16,6 +16,8 @@ class Screen_Options {
 	 */
 	public static function init() {
 		\add_filter( 'set-screen-option', array( self::class, 'set_per_page_option' ), 10, 3 );
+		\add_filter( 'screen_settings', array( self::class, 'add_screen_option' ), 10, 2 );
+		\add_filter( 'screen_options_show_submit', array( self::class, 'screen_options_show_submit' ), 10, 2 );
 	}
 
 	/**
@@ -86,5 +88,83 @@ class Screen_Options {
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Add screen options.
+	 *
+	 * @param string $screen_settings The screen settings.
+	 * @param object $screen          The screen object.
+	 *
+	 * @return string The screen settings.
+	 */
+	public static function add_screen_option( $screen_settings, $screen ) {
+		if ( 'settings_page_activitypub' !== $screen->id ) {
+			return $screen_settings;
+		}
+
+		// Verify screen options nonce.
+		if ( isset( $_POST['screenoptionnonce'] ) ) {
+			$nonce = \sanitize_text_field( \wp_unslash( $_POST['screenoptionnonce'] ) );
+			if ( ! \wp_verify_nonce( $nonce, 'screen-options-nonce' ) ) {
+				return $screen_settings;
+			}
+		}
+
+		$screen_options = array(
+			'activitypub_show_welcome_tab'  => __( 'Welcome Page', 'activitypub' ),
+			'activitypub_show_advanced_tab' => __( 'Advanced Settings', 'activitypub' ),
+		);
+
+		/**
+		 * Filters Activitypub settings screen options.
+		 *
+		 * @param string[] $screen_options Screen options. An array of user meta keys and screen option labels.
+		 */
+		$screen_options = \apply_filters( 'activitypub_screen_options', $screen_options );
+		if ( empty( $screen_options ) ) {
+			return $screen_settings;
+		}
+
+		foreach ( $screen_options as $option => $label ) {
+			if ( isset( $_POST[ $option ] ) ) {
+				$value = \sanitize_text_field( \wp_unslash( $_POST[ $option ] ) );
+				\update_user_meta( \get_current_user_id(), $option, empty( $value ) ? 0 : 1 );
+			}
+		}
+
+		ob_start();
+		?>
+		<fieldset>
+			<legend class="screen-layout"><?php \esc_html_e( 'Settings Pages', 'activitypub' ); ?></legend>
+			<div class="metabox-prefs-container">
+				<?php foreach ( $screen_options as $option => $label ) : ?>
+					<label for="<?php echo \esc_attr( $option ); ?>">
+						<input name="<?php echo \esc_attr( $option ); ?>" type="hidden" value="0" />
+						<input name="<?php echo \esc_attr( $option ); ?>" type="checkbox" id="<?php echo \esc_attr( $option ); ?>" value="1" <?php \checked( 1, \get_user_meta( \get_current_user_id(), $option, true ) ); ?> />
+						<?php echo \esc_html( $label ); ?>
+					</label>
+				<?php endforeach; ?>
+			</div>
+		</fieldset>
+		<?php
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Show the submit button on the screen options page.
+	 *
+	 * @param bool   $show_submit Whether to show the submit button.
+	 * @param object $screen      The screen object.
+	 *
+	 * @return bool Whether to show the submit button.
+	 */
+	public static function screen_options_show_submit( $show_submit, $screen ) {
+		if ( 'settings_page_activitypub' !== $screen->id ) {
+			return $show_submit;
+		}
+
+		return true;
 	}
 }

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -24,8 +24,6 @@ class Settings {
 		\add_action( 'admin_menu', array( self::class, 'add_settings_page' ) );
 
 		\add_action( 'load-settings_page_activitypub', array( self::class, 'handle_welcome_query_arg' ) );
-		\add_filter( 'screen_settings', array( self::class, 'add_screen_option' ), 10, 2 );
-		\add_filter( 'screen_options_show_submit', array( self::class, 'screen_options_show_submit' ), 10, 2 );
 	}
 
 	/**
@@ -544,85 +542,6 @@ class Settings {
 			\wp_safe_redirect( \admin_url( 'options-general.php?page=activitypub&tab=settings' ) );
 			exit;
 		}
-	}
-
-	/**
-	 * Add screen option.
-	 *
-	 * @param string $screen_settings The screen settings.
-	 * @param object $screen          The screen object.
-	 *
-	 * @return string The screen settings.
-	 */
-	public static function add_screen_option( $screen_settings, $screen ) {
-		if ( 'settings_page_activitypub' !== $screen->id ) {
-			return $screen_settings;
-		}
-
-		// Verify screen options nonce.
-		if ( isset( $_POST['screenoptionnonce'] ) ) {
-			$nonce = \sanitize_text_field( \wp_unslash( $_POST['screenoptionnonce'] ) );
-			if ( ! \wp_verify_nonce( $nonce, 'screen-options-nonce' ) ) {
-				return $screen_settings;
-			}
-		}
-
-		$screen_options = array(
-			'activitypub_show_welcome_tab'  => __( 'Welcome Page', 'activitypub' ),
-			'activitypub_show_advanced_tab' => __( 'Advanced Settings', 'activitypub' ),
-		);
-
-		/**
-		 * Filters Activitypub settings screen options.
-		 *
-		 * @param string[] $screen_options Screen options. An array of user meta keys and screen option labels.
-		 */
-		$screen_options = \apply_filters( 'activitypub_screen_options', $screen_options );
-		if ( empty( $screen_options ) ) {
-			return $screen_settings;
-		}
-
-		foreach ( $screen_options as $option => $label ) {
-			if ( isset( $_POST[ $option ] ) ) {
-				$value = \sanitize_text_field( \wp_unslash( $_POST[ $option ] ) );
-				\update_user_meta( \get_current_user_id(), $option, empty( $value ) ? 0 : 1 );
-			}
-		}
-
-		ob_start();
-		?>
-		<fieldset>
-			<legend class="screen-layout"><?php \esc_html_e( 'Settings Pages', 'activitypub' ); ?></legend>
-			<p><?php \esc_html_e( 'Some settings pages can be shown or hidden by using the checkboxes.', 'activitypub' ); ?></p>
-			<div class="metabox-prefs-container">
-				<?php foreach ( $screen_options as $option => $label ) : ?>
-					<label for="<?php echo \esc_attr( $option ); ?>">
-						<input name="<?php echo \esc_attr( $option ); ?>" type="hidden" value="0" />
-						<input name="<?php echo \esc_attr( $option ); ?>" type="checkbox" id="<?php echo \esc_attr( $option ); ?>" value="1" <?php \checked( 1, \get_user_meta( \get_current_user_id(), $option, true ) ); ?> />
-						<?php echo \esc_html( $label ); ?>
-					</label>
-				<?php endforeach; ?>
-			</div>
-		</fieldset>
-		<?php
-
-		return ob_get_clean();
-	}
-
-	/**
-	 * Show the submit button on the screen options page.
-	 *
-	 * @param bool   $show_submit Whether to show the submit button.
-	 * @param object $screen      The screen object.
-	 *
-	 * @return bool Whether to show the submit button.
-	 */
-	public static function screen_options_show_submit( $show_submit, $screen ) {
-		if ( 'settings_page_activitypub' !== $screen->id ) {
-			return $show_submit;
-		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
Follow up to #1925.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Transferred the handling of screen options and submit button display from Settings to Screen_Options for better separation of concerns. 
* Removed context string for improved compatibility with table screen options.
