### PR TITLE
Add code coverage reporting to GitHub Actions workflow

### DIFF
--- a/.github/changelog/2044-from-description
+++ b/.github/changelog/2044-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add code coverage reporting to GitHub Actions PHPUnit workflow with dedicated coverage job using Xdebug

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -91,32 +91,56 @@ jobs:
 
       - name: Check for Coverage Warnings
         run: |
-          if grep -q "Warning\|Error" coverage-output.log; then
-            echo "Coverage warnings/errors found:"
+          echo "Checking for coverage warnings in output..."
+          
+          # Check for warnings and errors
+          WARNINGS_FOUND=false
+          
+          # Look for PHPUnit warnings summary
+          if grep -q "WARNINGS!\|There was.*warning" coverage-output.log; then
+            echo "PHPUnit warnings found in output:"
+            WARNINGS_FOUND=true
             
-            # Parse warnings and create GitHub annotations
-            grep "Warning\|Error" coverage-output.log | while IFS= read -r line; do
-              echo "$line"
+            # Show the warnings section for debugging
+            echo "--- Warnings Section ---"
+            sed -n '/There was.*warning/,/^$/p' coverage-output.log | head -20
+            echo "--- End Warnings Section ---"
+            
+            # Extract and create annotations for @covers warnings
+            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | while IFS= read -r line; do
+              # Skip empty lines and numbered test items
+              if [[ -z "$line" || "$line" =~ ^[0-9]+\)$ || "$line" =~ ^Time: || "$line" =~ ^Tests: ]]; then
+                continue
+              fi
               
