### PR TITLE
Fix deprecated explode() warning with null parameter

### DIFF
--- a/.github/changelog/2137-from-description
+++ b/.github/changelog/2137-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP warning when saving ActivityPub settings.

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -22,7 +22,7 @@ class Sanitize {
 	 */
 	public static function url_list( $value ) {
 		if ( ! \is_array( $value ) ) {
-			$value = \explode( PHP_EOL, $value );
+			$value = \explode( PHP_EOL, (string) $value );
 		}
 
 		$value = \array_filter( $value );
@@ -45,7 +45,7 @@ class Sanitize {
 	 */
 	public static function identifier_list( $value ) {
 		if ( ! \is_array( $value ) ) {
-			$value = \explode( PHP_EOL, $value );
+			$value = \explode( PHP_EOL, (string) $value );
 		}
 
 		$value = \array_filter( $value );
@@ -84,7 +84,7 @@ class Sanitize {
 	 * @return string The sanitized list of hosts.
 	 */
 	public static function host_list( $value ) {
-		$value = \explode( PHP_EOL, $value );
+		$value = \explode( PHP_EOL, (string) $value );
 		$value = \array_map(
 			function ( $host ) {
 				$host = \trim( $host );
@@ -113,7 +113,7 @@ class Sanitize {
 	 */
 	public static function blog_identifier( $value ) {
 		// Hack to allow dots in the username.
-		$parts     = \explode( '.', $value );
+		$parts     = \explode( '.', (string) $value );
 		$sanitized = \array_map( 'sanitize_title', $parts );
 		$sanitized = \implode( '.', $sanitized );
 


### PR DESCRIPTION
## Proposed changes:
* Fix PHP 8.1+ deprecation warning in ActivityPub settings when null values are passed to explode() function
* Updated sanitization methods to handle null input gracefully by casting to string

### Other information:

- [x] Have you written new tests for your changes, if applicable?
  - No new tests needed as this is a PHP compatibility fix that maintains existing functionality

## Testing instructions:

* Install a fresh copy of WordPress with the ActivityPub plugin
* Go to Settings > ActivityPub 
* Click "Save Changes" without modifying any settings
* Verify no PHP deprecation warnings appear in the error logs
* Test with PHP 8.1+ to confirm the warning is resolved

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix PHP warning when saving ActivityPub settings.

</details>