### PR TITLE
Signature: Prevent double knock if signing data is missing

### DIFF
--- a/.github/changelog/1985-from-description
+++ b/.github/changelog/1985-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed potential errors when unrelated requests get caught in double-knocking callback.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -85,11 +85,6 @@ class Signature {
 	 * @return array The HTTP response.
 	 */
 	public static function maybe_double_knock( $response, $args, $url ) {
-		// Bail if there's nothing to sign with. It's likely an unrelated request getting processed first.
-		if ( ! isset( $args['key_id'], $args['private_key'], $args['headers']['Date'] ) ) {
-			return $response;
-		}
-
 		// Remove this filter to prevent infinite recursion.
 		\remove_filter( 'http_response', array( self::class, 'maybe_double_knock' ) );
 

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -85,6 +85,11 @@ class Signature {
 	 * @return array The HTTP response.
 	 */
 	public static function maybe_double_knock( $response, $args, $url ) {
+		// Bail if there's nothing to sign with. It's likely an unrelated request getting processed first.
+		if ( ! isset( $args['key_id'], $args['private_key'], $args['headers']['Date'] ) ) {
+			return $response;
+		}
+
 		// Remove this filter to prevent infinite recursion.
 		\remove_filter( 'http_response', array( self::class, 'maybe_double_knock' ) );
 


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check in `maybe_double_knock` to return early if key_id, private_key, or Date header are not set in the response, avoiding processing for unrelated requests.
* Adds unit test.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not sure there's a good way to manually test this. Unit tests should be enough.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed potential errors when unrelated requests get caught in double-knocking callback.

</details>
