### PR TITLE
Send Delete activities to comment actors when posts are deleted

### DIFF
--- a/.github/changelog/2140-from-description
+++ b/.github/changelog/2140-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Send Delete activities to comment actors when posts are permanently deleted.

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -10,8 +10,6 @@ namespace Activitypub;
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Outbox;
-use Activitypub\Http;
-use Activitypub\Mention;
 
 /**
  * ActivityPub Dispatcher Class.
@@ -400,8 +398,6 @@ class Dispatcher {
 			return $inboxes;
 		}
 
-		global $wpdb;
-
 		// Get the original post ID from the activity object.
 		$object_id = object_to_uri( $activity->get_object() );
 		if ( ! is_string( $object_id ) ) {
@@ -431,6 +427,8 @@ class Dispatcher {
 		if ( ! $post_id ) {
 			return $inboxes;
 		}
+
+		global $wpdb;
 
 		// Get all federated comments for this post.
 		$comment_actors = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -10,6 +10,8 @@ namespace Activitypub;
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Outbox;
+use Activitypub\Http;
+use Activitypub\Mention;
 
 /**
  * ActivityPub Dispatcher Class.
@@ -44,6 +46,7 @@ class Dispatcher {
 		// Default filters to add Inboxes to sent to.
 		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_by_mentioned_actors' ), 10, 3 );
 		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_of_replied_urls' ), 10, 3 );
+		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_of_comment_actors' ), 10, 3 );
 		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_of_relays' ), 10, 3 );
 	}
 
@@ -380,6 +383,93 @@ class Dispatcher {
 		 * @param \WP_Post $outbox_item                The WordPress object.
 		 */
 		return apply_filters( 'activitypub_send_activity_to_followers', $send, $activity, $outbox_item->post_author, $outbox_item );
