### PR TITLE
Settings: Disable screen options on followers/following tabs

### DIFF
--- a/includes/wp-admin/class-screen-options.php
+++ b/includes/wp-admin/class-screen-options.php
@@ -103,6 +103,11 @@ class Screen_Options {
 			return $screen_settings;
 		}
 
+		// No screen options on followers and following tabs. The per_page screen options interfere with them.
+		if ( \in_array( \sanitize_text_field( \wp_unslash( $_GET['tab'] ?? 'welcome' ) ), array( 'followers', 'following' ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return $screen_settings;
+		}
+
 		// Verify screen options nonce.
 		if ( isset( $_POST['screenoptionnonce'] ) ) {
 			$nonce = \sanitize_text_field( \wp_unslash( $_POST['screenoptionnonce'] ) );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevents the display of screen options on the 'followers' and 'following' tabs to avoid interference from per_page settings. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > ActivityPub.
* Have the blog actor enabled and go to the Follower tab.
* Open screen options and see that the tab options are unavailable.
* Switch to any other tab and make sure the options show up and are functional.
