### PR TITLE
Fix query args preservation in collection pagination links

### DIFF
--- a/.github/changelog/2120-from-description
+++ b/.github/changelog/2120-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix query args preservation in collection pagination links

--- a/includes/rest/trait-collection.php
+++ b/includes/rest/trait-collection.php
@@ -27,8 +27,7 @@ trait Collection {
 	 */
 	public function prepare_collection_response( $response, $request ) {
 		$page      = $request->get_param( 'page' );
-		$per_page  = $request->get_param( 'per_page' );
-		$max_pages = \ceil( $response['totalItems'] / $per_page );
+		$max_pages = \ceil( $response['totalItems'] / $request->get_param( 'per_page' ) );
 
 		if ( $page > $max_pages ) {
 			return new \WP_Error(
@@ -43,6 +42,7 @@ trait Collection {
 			return $response;
 		}
 
+		$response['id']    = \add_query_arg( $request->get_query_params(), $response['id'] );
 		$response['first'] = \add_query_arg( 'page', 1, $response['id'] );
 		$response['last']  = \add_query_arg( 'page', $max_pages, $response['id'] );
 
@@ -56,7 +56,7 @@ trait Collection {
 
 		// Still here, so this is a Page request. Append the type.
 		$response['type']  .= 'Page';
-		$response['partOf'] = $response['id'];
+		$response['partOf'] = \remove_query_arg( 'page', $response['id'] );
 		$response['id']     = \add_query_arg( 'page', $page, $response['id'] );
 
 		if ( $max_pages > $page ) {

--- a/includes/rest/trait-collection.php
+++ b/includes/rest/trait-collection.php
@@ -57,14 +57,14 @@ trait Collection {
 		// Still here, so this is a Page request. Append the type.
 		$response['type']  .= 'Page';
 		$response['partOf'] = $response['id'];
-		$response['id']    .= '?page=' . $page;
+		$response['id']     = \add_query_arg( 'page', $page, $response['id'] );
 
 		if ( $max_pages > $page ) {
-			$response['next'] = \add_query_arg( 'page', $page + 1, $response['id'] );
+			$response['next'] = \add_query_arg( 'page', $page + 1, $response['partOf'] );
 		}
 
 		if ( $page > 1 ) {
-			$response['prev'] = \add_query_arg( 'page', $page - 1, $response['id'] );
+			$response['prev'] = \add_query_arg( 'page', $page - 1, $response['partOf'] );
 		}
 
 		return $response;

--- a/includes/rest/trait-collection.php
+++ b/includes/rest/trait-collection.php
@@ -57,7 +57,6 @@ trait Collection {
 		// Still here, so this is a Page request. Append the type.
 		$response['type']  .= 'Page';
 		$response['partOf'] = \remove_query_arg( 'page', $response['id'] );
-		$response['id']     = \add_query_arg( 'page', $page, $response['id'] );
 
 		if ( $max_pages > $page ) {
 			$response['next'] = \add_query_arg( 'page', $page + 1, $response['partOf'] );

--- a/tests/includes/rest/class-test-trait-collection.php
+++ b/tests/includes/rest/class-test-trait-collection.php
@@ -80,8 +80,8 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'Collection', $result['type'] );
-		$this->assertEquals( 'https://example.org/collection?page=1', $result['first'] );
-		$this->assertEquals( 'https://example.org/collection?page=3', $result['last'] );
+		$this->assertEquals( 'https://example.org/collection?per_page=10&page=1', $result['first'] );
+		$this->assertEquals( 'https://example.org/collection?per_page=10&page=3', $result['last'] );
 		$this->assertArrayNotHasKey( 'items', $result );
 		$this->assertArrayNotHasKey( 'orderedItems', $result );
 	}
@@ -106,12 +106,12 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'CollectionPage', $result['type'] );
-		$this->assertEquals( 'https://example.org/collection', $result['partOf'] );
-		$this->assertEquals( 'https://example.org/collection?page=2', $result['id'] );
-		$this->assertEquals( 'https://example.org/collection?page=1', $result['first'] );
-		$this->assertEquals( 'https://example.org/collection?page=3', $result['last'] );
-		$this->assertEquals( 'https://example.org/collection?page=3', $result['next'] );
-		$this->assertEquals( 'https://example.org/collection?page=1', $result['prev'] );
+		$this->assertEquals( 'https://example.org/collection?per_page=10', $result['partOf'] );
+		$this->assertEquals( 'https://example.org/collection?page=2&per_page=10', $result['id'] );
+		$this->assertEquals( 'https://example.org/collection?page=1&per_page=10', $result['first'] );
+		$this->assertEquals( 'https://example.org/collection?page=3&per_page=10', $result['last'] );
+		$this->assertEquals( 'https://example.org/collection?per_page=10&page=3', $result['next'] );
+		$this->assertEquals( 'https://example.org/collection?per_page=10&page=1', $result['prev'] );
 	}
 
 	/**
@@ -134,8 +134,8 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'OrderedCollectionPage', $result['type'] );
-		$this->assertEquals( 'https://example.org/collection?page=1', $result['id'] );
-		$this->assertEquals( 'https://example.org/collection?page=2', $result['next'] );
+		$this->assertEquals( 'https://example.org/collection?page=1&per_page=10', $result['id'] );
+		$this->assertEquals( 'https://example.org/collection?per_page=10&page=2', $result['next'] );
 		$this->assertArrayNotHasKey( 'prev', $result );
 	}
 
@@ -159,8 +159,8 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'CollectionPage', $result['type'] );
-		$this->assertEquals( 'https://example.org/collection?page=3', $result['id'] );
-		$this->assertEquals( 'https://example.org/collection?page=2', $result['prev'] );
+		$this->assertEquals( 'https://example.org/collection?page=3&per_page=10', $result['id'] );
+		$this->assertEquals( 'https://example.org/collection?per_page=10&page=2', $result['prev'] );
 		$this->assertArrayNotHasKey( 'next', $result );
 	}
 
@@ -211,7 +211,7 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 
 		$response = array(
 			'type'         => 'OrderedCollection',
-			'id'           => 'https://example.org/collection?context=full&order=asc',
+			'id'           => 'https://example.org/collection',
 			'totalItems'   => 35,
 			'orderedItems' => array( 'item11', 'item12', 'item13' ),
 		);
@@ -219,24 +219,64 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 		$result = $this->instance->prepare_collection_response( $response, $request );
 
 		$this->assertEquals( 'OrderedCollectionPage', $result['type'] );
-		$this->assertEquals( 'https://example.org/collection?context=full&order=asc', $result['partOf'] );
-		$this->assertEquals( 'https://example.org/collection?context=full&order=asc&page=2', $result['id'] );
+		$this->assertEquals( 'https://example.org/collection?per_page=10&context=full&order=asc', $result['partOf'] );
+		$this->assertEquals( 'https://example.org/collection?page=2&per_page=10&context=full&order=asc', $result['id'] );
 
 		// Check that query parameters are preserved in pagination links.
 		$this->assertStringContainsString( 'context=full', $result['first'] );
 		$this->assertStringContainsString( 'order=asc', $result['first'] );
+		$this->assertStringContainsString( 'per_page=10', $result['first'] );
 		$this->assertStringContainsString( 'page=1', $result['first'] );
 
 		$this->assertStringContainsString( 'context=full', $result['last'] );
 		$this->assertStringContainsString( 'order=asc', $result['last'] );
+		$this->assertStringContainsString( 'per_page=10', $result['last'] );
 		$this->assertStringContainsString( 'page=4', $result['last'] );
 
 		$this->assertStringContainsString( 'context=full', $result['next'] );
 		$this->assertStringContainsString( 'order=asc', $result['next'] );
+		$this->assertStringContainsString( 'per_page=10', $result['next'] );
 		$this->assertStringContainsString( 'page=3', $result['next'] );
 
 		$this->assertStringContainsString( 'context=full', $result['prev'] );
 		$this->assertStringContainsString( 'order=asc', $result['prev'] );
+		$this->assertStringContainsString( 'per_page=10', $result['prev'] );
 		$this->assertStringContainsString( 'page=1', $result['prev'] );
+	}
+
+	/**
+	 * Test that pagination links preserve query parameters for Collection (non-page) requests.
+	 *
+	 * @covers ::prepare_collection_response
+	 */
+	public function test_prepare_collection_response_preserves_query_args_for_collection() {
+		$request = new \WP_REST_Request();
+		$request->set_param( 'per_page', 2 );
+		$request->set_param( 'context', 'full' );
+		$request->set_param( 'order', 'desc' );
+
+		$response = array(
+			'type'       => 'OrderedCollection',
+			'id'         => 'https://example.org/collection',
+			'totalItems' => 5,
+			'items'      => array( 'item1', 'item2', 'item3', 'item4', 'item5' ),
+		);
+
+		$result = $this->instance->prepare_collection_response( $response, $request );
+
+		$this->assertEquals( 'OrderedCollection', $result['type'] );
+		$this->assertArrayNotHasKey( 'items', $result );
+		$this->assertArrayNotHasKey( 'orderedItems', $result );
+
+		// Check that query parameters are preserved in first and last links.
+		$this->assertStringContainsString( 'context=full', $result['first'] );
+		$this->assertStringContainsString( 'order=desc', $result['first'] );
+		$this->assertStringContainsString( 'per_page=2', $result['first'] );
+		$this->assertStringContainsString( 'page=1', $result['first'] );
+
+		$this->assertStringContainsString( 'context=full', $result['last'] );
+		$this->assertStringContainsString( 'order=desc', $result['last'] );
+		$this->assertStringContainsString( 'per_page=2', $result['last'] );
+		$this->assertStringContainsString( 'page=3', $result['last'] );
 	}
 }

--- a/tests/includes/rest/class-test-trait-collection.php
+++ b/tests/includes/rest/class-test-trait-collection.php
@@ -210,9 +210,9 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 		$request->set_param( 'order', 'asc' );
 
 		$response = array(
-			'type'       => 'OrderedCollection',
-			'id'         => 'https://example.org/collection?context=full&order=asc',
-			'totalItems' => 35,
+			'type'         => 'OrderedCollection',
+			'id'           => 'https://example.org/collection?context=full&order=asc',
+			'totalItems'   => 35,
 			'orderedItems' => array( 'item11', 'item12', 'item13' ),
 		);
 

--- a/tests/includes/rest/class-test-trait-collection.php
+++ b/tests/includes/rest/class-test-trait-collection.php
@@ -196,4 +196,47 @@ class Test_Trait_Collection extends \WP_UnitTestCase {
 		$this->assertEquals( 'rest_post_invalid_page_number', $result->get_error_code() );
 		$this->assertEquals( 400, $result->get_error_data()['status'] );
 	}
+
+	/**
+	 * Test that pagination links preserve query parameters from original request.
+	 *
+	 * @covers ::prepare_collection_response
+	 */
+	public function test_prepare_collection_response_preserves_query_args() {
+		$request = new \WP_REST_Request();
+		$request->set_param( 'page', 2 );
+		$request->set_param( 'per_page', 10 );
+		$request->set_param( 'context', 'full' );
+		$request->set_param( 'order', 'asc' );
+
+		$response = array(
+			'type'       => 'OrderedCollection',
+			'id'         => 'https://example.org/collection?context=full&order=asc',
+			'totalItems' => 35,
+			'orderedItems' => array( 'item11', 'item12', 'item13' ),
+		);
+
+		$result = $this->instance->prepare_collection_response( $response, $request );
+
+		$this->assertEquals( 'OrderedCollectionPage', $result['type'] );
+		$this->assertEquals( 'https://example.org/collection?context=full&order=asc', $result['partOf'] );
+		$this->assertEquals( 'https://example.org/collection?context=full&order=asc&page=2', $result['id'] );
+
+		// Check that query parameters are preserved in pagination links.
+		$this->assertStringContainsString( 'context=full', $result['first'] );
+		$this->assertStringContainsString( 'order=asc', $result['first'] );
+		$this->assertStringContainsString( 'page=1', $result['first'] );
+
+		$this->assertStringContainsString( 'context=full', $result['last'] );
+		$this->assertStringContainsString( 'order=asc', $result['last'] );
+		$this->assertStringContainsString( 'page=4', $result['last'] );
+
+		$this->assertStringContainsString( 'context=full', $result['next'] );
+		$this->assertStringContainsString( 'order=asc', $result['next'] );
+		$this->assertStringContainsString( 'page=3', $result['next'] );
+
+		$this->assertStringContainsString( 'context=full', $result['prev'] );
+		$this->assertStringContainsString( 'order=asc', $result['prev'] );
+		$this->assertStringContainsString( 'page=1', $result['prev'] );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

See https://wordpress.org/support/topic/follower-are-not-displayed-in-follower-list/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix pagination links in REST API collections to preserve query parameters from original requests
* Add comprehensive test coverage for query parameter preservation in pagination links

### Before:

**Request:**
`https://obietester.blog/wp-json/activitypub/1.0/actors/0/followers?context=full&per_page=2`

**Result:**
```json
{
	"@context": [
		"https://www.w3.org/ns/activitystreams"
	],
	"id": "https://obietester.blog/wp-json/activitypub/1.0/actors/0/followers",
	"generator": "https://wordpress.org/?v=6.8",
	"type": "OrderedCollection",
	"totalItems": 5,
	"first": "https://obietester.blog/wp-json/activitypub/1.0/actors/0/followers?page=1",
	"last": "https://obietester.blog/wp-json/activitypub/1.0/actors/0/followers?page=3"
}
```


### After:

**Request:**
`https://obietester.blog/wp-json/activitypub/1.0/actors/0/followers?context=full&per_page=2`

**Result:**
```json
{
	"@context": [
		"https://www.w3.org/ns/activitystreams"
	],
	"id": "https://obietester.blog/wp-json/activitypub/1.0/actors/0/followers?context=full&per_page=2",
	"generator": "https://wordpress.org/?v=6.8",
	"type": "OrderedCollection",
	"totalItems": 5,
	"first": "https://obietester.blog/wp-json/activitypub/1.0/actors/0/followers?context=full&per_page=2&page=1",
	"last": "https://obietester.blog/wp-json/activitypub/1.0/actors/0/followers?context=full&per_page=2&page=3"
}
```

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `npm run env-test -- --filter=Test_Trait_Collection` to verify all collection tests pass
* Test followers endpoint with query parameters: `/wp-json/activitypub/1.0/actors/0/followers?context=full&page=1`
* Verify that pagination links (`first`, `last`, `next`, `prev`) preserve the `context=full` parameter
* Before fix: pagination links would be malformed like `?page=1?context=full` or missing query args
* After fix: pagination links properly preserve all query parameters using `add_query_arg()`

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->
Fix query args preservation in collection pagination links

</details>