### PR TITLE
Prevent notifications to Application user in new_follower

### DIFF
--- a/.github/changelog/2117-from-description
+++ b/.github/changelog/2117-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stopp sending follow notifications to the Application user, since system-level accounts cannot be followed.

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -126,6 +126,11 @@ class Mailer {
 	 * @param int   $user_id  The id of the local blog-user.
 	 */
 	public static function new_follower( $activity, $user_id ) {
+		// Do not send notifications to the Application user.
+		if ( Actors::APPLICATION_USER_ID === $user_id ) {
+			return;
+		}
+
 		if ( $user_id > Actors::BLOG_USER_ID ) {
 			if ( ! \get_user_option( 'activitypub_mailer_new_follower', $user_id ) ) {
 				return;


### PR DESCRIPTION
Added a check in `Mailer::new_follower` to skip sending notifications if the recipient is the Application user. This prevents unnecessary or unintended notifications to system-level users.

It is not possible to follow the Application Actor, so there is no need to send `follow` notifications.

## Proposed changes:
- Added a guard clause in the `new_follower` method to skip notifications for the Application user
- Uses the existing `Actors::APPLICATION_USER_ID` constant for the check

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the Application user on Mastodon and check for follow E-Mails.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Stopp sending follow notifications to the Application user, since system-level accounts cannot be followed.

</details>