+	}
+
+	/**
+	 * Add inboxes of actors who have commented on the post being deleted.
+	 *
+	 * @param array    $inboxes  The list of Inboxes.
+	 * @param int      $actor_id The Actor-ID.
+	 * @param Activity $activity The ActivityPub Activity.
+	 *
+	 * @return array The filtered Inboxes.
+	 */
+	public static function add_inboxes_of_comment_actors( $inboxes, $actor_id, $activity ) {
+		// Only process Delete activities.
+		if ( 'Delete' !== $activity->get_type() ) {
+			return $inboxes;
+		}
+
+		global $wpdb;
+
+		// Get the original post ID from the activity object.
+		$object_id = $activity->get_object();
+		if ( ! is_string( $object_id ) ) {
+			return $inboxes;
+		}
+
+		// Extract post ID from the ActivityPub URL.
+		$post_id = url_to_postid( $object_id );
+		if ( ! $post_id ) {
+			// Try to get post ID from the URL pattern (e.g., ?p=123).
+			if ( preg_match( '/[?&]p=(\d+)/', $object_id, $matches ) ) {
+				$post_id = (int) $matches[1];
+			}
+		}
+
+		if ( ! $post_id ) {
+			// Try parsing the URL to get query parameters.
+			$parsed_url = wp_parse_url( $object_id );
+			if ( isset( $parsed_url['query'] ) ) {
+				parse_str( $parsed_url['query'], $query_vars );
+				if ( isset( $query_vars['p'] ) ) {
+					$post_id = (int) $query_vars['p'];
+				}
+			}
+		}
+
+		if ( ! $post_id ) {
+			return $inboxes;
+		}
+
+		// Get all federated comments for this post.
+		$comment_actors = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT cm.meta_value 
+				FROM {$wpdb->comments} c
+				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
+				WHERE c.comment_post_ID = %d 
+				AND cm.meta_key = 'activitypub_actor_id'
+				AND cm.meta_value != ''",
+				$post_id
+			)
+		);
+
+		if ( empty( $comment_actors ) ) {
+			return $inboxes;
+		}
+
+		// Get inboxes for these actors.
+		foreach ( $comment_actors as $actor_url ) {
+			// Skip same domain actors.
+			if ( is_same_domain( $actor_url ) ) {
+				continue;
+			}
+
+			$actor = Http::get_remote_object( $actor_url );
+
+			if ( ! $actor || \is_wp_error( $actor ) ) {
+				continue;
+			}
+
+			if ( ! empty( $actor['endpoints']['sharedInbox'] ) ) {
+				$inboxes[] = $actor['endpoints']['sharedInbox'];
+			} elseif ( ! empty( $actor['inbox'] ) ) {
+				$inboxes[] = $actor['inbox'];
+			}
+		}
+
+		return $inboxes;
 	}
 
 	/**

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -8,6 +8,7 @@
 namespace Activitypub;
 
 use Activitypub\Activity\Activity;
+use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Outbox;
 
@@ -400,30 +401,12 @@ class Dispatcher {
 
 		// Get the original post ID from the activity object.
 		$object_id = object_to_uri( $activity->get_object() );
-		if ( ! is_string( $object_id ) ) {
+		if ( ! \is_string( $object_id ) ) {
 			return $inboxes;
 		}
 
 		// Extract post ID from the ActivityPub URL.
-		$post_id = url_to_postid( $object_id );
-		if ( ! $post_id ) {
-			// Try to get post ID from the URL pattern (e.g., ?p=123).
-			if ( preg_match( '/[?&]p=(\d+)/', $object_id, $matches ) ) {
-				$post_id = (int) $matches[1];
-			}
-		}
-
-		if ( ! $post_id ) {
-			// Try parsing the URL to get query parameters.
-			$parsed_url = wp_parse_url( $object_id );
-			if ( isset( $parsed_url['query'] ) ) {
-				parse_str( $parsed_url['query'], $query_vars );
-				if ( isset( $query_vars['p'] ) ) {
-					$post_id = (int) $query_vars['p'];
-				}
-			}
-		}
-
+		$post_id = \url_to_postid( $object_id );
 		if ( ! $post_id ) {
 			return $inboxes;
 		}
@@ -454,15 +437,20 @@ class Dispatcher {
 				continue;
 			}
 
-			$actor = Http::get_remote_object( $actor_url );
-			if ( ! $actor || \is_wp_error( $actor ) ) {
+			$actor_post = Actors::fetch_remote_by_uri( $actor_url );
+			if ( \is_wp_error( $actor_post ) ) {
 				continue;
 			}
 
-			if ( ! empty( $actor['endpoints']['sharedInbox'] ) ) {
-				$inboxes[] = $actor['endpoints']['sharedInbox'];
-			} elseif ( ! empty( $actor['inbox'] ) ) {
-				$inboxes[] = $actor['inbox'];
+			$actor = Actors::get_actor( $actor_post );
+			if ( \is_wp_error( $actor ) ) {
+				continue;
+			}
+
+			if ( ! empty( $actor->get_endpoints()['sharedInbox'] ) ) {
+				$inboxes[] = $actor->get_endpoints()['sharedInbox'];
+			} elseif ( ! empty( $actor->get_inbox() ) ) {
+				$inboxes[] = $actor->get_inbox();
 			}
 		}
 

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -433,7 +433,7 @@ class Dispatcher {
 		}
 
 		// Get all federated comments for this post.
-		$comment_actors = $wpdb->get_col(
+		$comment_actors = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$wpdb->prepare(
 				"SELECT DISTINCT cm.meta_value 
 				FROM {$wpdb->comments} c

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -389,7 +389,7 @@ class Dispatcher {
 	 * Add inboxes of actors who have commented on the post being deleted.
 	 *
 	 * @param array    $inboxes  The list of Inboxes.
-	 * @param int      $actor_id The Actor-ID.
+	 * @param int      $actor_id The Actor ID.
 	 * @param Activity $activity The ActivityPub Activity.
 	 *
 	 * @return array The filtered Inboxes.
@@ -403,7 +403,7 @@ class Dispatcher {
 		global $wpdb;
 
 		// Get the original post ID from the activity object.
-		$object_id = $activity->get_object();
+		$object_id = object_to_uri( $activity->get_object() );
 		if ( ! is_string( $object_id ) ) {
 			return $inboxes;
 		}
@@ -457,7 +457,6 @@ class Dispatcher {
 			}
 
 			$actor = Http::get_remote_object( $actor_url );
-
 			if ( ! $actor || \is_wp_error( $actor ) ) {
 				continue;
 			}

--- a/tests/includes/class-test-dispatcher.php
+++ b/tests/includes/class-test-dispatcher.php
@@ -353,4 +353,101 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		// Clean up.
 		remove_filter( 'pre_http_request', $callback );
 	}
+
+	/**
+	 * Test that Delete activities are sent to comment actors.
+	 *
+	 * @covers ::add_inboxes_of_comment_actors
+	 */
+	public function test_send_delete_to_comment_actors() {
+		// Create a test post.
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+
+		// Create a federated comment on the post.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_author'  => 'Remote User',
+				'comment_content' => 'This is a federated comment',
+			)
+		);
+
+		// Add comment meta manually.
+		add_comment_meta( $comment_id, 'activitypub_actor_id', 'https://mastodon.social/users/testuser' );
+
+		// Create a Delete activity for the post.
+		$activity = new Activity();
+		$activity->set_type( 'Delete' );
+		$activity->set_id( 'https://example.com/delete-activity' );
+		$activity->set_object( \add_query_arg( 'p', $post_id, \home_url( '/' ) ) );
+
+		// Mock HTTP responses for actor lookups.
+		$callback = function ( $pre, $parsed_args, $url ) {
+			if ( 'https://mastodon.social/users/testuser' === $url ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => \wp_json_encode(
+						array(
+							'type'  => 'Person',
+							'id'    => 'https://mastodon.social/users/testuser',
+							'inbox' => 'https://mastodon.social/users/testuser/inbox',
+						)
+					),
+				);
+			}
+
+			return $pre;
+		};
+
+		add_filter( 'pre_http_request', $callback, 10, 3 );
+
+		// Get inboxes for comment actors.
+		$inboxes = Dispatcher::add_inboxes_of_comment_actors( array(), self::$user_id, $activity );
+
+		// Verify that the comment actor's inbox was added.
+		$this->assertContains( 'https://mastodon.social/users/testuser/inbox', $inboxes, 'Should include comment actor inbox' );
+
+		// Clean up.
+		remove_filter( 'pre_http_request', $callback );
+		wp_delete_comment( $comment_id, true );
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test that non-Delete activities don't add comment actor inboxes.
+	 *
+	 * @covers ::add_inboxes_of_comment_actors
+	 */
+	public function test_non_delete_activities_ignore_comment_actors() {
+		// Create a test post.
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+
+		// Create a federated comment on the post.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_author'  => 'Remote User',
+				'comment_content' => 'This is a federated comment',
+				'meta_input'      => array(
+					'activitypub_actor_id' => 'https://mastodon.social/@user',
+				),
+			)
+		);
+
+		// Create a Create activity (not Delete).
+		$activity = new Activity();
+		$activity->set_type( 'Create' );
+		$activity->set_id( 'https://example.com/create-activity' );
+		$activity->set_object( \add_query_arg( 'p', $post_id, \home_url( '/' ) ) );
+
+		// Get inboxes for comment actors.
+		$inboxes = Dispatcher::add_inboxes_of_comment_actors( array(), self::$user_id, $activity );
+
+		// Verify that no inboxes were added since it's not a Delete activity.
+		$this->assertEmpty( $inboxes, 'Should not add comment actor inboxes for non-Delete activities' );
+
+		// Clean up.
+		wp_delete_comment( $comment_id, true );
+		wp_delete_post( $post_id, true );
+	}
 }


