### PR TITLE
Add activitypub_json REST field for ap_actor posts

### DIFF
--- a/.github/changelog/2121-from-description
+++ b/.github/changelog/2121-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add activitypub_json REST field for ap_actor posts to access raw JSON data

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -31,6 +31,8 @@ class Activitypub {
 		\add_action( 'init', array( self::class, 'register_post_types' ), 11 );
 		\add_action( 'init', array( self::class, 'register_oembed_providers' ), 11 );
 
+		\add_action( 'rest_api_init', array( self::class, 'register_ap_actor_rest_field' ) );
+
 		\add_filter( 'template_include', array( self::class, 'render_activitypub_template' ), 99 );
 		\add_action( 'template_redirect', array( self::class, 'template_redirect' ) );
 		\add_filter( 'redirect_canonical', array( self::class, 'redirect_canonical' ), 10, 2 );
@@ -799,9 +801,6 @@ class Activitypub {
 
 		\register_post_type( Extra_Fields::USER_POST_TYPE, $extra_field_args );
 		\register_post_type( Extra_Fields::BLOG_POST_TYPE, $extra_field_args );
-
-		// Register REST field for ap_actor posts.
-		\add_action( 'rest_api_init', array( self::class, 'register_ap_actor_rest_field' ) );
 
 		/**
 		 * Fires after ActivityPub custom post types have been registered.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -800,10 +800,39 @@ class Activitypub {
 		\register_post_type( Extra_Fields::USER_POST_TYPE, $extra_field_args );
 		\register_post_type( Extra_Fields::BLOG_POST_TYPE, $extra_field_args );
 
+		// Register REST field for ap_actor posts.
+		\add_action( 'rest_api_init', array( self::class, 'register_ap_actor_rest_field' ) );
+
 		/**
 		 * Fires after ActivityPub custom post types have been registered.
 		 */
 		\do_action( 'activitypub_after_register_post_type' );
+	}
+
+	/**
+	 * Register REST field for ap_actor posts.
+	 */
+	public static function register_ap_actor_rest_field() {
+		\register_rest_field(
+			Actors::POST_TYPE,
+			'activitypub_json',
+			array(
+				/**
+				 * Get the raw post content without WordPress content filtering.
+				 *
+				 * @param array $response Prepared response array.
+				 * @return string The raw post content.
+				 */
+				'get_callback' => function ( $response ) {
+					return \get_post_field( 'post_content', $response['id'] );
+				},
+				'schema'       => array(
+					'description' => 'Raw ActivityPub JSON data without WordPress content filtering',
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes debugging issues with corrupted ActivityPub JSON data in REST API responses.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `activitypub_json` REST field to ap_actor post type that exposes raw post_content without WordPress content filtering
* Register the field alongside post type registration for better code organization
* Provide developers with access to original JSON data for debugging purposes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create or find an ap_actor post with JSON content in the database
* Make a GET request to `/wp-json/wp/v2/ap_actor/{id}`  
* Verify the response includes an `activitypub_json` field containing the raw JSON string
* Compare with the `content.rendered` field to see the difference between raw and processed content
* Verify the `activitypub_json` field contains valid, parseable JSON without HTML entities or escaped characters

### Example comparison

**Before (content.rendered):** Shows corrupted JSON with HTML entities:
```
"content": {
  "rendered": "<p>{&#8222;@context&#8220;:[&#8222;https:\\\/\\\/www.w3.org..."
}
```

**After (activitypub_json):** Shows clean, parseable JSON:
```
"activitypub_json": "{\"@context\":[\"https://www.w3.org/ns/activitystreams\"..."
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->
Add activitypub_json REST field for ap_actor posts to access raw JSON data

</details>