### PR TITLE
Follow[ers|ing]: Avoid errors when getting avatar url

### DIFF
--- a/.github/changelog/2088-from-description
+++ b/.github/changelog/2088-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add comprehensive unit tests for Followers and Following table classes with proper ActivityPub icon object handling.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -730,7 +730,8 @@ function object_to_uri( $data ) {
 	// Return part of Object that makes most sense.
 	switch ( $type ) {
 		case 'Image':
-			$data = $data['url'];
+			// See https://www.w3.org/TR/activitystreams-vocabulary/#dfn-image.
+			$data = object_to_uri( $data['url'] );
 			break;
 		case 'Link':
 			$data = $data['href'];

--- a/includes/wp-admin/table/class-followers.php
+++ b/includes/wp-admin/table/class-followers.php
@@ -223,7 +223,7 @@ class Followers extends \WP_List_Table {
 
 			$this->items[] = array(
 				'id'         => $follower->ID,
-				'icon'       => $actor->get_icon()['url'] ?? '',
+				'icon'       => object_to_uri( $actor->get_icon() ?? '' ),
 				'post_title' => $actor->get_name() ?? $actor->get_preferred_username(),
 				'username'   => $actor->get_preferred_username(),
 				'url'        => $url,

--- a/includes/wp-admin/table/class-following.php
+++ b/includes/wp-admin/table/class-following.php
@@ -240,7 +240,7 @@ class Following extends \WP_List_Table {
 
 			$this->items[] = array(
 				'id'         => $following->ID,
-				'icon'       => $actor->get_icon()['url'] ?? '',
+				'icon'       => object_to_uri( $actor->get_icon() ?? '' ),
 				'post_title' => $actor->get_name() ?? $actor->get_preferred_username(),
 				'username'   => $actor->get_preferred_username(),
 				'url'        => $url,

--- a/tests/includes/wp-admin/table/class-test-followers.php
+++ b/tests/includes/wp-admin/table/class-test-followers.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Test file for Followers Table.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\WP_Admin\Table;
+
+use Activitypub\WP_Admin\Table\Followers;
+use Activitypub\Collection\Actors;
+
+/**
+ * Test class for Followers Table.
+ *
+ * @coversDefaultClass \Activitypub\WP_Admin\Table\Followers
+ */
+class Test_Followers extends \WP_UnitTestCase {
+
+	/**
+	 * Followers table instance.
+	 *
+	 * @var Followers
+	 */
+	private $followers_table;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Set up global screen mock.
+		set_current_screen( 'users_page_activitypub-followers-list' );
+		
+		// Set current user.
+		wp_set_current_user( 1 );
+
+		// Create followers table instance.
+		$this->followers_table = new Followers();
+	}
+
+	/**
+	 * Test column_username with actor having icon object.
+	 *
+	 * This test simulates the prepare_items() data processing by creating
+	 * a realistic item array that includes an icon URL extracted from
+	 * an ActivityPub actor's icon object.
+	 *
+	 * @covers ::column_username
+	 */
+	public function test_column_username_with_icon_object() {
+		// Simulate how prepare_items() processes an ActivityPub actor with icon object.
+		// Real ActivityPub actor icon: {"type": "Image", "url": "..."}
+		$activitypub_actor_icon = array(
+			'type' => 'Image',
+			'url'  => 'https://secure.gravatar.com/avatar/example?s=120&d=mm&r=g',
+		);
+
+		// Simulate the icon URL extraction from prepare_items(): object_to_uri( $actor->get_icon() )
+		$extracted_icon_url = $activitypub_actor_icon['url'] ?? '';
+
+		// Create item array as prepare_items() would.
+		$item = array(
+			'id'         => 123,
+			'icon'       => $extracted_icon_url,
+			'post_title' => 'Test User',
+			'username'   => 'testuser',
+			'url'        => 'https://example.com/@testuser',
+			'webfinger'  => '@testuser@example.com',
+			'identifier' => 'https://example.com/users/testuser',
+			'modified'   => '2023-01-01 12:00:00',
+		);
+
+		// Test the column_username output.
+		$result = $this->followers_table->column_username( $item );
+
+		// Verify the icon URL was properly rendered (WordPress escapes & as &#038;).
+		$this->assertStringContainsString( 'https://secure.gravatar.com/avatar/example?s=120&#038;d=mm&#038;r=g', $result );
+		$this->assertStringContainsString( 'width="32" height="32"', $result );
+		$this->assertStringContainsString( 'alt="testuser"', $result );
+		$this->assertStringContainsString( 'loading="lazy"', $result );
+		$this->assertStringContainsString( '<strong><a href="https://example.com/@testuser" target="_blank">testuser</a></strong>', $result );
+	}
+}

--- a/tests/includes/wp-admin/table/class-test-followers.php
+++ b/tests/includes/wp-admin/table/class-test-followers.php
@@ -8,7 +8,7 @@
 namespace Activitypub\Tests\WP_Admin\Table;
 
 use Activitypub\WP_Admin\Table\Followers;
-use Activitypub\Collection\Actors;
+use Activitypub\Collection\Followers as Follower_Collection;
 
 /**
  * Test class for Followers Table.
@@ -32,7 +32,7 @@ class Test_Followers extends \WP_UnitTestCase {
 
 		// Set up global screen mock.
 		set_current_screen( 'users_page_activitypub-followers-list' );
-		
+
 		// Set current user.
 		wp_set_current_user( 1 );
 
@@ -43,43 +43,57 @@ class Test_Followers extends \WP_UnitTestCase {
 	/**
 	 * Test column_username with actor having icon object.
 	 *
-	 * This test simulates the prepare_items() data processing by creating
-	 * a realistic item array that includes an icon URL extracted from
-	 * an ActivityPub actor's icon object.
-	 *
 	 * @covers ::column_username
+	 * @covers ::prepare_items
 	 */
 	public function test_column_username_with_icon_object() {
-		// Simulate how prepare_items() processes an ActivityPub actor with icon object.
-		// Real ActivityPub actor icon: {"type": "Image", "url": "..."}
-		$activitypub_actor_icon = array(
-			'type' => 'Image',
-			'url'  => 'https://secure.gravatar.com/avatar/example?s=120&d=mm&r=g',
+		// Mock remote metadata for the actor with icon object.
+		$actor_url  = 'https://example.com/users/testuser';
+		$actor_data = array(
+			'name'              => 'Test User',
+			'icon'              => array(
+				'type' => 'Image',
+				'url'  => 'https://secure.gravatar.com/avatar/example?s=120&d=mm&r=g',
+			),
+			'url'               => $actor_url,
+			'id'                => 'https://example.com/users/testuser',
+			'preferredUsername' => 'testuser',
+			'inbox'             => 'https://example.com/users/testuser/inbox',
 		);
 
-		// Simulate the icon URL extraction from prepare_items(): object_to_uri( $actor->get_icon() )
-		$extracted_icon_url = $activitypub_actor_icon['url'] ?? '';
-
-		// Create item array as prepare_items() would.
-		$item = array(
-			'id'         => 123,
-			'icon'       => $extracted_icon_url,
-			'post_title' => 'Test User',
-			'username'   => 'testuser',
-			'url'        => 'https://example.com/@testuser',
-			'webfinger'  => '@testuser@example.com',
-			'identifier' => 'https://example.com/users/testuser',
-			'modified'   => '2023-01-01 12:00:00',
+		// Mock the remote metadata call using the correct filter.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function ( $value, $actor ) use ( $actor_url, $actor_data ) {
+				if ( $actor === $actor_url ) {
+					return $actor_data;
+				}
+				return $value;
+			},
+			10,
+			2
 		);
 
-		// Test the column_username output.
+		// Add the follower.
+		Follower_Collection::add_follower( get_current_user_id(), $actor_url );
+
+		// Use the real prepare_items() method.
+		$this->followers_table->prepare_items();
+
+		// Verify we have items.
+		$this->assertNotEmpty( $this->followers_table->items );
+
+		// Get the first item and test column_username.
+		$item   = $this->followers_table->items[0];
 		$result = $this->followers_table->column_username( $item );
 
-		// Verify the icon URL was properly rendered (WordPress escapes & as &#038;).
-		$this->assertStringContainsString( 'https://secure.gravatar.com/avatar/example?s=120&#038;d=mm&#038;r=g', $result );
-		$this->assertStringContainsString( 'width="32" height="32"', $result );
-		$this->assertStringContainsString( 'alt="testuser"', $result );
-		$this->assertStringContainsString( 'loading="lazy"', $result );
-		$this->assertStringContainsString( '<strong><a href="https://example.com/@testuser" target="_blank">testuser</a></strong>', $result );
+		// Verify the icon URL was extracted from the object by object_to_uri() and properly rendered.
+		$this->assertStringContainsString( 'src="https://secure.gravatar.com/avatar/example?s=120&#038;d=mm&#038;r=g"', $result );
+
+		// Verify that the icon was processed correctly: from object to URL.
+		$this->assertEquals( 'https://secure.gravatar.com/avatar/example?s=120&d=mm&r=g', $item['icon'] );
+
+		// Clean up.
+		\remove_all_filters( 'pre_get_remote_metadata_by_actor' );
 	}
 }

--- a/tests/includes/wp-admin/table/class-test-following.php
+++ b/tests/includes/wp-admin/table/class-test-following.php
@@ -7,8 +7,9 @@
 
 namespace Activitypub\Tests\WP_Admin\Table;
 
-use Activitypub\WP_Admin\Table\Following;
+use Activitypub\Collection\Actors;
 use Activitypub\Collection\Following as Following_Collection;
+use Activitypub\WP_Admin\Table\Following;
 
 /**
  * Test class for Following Table.
@@ -52,7 +53,7 @@ class Test_Following extends \WP_UnitTestCase {
 	 */
 	public function test_column_username_with_icon_object() {
 		// Mock remote metadata for the actor with icon object.
-		$actor_url = 'https://example.com/users/testuser';
+		$actor_url  = 'https://example.com/users/testuser';
 		$actor_data = array(
 			'name'              => 'Test User',
 			'icon'              => array(
@@ -79,14 +80,10 @@ class Test_Following extends \WP_UnitTestCase {
 		);
 
 		// Add the actor first, then follow them.
-		$actor_post_id = \Activitypub\Collection\Actors::upsert( $actor_data );
-		$this->assertIsInt( $actor_post_id );
-		$this->assertGreaterThan( 0, $actor_post_id );
+		$actor_post_id = Actors::upsert( $actor_data );
 
 		// Follow the actor using the proper method.
-		$result = Following_Collection::follow( $actor_post_id, get_current_user_id() );
-		$this->assertIsInt( $result );
-		$this->assertGreaterThan( 0, $result );
+		Following_Collection::follow( $actor_post_id, get_current_user_id() );
 
 		// Use the real prepare_items() method.
 		$this->following_table->prepare_items();
@@ -95,7 +92,7 @@ class Test_Following extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $this->following_table->items );
 
 		// Get the first item and test column_username.
-		$item = $this->following_table->items[0];
+		$item   = $this->following_table->items[0];
 		$result = $this->following_table->column_username( $item );
 
 		// Verify the icon URL was extracted from the object by object_to_uri() and properly rendered.

--- a/tests/includes/wp-admin/table/class-test-following.php
+++ b/tests/includes/wp-admin/table/class-test-following.php
@@ -105,4 +105,60 @@ class Test_Following extends \WP_UnitTestCase {
 		\remove_all_filters( 'pre_get_remote_metadata_by_actor' );
 		wp_delete_post( $actor_post_id, true );
 	}
+
+	/**
+	 * Test prepare_items with actor having icon array of URLs.
+	 *
+	 * This test verifies that when an icon field contains an array of URLs,
+	 * the object_to_uri() function correctly extracts the first URL from the array.
+	 *
+	 * @covers ::prepare_items
+	 */
+	public function test_prepare_items_with_icon_array_of_urls() {
+		// Mock remote metadata for the actor with icon as direct array of URLs.
+		$actor_url  = 'https://example.com/users/arrayuser';
+		$actor_data = array(
+			'name'              => 'Array User',
+			'icon'              => array(
+				'url'       => array(
+					'https://example.com/storage/profile.webp',
+				),
+				'type'      => 'Image',
+				'mediaType' => 'image/webp',
+			),
+			'url'               => $actor_url,
+			'id'                => 'https://example.com/users/arrayuser',
+			'preferredUsername' => 'arrayuser',
+			'inbox'             => 'https://example.com/users/arrayuser/inbox',
+		);
+
+		// Mock the remote metadata call using the correct filter.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function ( $value, $actor ) use ( $actor_url, $actor_data ) {
+				if ( $actor === $actor_url ) {
+					return $actor_data;
+				}
+				return $value;
+			},
+			10,
+			2
+		);
+
+		// Add the actor first, then follow them.
+		$actor_post_id = Actors::upsert( $actor_data );
+
+		// Follow the actor using the proper method.
+		Following_Collection::follow( $actor_post_id, get_current_user_id() );
+
+		// Use the real prepare_items() method.
+		$this->following_table->prepare_items();
+
+		// Verify that the icon array was processed correctly: from array to first URL.
+		$this->assertEquals( 'https://example.com/storage/profile.webp', $this->following_table->items[0]['icon'] );
+
+		// Clean up.
+		\remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		wp_delete_post( $actor_post_id, true );
+	}
 }

--- a/tests/includes/wp-admin/table/class-test-following.php
+++ b/tests/includes/wp-admin/table/class-test-following.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Test file for Following Table.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\WP_Admin\Table;
+
+use Activitypub\WP_Admin\Table\Following;
+use Activitypub\Collection\Following as Following_Collection;
+
+/**
+ * Test class for Following Table.
+ *
+ * @coversDefaultClass \Activitypub\WP_Admin\Table\Following
+ */
+class Test_Following extends \WP_UnitTestCase {
+
+	/**
+	 * Following table instance.
+	 *
+	 * @var Following
+	 */
+	private $following_table;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Set up global screen mock.
+		set_current_screen( 'users_page_activitypub-following-list' );
+
+		// Set current user.
+		wp_set_current_user( 1 );
+
+		// Create following table instance.
+		$this->following_table = new Following();
+	}
+
+	/**
+	 * Test column_username with actor having icon object using real prepare_items().
+	 *
+	 * This test uses Following::follow() to create a real following and uses
+	 * the actual prepare_items() method to test the complete data flow from
+	 * ActivityPub actor with icon object to the final column output.
+	 *
+	 * @covers ::column_username
+	 * @covers ::prepare_items
+	 */
+	public function test_column_username_with_icon_object() {
+		// Mock remote metadata for the actor with icon object.
+		$actor_url = 'https://example.com/users/testuser';
+		$actor_data = array(
+			'name'              => 'Test User',
+			'icon'              => array(
+				'type' => 'Image',
+				'url'  => 'https://secure.gravatar.com/avatar/example?s=120&d=mm&r=g',
+			),
+			'url'               => $actor_url,
+			'id'                => 'https://example.com/users/testuser',
+			'preferredUsername' => 'testuser',
+			'inbox'             => 'https://example.com/users/testuser/inbox',
+		);
+
+		// Mock the remote metadata call using the correct filter.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function ( $value, $actor ) use ( $actor_url, $actor_data ) {
+				if ( $actor === $actor_url ) {
+					return $actor_data;
+				}
+				return $value;
+			},
+			10,
+			2
+		);
+
+		// Add the actor first, then follow them.
+		$actor_post_id = \Activitypub\Collection\Actors::upsert( $actor_data );
+		$this->assertIsInt( $actor_post_id );
+		$this->assertGreaterThan( 0, $actor_post_id );
+
+		// Follow the actor using the proper method.
+		$result = Following_Collection::follow( $actor_post_id, get_current_user_id() );
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		// Use the real prepare_items() method.
+		$this->following_table->prepare_items();
+
+		// Verify we have items.
+		$this->assertNotEmpty( $this->following_table->items );
+
+		// Get the first item and test column_username.
+		$item = $this->following_table->items[0];
+		$result = $this->following_table->column_username( $item );
+
+		// Verify the icon URL was extracted from the object by object_to_uri() and properly rendered.
+		$this->assertStringContainsString( 'src="https://secure.gravatar.com/avatar/example?s=120&#038;d=mm&#038;r=g"', $result );
+
+		// Verify that the icon was processed correctly: from object to URL.
+		$this->assertEquals( 'https://secure.gravatar.com/avatar/example?s=120&d=mm&r=g', $item['icon'] );
+
+		// Clean up.
+		\remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		wp_delete_post( $actor_post_id, true );
+	}
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

See https://wordpress.org/support/topic/critical-error-on-this-website-on-followerspage-page-1-page-2-works/

## Proposed changes:
<!-- Explain what functional changes your PR includes -->
This PR adds comprehensive unit tests for the Followers and Following table classes in response to a critical error reported on the WordPress support forums where avatar data processing was failing with a TypeError.

### Changes made:
* Added unit tests for the Followers table class (`tests/includes/wp-admin/table/class-test-followers.php`)
* Added unit tests for the Following table class (`tests/includes/wp-admin/table/class-test-following.php`)
* Fixed icon processing in the Following table to use `object_to_uri()` consistently like the Followers table
* Tests specifically cover the `column_username` method with ActivityPub icon objects
* Tests use real `prepare_items()` methods and proper ActivityPub actor creation to verify the complete data flow

### Bug context:
The tests were created in response to [this WordPress support topic](https://wordpress.org/support/topic/critical-error-on-this-website-on-followerspage-page-1-page-2-works/) where users experienced a PHP Fatal TypeError with `ltrim()` when processing avatar data that was an array instead of a string. The tests ensure proper handling of ActivityPub actor icon objects throughout the data processing pipeline.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your change as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Running the new tests:
1. Ensure you have the WordPress test environment set up with `npm run env-start`
2. Run the specific new tests:
   ```bash
   npm run env-test -- --filter=test_column_username_with_icon_object
   ```
3. Or run all table tests:
   ```bash
   npm run env-test tests/includes/wp-admin/table/
   ```

### Verifying the fix:
1. The tests create real ActivityPub actors with icon objects (containing `type` and `url` properties)
2. They use the actual `prepare_items()` methods to process this data
3. The tests verify that icon objects are properly converted to URL strings using `object_to_uri()`
4. Tests confirm the final HTML output contains the correct escaped avatar URLs

### Manual testing (optional):
1. Set up followers with ActivityPub actors that have complex icon objects
2. Navigate to WP Admin → Users → Followers page
3. Verify that avatar images display correctly without PHP errors
4. Check that the Following page also processes avatars consistently

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

Add comprehensive unit tests for Followers and Following table classes with proper ActivityPub icon object handling.

</details>