-              # Extract file path and line number from xdebug warnings
-              if [[ "$line" =~ in\ ([^\ ]+)\ on\ line\ ([0-9]+) ]]; then
-                file="${BASH_REMATCH[1]}"
-                line_num="${BASH_REMATCH[2]}"
-                # Remove leading ./ if present
-                file="${file#./}"
-                echo "::warning file=${file},line=${line_num}::${line}"
-              elif [[ "$line" =~ ([^:]+):([0-9]+) ]]; then
-                file="${BASH_REMATCH[1]}"
-                line_num="${BASH_REMATCH[2]}"
-                file="${file#./}"
-                echo "::warning file=${file},line=${line_num}::${line}"
-              else
-                echo "::warning::${line}"
+              # Look for @covers warnings - these are the actual warning messages
+              if [[ "$line" =~ \"@covers.*is\ invalid ]]; then
+                echo "::warning::PHPUnit @covers annotation error: ${line}"
+              # Look for deprecated warnings
+              elif [[ "$line" =~ (deprecated|will\ no\ longer\ be\ possible) ]]; then
+                echo "::warning::PHPUnit deprecation warning: ${line}"
+              # Look for other error patterns
+              elif [[ "$line" =~ (Error|Exception) ]] && [[ ! "$line" =~ ^[[:space:]]*$ ]]; then
+                echo "::warning::PHPUnit error: ${line}"
               fi
             done
+          fi
+          
+          # Also check for expectError deprecation warnings specifically
+          if grep -qE "(Expecting E_ERROR.*deprecated|will no longer be possible)" coverage-output.log; then
+            echo "Found expectError deprecation warnings"
+            WARNINGS_FOUND=true
             
-            echo "::error::Coverage analysis produced warnings or errors"
+            grep -E "(Expecting E_ERROR.*deprecated|will no longer be possible)" coverage-output.log | while IFS= read -r line; do
+              echo "::warning::PHPUnit expectError deprecation: ${line}"
+            done
+          fi
+          
+          if [ "$WARNINGS_FOUND" = true ]; then
+            echo "::error::Coverage analysis produced warnings"
             exit 1
+          else
+            echo "No coverage warnings found"
           fi
 
       - name: Annotate Test Results

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -93,13 +93,13 @@ jobs:
         if: always()
         run: |
           echo "Generating checkstyle report for coverage warnings..."
-          
+
           # Create checkstyle XML header
           cat > coverage-warnings.xml << 'EOF'
           <?xml version="1.0" encoding="UTF-8"?>
           <checkstyle version="4.3">
           EOF
-          
+
           # Check for PHPUnit warnings and process them
           if grep -q "WARNINGS!\|There was.*warning" coverage-output.log; then
             echo "Processing coverage warnings for checkstyle report..."
@@ -155,14 +155,14 @@ jobs:
             echo "No coverage warnings found"
             WARNINGS_FOUND=false
           fi
-          
+
           # Close the checkstyle XML
           echo '</checkstyle>' >> coverage-warnings.xml
-          
+
           # Debug: show the generated checkstyle content
           echo "Generated checkstyle report:"
           cat coverage-warnings.xml
-          
+
           # Exit with error if warnings were found
           if [ "$WARNINGS_FOUND" = true ]; then
             echo "::error::Coverage analysis produced warnings"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -88,7 +88,7 @@ jobs:
         run: ./vendor/bin/phpunit --coverage-text --coverage-clover coverage.xml --log-junit junit.xml 2>&1 | tee coverage-output.log
         env:
           WP_ENVIRONMENT_TYPE: production
-          
+
       - name: Check for Coverage Warnings
         run: |
           if grep -q "Warning\|Error" coverage-output.log; then
@@ -97,7 +97,7 @@ jobs:
             echo "::error::Coverage analysis produced warnings or errors"
             exit 1
           fi
-          
+
       - name: Annotate Test Results
         if: always()
         uses: dorny/test-reporter@v1

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -93,7 +93,28 @@ jobs:
         run: |
           if grep -q "Warning\|Error" coverage-output.log; then
             echo "Coverage warnings/errors found:"
-            grep -n "Warning\|Error" coverage-output.log
+            
+            # Parse warnings and create GitHub annotations
+            grep "Warning\|Error" coverage-output.log | while IFS= read -r line; do
+              echo "$line"
+              
+              # Extract file path and line number from xdebug warnings
+              if [[ "$line" =~ in\ ([^\ ]+)\ on\ line\ ([0-9]+) ]]; then
+                file="${BASH_REMATCH[1]}"
+                line_num="${BASH_REMATCH[2]}"
+                # Remove leading ./ if present
+                file="${file#./}"
+                echo "::warning file=${file},line=${line_num}::${line}"
+              elif [[ "$line" =~ ([^:]+):([0-9]+) ]]; then
+                file="${BASH_REMATCH[1]}"
+                line_num="${BASH_REMATCH[2]}"
+                file="${file#./}"
+                echo "::warning file=${file},line=${line_num}::${line}"
+              else
+                echo "::warning::${line}"
+              fi
+            done
+            
             echo "::error::Coverage analysis produced warnings or errors"
             exit 1
           fi

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup PHP with Xdebug
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: xdebug
           tools: composer, phpunit-polyfills, cs2pr
           extensions: mysql

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -114,16 +114,20 @@ jobs:
             
             # Process each line
             while IFS= read -r line; do
+              echo "Processing line: $line"
               # Look for @covers warnings
-              if [[ "$line" =~ \"@covers.*is\ invalid ]]; then
-                # Extract the @covers target
-                if [[ "$line" =~ @covers\ \\\\([^\"]+) ]]; then
+              if [[ "$line" =~ \"@covers.*\"\ is\ invalid ]]; then
+                echo "Found @covers warning line: $line"
+                # Extract the @covers target - everything between quotes
+                if [[ "$line" =~ \"@covers\ ([^\"]+)\" ]]; then
                   COVERS_TARGET="${BASH_REMATCH[1]}"
                   echo "Processing @covers warning for: $COVERS_TARGET"
                   
                   # Find test file and line number
                   if TEST_FILE=$(find tests/ -name "*.php" -type f -exec grep -l "@covers.*$COVERS_TARGET" {} \; | head -1); then
+                    echo "Found test file: $TEST_FILE"
                     if LINE_NUM=$(grep -n "@covers.*$COVERS_TARGET" "$TEST_FILE" | head -1 | cut -d: -f1); then
+                      echo "Found line number: $LINE_NUM"
                       # Escape XML characters and add checkstyle entry
                       MESSAGE=$(echo "Invalid @covers annotation: $COVERS_TARGET" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
                       cat >> coverage-warnings.xml << EOF

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -51,3 +51,40 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php-versions }}
           WP_ENVIRONMENT_TYPE: production
+
+  coverage:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mariadb:10.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
+    steps:
+      - name: Install svn
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP with Xdebug
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: xdebug
+          tools: composer, phpunit-polyfills
+          extensions: mysql
+
+      - name: Install Composer dependencies for PHP
+        uses: ramsey/composer-install@v3
+
+      - name: Setup Test Environment
+        run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest
+
+      - name: Unit Testing with Coverage
+        run: ./vendor/bin/phpunit --coverage-text --coverage-clover coverage.xml
+        env:
+          WP_ENVIRONMENT_TYPE: production

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -68,7 +68,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install subversion
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP with Xdebug
         uses: shivammathur/setup-php@v2
@@ -89,110 +89,6 @@ jobs:
         env:
           WP_ENVIRONMENT_TYPE: production
 
-      - name: Check for Coverage Warnings
-        run: |
-          echo "Checking for coverage warnings in output..."
-          
-          # Check for warnings and errors
-          WARNINGS_FOUND=false
-          
-          # Look for PHPUnit warnings summary
-          if grep -q "WARNINGS!\|There was.*warning" coverage-output.log; then
-            echo "PHPUnit warnings found in output:"
-            WARNINGS_FOUND=true
-            
-            # Show the warnings section for debugging
-            echo "--- Warnings Section ---"
-            sed -n '/There was.*warning/,/^$/p' coverage-output.log | head -20
-            echo "--- End Warnings Section ---"
-            
-            # Extract and create annotations for @covers warnings
-            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | while IFS= read -r line; do
-              # Skip empty lines and numbered test items
-              if [[ -z "$line" || "$line" =~ ^[0-9]+\)$ || "$line" =~ ^Time: || "$line" =~ ^Tests: ]]; then
-                continue
-              fi
-              
-              # Look for @covers warnings - these are the actual warning messages
-              if [[ "$line" =~ \"@covers.*is\ invalid ]]; then
-                echo "::warning::PHPUnit @covers annotation error: ${line}"
-              # Look for deprecated warnings
-              elif [[ "$line" =~ (deprecated|will\ no\ longer\ be\ possible) ]]; then
-                echo "::warning::PHPUnit deprecation warning: ${line}"
-              # Look for other error patterns
-              elif [[ "$line" =~ (Error|Exception) ]] && [[ ! "$line" =~ ^[[:space:]]*$ ]]; then
-                echo "::warning::PHPUnit error: ${line}"
-              fi
-            done
-          fi
-          
-          # Also check for expectError deprecation warnings specifically
-          if grep -qE "(Expecting E_ERROR.*deprecated|will no longer be possible)" coverage-output.log; then
-            echo "Found expectError deprecation warnings"
-            WARNINGS_FOUND=true
-            
-            grep -E "(Expecting E_ERROR.*deprecated|will no longer be possible)" coverage-output.log | while IFS= read -r line; do
-              echo "::warning::PHPUnit expectError deprecation: ${line}"
-            done
-          fi
-          
-          if [ "$WARNINGS_FOUND" = true ]; then
-            echo "::error::Coverage analysis produced warnings"
-            exit 1
-          else
-            echo "No coverage warnings found"
-          fi
-
-      - name: Parse Coverage Warnings for File Annotations
-        if: always()
-        run: |
-          echo "Parsing coverage warnings for file-level annotations..."
-          
-          # Create annotations file
-          cat > coverage-annotations.json << 'EOF'
-          []
-          EOF
-          
-          # Extract coverage warnings and map them to files
-          if grep -q "WARNINGS!\|There was.*warning" coverage-output.log; then
-            echo "Parsing warnings to create file annotations..."
-            
-            # Use a temporary file to collect annotations
-            echo '[]' > temp-annotations.json
-            
-            # Parse the warnings section
-            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | while IFS= read -r line; do
-              # Look for @covers warnings that mention class/method names
-              if [[ "$line" =~ \"@covers.*is\ invalid ]]; then
-                # Extract the @covers target (class or method name)
-                if [[ "$line" =~ @covers\ \\\\([^\"]+) ]]; then
-                  COVERS_TARGET="${BASH_REMATCH[1]}"
-                  echo "Found invalid @covers for: $COVERS_TARGET"
-                  
-                  # Try to find the test file that contains this @covers annotation
-                  # Search through test files for this specific @covers annotation
-                  if find tests/ -name "*.php" -type f -exec grep -l "@covers.*$COVERS_TARGET" {} \; | head -1 | read TEST_FILE; then
-                    echo "Found test file: $TEST_FILE"
-                    
-                    # Find the line number of the @covers annotation
-                    LINE_NUM=$(grep -n "@covers.*$COVERS_TARGET" "$TEST_FILE" | head -1 | cut -d: -f1)
-                    
-                    if [ ! -z "$LINE_NUM" ]; then
-                      echo "Found @covers annotation at line $LINE_NUM in $TEST_FILE"
-                      
-                      # Create file annotation in a format that can be used by reviewdog or similar tools
-                      echo "::warning file=$TEST_FILE,line=$LINE_NUM::Invalid @covers annotation: $line"
-                      
-                      # Also save to a structured format for potential use by other tools
-                      ANNOTATION="{\"file\":\"$TEST_FILE\",\"line\":$LINE_NUM,\"level\":\"warning\",\"message\":\"Invalid @covers annotation: $COVERS_TARGET\"}"
-                      echo "Annotation: $ANNOTATION"
-                    fi
-                  fi
-                fi
-              fi
-            done
-          fi
-
       - name: Generate Checkstyle Report for Coverage Warnings
         if: always()
         run: |
@@ -204,49 +100,52 @@ jobs:
           <checkstyle version="4.3">
           EOF
           
-          # Extract coverage warnings and format them for checkstyle
+          # Check for PHPUnit warnings and process them
           if grep -q "WARNINGS!\|There was.*warning" coverage-output.log; then
             echo "Processing coverage warnings for checkstyle report..."
             
-            # Parse the warnings section
+            # Show warnings section for debugging
+            echo "--- Warnings Found ---"
+            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | head -10
+            echo "--- End Warnings ---"
+            
+            # Parse warnings and create checkstyle entries
             sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | while IFS= read -r line; do
-              # Look for @covers warnings that mention class/method names
+              # Look for @covers warnings
               if [[ "$line" =~ \"@covers.*is\ invalid ]]; then
-                # Extract the @covers target (class or method name)
+                # Extract the @covers target
                 if [[ "$line" =~ @covers\ \\\\([^\"]+) ]]; then
                   COVERS_TARGET="${BASH_REMATCH[1]}"
                   echo "Processing @covers warning for: $COVERS_TARGET"
                   
-                  # Try to find the test file that contains this @covers annotation
+                  # Find test file and line number
                   if TEST_FILE=$(find tests/ -name "*.php" -type f -exec grep -l "@covers.*$COVERS_TARGET" {} \; | head -1); then
-                    echo "Found test file: $TEST_FILE"
-                    
-                    # Find the line number of the @covers annotation
                     if LINE_NUM=$(grep -n "@covers.*$COVERS_TARGET" "$TEST_FILE" | head -1 | cut -d: -f1); then
-                      echo "Adding checkstyle error for $TEST_FILE:$LINE_NUM"
-                      
-                      # Escape XML special characters in the message
+                      # Escape XML characters and add checkstyle entry
                       MESSAGE=$(echo "Invalid @covers annotation: $COVERS_TARGET" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
-                      
-                      # Add to checkstyle XML
                       cat >> coverage-warnings.xml << EOF
           <file name="$TEST_FILE">
             <error line="$LINE_NUM" column="1" severity="warning" message="$MESSAGE" source="phpunit.coverage"/>
           </file>
           EOF
+                      echo "::warning file=$TEST_FILE,line=$LINE_NUM::Invalid @covers annotation: $COVERS_TARGET"
                     fi
                   fi
                 fi
+              # Look for deprecation warnings
+              elif [[ "$line" =~ (deprecated|will\ no\ longer\ be\ possible) ]]; then
+                echo "::warning::PHPUnit deprecation warning: ${line}"
               fi
             done
+            
+            echo "::error::Coverage analysis produced warnings"
+            exit 1
+          else
+            echo "No coverage warnings found"
           fi
           
           # Close the checkstyle XML
           echo '</checkstyle>' >> coverage-warnings.xml
-          
-          # Show the generated XML for debugging
-          echo "Generated checkstyle report:"
-          cat coverage-warnings.xml
 
       - name: Annotate Coverage Warnings in PR
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           php-version: '8.3'
           coverage: xdebug
-          tools: composer, phpunit-polyfills
+          tools: composer, phpunit-polyfills, cs2pr
           extensions: mysql
 
       - name: Install Composer dependencies for PHP
@@ -124,9 +124,13 @@ jobs:
                   echo "Processing @covers warning for: $COVERS_TARGET"
                   
                   # Find test file and line number
-                  if TEST_FILE=$(find tests/ -name "*.php" -type f -exec grep -l "@covers.*$COVERS_TARGET" {} \; | head -1); then
+                  echo "Searching for @covers annotation with target: $COVERS_TARGET"
+                  # Escape backslashes for grep pattern
+                  ESCAPED_TARGET=$(echo "$COVERS_TARGET" | sed 's/\\/\\\\/g')
+                  echo "Escaped target for grep: $ESCAPED_TARGET"
+                  if TEST_FILE=$(find tests/ -name "*.php" -type f -exec grep -l "@covers.*$ESCAPED_TARGET" {} \; | head -1); then
                     echo "Found test file: $TEST_FILE"
-                    if LINE_NUM=$(grep -n "@covers.*$COVERS_TARGET" "$TEST_FILE" | head -1 | cut -d: -f1); then
+                    if LINE_NUM=$(grep -n "@covers.*$ESCAPED_TARGET" "$TEST_FILE" | head -1 | cut -d: -f1); then
                       echo "Found line number: $LINE_NUM"
                       # Escape XML characters and add checkstyle entry
                       MESSAGE=$(echo "Invalid @covers annotation: $COVERS_TARGET" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
@@ -170,15 +174,9 @@ jobs:
         run: |
           # Check if we have any errors in the checkstyle report
           if grep -q '<error' coverage-warnings.xml; then
-            echo "Found coverage warnings to annotate, installing cs2pr..."
-            
-            # Install cs2pr
-            curl -s https://raw.githubusercontent.com/staabm/cs2pr/master/cs2pr -o cs2pr
-            chmod +x cs2pr
-            
-            # Convert checkstyle report to PR annotations
+            echo "Found coverage warnings to annotate"
             echo "Converting checkstyle report to PR annotations..."
-            ./cs2pr coverage-warnings.xml
+            cs2pr coverage-warnings.xml
           else
             echo "No coverage warnings found in checkstyle report"
           fi

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -109,8 +109,11 @@ jobs:
             sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | head -10
             echo "--- End Warnings ---"
             
-            # Parse warnings and create checkstyle entries
-            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | while IFS= read -r line; do
+            # Extract warnings to temporary file to avoid subshell issues
+            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log > temp-warnings.txt
+            
+            # Process each line
+            while IFS= read -r line; do
               # Look for @covers warnings
               if [[ "$line" =~ \"@covers.*is\ invalid ]]; then
                 # Extract the @covers target
@@ -136,7 +139,9 @@ jobs:
               elif [[ "$line" =~ (deprecated|will\ no\ longer\ be\ possible) ]]; then
                 echo "::warning::PHPUnit deprecation warning: ${line}"
               fi
-            done
+            done < temp-warnings.txt
+            
+            rm -f temp-warnings.txt
             
             echo "::error::Coverage analysis produced warnings"
             exit 1
@@ -146,6 +151,10 @@ jobs:
           
           # Close the checkstyle XML
           echo '</checkstyle>' >> coverage-warnings.xml
+          
+          # Debug: show the generated checkstyle content
+          echo "Generated checkstyle report:"
+          cat coverage-warnings.xml
 
       - name: Annotate Coverage Warnings in PR
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -143,10 +143,127 @@ jobs:
             echo "No coverage warnings found"
           fi
 
-      - name: Annotate Test Results
+      - name: Parse Coverage Warnings for File Annotations
         if: always()
-        uses: dorny/test-reporter@v1
-        with:
-          name: PHPUnit Coverage Results
-          path: junit.xml
-          reporter: java-junit
+        run: |
+          echo "Parsing coverage warnings for file-level annotations..."
+          
+          # Create annotations file
+          cat > coverage-annotations.json << 'EOF'
+          []
+          EOF
+          
+          # Extract coverage warnings and map them to files
+          if grep -q "WARNINGS!\|There was.*warning" coverage-output.log; then
+            echo "Parsing warnings to create file annotations..."
+            
+            # Use a temporary file to collect annotations
+            echo '[]' > temp-annotations.json
+            
+            # Parse the warnings section
+            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | while IFS= read -r line; do
+              # Look for @covers warnings that mention class/method names
+              if [[ "$line" =~ \"@covers.*is\ invalid ]]; then
+                # Extract the @covers target (class or method name)
+                if [[ "$line" =~ @covers\ \\\\([^\"]+) ]]; then
+                  COVERS_TARGET="${BASH_REMATCH[1]}"
+                  echo "Found invalid @covers for: $COVERS_TARGET"
+                  
+                  # Try to find the test file that contains this @covers annotation
+                  # Search through test files for this specific @covers annotation
+                  if find tests/ -name "*.php" -type f -exec grep -l "@covers.*$COVERS_TARGET" {} \; | head -1 | read TEST_FILE; then
+                    echo "Found test file: $TEST_FILE"
+                    
+                    # Find the line number of the @covers annotation
+                    LINE_NUM=$(grep -n "@covers.*$COVERS_TARGET" "$TEST_FILE" | head -1 | cut -d: -f1)
+                    
+                    if [ ! -z "$LINE_NUM" ]; then
+                      echo "Found @covers annotation at line $LINE_NUM in $TEST_FILE"
+                      
+                      # Create file annotation in a format that can be used by reviewdog or similar tools
+                      echo "::warning file=$TEST_FILE,line=$LINE_NUM::Invalid @covers annotation: $line"
+                      
+                      # Also save to a structured format for potential use by other tools
+                      ANNOTATION="{\"file\":\"$TEST_FILE\",\"line\":$LINE_NUM,\"level\":\"warning\",\"message\":\"Invalid @covers annotation: $COVERS_TARGET\"}"
+                      echo "Annotation: $ANNOTATION"
+                    fi
+                  fi
+                fi
+              fi
+            done
+          fi
+
+      - name: Generate Checkstyle Report for Coverage Warnings
+        if: always()
+        run: |
+          echo "Generating checkstyle report for coverage warnings..."
+          
+          # Create checkstyle XML header
+          cat > coverage-warnings.xml << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <checkstyle version="4.3">
+          EOF
+          
+          # Extract coverage warnings and format them for checkstyle
+          if grep -q "WARNINGS!\|There was.*warning" coverage-output.log; then
+            echo "Processing coverage warnings for checkstyle report..."
+            
+            # Parse the warnings section
+            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | while IFS= read -r line; do
+              # Look for @covers warnings that mention class/method names
+              if [[ "$line" =~ \"@covers.*is\ invalid ]]; then
+                # Extract the @covers target (class or method name)
+                if [[ "$line" =~ @covers\ \\\\([^\"]+) ]]; then
+                  COVERS_TARGET="${BASH_REMATCH[1]}"
+                  echo "Processing @covers warning for: $COVERS_TARGET"
+                  
+                  # Try to find the test file that contains this @covers annotation
+                  if TEST_FILE=$(find tests/ -name "*.php" -type f -exec grep -l "@covers.*$COVERS_TARGET" {} \; | head -1); then
+                    echo "Found test file: $TEST_FILE"
+                    
+                    # Find the line number of the @covers annotation
+                    if LINE_NUM=$(grep -n "@covers.*$COVERS_TARGET" "$TEST_FILE" | head -1 | cut -d: -f1); then
+                      echo "Adding checkstyle error for $TEST_FILE:$LINE_NUM"
+                      
+                      # Escape XML special characters in the message
+                      MESSAGE=$(echo "Invalid @covers annotation: $COVERS_TARGET" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
+                      
+                      # Add to checkstyle XML
+                      cat >> coverage-warnings.xml << EOF
+          <file name="$TEST_FILE">
+            <error line="$LINE_NUM" column="1" severity="warning" message="$MESSAGE" source="phpunit.coverage"/>
+          </file>
+          EOF
+                    fi
+                  fi
+                fi
+              fi
+            done
+          fi
+          
+          # Close the checkstyle XML
+          echo '</checkstyle>' >> coverage-warnings.xml
+          
+          # Show the generated XML for debugging
+          echo "Generated checkstyle report:"
+          cat coverage-warnings.xml
+
+      - name: Annotate Coverage Warnings in PR
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          # Check if we have any errors in the checkstyle report
+          if grep -q '<error' coverage-warnings.xml; then
+            echo "Found coverage warnings to annotate, installing cs2pr..."
+            
+            # Install cs2pr
+            curl -s https://raw.githubusercontent.com/staabm/cs2pr/master/cs2pr -o cs2pr
+            chmod +x cs2pr
+            
+            # Convert checkstyle report to PR annotations
+            echo "Converting checkstyle report to PR annotations..."
+            ./cs2pr coverage-warnings.xml
+          else
+            echo "No coverage warnings found in checkstyle report"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -85,6 +85,23 @@ jobs:
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest
 
       - name: Unit Testing with Coverage
-        run: ./vendor/bin/phpunit --coverage-text --coverage-clover coverage.xml
+        run: ./vendor/bin/phpunit --coverage-text --coverage-clover coverage.xml --log-junit junit.xml 2>&1 | tee coverage-output.log
         env:
           WP_ENVIRONMENT_TYPE: production
+          
+      - name: Check for Coverage Warnings
+        run: |
+          if grep -q "Warning\|Error" coverage-output.log; then
+            echo "Coverage warnings/errors found:"
+            grep -n "Warning\|Error" coverage-output.log
+            echo "::error::Coverage analysis produced warnings or errors"
+            exit 1
+          fi
+          
+      - name: Annotate Test Results
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: PHPUnit Coverage Results
+          path: junit.xml
+          reporter: java-junit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -142,11 +142,10 @@ jobs:
             done < temp-warnings.txt
             
             rm -f temp-warnings.txt
-            
-            echo "::error::Coverage analysis produced warnings"
-            exit 1
+            WARNINGS_FOUND=true
           else
             echo "No coverage warnings found"
+            WARNINGS_FOUND=false
           fi
           
           # Close the checkstyle XML
@@ -155,6 +154,12 @@ jobs:
           # Debug: show the generated checkstyle content
           echo "Generated checkstyle report:"
           cat coverage-warnings.xml
+          
+          # Exit with error if warnings were found
+          if [ "$WARNINGS_FOUND" = true ]; then
+            echo "::error::Coverage analysis produced warnings"
+            exit 1
+          fi
 
       - name: Annotate Coverage Warnings in PR
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -125,12 +125,12 @@ jobs:
                   
                   # Find test file and line number
                   echo "Searching for @covers annotation with target: $COVERS_TARGET"
-                  # Escape backslashes for grep pattern
-                  ESCAPED_TARGET=$(echo "$COVERS_TARGET" | sed 's/\\/\\\\/g')
-                  echo "Escaped target for grep: $ESCAPED_TARGET"
-                  if TEST_FILE=$(find tests/ -name "*.php" -type f -exec grep -l "@covers.*$ESCAPED_TARGET" {} \; | head -1); then
+                  # Extract just the method name from the full class::method
+                  METHOD_NAME=$(echo "$COVERS_TARGET" | sed 's/.*:://')
+                  echo "Extracted method name: $METHOD_NAME"
+                  if TEST_FILE=$(find tests/ -name "*.php" -type f -exec grep -l "@covers.*$METHOD_NAME" {} \; | head -1); then
                     echo "Found test file: $TEST_FILE"
-                    if LINE_NUM=$(grep -n "@covers.*$ESCAPED_TARGET" "$TEST_FILE" | head -1 | cut -d: -f1); then
+                    if LINE_NUM=$(grep -n "@covers.*$METHOD_NAME" "$TEST_FILE" | head -1 | cut -d: -f1); then
                       echo "Found line number: $LINE_NUM"
                       # Escape XML characters and add checkstyle entry
                       MESSAGE=$(echo "Invalid @covers annotation: $COVERS_TARGET" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
@@ -176,7 +176,7 @@ jobs:
           if grep -q '<error' coverage-warnings.xml; then
             echo "Found coverage warnings to annotate"
             echo "Converting checkstyle report to PR annotations..."
-            cs2pr coverage-warnings.xml
+            cs2pr --graceful-warnings coverage-warnings.xml
           else
             echo "No coverage warnings found in checkstyle report"
           fi

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -139,7 +139,6 @@ jobs:
             <error line="$LINE_NUM" column="1" severity="warning" message="$MESSAGE" source="phpunit.coverage"/>
           </file>
           EOF
-                      echo "::warning file=$TEST_FILE,line=$LINE_NUM::Invalid @covers annotation: $COVERS_TARGET"
                     fi
                   fi
                 fi

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -104,7 +104,7 @@ The coverage configuration is already set up in `phpunit.xml.dist` to analyze th
 
 ```bash
 # Start the environment with Xdebug enabled.
-npm run env -- start --xdebug=coverage
+npm run env-start -- --xdebug=coverage
 ```
 ```bash
 # Run tests with code coverage.

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -61,7 +61,7 @@ use function Activitypub\snake_to_camel_case;
  * @method Base_Object set_summary( string $summary )             Sets the natural language summary of the object.
  * @method Base_Object set_summary_map( array|null $summary_map ) Sets the summary property of the object.
  * @method Base_Object set_target( string $target )               Sets the target property of the object.
- * @method Base_Object set_to( string|string[] $to )                 Sets the primary recipients of the object.
+ * @method Base_Object set_to( string|string[] $to )              Sets the primary recipients of the object.
  * @method Base_Object set_type( string $type )                   Sets the type of the object.
  * @method Base_Object set_updated( string $updated )             Sets the date and time the object was updated in ISO 8601 format.
  * @method Base_Object set_url( string $url )                     Sets the URL of the object.

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -61,7 +61,7 @@ use function Activitypub\snake_to_camel_case;
  * @method Base_Object set_summary( string $summary )             Sets the natural language summary of the object.
  * @method Base_Object set_summary_map( array|null $summary_map ) Sets the summary property of the object.
  * @method Base_Object set_target( string $target )               Sets the target property of the object.
- * @method Base_Object set_to( array|string $to )                 Sets the primary recipients of the object.
+ * @method Base_Object set_to( string|string[] $to )                 Sets the primary recipients of the object.
  * @method Base_Object set_type( string $type )                   Sets the type of the object.
  * @method Base_Object set_updated( string $updated )             Sets the date and time the object was updated in ISO 8601 format.
  * @method Base_Object set_url( string $url )                     Sets the URL of the object.

--- a/tests/includes/class-test-activitypub.php
+++ b/tests/includes/class-test-activitypub.php
@@ -321,7 +321,7 @@ class Test_Activitypub extends \WP_UnitTestCase {
 	/**
 	 * Test get_post_metadata method.
 	 *
-	 * @covers ::get_post_metadata
+	 * @covers ::default_post_metadata
 	 */
 	public function test_get_post_metadata() {
 		// Create a test post.

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -569,7 +569,7 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	 * @dataProvider get_post_summary_data
 	 *
 	 * @param string $desc     The description of the test.
-	 * @param object $post     The post object.
+	 * @param array  $post     The post object.
 	 * @param string $expected The expected summary.
 	 * @param int    $length   The length of the summary.
 	 */
@@ -714,7 +714,7 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	/**
 	 * Tests follow method.
 	 *
-	 * @covers ::follow
+	 * @covers \Activitypub\follow
 	 */
 	public function test_follow() {
 		$user_id = self::factory()->user->create(
@@ -758,7 +758,7 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	/**
 	 * Test that Update activities have the updated attribute set.
 	 *
-	 * @covers ::add_to_outbox
+	 * @covers \Activitypub\add_to_outbox
 	 */
 	public function test_webfinger_support() {
 		$follow = new Activity();
@@ -811,7 +811,7 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	 *
 	 * @dataProvider data_normalize_url
 	 *
-	 * @covers ::normalize_url
+	 * @covers \Activitypub\normalize_url
 	 *
 	 * @param string $url     The URL.
 	 * @param string $expected The expected result.
@@ -842,7 +842,7 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	 *
 	 * @dataProvider data_normalize_host
 	 *
-	 * @covers ::normalize_host
+	 * @covers \Activitypub\normalize_host
 	 *
 	 * @param string $host     The host.
 	 * @param string $expected The expected result.

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -60,25 +60,6 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
-	 * Test method to generate coverage warnings for testing annotation system.
-	 * TODO: Remove this test method after verifying coverage annotations work.
-	 */
-	public function test_coverage_warning_generator() {
-		// This will generate a coverage warning - accessing undefined variable
-		$undefined_variable = $non_existent_var ?? null;
-		
-		// This will generate an error that should be caught by coverage
-		@include '/non/existent/file.php';
-		
-		// Force a deprecated function call that might generate warnings
-		if ( function_exists( 'create_function' ) ) {
-			@create_function( '', 'return true;' );
-		}
-		
-		$this->assertTrue( true );
-	}
-
-	/**
 	 * Test object_id_to_comment.
 	 *
 	 * @covers \Activitypub\object_id_to_comment

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -60,6 +60,25 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
+	 * Test method to generate coverage warnings for testing annotation system.
+	 * TODO: Remove this test method after verifying coverage annotations work.
+	 */
+	public function test_coverage_warning_generator() {
+		// This will generate a coverage warning - accessing undefined variable
+		$undefined_variable = $non_existent_var ?? null;
+		
+		// This will generate an error that should be caught by coverage
+		@include '/non/existent/file.php';
+		
+		// Force a deprecated function call that might generate warnings
+		if ( function_exists( 'create_function' ) ) {
+			@create_function( '', 'return true;' );
+		}
+		
+		$this->assertTrue( true );
+	}
+
+	/**
 	 * Test object_id_to_comment.
 	 *
 	 * @covers \Activitypub\object_id_to_comment

--- a/tests/includes/class-test-moderation.php
+++ b/tests/includes/class-test-moderation.php
@@ -440,10 +440,15 @@ class Test_Moderation extends \WP_UnitTestCase {
 			static function ( $errno, $errstr ) {
 				throw new \Exception( \esc_html( $errstr ), \esc_html( $errno ) );
 			},
-			E_WARNING
+			E_NOTICE | E_WARNING
 		);
 
-		$this->expectExceptionMessage( 'Undefined array key &quot;id&quot;' );
+		// PHP 7.2 uses "Undefined index", PHP 8+ uses "Undefined array key".
+		if ( version_compare( PHP_VERSION, '8.0.0', '>=' ) ) {
+			$this->expectExceptionMessage( 'Undefined array key &quot;id&quot;' );
+		} else {
+			$this->expectExceptionMessage( 'Undefined index: id' );
+		}
 		$this->assertFalse( Moderation::activity_is_blocked( $activity ) );
 
 		\restore_error_handler();

--- a/tests/includes/class-test-moderation.php
+++ b/tests/includes/class-test-moderation.php
@@ -373,7 +373,7 @@ class Test_Moderation extends \WP_UnitTestCase {
 	/**
 	 * Test edge cases with malformed activity data.
 	 *
-	 * @covers ::activity_is_blockeded
+	 * @covers ::activity_is_blocked
 	 * @throws \Exception Thrown when an error occurs.
 	 */
 	public function test_activity_blocking_edge_cases() {

--- a/tests/includes/class-test-moderation.php
+++ b/tests/includes/class-test-moderation.php
@@ -202,7 +202,6 @@ class Test_Moderation extends \WP_UnitTestCase {
 	 *
 	 * @covers ::add_site_block
 	 * @covers ::get_site_blocks
-	 * @covers ::get_site_option_key_for_type
 	 */
 	public function test_add_site_block() {
 		$this->assertTrue( Moderation::add_site_block( 'domain', 'spam-instance.com' ) );
@@ -375,6 +374,7 @@ class Test_Moderation extends \WP_UnitTestCase {
 	 * Test edge cases with malformed activity data.
 	 *
 	 * @covers ::activity_is_blocked
+	 * @throws \Exception Thrown when an error occurs.
 	 */
 	public function test_activity_blocking_edge_cases() {
 		// Test with empty activity.
@@ -434,8 +434,19 @@ class Test_Moderation extends \WP_UnitTestCase {
 				),
 			)
 		);
-		$this->expectError();
+
+		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		\set_error_handler(
+			static function ( $errno, $errstr ) {
+				throw new \Exception( \esc_html( $errstr ), \esc_html( $errno ) );
+			},
+			E_WARNING
+		);
+
+		$this->expectExceptionMessage( 'Undefined array key &quot;id&quot;' );
 		$this->assertFalse( Moderation::activity_is_blocked( $activity ) );
+
+		\restore_error_handler();
 	}
 
 	/**

--- a/tests/includes/class-test-moderation.php
+++ b/tests/includes/class-test-moderation.php
@@ -373,7 +373,7 @@ class Test_Moderation extends \WP_UnitTestCase {
 	/**
 	 * Test edge cases with malformed activity data.
 	 *
-	 * @covers ::activity_is_blocked
+	 * @covers ::activity_is_blockeded
 	 * @throws \Exception Thrown when an error occurs.
 	 */
 	public function test_activity_blocking_edge_cases() {

--- a/tests/includes/class-test-signature.php
+++ b/tests/includes/class-test-signature.php
@@ -370,7 +370,6 @@ class Test_Signature extends \WP_UnitTestCase {
 	 * @covers \Activitypub\Signature\Http_Message_Signature::parse_signature_labels
 	 * @covers \Activitypub\Signature\Http_Message_Signature::verify_signature_label
 	 * @covers \Activitypub\Signature\Http_Message_Signature::verify_content_digest
-	 * @covers \Activitypub\Signature\Http_Message_Signature::resolve_algorithm
 	 * @covers \Activitypub\Signature\Http_Message_Signature::get_signature_base_string
 	 */
 	public function test_verify_http_signature_rfc9421() {
@@ -491,7 +490,6 @@ class Test_Signature extends \WP_UnitTestCase {
 	 * @covers \Activitypub\Signature\Http_Message_Signature::parse_signature_labels
 	 * @covers \Activitypub\Signature\Http_Message_Signature::verify_signature_label
 	 * @covers \Activitypub\Signature\Http_Message_Signature::verify_content_digest
-	 * @covers \Activitypub\Signature\Http_Message_Signature::resolve_algorithm
 	 * @covers \Activitypub\Signature\Http_Message_Signature::get_signature_base_string
 	 */
 	public function test_verify_http_signature_rfc9421_get_request() {
@@ -571,7 +569,6 @@ class Test_Signature extends \WP_UnitTestCase {
 	 * @covers \Activitypub\Signature\Http_Message_Signature::parse_signature_labels
 	 * @covers \Activitypub\Signature\Http_Message_Signature::verify_signature_label
 	 * @covers \Activitypub\Signature\Http_Message_Signature::verify_content_digest
-	 * @covers \Activitypub\Signature\Http_Message_Signature::resolve_algorithm
 	 * @covers \Activitypub\Signature\Http_Message_Signature::get_signature_base_string
 	 */
 	public function test_verify_http_signature_rfc9421_algorithms() {


### PR DESCRIPTION
I'd like to find a way to surface code coverage warnings so they can be fixed before they make it into the codebase.
At this point I'm not as interested in actual coverage information, although I'm happy to consider it if wanted.

## Proposed changes:
* Added a new 'coverage' job to the PHPUnit GitHub Actions workflow
* Configured the coverage job to run PHPUnit with Xdebug enabled for code coverage generation
* Set up coverage reporting with both text output and XML clover format
* Isolated coverage generation from main test matrix to avoid performance impact on regular test runs

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

To test this PR, you can verify the workflow changes by:

1. Go to the **Actions** tab in the GitHub repository
2. Look for the "Unit Testing" workflow runs after this PR is merged
3. Verify that both the existing `phpunit` job and the new `coverage` job run successfully
4. Click on the `coverage` job to see the detailed steps
5. Check that the "Unit Testing with Coverage" step shows coverage output in the logs
6. Verify that coverage.xml file is generated (visible in the job artifacts if configured)

Expected behavior:
- The `phpunit` job matrix should continue running as before with all PHP versions (7.2-8.4)
- The new `coverage` job should run independently on PHP 8.3 with latest WordPress
- Coverage reports should be visible in the job output showing percentage coverage for files/classes
- No performance impact on the main test suite since coverage runs separately

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Added - for new features

#### Message

Add code coverage reporting to GitHub Actions PHPUnit workflow with dedicated coverage job using Xdebug

</details>