### PR TITLE
Use a Github action to extract the provided WordPress Hooks

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,7 @@
 .distignore
 .DS_Store
 .editorconfig
+.extract-wp-hooks.json
 .git
 .github
 .gitignore

--- a/.extract-wp-hooks.json
+++ b/.extract-wp-hooks.json
@@ -1,0 +1,25 @@
+{
+    "namespace": "Activitypub",
+    "wiki_directory": "../activitypub.wiki",
+    "github_blob_url": "https://github.com/Automattic/wordpress-activitypub/blob/trunk/",
+    "ignore_filter": [
+        "comment_text",
+        "get_avatar_comment_types",
+        "get_avatar_url",
+        "http_headers_useragent",
+        "import_start",
+        "import_end",
+        "oembed_result",
+        "opengraph_metadata",
+        "rest_oembed_ttl",
+        "the_content",
+        "the_excerpt",
+        "webfinger_data",
+        "wp_import_existing_post",
+        "wpml_post_language_details"
+    ],
+    "exclude_dirs": [
+        "build",
+        "tests"
+    ]
+}

--- a/.github/workflows/extract-wp-hooks.yml
+++ b/.github/workflows/extract-wp-hooks.yml
@@ -1,0 +1,14 @@
+name: Extract WordPress Hooks
+
+on:
+  push:
+    branches: [trunk]
+    paths: ["**.php"]
+  workflow_dispatch:
+
+jobs:
+  extract-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: akirk/extract-wp-hooks@main

--- a/.github/workflows/extract-wp-hooks.yml
+++ b/.github/workflows/extract-wp-hooks.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   extract-hooks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push to wiki repository
     steps:
       - uses: actions/checkout@v4
       - uses: akirk/extract-wp-hooks@1.1.0

--- a/.github/workflows/extract-wp-hooks.yml
+++ b/.github/workflows/extract-wp-hooks.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: akirk/extract-wp-hooks@main
+      - uses: akirk/extract-wp-hooks@1.1.0


### PR DESCRIPTION

## Proposed changes:
* Automatically [extract the hooks](https://github.com/akirk/extract-wp-hooks) provided by the ActivityPub plugin into [the ActivityPub Github wiki](https://github.com/Automattic/wordpress-activitypub/wiki/Hooks) for reference for developers.
