### PR TITLE
Application Actor: Set `manuallyApprovesFollowers` property to `true`

### DIFF
--- a/.github/changelog/2113-from-description
+++ b/.github/changelog/2113-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Improved ActivityPub compatibility by aligning with Mastodon’s Application Actor.

--- a/includes/activity/class-actor.php
+++ b/includes/activity/class-actor.php
@@ -27,6 +27,7 @@ class Actor extends Base_Object {
 			'schema'                    => 'http://schema.org#',
 			'toot'                      => 'http://joinmastodon.org/ns#',
 			'lemmy'                     => 'https://join-lemmy.org/ns#',
+			'litepub'                   => 'http://litepub.social/ns#',
 			'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
 			'PropertyValue'             => 'schema:PropertyValue',
 			'value'                     => 'schema:value',
@@ -63,6 +64,7 @@ class Actor extends Base_Object {
 			'postingRestrictedToMods'   => 'lemmy:postingRestrictedToMods',
 			'discoverable'              => 'toot:discoverable',
 			'indexable'                 => 'toot:indexable',
+			'invisible'                 => 'litepub:invisible',
 		),
 	);
 
@@ -312,4 +314,13 @@ class Actor extends Base_Object {
 	 * @var array
 	 */
 	protected $implements;
+
+	/**
+	 * Whether the User is invisible.
+	 *
+	 * @see https://litepub.social/
+	 *
+	 * @var boolean
+	 */
+	protected $invisible = null;
 }

--- a/includes/model/class-application.php
+++ b/includes/model/class-application.php
@@ -72,7 +72,7 @@ class Application extends Actor {
 	);
 
 	/**
-	 * Whether the Application is invisible.
+	 * Set Application as invisible.
 	 *
 	 * @see https://litepub.social/
 	 *
@@ -81,18 +81,25 @@ class Application extends Actor {
 	protected $invisible = true;
 
 	/**
-	 * Returns the type of the object.
+	 * The type of the Actor.
 	 *
-	 * @var string The type of the object.
+	 * @var string
 	 */
 	protected $type = 'Application';
 
 	/**
-	 * Get the Username.
+	 * The Username.
 	 *
-	 * @var string The Username.
+	 * @var string
 	 */
 	protected $name = 'application';
+
+	/**
+	 * The preferred username.
+	 *
+	 * @var string
+	 */
+	protected $preferred_username = 'application';
 
 	/**
 	 * Returns the ID of the Application.
@@ -119,15 +126,6 @@ class Application extends Actor {
 	 */
 	public function get_alternate_url() {
 		return $this->get_id();
-	}
-
-	/**
-	 * Get the preferred username.
-	 *
-	 * @return string The preferred username.
-	 */
-	public function get_preferred_username() {
-		return $this->get_name();
 	}
 
 	/**

--- a/includes/model/class-application.php
+++ b/includes/model/class-application.php
@@ -47,6 +47,17 @@ class Application extends Actor {
 	protected $indexable = false;
 
 	/**
+	 * Whether the Application manually approves followers.
+	 *
+	 * @see https://docs.joinmastodon.org/spec/activitypub/#as
+	 *
+	 * @context as:manuallyApprovesFollowers
+	 *
+	 * @var boolean
+	 */
+	protected $manually_approves_followers = true;
+
+	/**
 	 * List of software capabilities implemented by the Application.
 	 *
 	 * @see https://codeberg.org/silverpill/feps/src/branch/main/844e/fep-844e.md

--- a/includes/model/class-application.php
+++ b/includes/model/class-application.php
@@ -72,6 +72,15 @@ class Application extends Actor {
 	);
 
 	/**
+	 * Whether the Application is invisible.
+	 *
+	 * @see https://litepub.social/
+	 *
+	 * @var boolean
+	 */
+	protected $invisible = true;
+
+	/**
 	 * Returns the type of the object.
 	 *
 	 * @return string The type of the object.

--- a/includes/model/class-application.php
+++ b/includes/model/class-application.php
@@ -33,7 +33,7 @@ class Application extends Actor {
 	 *
 	 * @context http://joinmastodon.org/ns#discoverable
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $discoverable = false;
 
@@ -42,7 +42,7 @@ class Application extends Actor {
 	 *
 	 * @context http://joinmastodon.org/ns#indexable
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $indexable = false;
 
@@ -53,7 +53,7 @@ class Application extends Actor {
 	 *
 	 * @context as:manuallyApprovesFollowers
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $manually_approves_followers = true;
 
@@ -76,27 +76,23 @@ class Application extends Actor {
 	 *
 	 * @see https://litepub.social/
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $invisible = true;
 
 	/**
 	 * Returns the type of the object.
 	 *
-	 * @return string The type of the object.
+	 * @var string The type of the object.
 	 */
-	public function get_type() {
-		return 'Application';
-	}
+	protected $type = 'Application';
 
 	/**
-	 * Returns whether the Application manually approves followers.
+	 * Get the Username.
 	 *
-	 * @return true Whether the Application manually approves followers.
+	 * @var string The Username.
 	 */
-	public function get_manually_approves_followers() {
-		return true;
-	}
+	protected $name = 'application';
 
 	/**
 	 * Returns the ID of the Application.
@@ -123,15 +119,6 @@ class Application extends Actor {
 	 */
 	public function get_alternate_url() {
 		return $this->get_id();
-	}
-
-	/**
-	 * Get the Username.
-	 *
-	 * @return string The Username.
-	 */
-	public function get_name() {
-		return 'application';
 	}
 
 	/**


### PR DESCRIPTION
It seems that most of the ActivityPub platforms only support `Reject`s when `manuallyApprovesFollowers` is set to `true`.

I also [evaluated the `Application` Actors of other platforms](https://codeberg.org/fediverse/fep/src/branch/main/fep/2677/fep-2677.md#currently-implemented-application-actors) to check their configuration and discovered the `invisible` flag from the Litepub spec. I am not sure how well it is supported, but it might help to "hide" the Application user a bit more.

Introduces a new protected property, $manually_approves_followers, to the Application class to indicate whether the application manually approves followers. This aligns with the ActivityPub specification.

Align with Mastodons Application Actor: https://mastodon.social/actor

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set manuallyApprovesFollowers to true for the Application Actor to support rejection of follow requests
* Add support for the invisible property from the Litepub specification to improve Application Actor visibility control
* Introduce proper context mapping for the new Litepub namespace


### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load the Application Actors JSON and check if `manuallyApprovesFollowers` and `invisible` is set to `true`
* Load User Actor to see if `manuallyApprovesFollowers` is set to `false` and `invisible` is not added.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Improved ActivityPub compatibility by aligning with Mastodon’s Application Actor.

</details>
