### PR TITLE
Starter Pack: Support `OrderedCollection`s

### DIFF
--- a/.github/changelog/2028-from-description
+++ b/.github/changelog/2028-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+You can now use `OrderedCollection`s as starter packs — just drop in the output from a Follower or Following endpoint.

--- a/includes/wp-admin/import/class-starter-kit.php
+++ b/includes/wp-admin/import/class-starter-kit.php
@@ -240,7 +240,7 @@ class Starter_Kit {
 		$skipped  = 0;
 		$followed = 0;
 
-		$items = self::$starter_kit['items'] ?? array();
+		$items = self::$starter_kit['items'] ?? self::$starter_kit['orderedItems'] ?? array();
 
 		foreach ( $items as $item ) {
 			if ( ! is_actor( $item ) ) {


### PR DESCRIPTION
This way it is possible to simply use the output of a Follower/Following endpoint and import it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check also for an `orderedItems` list

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load a following endpoint with `?context=full` (for example `https://notiz.blog/wp-api/activitypub/1.0/actors/1/following?page=1&context=full`)
* Save JSON file
* Import JSON file

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

You can now use `OrderedCollection`s as starter packs — just drop in the output from a Follower or Following endpoint.

</details>
