### PR TITLE
Ensure that all schedulers are registered

### DIFF
--- a/.github/changelog/1959-from-description
+++ b/.github/changelog/1959-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Ensure that all schedulers are registered during every plugin update.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -752,8 +752,6 @@ class Migration {
 	public static function add_default_settings() {
 		self::add_activitypub_capability();
 		self::add_default_extra_field();
-
-		Scheduler::register_schedules();
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -199,8 +199,7 @@ class Migration {
 			}
 		}
 
-		// Always register schedules, to ensure they are registered even
-		// if the plugin is activated after the first activation.
+		// Ensure all required cron schedules are registered.
 		Scheduler::register_schedules();
 
 		/*

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -160,13 +160,9 @@ class Migration {
 			add_action( 'init', 'flush_rewrite_rules', 20 );
 		}
 		if ( \version_compare( $version_from_db, '5.0.0', '<' ) ) {
-			Scheduler::register_schedules();
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'create_post_outbox_items' ) );
 			\wp_schedule_single_event( \time() + 15, 'activitypub_upgrade', array( 'create_comment_outbox_items' ) );
 			add_action( 'init', 'flush_rewrite_rules', 20 );
-		}
-		if ( \version_compare( $version_from_db, '5.2.0', '<' ) ) {
-			Scheduler::register_schedules();
 		}
 		if ( \version_compare( $version_from_db, '5.4.0', '<' ) ) {
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'update_actor_json_slashing' ) );
@@ -202,6 +198,10 @@ class Migration {
 				\wp_schedule_event( time(), 'daily', 'activitypub_cleanup_remote_actors' );
 			}
 		}
+
+		// Always register schedules, to ensure they are registered even
+		// if the plugin is activated after the first activation.
+		Scheduler::register_schedules();
 
 		/*
 		 * Add new update routines above this comment. ^
@@ -752,6 +752,8 @@ class Migration {
 	public static function add_default_settings() {
 		self::add_activitypub_capability();
 		self::add_default_extra_field();
+
+		Scheduler::register_schedules();
 	}
 
 	/**


### PR DESCRIPTION
Ensure that all schedulers are registered during every new migration process. This guarantees they are refreshed at least every one to two weeks.

This also protects against accidental cleanup or deletion of schedules, as previously experienced by @jeherve.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Run `Scheduler::register_schedules()` on every migration process.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Remove one of the schedules
* Run the migration
* Check if all schedules are properly set

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Ensure that all schedulers are registered during every plugin update.

</details>
