### PR TITLE
Add Yoast SEO integration for media pages site health check

### DIFF
--- a/.github/changelog/2136-from-description
+++ b/.github/changelog/2136-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Yoast SEO integration for media pages site health check

--- a/integration/class-yoast-seo.php
+++ b/integration/class-yoast-seo.php
@@ -29,7 +29,7 @@ class Yoast_Seo {
 	public static function add_site_health_tests( $tests ) {
 		// Only add the test if attachment post type is supported by ActivityPub.
 		if ( self::is_attachment_supported() ) {
-			$tests['direct']['activitypub_yoast_media_pages'] = array(
+			$tests['direct']['activitypub_yoast_seo_media_pages'] = array(
 				'label' => \__( 'Yoast SEO Media Pages Test', 'activitypub' ),
 				'test'  => array( self::class, 'test_yoast_seo_media_pages' ),
 			);

--- a/integration/class-yoast-seo.php
+++ b/integration/class-yoast-seo.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Yoast SEO integration file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Integration;
+
+/**
+ * Yoast SEO integration class.
+ */
+class Yoast_Seo {
+
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_filter( 'site_status_tests', array( self::class, 'add_site_health_tests' ) );
+	}
+
+	/**
+	 * Add Yoast-specific site health tests.
+	 *
+	 * @param array $tests The site health tests array.
+	 *
+	 * @return array The modified tests array.
+	 */
+	public static function add_site_health_tests( $tests ) {
+		// Only add the test if attachment post type is supported by ActivityPub.
+		if ( self::is_attachment_supported() ) {
+			$tests['direct']['activitypub_yoast_media_pages'] = array(
+				'label' => \__( 'Yoast SEO Media Pages Test', 'activitypub' ),
+				'test'  => array( self::class, 'test_yoast_seo_media_pages' ),
+			);
+		}
+
+		return $tests;
+	}
+
+	/**
+	 * Test if Yoast's "Enable media pages" setting is properly configured.
+	 *
+	 * @return array The test result.
+	 */
+	public static function test_yoast_seo_media_pages() {
+		$result = array(
+			'label'       => \__( 'Yoast SEO media pages are enabled', 'activitypub' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => \__( 'ActivityPub', 'activitypub' ),
+				'color' => 'green',
+			),
+			'description' => \sprintf(
+				'<p>%s</p>',
+				\__( 'Media pages are enabled in Yoast SEO, which allows media attachments to be federated and interacted with through ActivityPub.', 'activitypub' )
+			),
+			'actions'     => '',
+			'test'        => 'test_yoast_seo_media_pages',
+		);
+
+		if ( self::is_media_pages_disabled() ) {
+			$result['status']         = 'recommended';
+			$result['label']          = \__( 'Yoast SEO media pages should be enabled', 'activitypub' );
+			$result['badge']['color'] = 'orange';
+			$result['description']    = \sprintf(
+				'<p>%s</p>',
+				\__( 'Yoast SEO&#8217;s &#8220;Enable media pages&#8221; setting is currently disabled. Since you have media attachments configured to be federated through ActivityPub, you should enable media pages so that media can be properly accessed and interacted with by ActivityPub clients and other federated platforms.', 'activitypub' )
+			);
+			$result['actions']        = \sprintf(
+				'<p>%s</p>',
+				\sprintf(
+					// translators: %s: Yoast SEO settings URL.
+					\__( 'You can enable media pages in <a href="%s">Yoast SEO > Settings > Advanced > Media pages</a>.', 'activitypub' ),
+					\esc_url( \admin_url( 'admin.php?page=wpseo_page_settings#/media-pages' ) )
+				)
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Check if Yoast SEO media pages are disabled.
+	 *
+	 * @return bool True if media pages are disabled, false otherwise.
+	 */
+	public static function is_media_pages_disabled() {
+		// Get Yoast SEO options.
+		$yoast_options = \get_option( 'wpseo_titles' );
+
+		if ( ! is_array( $yoast_options ) ) {
+			return false;
+		}
+
+		// Check if disable-attachment is set to true (media pages disabled).
+		return isset( $yoast_options['disable-attachment'] ) && true === $yoast_options['disable-attachment'];
+	}
+
+	/**
+	 * Check if attachment post type is supported by ActivityPub.
+	 *
+	 * @return bool True if attachment is supported, false otherwise.
+	 */
+	private static function is_attachment_supported() {
+		$supported_post_types = \get_option( 'activitypub_support_post_types', array( 'post' ) );
+		return in_array( 'attachment', $supported_post_types, true );
+	}
+}

--- a/integration/load.php
+++ b/integration/load.php
@@ -128,6 +128,17 @@ function plugin_init() {
 	}
 
 	/**
+	 * Adds Yoast SEO support.
+	 *
+	 * This class handles the compatibility with Yoast SEO.
+	 *
+	 * @see https://wordpress.org/plugins/wordpress-seo/
+	 */
+	if ( \defined( 'WPSEO_VERSION' ) ) {
+		Yoast_Seo::init();
+	}
+
+	/**
 	 * Load the Surge integration.
 	 *
 	 * Only load code that needs Surge to run once Surge is loaded and initialized.

--- a/tests/integration/class-test-yoast-seo.php
+++ b/tests/integration/class-test-yoast-seo.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Test Yoast SEO integration.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Integration;
+
+use Activitypub\Integration\Yoast_Seo;
+
+/**
+ * Test the Yoast integration.
+ *
+ * @group integration
+ * @coversDefaultClass \Activitypub\Integration\Yoast_Seo
+ */
+class Test_Yoast_Seo extends \WP_UnitTestCase {
+
+	/**
+	 * Test that Yoast SEO integration adds site health tests when attachment is supported.
+	 */
+	public function test_yoast_seo_site_health_test_registration_with_attachment_support() {
+		// Simulate Yoast being active.
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			define( 'WPSEO_VERSION', '20.0' );
+		}
+
+		// Add attachment to supported post types.
+		\update_option( 'activitypub_support_post_types', array( 'post', 'attachment' ) );
+
+		// Initialize the Yoast integration.
+		Yoast_Seo::init();
+
+		// Get site health tests.
+		$tests = \apply_filters( 'site_status_tests', array() );
+
+		// Check if our test is registered.
+		$this->assertArrayHasKey( 'direct', $tests );
+		$this->assertArrayHasKey( 'activitypub_yoast_media_pages', $tests['direct'] );
+		$this->assertEquals( 'Yoast SEO Media Pages Test', $tests['direct']['activitypub_yoast_media_pages']['label'] );
+	}
+
+	/**
+	 * Test that Yoast SEO integration does not add site health tests when attachment is not supported.
+	 */
+	public function test_yoast_seo_site_health_test_not_registered_without_attachment_support() {
+		// Simulate Yoast being active.
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			define( 'WPSEO_VERSION', '20.0' );
+		}
+
+		// Remove attachment from supported post types.
+		\update_option( 'activitypub_support_post_types', array( 'post' ) );
+
+		// Initialize the Yoast integration.
+		Yoast_Seo::init();
+
+		// Get site health tests.
+		$tests = \apply_filters( 'site_status_tests', array( 'direct' => array() ) );
+
+		// Check if our test is NOT registered.
+		$this->assertArrayNotHasKey( 'activitypub_yoast_media_pages', $tests['direct'] );
+	}
+
+	/**
+	 * Test media pages disabled check.
+	 */
+	public function test_is_media_pages_disabled() {
+		// Test with media pages enabled (default WordPress behavior).
+		\update_option( 'wpseo_titles', array( 'disable-attachment' => false ) );
+		$this->assertFalse( Yoast_Seo::is_media_pages_disabled() );
+
+		// Test with media pages disabled (recommended setting).
+		\update_option( 'wpseo_titles', array( 'disable-attachment' => true ) );
+		$this->assertTrue( Yoast_Seo::is_media_pages_disabled() );
+
+		// Test with no Yoast options.
+		\delete_option( 'wpseo_titles' );
+		$this->assertFalse( Yoast_Seo::is_media_pages_disabled() );
+	}
+
+	/**
+	 * Test the site health test execution.
+	 */
+	public function test_yoast_media_pages_site_health_test() {
+		// Test when media pages are properly enabled (good status for ActivityPub).
+		\update_option( 'wpseo_titles', array( 'disable-attachment' => false ) );
+		$result = Yoast_Seo::test_yoast_seo_media_pages();
+
+		$this->assertEquals( 'good', $result['status'] );
+		$this->assertEquals( 'Yoast SEO media pages are enabled', $result['label'] );
+		$this->assertEquals( 'green', $result['badge']['color'] );
+
+		// Test when media pages are disabled (recommended status to enable them).
+		\update_option( 'wpseo_titles', array( 'disable-attachment' => true ) );
+		$result = Yoast_Seo::test_yoast_seo_media_pages();
+
+		$this->assertEquals( 'recommended', $result['status'] );
+		$this->assertEquals( 'Yoast SEO media pages should be enabled', $result['label'] );
+		$this->assertEquals( 'orange', $result['badge']['color'] );
+		$this->assertStringContainsString( 'Yoast SEO > Settings', $result['actions'] );
+	}
+}

--- a/tests/integration/class-test-yoast-seo.php
+++ b/tests/integration/class-test-yoast-seo.php
@@ -37,8 +37,8 @@ class Test_Yoast_Seo extends \WP_UnitTestCase {
 
 		// Check if our test is registered.
 		$this->assertArrayHasKey( 'direct', $tests );
-		$this->assertArrayHasKey( 'activitypub_yoast_media_pages', $tests['direct'] );
-		$this->assertEquals( 'Yoast SEO Media Pages Test', $tests['direct']['activitypub_yoast_media_pages']['label'] );
+		$this->assertArrayHasKey( 'activitypub_yoast_seo_media_pages', $tests['direct'] );
+		$this->assertEquals( 'Yoast SEO Media Pages Test', $tests['direct']['activitypub_yoast_seo_media_pages']['label'] );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Test_Yoast_Seo extends \WP_UnitTestCase {
 		$tests = \apply_filters( 'site_status_tests', array( 'direct' => array() ) );
 
 		// Check if our test is NOT registered.
-		$this->assertArrayNotHasKey( 'activitypub_yoast_media_pages', $tests['direct'] );
+		$this->assertArrayNotHasKey( 'activitypub_yoast_seo_media_pages', $tests['direct'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds a Yoast SEO integration that creates a site health check to ensure media pages are enabled when media attachments are configured for ActivityPub federation.

Fixes #2134

## Proposed changes:

- **New Yoast_Seo integration class**: Checks if Yoast SEO's "Enable media pages" setting is properly configured for ActivityPub
- **Conditional activation**: Only runs when both Yoast SEO is active AND attachment post type is supported by ActivityPub  
- **Site health integration**: Adds a dedicated site health test that:
  - Shows "good" status (green) when media pages are enabled
  - Shows "recommended" status (orange) when media pages are disabled, with instructions to enable them
- **Direct settings link**: Provides a clickable link to the exact Yoast SEO settings page for easy configuration
- **Comprehensive tests**: Full test coverage including attachment support detection, media pages status checking, and site health test scenarios

## Why this change is needed:

When Yoast SEO's media pages are disabled, WordPress attachment URLs redirect to the media file itself rather than displaying an attachment page. This breaks ActivityPub federation of media because:

1. ActivityPub clients expect to find structured data on attachment pages
2. Media interactions (likes, shares, comments) need a proper page to target  
3. The media becomes unfederated even when attachment post type is enabled

## Testing instructions:

1. Install Yoast SEO plugin
2. Enable attachment post type in ActivityPub settings  
3. Go to Tools > Site Health > Info tab
4. Check the site health tests - you should see "Yoast SEO Media Pages Test"
5. Try both scenarios:
   - **Yoast media pages enabled**: Should show green "good" status
   - **Yoast media pages disabled**: Should show orange "recommended" status with link to settings

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Minor

#### Type

- [x] Added - for new features

#### Message

Add Yoast SEO integration for media pages site health check

</details>