### PR TITLE
Fix content visibility override bug from PR #1900

### DIFF
--- a/.github/changelog/2139-from-description
+++ b/.github/changelog/2139-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix content visibility override issue preventing authors from changing visibility on older posts.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -887,6 +887,11 @@ class Activitypub {
 			return $meta_value;
 		}
 
+		// If meta value is already explicitly set, respect the author's choice.
+		if ( null !== $meta_value ) {
+			return $meta_value;
+		}
+
 		// If the post is federated, return the default visibility.
 		if ( 'federated' === \get_post_meta( $object_id, 'activitypub_status', true ) ) {
 			return $meta_value;


### PR DESCRIPTION
Fixes #2125.

## Proposed changes:
This PR fixes a bug introduced in PR #1900 where post authors couldn't change content visibility settings on older unfederated posts. Even when they explicitly selected "public" visibility, it would revert to "local" upon saving.

### Root cause:
The `default_post_metadata` filter was being applied on every meta value retrieval, not just when setting defaults. This caused explicitly set values to be overridden by the default logic.

### Solution:
- Add a null check to only apply the default "local" visibility when no explicit value is set
- Preserve the original functionality from #1900 for truly unset meta values
- Respect author's explicit visibility choices

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create a post that's older than 1 month
2. Ensure the post is not federated (no `activitypub_status` = 'federated' meta)
3. Go to edit the post and change content visibility to "Public"
4. Save the post
5. Verify the visibility remains "Public" instead of reverting to "Local"
6. Create a new old post without any visibility setting - verify it defaults to "Local"

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed - for any bug fixes

#### Message

Fix content visibility override issue preventing authors from changing visibility on older posts.

</details>