### PR TITLE
Update wp-env config and simplify env-start script

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,17 +1,17 @@
 {
 	"core": null,
 	"plugins": [ "." ],
-	"port": 80,
 	"env": {
 		"tests": {
 			"config": {
 				"WP_ENVIRONMENT_TYPE": "production"
 			},
 			"mappings": {
-				"wp-content/plugins/activitypub": ".",
-				"wp-content/plugins/activitypub/tests": "./tests",
-				"wp-content/plugins/activitypub/coverage": "./coverage"
+				"wp-content/plugins/activitypub": "."
 			}
 		}
+	},
+	"lifecycleScripts": {
+		"afterStart": "npx wp-env run cli wp rewrite structure /%year%/%monthnum%/%postname%/"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
 		"env": "wp-env",
-		"env-start": "wp-env start && wp-env run cli wp rewrite structure '/%year%/%monthnum%/%postname%/'",
+		"env-start": "wp-env start",
 		"env-stop": "wp-env stop",
 		"env-test": "wp-env run tests-cli --env-cwd=\"wp-content/plugins/activitypub\" vendor/bin/phpunit",
 		"release": "node bin/release.js"


### PR DESCRIPTION
Moving the permalink command into `afterStart` makes things like this possible:
* `npm run env-start -- --update`
* `npm run env-start -- --xdebug=coverage`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moved the permalink structure rewrite command to the wp-env afterStart lifecycle script to allow for params being passed to `wp-env start`.
* Restores 8888 as the default port. Any individual customizations can be done in a `.wp-env.override.json` file.
* Removes unnecessary mappings.

