### PR TITLE
Do not purge `Follow` items from the Outbox

### DIFF
--- a/.github/changelog/1980-from-description
+++ b/.github/changelog/1980-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop purging Follow activities from the Outbox to allow proper Unfollow (Undo) handling.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -278,7 +278,7 @@ class Scheduler {
 
 		$date->sub( \DateInterval::createFromDateString( "$days days" ) );
 
-		$post_ids = get_posts(
+		$post_ids = \get_posts(
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'any',
@@ -287,6 +287,14 @@ class Scheduler {
 				'date_query'  => array(
 					array(
 						'before' => $date->format( 'Y-m-d' ),
+					),
+				),
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'     => '_activitypub_activity_type',
+						'value'   => 'Follow',
+						'compare' => '!=',
 					),
 				),
 			)

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -268,6 +268,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
 				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'meta_input'  => array(
+					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Update',
+				),
 			)
 		);
 		self::factory()->post->create_many(
@@ -276,6 +279,20 @@ class Test_Scheduler extends \WP_UnitTestCase {
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
 				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'meta_input'  => array(
+					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Update',
+				),
+			)
+		);
+		self::factory()->post->create_many(
+			5,
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'_activitypub_activity_type' => 'Follow',
+				),
 			)
 		);
 
@@ -283,7 +300,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
 		// Assert that 5 posts were deleted, leaving 25.
-		$this->assertEquals( 25, wp_count_posts( Outbox::POST_TYPE )->publish );
+		$this->assertEquals( 30, wp_count_posts( Outbox::POST_TYPE )->publish );
 	}
 
 	/**
@@ -322,6 +339,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 				'post_type'   => Outbox::POST_TYPE,
 				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-4 months' ) ),
 				'post_status' => 'publish',
+				'meta_input'  => array(
+					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Update',
+				),
 			)
 		);
 


### PR DESCRIPTION
Now that `Follow` and `Unfollow` are implemented, we should stop purging `Follow` Activities from the Outbox. Technically, an `Unfollow` is represented as an `Undo` Activity targeting the original `Follow`. If the `Follow` has been purged, we can no longer reference it properly—making it impossible to construct a valid `Unfollow`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not purge `Follow` requests

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See Unittests

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Stop purging Follow activities from the Outbox to allow proper Unfollow (Undo) handling.

</details>
