### PR TITLE
Deprecate some global functions that should no longer be used

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -491,7 +491,7 @@ function site_supports_blocks() {
 /**
  * Check if data is valid JSON.
  *
- * @deprecated since unreleased, use json_decode instead.
+ * @deprecated unreleased Use {@see \json_decode} instead.
  *
  * @param string $data The data to check.
  *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -64,11 +64,15 @@ function safe_remote_get( $url ) {
 /**
  * Returns a users WebFinger "resource".
  *
+ * @deprecated since unreleased, use Activitypub\Webfinger::get_user_resource instead.
+ *
  * @param int $user_id The user ID.
  *
  * @return string The User resource.
  */
 function get_webfinger_resource( $user_id ) {
+	\_deprecated_function( __FUNCTION__, 'unreleased', 'Activitypub\Webfinger::get_user_resource' );
+
 	return Webfinger::get_user_resource( $user_id );
 }
 
@@ -170,9 +174,13 @@ function url_to_authorid( $url ) {
 /**
  * Verify that url is a wp_ap_comment or a previously received remote comment.
  *
+ * @deprecated since unreleased.
+ *
  * @return int|bool Comment ID or false if not found.
  */
 function is_comment() {
+	\_deprecated_function( __FUNCTION__, 'unreleased' );
+
 	$comment_id = get_query_var( 'c', null );
 
 	if ( ! is_null( $comment_id ) ) {
@@ -483,11 +491,15 @@ function site_supports_blocks() {
 /**
  * Check if data is valid JSON.
  *
+ * @deprecated since unreleased, use json_decode instead.
+ *
  * @param string $data The data to check.
  *
  * @return boolean True if the data is JSON, false otherwise.
  */
 function is_json( $data ) {
+	\_deprecated_function( __FUNCTION__, 'unreleased', 'json_decode' );
+
 	return \is_array( \json_decode( $data, true ) );
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -174,7 +174,7 @@ function url_to_authorid( $url ) {
 /**
  * Verify that url is a wp_ap_comment or a previously received remote comment.
  *
- * @deprecated since unreleased.
+ * @deprecated unreleased
  *
  * @return int|bool Comment ID or false if not found.
  */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -64,7 +64,7 @@ function safe_remote_get( $url ) {
 /**
  * Returns a users WebFinger "resource".
  *
- * @deprecated since unreleased, use Activitypub\Webfinger::get_user_resource instead.
+ * @deprecated unreleased Use {@see \Activitypub\Webfinger::get_user_resource} instead.
  *
  * @param int $user_id The user ID.
  *


### PR DESCRIPTION
These functions were not used internally or by implementers, so I think it makes sense to discard them.

### Proposed changes:

* deprecated `get_webfinger_resource`
* deprecated `is_comment`
* deprecated `is_json`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
