### PR TITLE
Defer signature verification on local env

### DIFF
--- a/local/load.php
+++ b/local/load.php
@@ -11,6 +11,7 @@ namespace Activitypub\Development;
 
 // Initialize local development tools below.
 
+// Load development WP-CLI commands.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command(
 		'activitypub',
@@ -20,3 +21,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		)
 	);
 }
+
+// Defer signature verification on local development to better test API requests.
+\add_filter( 'activitypub_defer_signature_verification', '__return_true', 20 );


### PR DESCRIPTION
Defer signature verification on local development to better test API requests and responses.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Always defer signature verification when `WP_ENVIRONMENT_TYPE` is `local`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
