### PR TITLE
Following: Improve follow error handling

### DIFF
--- a/includes/table/class-following.php
+++ b/includes/table/class-following.php
@@ -111,7 +111,7 @@ class Following extends \WP_List_Table {
 				}
 				break;
 			case 'follow':
-				$redirect_to = \remove_query_arg( array( 's' ), $redirect_to );
+				$redirect_to = \remove_query_arg( array( 'resource', 's' ), $redirect_to );
 
 				if ( ! isset( $_REQUEST['activitypub-profile'], $_REQUEST['_wpnonce'] ) ) {
 					return;
@@ -125,7 +125,9 @@ class Following extends \WP_List_Table {
 				$profile = \sanitize_text_field( \wp_unslash( $_REQUEST['activitypub-profile'] ) );
 				$result  = follow( $profile, $this->user_id );
 				if ( \is_wp_error( $result ) ) {
-					\add_settings_error( 'activitypub', 'followed', $result->get_error_message() );
+					/* translators: %s: Account profile that could not be followed */
+					\add_settings_error( 'activitypub', 'followed', \sprintf( \__( 'Unable to follow account &#8220;%s&#8221;. Please verify the account exists and try again.', 'activitypub' ), \esc_html( $profile ) ) );
+					$redirect_to = \add_query_arg( 'resource', $profile, $redirect_to );
 				} else {
 					\add_settings_error( 'activitypub', 'followed', \__( 'Account followed.', 'activitypub' ), 'success' );
 				}

--- a/templates/following-list.php
+++ b/templates/following-list.php
@@ -63,7 +63,7 @@ $following_list_table->prepare_items();
 						<li><p><?php echo wp_kses_post( __( 'Profile link: <code>https://example.com/@username</code>', 'activitypub' ) ); ?></p></li>
 					</ul>
 
-					<p><?php echo esc_html__( '(Make sure the user you&rsquo;re following is part of the fediverse and supports ActivityPub)', 'activitypub' ); ?></p>
+					<p><?php echo esc_html__( '(Make sure the user you&#8217;re following is part of the fediverse and supports ActivityPub)', 'activitypub' ); ?></p>
 				</div>
 			</div>
 		</div>
@@ -78,11 +78,10 @@ $following_list_table->prepare_items();
 					</form>
 					<div class="edit-term-notes">
 						<strong><?php esc_html_e( 'About Followings', 'activitypub' ); ?></strong>
-						<p class="description"><?php esc_html_e( 'When you follow another author, a follow request is sent on your behalf. If you see &#8220;Pending,&#8221; it means your follow request hasn&#8217;t been accepted yet—so you aren&#8217;t following that author until they approve your request. This is a normal part of the ActivityPub protocol and helps ensure that authors have control over who follows them.', 'activitypub' ); ?></p>
+						<p class="description"><?php esc_html_e( 'When you follow another author, a follow request is sent on your behalf. If you see &#8220;Pending,&#8212;&#8221; it means your follow request hasn&#8217;t been accepted yet&#8212;so you aren&#8217;t following that author until they approve your request. This is a normal part of the ActivityPub protocol and helps ensure that authors have control over who follows them.', 'activitypub' ); ?></p>
 					</div>
 				</div>
 			</div>
 		</div>
 	</div>
 </div>
-

--- a/templates/following-list.php
+++ b/templates/following-list.php
@@ -78,7 +78,7 @@ $following_list_table->prepare_items();
 					</form>
 					<div class="edit-term-notes">
 						<strong><?php esc_html_e( 'About Followings', 'activitypub' ); ?></strong>
-						<p class="description"><?php esc_html_e( 'When you follow another author, a follow request is sent on your behalf. If you see &#8220;Pending,&#8212;&#8221; it means your follow request hasn&#8217;t been accepted yet&#8212;so you aren&#8217;t following that author until they approve your request. This is a normal part of the ActivityPub protocol and helps ensure that authors have control over who follows them.', 'activitypub' ); ?></p>
+						<p class="description"><?php esc_html_e( 'When you follow another author, a follow request is sent on your behalf. If you see &#8220;Pending&#8221;, it means your follow request hasn&#8217;t been accepted yet&#8212;so you aren&#8217;t following that author until they approve your request. This is a normal part of the ActivityPub protocol and helps ensure that authors have control over who follows them.', 'activitypub' ); ?></p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
`The WebFinger Resource is not accessible.` or `The "object" is/has no valid URL` are not terribly great error messages. This PR updates the error message when we can't follow an account to something more user-friendly, albeit slightly less detailed.
It also improves user experience by re-supplying the attempted username, instead of forcing folks to type it back in again.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes resource query arg to not pre-fill the username again after submitting the follow form.
* Updated error message to be a bit more user-friendly.
* Re-fills the username after a failed follow attempt.
* Also updates missing html entities in form string (sorry, Claude went above and beyond)