### PR DESCRIPTION
Fixes #2065

## Proposed changes:
This PR implements a solution to address the issue where federated comments remain orphaned in the Fediverse when a WordPress post is permanently deleted. The solution automatically sends Delete activities to actors who have commented on a post when that post is permanently deleted.

### How it works:
1. When a Delete activity is processed in the dispatcher, it now checks if the deleted object is a post with federated comments
2. Extracts the post ID from the ActivityPub object URL
3. Queries the database for comments with `activitypub_actor_id` meta on that post  
4. Fetches the actor details for each commenting actor
5. Adds their inboxes to the Delete activity's recipient list
6. The Delete activity is then sent to these comment actors, notifying them of the post deletion

### Benefits:
- Maintains conversation integrity across federated platforms
- Prevents orphaned comments from losing their context
- Follows ActivityPub best practices for content lifecycle management
- Only processes Delete activities (non-intrusive for other activity types)

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create a WordPress post that gets federated
2. Receive federated comments on the post from remote actors
3. Verify comments are stored with `activitypub_actor_id` meta
4. Permanently delete the WordPress post (not just trash)
5. Monitor outgoing ActivityPub activities to verify Delete activity is sent to comment actors' inboxes
6. Verify remote platforms receive the Delete activity and can handle the orphaned comments appropriately

### Manual testing (requires federated environment):
1. Set up local ActivityPub-enabled WordPress instance
2. Create and publish a post 
3. Have remote actors comment on the post
4. Delete the post permanently
5. Check remote platforms to see if they received Delete activity

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Minor

#### Type

- [x] Added - for new features

#### Message

Send Delete activities to comment actors when posts are permanently deleted.

</details>