### PR TITLE
Fix duplicate HTML IDs and missing form labels in modal blocks

### DIFF
--- a/.github/changelog/2083-from-description
+++ b/.github/changelog/2083-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix duplicate HTML IDs and missing form labels in modal blocks

--- a/build/follow-me/render.php
+++ b/build/follow-me/render.php
@@ -8,6 +8,7 @@
 use Activitypub\Blocks;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+
 use function Activitypub\is_activitypub_request;
 
 if ( is_activitypub_request() || is_feed() ) {
@@ -96,7 +97,7 @@ $content = Blocks::add_directions(
 		'data-wp-bind--aria-expanded' => 'context.modal.isOpen',
 		'aria-label'                  => __( 'Follow me on the Fediverse', 'activitypub' ),
 		'aria-haspopup'               => 'dialog',
-		'aria-controls'               => 'modal-heading',
+		'aria-controls'               => $block_id . '-modal-title',
 		'role'                        => 'button',
 		'tabindex'                    => '0',
 	)
@@ -118,9 +119,12 @@ ob_start();
 		<?php esc_html_e( 'Copy and paste my profile into the search field of your favorite fediverse app or server.', 'activitypub' ); ?>
 	</div>
 	<div class="activitypub-dialog__button-group">
+		<label for="<?php echo esc_attr( $block_id . '-profile-handle' ); ?>" class="screen-reader-text">
+			<?php esc_html_e( 'My Fediverse handle', 'activitypub' ); ?>
+		</label>
 		<input
 			aria-readonly="true"
-			id="profile-handle"
+			id="<?php echo esc_attr( $block_id . '-profile-handle' ); ?>"
 			readonly
 			tabindex="-1"
 			type="text"
@@ -142,12 +146,15 @@ ob_start();
 		<?php esc_html_e( 'Or, if you know your own profile, we can start things that way!', 'activitypub' ); ?>
 	</div>
 	<div class="activitypub-dialog__button-group">
+		<label for="<?php echo esc_attr( $block_id . '-remote-profile' ); ?>" class="screen-reader-text">
+			<?php esc_html_e( 'Your Fediverse profile', 'activitypub' ); ?>
+		</label>
 		<input
 			data-wp-bind--aria-invalid="context.isError"
 			data-wp-bind--value="context.remoteProfile"
 			data-wp-on--input="actions.updateRemoteProfile"
 			data-wp-on--keydown="actions.handleKeyDown"
-			id="remote-profile"
+			id="<?php echo esc_attr( $block_id . '-remote-profile' ); ?>"
 			placeholder="<?php esc_attr_e( '@username@example.com', 'activitypub' ); ?>"
 			type="text"
 		/>
@@ -235,6 +242,7 @@ $modal_content = ob_get_clean();
 	// Render the modal using the Blocks class.
 	Blocks::render_modal(
 		array(
+			'id'      => $block_id . '-modal',
 			'content' => $modal_content,
 			/* translators: %s: Profile name. */
 			'title'   => sprintf( esc_html__( 'Follow %s', 'activitypub' ), esc_html( $actor->get_name() ) ),

--- a/build/remote-reply/render.php
+++ b/build/remote-reply/render.php
@@ -7,6 +7,10 @@
 
 use Activitypub\Blocks;
 
+if ( is_activitypub_request() || is_feed() ) {
+	return;
+}
+
 /* @var array $attributes Block attributes. */
 $attributes = wp_parse_args( $attributes );
 
@@ -68,9 +72,12 @@ ob_start();
 		<?php esc_html_e( 'Copy and paste the Comment URL into the search field of your favorite fediverse app or server.', 'activitypub' ); ?>
 	</div>
 	<div class="activitypub-dialog__button-group">
+		<label for="<?php echo esc_attr( $block_id . '-profile-handle' ); ?>" class="screen-reader-text">
+			<?php esc_html_e( 'Comment URL', 'activitypub' ); ?>
+		</label>
 		<input
 			aria-readonly="true"
-			id="profile-handle"
+			id="<?php echo esc_attr( $block_id . '-profile-handle' ); ?>"
 			readonly
 			tabindex="-1"
 			type="text"
@@ -92,12 +99,15 @@ ob_start();
 		<?php esc_html_e( 'Or, if you know your own profile, we can start things that way!', 'activitypub' ); ?>
 	</div>
 	<div class="activitypub-dialog__button-group">
+		<label for="<?php echo esc_attr( $block_id . '-remote-profile' ); ?>" class="screen-reader-text">
+			<?php esc_html_e( 'Your Fediverse profile', 'activitypub' ); ?>
+		</label>
 		<input
 			data-wp-bind--aria-invalid="context.isError"
 			data-wp-bind--value="context.remoteProfile"
 			data-wp-on--input="actions.updateRemoteProfile"
 			data-wp-on--keydown="actions.onInputKeydown"
-			id="remote-profile"
+			id="<?php echo esc_attr( $block_id . '-remote-profile' ); ?>"
 			placeholder="<?php esc_attr_e( '@username@example.com', 'activitypub' ); ?>"
 			type="text"
 		/>
@@ -172,7 +182,7 @@ $modal_content = ob_get_clean();
 		data-wp-bind--aria-expanded="context.modal.isOpen"
 		aria-label="<?php esc_attr_e( 'Reply on the Fediverse', 'activitypub' ); ?>"
 		aria-haspopup="dialog"
-		aria-controls="modal-heading"
+		aria-controls="<?php echo esc_attr( $block_id . '-modal-title' ); ?>"
 		role="button"
 		tabindex="0"
 		hidden
@@ -183,6 +193,7 @@ $modal_content = ob_get_clean();
 	<?php
 	Blocks::render_modal(
 		array(
+			'id'      => $block_id . '-modal',
 			'title'   => __( 'Remote Reply', 'activitypub' ),
 			'content' => $modal_content,
 		)

--- a/build/remote-reply/render.php
+++ b/build/remote-reply/render.php
@@ -6,6 +6,7 @@
  */
 
 use Activitypub\Blocks;
+use function Activitypub\is_activitypub_request;
 
 if ( is_activitypub_request() || is_feed() ) {
 	return;

--- a/build/remote-reply/render.php
+++ b/build/remote-reply/render.php
@@ -150,6 +150,7 @@ $modal_content = ob_get_clean();
 >
 	<div class="activitypub-remote-profile" hidden data-wp-bind--hidden="!context.hasRemoteUser">
 		<a
+			href=""
 			class="comment-reply-link activitypub-remote-profile__link"
 			data-wp-bind--href="state.remoteProfileUrl"
 			target="_blank"

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -282,6 +282,7 @@ class Blocks {
 	public static function render_modal( $args = array() ) {
 		$defaults = array(
 			'content'    => '',
+			'id'         => '',
 			'is_compact' => false,
 			'title'      => '',
 		);
@@ -300,7 +301,12 @@ class Blocks {
 			<div class="activitypub-modal__frame">
 				<?php if ( ! $args['is_compact'] || ! empty( $args['title'] ) ) : ?>
 					<div class="activitypub-modal__header">
-						<h2 class="activitypub-modal__title"><?php echo \esc_html( $args['title'] ); ?></h2>
+						<h2 
+							class="activitypub-modal__title"
+							<?php if ( ! empty( $args['id'] ) ) : ?>
+								id="<?php echo \esc_attr( $args['id'] . '-title' ); ?>"
+							<?php endif; ?>
+						><?php echo \esc_html( $args['title'] ); ?></h2>
 						<button
 							type="button"
 							class="activitypub-modal__close wp-element-button wp-block-button__link"

--- a/src/follow-me/render.php
+++ b/src/follow-me/render.php
@@ -97,7 +97,7 @@ $content = Blocks::add_directions(
 		'data-wp-bind--aria-expanded' => 'context.modal.isOpen',
 		'aria-label'                  => __( 'Follow me on the Fediverse', 'activitypub' ),
 		'aria-haspopup'               => 'dialog',
-		'aria-controls'               => 'modal-heading',
+		'aria-controls'               => $block_id . '-modal-title',
 		'role'                        => 'button',
 		'tabindex'                    => '0',
 	)
@@ -119,9 +119,12 @@ ob_start();
 		<?php esc_html_e( 'Copy and paste my profile into the search field of your favorite fediverse app or server.', 'activitypub' ); ?>
 	</div>
 	<div class="activitypub-dialog__button-group">
+		<label for="<?php echo esc_attr( $block_id . '-profile-handle' ); ?>" class="screen-reader-text">
+			<?php esc_html_e( 'My Fediverse handle', 'activitypub' ); ?>
+		</label>
 		<input
 			aria-readonly="true"
-			id="profile-handle"
+			id="<?php echo esc_attr( $block_id . '-profile-handle' ); ?>"
 			readonly
 			tabindex="-1"
 			type="text"
@@ -143,12 +146,15 @@ ob_start();
 		<?php esc_html_e( 'Or, if you know your own profile, we can start things that way!', 'activitypub' ); ?>
 	</div>
 	<div class="activitypub-dialog__button-group">
+		<label for="<?php echo esc_attr( $block_id . '-remote-profile' ); ?>" class="screen-reader-text">
+			<?php esc_html_e( 'Your Fediverse profile', 'activitypub' ); ?>
+		</label>
 		<input
 			data-wp-bind--aria-invalid="context.isError"
 			data-wp-bind--value="context.remoteProfile"
 			data-wp-on--input="actions.updateRemoteProfile"
 			data-wp-on--keydown="actions.handleKeyDown"
-			id="remote-profile"
+			id="<?php echo esc_attr( $block_id . '-remote-profile' ); ?>"
 			placeholder="<?php esc_attr_e( '@username@example.com', 'activitypub' ); ?>"
 			type="text"
 		/>
@@ -236,6 +242,7 @@ $modal_content = ob_get_clean();
 	// Render the modal using the Blocks class.
 	Blocks::render_modal(
 		array(
+			'id'      => $block_id . '-modal',
 			'content' => $modal_content,
 			/* translators: %s: Profile name. */
 			'title'   => sprintf( esc_html__( 'Follow %s', 'activitypub' ), esc_html( $actor->get_name() ) ),

--- a/src/remote-reply/render.php
+++ b/src/remote-reply/render.php
@@ -6,6 +6,7 @@
  */
 
 use Activitypub\Blocks;
+use function Activitypub\is_activitypub_request;
 
 if ( is_activitypub_request() || is_feed() ) {
 	return;

--- a/src/remote-reply/render.php
+++ b/src/remote-reply/render.php
@@ -72,9 +72,12 @@ ob_start();
 		<?php esc_html_e( 'Copy and paste the Comment URL into the search field of your favorite fediverse app or server.', 'activitypub' ); ?>
 	</div>
 	<div class="activitypub-dialog__button-group">
+		<label for="<?php echo esc_attr( $block_id . '-profile-handle' ); ?>" class="screen-reader-text">
+			<?php esc_html_e( 'Comment URL', 'activitypub' ); ?>
+		</label>
 		<input
 			aria-readonly="true"
-			id="profile-handle"
+			id="<?php echo esc_attr( $block_id . '-profile-handle' ); ?>"
 			readonly
 			tabindex="-1"
 			type="text"
@@ -96,12 +99,15 @@ ob_start();
 		<?php esc_html_e( 'Or, if you know your own profile, we can start things that way!', 'activitypub' ); ?>
 	</div>
 	<div class="activitypub-dialog__button-group">
+		<label for="<?php echo esc_attr( $block_id . '-remote-profile' ); ?>" class="screen-reader-text">
+			<?php esc_html_e( 'Your Fediverse profile', 'activitypub' ); ?>
+		</label>
 		<input
 			data-wp-bind--aria-invalid="context.isError"
 			data-wp-bind--value="context.remoteProfile"
 			data-wp-on--input="actions.updateRemoteProfile"
 			data-wp-on--keydown="actions.onInputKeydown"
-			id="remote-profile"
+			id="<?php echo esc_attr( $block_id . '-remote-profile' ); ?>"
 			placeholder="<?php esc_attr_e( '@username@example.com', 'activitypub' ); ?>"
 			type="text"
 		/>
@@ -176,7 +182,7 @@ $modal_content = ob_get_clean();
 		data-wp-bind--aria-expanded="context.modal.isOpen"
 		aria-label="<?php esc_attr_e( 'Reply on the Fediverse', 'activitypub' ); ?>"
 		aria-haspopup="dialog"
-		aria-controls="modal-heading"
+		aria-controls="<?php echo esc_attr( $block_id . '-modal-title' ); ?>"
 		role="button"
 		tabindex="0"
 		hidden
@@ -187,6 +193,7 @@ $modal_content = ob_get_clean();
 	<?php
 	Blocks::render_modal(
 		array(
+			'id'      => $block_id . '-modal',
 			'title'   => __( 'Remote Reply', 'activitypub' ),
 			'content' => $modal_content,
 		)

--- a/src/remote-reply/render.php
+++ b/src/remote-reply/render.php
@@ -150,6 +150,7 @@ $modal_content = ob_get_clean();
 >
 	<div class="activitypub-remote-profile" hidden data-wp-bind--hidden="!context.hasRemoteUser">
 		<a
+			href=""
 			class="comment-reply-link activitypub-remote-profile__link"
 			data-wp-bind--href="state.remoteProfileUrl"
 			target="_blank"


### PR DESCRIPTION
See #2069

## Proposed changes:
- Fix duplicate HTML IDs in remote-reply and follow-me modal blocks by using unique identifiers with wp_unique_id()
- Add proper form labels with screen-reader-text class for all input fields to resolve WebAIM accessibility violations
- Fix aria-controls attributes to reference actual modal title elements instead of non-existent IDs
- Update render_modal() function to support unique modal title IDs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create a post with comments enabled
2. Add the remote-reply block to the post
3. Add the follow-me block to the post  
4. View the post on the frontend
5. Run HTML validation tool (like WebAIM) - should show no duplicate ID errors
6. Test with screen reader - all inputs should have proper labels
7. Verify modal accessibility with keyboard navigation

Before: HTML validation errors for duplicate IDs (profile-handle, remote-profile) and missing form labels
After: Clean HTML validation and proper accessibility labels

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix duplicate HTML IDs and missing form labels in modal blocks

</details>