### PR TITLE
Admin-Notices: Adapt width of settings-site

### DIFF
--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -4,12 +4,12 @@
 	position: relative;
 }
 
-.settings_page_activitypub #setting-error-settings_updated {
+.settings_page_activitypub :not(.wrap) .notice {
 	max-width: 800px;
 	margin: 0 auto 30px;
 }
 
-.settings_page_activitypub #setting-error-settings_updated .update-nag {
+.settings_page_activitypub :not(.wrap) .update-nag {
 	margin: 25px 20px 15px 22px;
 }
 

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -4,12 +4,12 @@
 	position: relative;
 }
 
-.settings_page_activitypub .notice {
+.settings_page_activitypub #setting-error-settings_updated {
 	max-width: 800px;
 	margin: 0 auto 30px;
 }
 
-.settings_page_activitypub .update-nag {
+.settings_page_activitypub #setting-error-settings_updated .update-nag {
 	margin: 25px 20px 15px 22px;
 }
 

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -4,12 +4,12 @@
 	position: relative;
 }
 
-.settings_page_activitypub :not(.wrap) .notice {
+.settings_page_activitypub div:not(.wrap) .notice {
 	max-width: 800px;
 	margin: 0 auto 30px;
 }
 
-.settings_page_activitypub :not(.wrap) .update-nag {
+.settings_page_activitypub div:not(.wrap) .update-nag {
 	margin: 25px 20px 15px 22px;
 }
 

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -4,12 +4,12 @@
 	position: relative;
 }
 
-.settings_page_activitypub div:not(.wrap) .notice {
+.settings_page_activitypub div:not(.wrap) > .notice {
 	max-width: 800px;
 	margin: 0 auto 30px;
 }
 
-.settings_page_activitypub div:not(.wrap) .update-nag {
+.settings_page_activitypub div:not(.wrap) > .update-nag {
 	margin: 25px 20px 15px 22px;
 }
 


### PR DESCRIPTION
Adjusts the admin notice to the page width used.

Before:

<img width="1618" height="582" alt="Screenshot 2025-07-18 at 12 31 00" src="https://github.com/user-attachments/assets/b6014a86-cbdd-49e7-87ff-7207d5a073f7" />

After:

| <img width="1048" height="265" alt="Screenshot 2025-07-18 at 12 25 40" src="https://github.com/user-attachments/assets/3d9359ac-66b7-4ffc-a473-7f29adeb9ee5" /> | <img width="1624" height="317" alt="Screenshot 2025-07-18 at 12 26 01" src="https://github.com/user-attachments/assets/a8ebb5b5-352a-45b0-98de-a39a9d1dfca4" /> |
|---|---|


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use a more specific CSS cascade to reduce the width of the admin notice on settings sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out the branch and change settings and/or add/remove followers

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
