### PR TITLE
Following: Check remote URLs/Objects for `Actor` type

### DIFF
--- a/.github/changelog/2041-from-description
+++ b/.github/changelog/2041-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+More reliable Actor checks during the follow process.

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -14,11 +14,12 @@ use Activitypub\Model\Application;
 use Activitypub\Activity\Actor;
 
 use function Activitypub\get_remote_metadata_by_actor;
-use function Activitypub\object_to_uri;
-use function Activitypub\normalize_url;
-use function Activitypub\normalize_host;
-use function Activitypub\url_to_authorid;
+use function Activitypub\is_actor;
 use function Activitypub\is_user_type_disabled;
+use function Activitypub\normalize_host;
+use function Activitypub\normalize_url;
+use function Activitypub\object_to_uri;
+use function Activitypub\url_to_authorid;
 use function Activitypub\user_can_activitypub;
 
 /**
@@ -559,6 +560,14 @@ class Actors {
 
 		if ( \is_wp_error( $object ) ) {
 			return $object;
+		}
+
+		if ( ! is_actor( $object ) ) {
+			return new \WP_Error(
+				'activitypub_no_actor',
+				\__( 'Object is not an Actor', 'activitypub' ),
+				array( 'status' => 400 )
+			);
 		}
 
 		$post_id = self::upsert( $object );

--- a/tests/includes/class-test-scheduler.php
+++ b/tests/includes/class-test-scheduler.php
@@ -459,6 +459,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			'activitypub_pre_http_get_remote_object',
 			function () {
 				return array(
+					'type'              => 'Person',
 					'name'              => 'Test User',
 					'preferredUsername' => 'test',
 					'id'                => 'https://example.com/users/test',


### PR DESCRIPTION
We currently use WebFinger lookup to verify that a remote URL or object is an Actor. This approach is rather lazy and only works because, so far, non-Actor objects don’t include a self link.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check remote Object for Type `Actor` 

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

More reliable Actor checks during the follow process.

</details>
