### PR TITLE
Hide site-wide checkbox in block confirmations on ActivityPub settings

### DIFF
--- a/.github/changelog/2114-from-description
+++ b/.github/changelog/2114-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hide site-wide checkbox in block confirmations when accessed from ActivityPub settings page

--- a/templates/block-confirmation.php
+++ b/templates/block-confirmation.php
@@ -52,7 +52,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 		<p><?php esc_html_e( 'You can unblock this account later from your Blocked Actors list.', 'activitypub' ); ?></p>
 
-		<?php if ( current_user_can( 'manage_options' ) ) : ?>
+		<?php if ( current_user_can( 'manage_options' ) && get_current_screen()->id !== 'settings_page_activitypub' ) : ?>
 			<p>
 				<label>
 					<input type="checkbox" name="site_wide" value="1" />

--- a/templates/bulk-block-confirmation.php
+++ b/templates/bulk-block-confirmation.php
@@ -69,7 +69,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 		<p><?php esc_html_e( 'You can unblock these accounts later from your Blocked Actors list.', 'activitypub' ); ?></p>
 
-		<?php if ( current_user_can( 'manage_options' ) ) : ?>
+		<?php if ( current_user_can( 'manage_options' ) && get_current_screen()->id !== 'settings_page_activitypub' ) : ?>
 			<p>
 				<label>
 					<input type="checkbox" name="site_wide" value="1" />


### PR DESCRIPTION
<!--- Hide site-wide checkbox in block confirmations when accessed from ActivityPub settings -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide the site-wide blocking checkbox in block confirmation dialogs when accessed from the ActivityPub settings page
* Prevents redundant option since blocking from the ActivityPub settings already affects the blog actor site-wide
* Updated both `block-confirmation.php` and `bulk-block-confirmation.php` templates to check current screen ID

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- Testing the site-wide checkbox visibility based on context -->

* Go to 'Settings > ActivityPub > Followers tab'
* Try to block a follower from the list - confirm the site-wide checkbox is NOT displayed in the confirmation dialog
* Go to 'Users > Your Profile > Followers tab' (or any user's followers page if you're an admin)
* Try to block a follower from that list - confirm the site-wide checkbox IS displayed for users with manage_options capability
* Test bulk blocking from both contexts to ensure the checkbox behavior is consistent
* Verify that the actual blocking functionality works correctly in both contexts

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->
Hide site-wide checkbox in block confirmations when accessed from ActivityPub settings page

</details>