### PR TITLE
Tombstone: Add `remove` method

### DIFF
--- a/.github/changelog/2116-from-description
+++ b/.github/changelog/2116-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds support for virtual deletes and restores, allowing objects to be removed from the fediverse without being deleted locally.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -135,7 +135,7 @@ class Activitypub {
 			return $template;
 		}
 
-		if ( Tombstone::was_buried( Query::get_instance()->get_request_url() ) ) {
+		if ( Tombstone::exists_local( Query::get_instance()->get_request_url() ) ) {
 			\status_header( 410 );
 			return ACTIVITYPUB_PLUGIN_DIR . 'templates/tombstone-json.php';
 		}

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -135,7 +135,7 @@ class Activitypub {
 			return $template;
 		}
 
-		if ( Tombstone::exists_local( Query::get_instance()->get_request_url() ) ) {
+		if ( Tombstone::was_buried( Query::get_instance()->get_request_url() ) ) {
 			\status_header( 410 );
 			return ACTIVITYPUB_PLUGIN_DIR . 'templates/tombstone-json.php';
 		}

--- a/includes/class-tombstone.php
+++ b/includes/class-tombstone.php
@@ -219,12 +219,7 @@ class Tombstone {
 	 */
 	public static function exhume( $url ) {
 		$urls = \get_option( 'activitypub_tombstone_urls', array() );
-		$urls = \array_filter(
-			$urls,
-			function ( $_url ) use ( $url ) {
-				return normalize_url( $_url ) !== normalize_url( $url );
-			}
-		);
+		$urls = \array_diff( $urls, array( normalize_url( $url ) ) );
 		\update_option( 'activitypub_tombstone_urls', $urls );
 	}
 }

--- a/includes/class-tombstone.php
+++ b/includes/class-tombstone.php
@@ -211,13 +211,13 @@ class Tombstone {
 	/**
 	 * Remove a URL from the local tombstone registry.
 	 *
-	 * "Exhumes" a URL by removing it from the local tombstone URL registry.
+	 * Removes a URL from the local tombstone URL registry.
 	 * The URL is normalized before comparison to ensure consistent matching.
 	 * This marks the URL as no longer tombstoned for future local checks.
 	 *
 	 * @param string $url The URL to remove from the tombstone registry.
 	 */
-	public static function exhume( $url ) {
+	public static function remove( $url ) {
 		$urls = \get_option( 'activitypub_tombstone_urls', array() );
 		$urls = \array_diff( $urls, array( normalize_url( $url ) ) );
 		\update_option( 'activitypub_tombstone_urls', $urls );

--- a/includes/class-tombstone.php
+++ b/includes/class-tombstone.php
@@ -52,7 +52,7 @@ class Tombstone {
 
 		if ( \is_string( $various ) ) {
 			if ( is_same_domain( $various ) ) {
-				return self::exists_local( $various );
+				return self::was_buried( $various );
 			}
 			return self::exists_remote( $various );
 		}
@@ -111,7 +111,7 @@ class Tombstone {
 	 *
 	 * @return bool True if the local URL is in the tombstone registry, false otherwise.
 	 */
-	public static function exists_local( $url ) {
+	public static function was_buried( $url ) {
 		$urls = get_option( 'activitypub_tombstone_urls', array() );
 
 		return in_array( normalize_url( $url ), $urls, true );
@@ -205,6 +205,26 @@ class Tombstone {
 		$urls[] = normalize_url( $url );
 		$urls   = \array_unique( $urls );
 
+		\update_option( 'activitypub_tombstone_urls', $urls );
+	}
+
+	/**
+	 * Remove a URL from the local tombstone registry.
+	 *
+	 * "Exhumes" a URL by removing it from the local tombstone URL registry.
+	 * The URL is normalized before comparison to ensure consistent matching.
+	 * This marks the URL as no longer tombstoned for future local checks.
+	 *
+	 * @param string $url The URL to remove from the tombstone registry.
+	 */
+	public static function exhume( $url ) {
+		$urls = \get_option( 'activitypub_tombstone_urls', array() );
+		$urls = \array_filter(
+			$urls,
+			function ( $_url ) use ( $url ) {
+				return normalize_url( $_url ) !== normalize_url( $url );
+			}
+		);
 		\update_option( 'activitypub_tombstone_urls', $urls );
 	}
 }

--- a/includes/class-tombstone.php
+++ b/includes/class-tombstone.php
@@ -52,7 +52,7 @@ class Tombstone {
 
 		if ( \is_string( $various ) ) {
 			if ( is_same_domain( $various ) ) {
-				return self::was_buried( $various );
+				return self::exists_local( $various );
 			}
 			return self::exists_remote( $various );
 		}
@@ -111,7 +111,7 @@ class Tombstone {
 	 *
 	 * @return bool True if the local URL is in the tombstone registry, false otherwise.
 	 */
-	public static function was_buried( $url ) {
+	public static function exists_local( $url ) {
 		$urls = get_option( 'activitypub_tombstone_urls', array() );
 
 		return in_array( normalize_url( $url ), $urls, true );

--- a/tests/includes/class-test-tombstone.php
+++ b/tests/includes/class-test-tombstone.php
@@ -164,7 +164,8 @@ class Test_Tombstone extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Response code is 404 -> is_tombstone returns true
+	 * Tests that the exhume method removes a URL from the tombstone list,
+	 * so that was_buried returns false after exhuming.
 	 *
 	 * @covers ::exhume
 	 */

--- a/tests/includes/class-test-tombstone.php
+++ b/tests/includes/class-test-tombstone.php
@@ -164,12 +164,12 @@ class Test_Tombstone extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the exhume method removes a URL from the tombstone list,
-	 * so that was_buried returns false after exhuming.
+	 * Tests that the remove method removes a URL from the tombstone list,
+	 * so that was_buried returns false after removing.
 	 *
-	 * @covers ::exhume
+	 * @covers ::remove
 	 */
-	public function test_exhume() {
+	public function test_remove() {
 		$url = 'https://fake.test/object/123';
 
 		Tombstone::bury( $url );
@@ -177,7 +177,7 @@ class Test_Tombstone extends \WP_UnitTestCase {
 		$response = Tombstone::was_buried( $url );
 		$this->assertTrue( $response );
 
-		Tombstone::exhume( $url );
+		Tombstone::remove( $url );
 
 		$response = Tombstone::was_buried( $url );
 		$this->assertFalse( $response );

--- a/tests/includes/class-test-tombstone.php
+++ b/tests/includes/class-test-tombstone.php
@@ -147,19 +147,38 @@ class Test_Tombstone extends \WP_UnitTestCase {
 	/**
 	 * Response code is 404 -> is_tombstone returns true
 	 *
-	 * @covers ::exists_local
+	 * @covers ::was_buried
 	 */
-	public function test_exists_local() {
+	public function test_was_buried() {
 		$url = 'https://fake.test/object/123';
 
-		$response = Tombstone::exists_local( $url );
+		$response = Tombstone::was_buried( $url );
 		$this->assertFalse( $response );
 
 		Tombstone::bury( $url );
 
-		$response = Tombstone::exists_local( $url );
+		$response = Tombstone::was_buried( $url );
 		$this->assertTrue( $response );
 
 		\delete_option( 'activitypub_tombstone_urls' );
+	}
+
+	/**
+	 * Response code is 404 -> is_tombstone returns true
+	 *
+	 * @covers ::exhume
+	 */
+	public function test_exhume() {
+		$url = 'https://fake.test/object/123';
+
+		Tombstone::bury( $url );
+
+		$response = Tombstone::was_buried( $url );
+		$this->assertTrue( $response );
+
+		Tombstone::exhume( $url );
+
+		$response = Tombstone::was_buried( $url );
+		$this->assertFalse( $response );
 	}
 }

--- a/tests/includes/class-test-tombstone.php
+++ b/tests/includes/class-test-tombstone.php
@@ -147,17 +147,17 @@ class Test_Tombstone extends \WP_UnitTestCase {
 	/**
 	 * Response code is 404 -> is_tombstone returns true
 	 *
-	 * @covers ::was_buried
+	 * @covers ::exists_local
 	 */
-	public function test_was_buried() {
+	public function test_exists_local() {
 		$url = 'https://fake.test/object/123';
 
-		$response = Tombstone::was_buried( $url );
+		$response = Tombstone::exists_local( $url );
 		$this->assertFalse( $response );
 
 		Tombstone::bury( $url );
 
-		$response = Tombstone::was_buried( $url );
+		$response = Tombstone::exists_local( $url );
 		$this->assertTrue( $response );
 
 		\delete_option( 'activitypub_tombstone_urls' );
@@ -165,7 +165,7 @@ class Test_Tombstone extends \WP_UnitTestCase {
 
 	/**
 	 * Tests that the remove method removes a URL from the tombstone list,
-	 * so that was_buried returns false after removing.
+	 * so that exists_local returns false after removing.
 	 *
 	 * @covers ::remove
 	 */
@@ -174,12 +174,12 @@ class Test_Tombstone extends \WP_UnitTestCase {
 
 		Tombstone::bury( $url );
 
-		$response = Tombstone::was_buried( $url );
+		$response = Tombstone::exists_local( $url );
 		$this->assertTrue( $response );
 
 		Tombstone::remove( $url );
 
-		$response = Tombstone::was_buried( $url );
+		$response = Tombstone::exists_local( $url );
 		$this->assertFalse( $response );
 	}
 }


### PR DESCRIPTION
~Renames the `Tombstone::exists_local` method to `Tombstone::was_buried` for clarity and updates all references accordingly. Adds a new `Tombstone::exhume` method to remove URLs from the local tombstone registry. Updates and expands tests to cover the new method and renamed functionality.~

~The renaming aligns with the `bury` function, since `exists_local` literally checks whether something is buried.~

This PR lays the groundwork for virtual deletes and undeletes. In practice, that means an object will be removed from the fediverse but remain locally. A potential use case is removing the `activitypub` capability from a user.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* ~Renames Tombstone::exists_local() to Tombstone::was_buried() for better semantic alignment with the bury() method~
* Adds new Tombstone::remove() method to remove URLs from the tombstone registry
* ~Updates all references to use the renamed method and adds comprehensive test coverage~

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See unit-tests

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Adds support for virtual deletes and restores, allowing objects to be removed from the fediverse without being deleted locally.

</details>
