### PR TITLE
Ensure correct visibility handling for `Undo` and `Follow` requests

### DIFF
--- a/.github/changelog/1988-from-description
+++ b/.github/changelog/1988-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure correct visibility handling for `Undo` and `Follow` requests

--- a/includes/collection/class-following.php
+++ b/includes/collection/class-following.php
@@ -89,7 +89,7 @@ class Following {
 			$follow->set_object( $post->guid );
 			$follow->set_to( array( $post->guid ) );
 
-			return add_to_outbox( $follow, null, $user_id );
+			return add_to_outbox( $follow, null, $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 		}
 
 		return $post;

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -180,7 +180,9 @@ class Outbox {
 			$type = 'Remove';
 		}
 
-		return add_to_outbox( $activity, $type, $outbox_item->post_author );
+		$visibility = \get_post_meta( $outbox_item->ID, 'activitypub_content_visibility', true );
+
+		return add_to_outbox( $activity, $type, $outbox_item->post_author, $visibility );
 	}
 
 	/**


### PR DESCRIPTION
Make sure to retain the visibility settings of the original object when performing an `Undo`, and send `Follow` requests only to the platform where the followed account resides.

## Proposed changes:
* Preserve the visibility of the original Activity when sending an `Undo`.
* Send `Follow` requests with private visibility.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Ensure correct visibility handling for `Undo` and `Follow` requests

</details>
