### PR TITLE
Add default avatars for actors without icons in admin tables

### DIFF
--- a/.github/changelog/2106-from-description
+++ b/.github/changelog/2106-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add default avatars for actors without icons in admin tables

--- a/includes/wp-admin/table/class-blocked-actors.php
+++ b/includes/wp-admin/table/class-blocked-actors.php
@@ -231,14 +231,12 @@ class Blocked_Actors extends \WP_List_Table {
 				continue;
 			}
 
-			$url = object_to_uri( $actor->get_url() ?? $actor->get_id() );
-
 			$this->items[] = array(
 				'id'         => $blocked_actor_post->ID,
-				'icon'       => object_to_uri( $actor->get_icon() ?? '' ),
+				'icon'       => object_to_uri( $actor->get_icon() ?? ACTIVITYPUB_PLUGIN_URL . 'assets/img/mp.jpg' ),
 				'post_title' => $actor->get_name() ?? $actor->get_preferred_username(),
 				'username'   => $actor->get_preferred_username(),
-				'url'        => $url,
+				'url'        => object_to_uri( $actor->get_url() ?? $actor->get_id() ),
 				'webfinger'  => $this->get_webfinger( $actor ),
 				'identifier' => $actor->get_id(),
 				'modified'   => $blocked_actor_post->post_modified_gmt,

--- a/includes/wp-admin/table/class-followers.php
+++ b/includes/wp-admin/table/class-followers.php
@@ -275,19 +275,16 @@ class Followers extends \WP_List_Table {
 
 		foreach ( $followers as $follower ) {
 			$actor = Actors::get_actor( $follower );
-
 			if ( \is_wp_error( $actor ) ) {
 				continue;
 			}
 
-			$url = object_to_uri( $actor->get_url() ?? $actor->get_id() );
-
 			$this->items[] = array(
 				'id'         => $follower->ID,
-				'icon'       => object_to_uri( $actor->get_icon() ?? '' ),
+				'icon'       => object_to_uri( $actor->get_icon() ?? ACTIVITYPUB_PLUGIN_URL . 'assets/img/mp.jpg' ),
 				'post_title' => $actor->get_name() ?? $actor->get_preferred_username(),
 				'username'   => $actor->get_preferred_username(),
-				'url'        => $url,
+				'url'        => object_to_uri( $actor->get_url() ?? $actor->get_id() ),
 				'webfinger'  => $this->get_webfinger( $actor ),
 				'identifier' => $actor->get_id(),
 				'modified'   => $follower->post_modified_gmt,

--- a/includes/wp-admin/table/class-following.php
+++ b/includes/wp-admin/table/class-following.php
@@ -256,19 +256,16 @@ class Following extends \WP_List_Table {
 
 		foreach ( $followings as $following ) {
 			$actor = Actors::get_actor( $following );
-
 			if ( \is_wp_error( $actor ) ) {
 				continue;
 			}
 
-			$url = object_to_uri( $actor->get_url() ?? $actor->get_id() );
-
 			$this->items[] = array(
 				'id'         => $following->ID,
-				'icon'       => object_to_uri( $actor->get_icon() ?? '' ),
+				'icon'       => object_to_uri( $actor->get_icon() ?? ACTIVITYPUB_PLUGIN_URL . 'assets/img/mp.jpg' ),
 				'post_title' => $actor->get_name() ?? $actor->get_preferred_username(),
 				'username'   => $actor->get_preferred_username(),
-				'url'        => $url,
+				'url'        => object_to_uri( $actor->get_url() ?? $actor->get_id() ),
 				'webfinger'  => $this->get_webfinger( $actor ),
 				'status'     => Following_Collection::check_status( $this->user_id, $following->ID ),
 				'identifier' => $actor->get_id(),


### PR DESCRIPTION
Before | After
--- | ---
<img width="351" height="328" alt="Screenshot 2025-08-27 at 4 40 10 PM" src="https://github.com/user-attachments/assets/8082bd3f-335b-4f01-9ee1-39dc0581e407" /> | <img width="355" height="331" alt="Screenshot 2025-08-27 at 4 39 53 PM" src="https://github.com/user-attachments/assets/da03ed4b-534f-4297-add5-f765537e7445" />


## Proposed changes:
* Add default avatar fallback for actors without profile images in admin tables
* Update Followers, Following, and Blocked Actors tables to display consistent avatars
* Use existing default avatar (ACTIVITYPUB_PLUGIN_URL . 'assets/img/mp.jpg') from blocks
* Apply fallback during data preparation phase for cleaner, more maintainable code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Go to 'Users > Followers', 'Users > Following', or 'Users > Blocked Actors' 
* Look for actors that don't have profile images set
* Verify that these actors now display the default avatar instead of empty/broken images
* Check that actors with existing avatars continue to display correctly
* Test across different admin table views (Settings > ActivityPub tables as well)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Changed - for changes in existing functionality

#### Message

Add default avatars for actors without icons in admin tables

</details>