### PR TITLE
Add Delete activity support for permanently deleted federated comments

### DIFF
--- a/.github/changelog/2141-from-description
+++ b/.github/changelog/2141-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Delete activity support for permanently deleted federated comments.

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -25,6 +25,7 @@ class Comment {
 		// Comment transitions.
 		\add_action( 'transition_comment_status', array( self::class, 'schedule_comment_activity' ), 20, 3 );
 		\add_action( 'wp_insert_comment', array( self::class, 'schedule_comment_activity_on_insert' ), 10, 2 );
+		\add_action( 'delete_comment', array( self::class, 'schedule_comment_delete_activity' ), 10, 2 );
 	}
 
 	/**
@@ -59,8 +60,9 @@ class Comment {
 			$type = 'Update';
 			\update_comment_meta( $comment->comment_ID, 'activitypub_comment_modified', time(), true );
 		} elseif (
-			\in_array( $new_status, array( 'trash', 'delete', 'spam' ), true ) &&
-			\Activitypub\Comment::was_received( $comment->comment_parent )
+			'trash' === $new_status ||
+			( 'delete' === $new_status && '' === $old_status ) || // Went through schedule_comment_delete_activity().
+			'spam' === $new_status
 		) {
 			$type = 'Delete';
 		}
@@ -86,6 +88,19 @@ class Comment {
 	public static function schedule_comment_activity_on_insert( $comment_id, $comment ) {
 		if ( 1 === (int) $comment->comment_approved ) {
 			self::schedule_comment_activity( 'approved', '', $comment );
+		}
+	}
+
+	/**
+	 * Schedule Delete activity when a comment is permanently deleted.
+	 *
+	 * @param int         $comment_id Comment ID.
+	 * @param \WP_Comment $comment    Comment object.
+	 */
+	public static function schedule_comment_delete_activity( $comment_id, $comment ) {
+		// Only send Delete activities for comments that were previously federated.
+		if ( \Activitypub\Comment::was_sent( $comment ) ) {
+			self::schedule_comment_activity( 'delete', '', $comment );
 		}
 	}
 }

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -25,6 +25,7 @@ class Comment {
 		// Comment transitions.
 		\add_action( 'transition_comment_status', array( self::class, 'schedule_comment_activity' ), 20, 3 );
 		\add_action( 'wp_insert_comment', array( self::class, 'schedule_comment_activity_on_insert' ), 10, 2 );
+		\add_action( 'delete_comment', array( self::class, 'schedule_comment_delete_activity' ), 10, 2 );
 	}
 
 	/**
@@ -87,5 +88,29 @@ class Comment {
 		if ( 1 === (int) $comment->comment_approved ) {
 			self::schedule_comment_activity( 'approved', '', $comment );
 		}
+	}
+
+	/**
+	 * Schedule Delete activity when a comment is permanently deleted.
+	 *
+	 * @param int         $comment_id Comment ID.
+	 * @param \WP_Comment $comment    Comment object.
+	 */
+	public static function schedule_comment_delete_activity( $comment_id, $comment ) {
+		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+			return;
+		}
+
+		// Only send Delete activities for comments that were previously federated.
+		if ( ! \Activitypub\Comment::was_sent( $comment ) ) {
+			return;
+		}
+
+		// Federate only comments that are written by a registered user.
+		if ( ! $comment || ! $comment->user_id ) {
+			return;
+		}
+
+		add_to_outbox( $comment, 'Delete', $comment->user_id );
 	}
 }

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -25,7 +25,6 @@ class Comment {
 		// Comment transitions.
 		\add_action( 'transition_comment_status', array( self::class, 'schedule_comment_activity' ), 20, 3 );
 		\add_action( 'wp_insert_comment', array( self::class, 'schedule_comment_activity_on_insert' ), 10, 2 );
-		\add_action( 'delete_comment', array( self::class, 'schedule_comment_delete_activity' ), 10, 2 );
 	}
 
 	/**
@@ -59,10 +58,7 @@ class Comment {
 		} elseif ( 'approved' === $new_status ) {
 			$type = 'Update';
 			\update_comment_meta( $comment->comment_ID, 'activitypub_comment_modified', time(), true );
-		} elseif (
-			'trash' === $new_status ||
-			'spam' === $new_status
-		) {
+		} elseif ( \in_array( $new_status, array( 'trash', 'delete', 'spam' ), true ) ) {
 			$type = 'Delete';
 		}
 
@@ -88,29 +84,5 @@ class Comment {
 		if ( 1 === (int) $comment->comment_approved ) {
 			self::schedule_comment_activity( 'approved', '', $comment );
 		}
-	}
-
-	/**
-	 * Schedule Delete activity when a comment is permanently deleted.
-	 *
-	 * @param int         $comment_id Comment ID.
-	 * @param \WP_Comment $comment    Comment object.
-	 */
-	public static function schedule_comment_delete_activity( $comment_id, $comment ) {
-		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
-			return;
-		}
-
-		// Only send Delete activities for comments that were previously federated.
-		if ( ! \Activitypub\Comment::was_sent( $comment ) ) {
-			return;
-		}
-
-		// Federate only comments that are written by a registered user.
-		if ( ! $comment || ! $comment->user_id ) {
-			return;
-		}
-
-		add_to_outbox( $comment, 'Delete', $comment->user_id );
 	}
 }

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -7,6 +7,8 @@
 
 namespace Activitypub\Scheduler;
 
+use Activitypub\Comment as Comment_Utils;
+
 use function Activitypub\add_to_outbox;
 use function Activitypub\should_comment_be_federated;
 
@@ -99,7 +101,7 @@ class Comment {
 	 */
 	public static function schedule_comment_delete_activity( $comment_id, $comment ) {
 		// Only send Delete activities for comments that were previously federated.
-		if ( \Activitypub\Comment::was_sent( $comment ) ) {
+		if ( Comment_Utils::was_sent( $comment ) ) {
 			self::schedule_comment_activity( 'delete', '', $comment );
 		}
 	}

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -58,7 +58,10 @@ class Comment {
 		} elseif ( 'approved' === $new_status ) {
 			$type = 'Update';
 			\update_comment_meta( $comment->comment_ID, 'activitypub_comment_modified', time(), true );
-		} elseif ( \in_array( $new_status, array( 'trash', 'delete', 'spam' ), true ) ) {
+		} elseif (
+			\in_array( $new_status, array( 'trash', 'delete', 'spam' ), true ) &&
+			\Activitypub\Comment::was_received( $comment->comment_parent )
+		) {
 			$type = 'Delete';
 		}
 

--- a/tests/includes/scheduler/class-test-comment.php
+++ b/tests/includes/scheduler/class-test-comment.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests\Scheduler;
 
+use Activitypub\Collection\Outbox;
 use Activitypub\Comment;
 
 /**
@@ -136,16 +137,29 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 */
 	public function test_schedule_comment_delete_activity() {
 		// Create a comment that gets federated.
+		$parent_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$comment_post_ID,
+				'user_id'          => 0,
+				'comment_approved' => 1,
+				'comment_meta'     => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+
+		// Create a comment that gets federated.
 		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$comment_post_ID,
 				'user_id'          => self::$user_id,
 				'comment_approved' => 1,
+				'comment_parent'   => $parent_comment_id,
+				'comment_meta'     => array(
+					'activitypub_status' => 'federated',
+				),
 			)
 		);
-
-		// Mark the comment as sent (federated).
-		\add_comment_meta( $comment_id, 'activitypub_status', 'federated' );
 
 		$activitypub_id = Comment::generate_id( $comment_id );
 
@@ -155,7 +169,7 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Check if a Delete activity was created.
 		$outbox_posts = \get_posts(
 			array(
-				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
+				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
 				'numberposts' => 1,
 				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -178,5 +192,50 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$this->assertEquals( 'Delete', \get_post_meta( $outbox_post->ID, '_activitypub_activity_type', true ) );
 		$this->assertEquals( $activitypub_id, \get_post_meta( $outbox_post->ID, '_activitypub_object_id', true ) );
 		$this->assertEquals( self::$user_id, $outbox_post->post_author );
+	}
+
+	/**
+	 * Test that non-federated comments don't create Delete activities.
+	 *
+	 * @covers ::schedule_comment_delete_activity
+	 */
+	public function test_no_delete_activity_for_non_federated_comment() {
+		// Create a comment that was NOT federated.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$comment_post_ID,
+				'user_id'          => self::$user_id,
+				'comment_approved' => 1,
+			)
+		);
+
+		$activitypub_id = Comment::generate_id( $comment_id );
+
+		// Ensure this comment is NOT marked as sent.
+		\delete_comment_meta( $comment_id, 'activitypub_status' );
+
+		// Permanently delete the comment.
+		\wp_delete_comment( $comment_id, true );
+
+		// Check that no Delete activity was created for this specific comment.
+		$outbox_posts = \get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
+				'numberposts' => 1,
+				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					array(
+						'key'   => '_activitypub_object_id',
+						'value' => $activitypub_id,
+					),
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Delete',
+					),
+				),
+			)
+		);
+
+		$this->assertEmpty( $outbox_posts, 'Should not create Delete activity for non-federated comment deletion' );
 	}
 }

--- a/tests/includes/scheduler/class-test-comment.php
+++ b/tests/includes/scheduler/class-test-comment.php
@@ -137,24 +137,11 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 */
 	public function test_schedule_comment_delete_activity() {
 		// Create a comment that gets federated.
-		$parent_comment_id = self::factory()->comment->create(
-			array(
-				'comment_post_ID'  => self::$comment_post_ID,
-				'user_id'          => 0,
-				'comment_approved' => 1,
-				'comment_meta'     => array(
-					'protocol' => 'activitypub',
-				),
-			)
-		);
-
-		// Create a comment that gets federated.
 		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$comment_post_ID,
 				'user_id'          => self::$user_id,
 				'comment_approved' => 1,
-				'comment_parent'   => $parent_comment_id,
 				'comment_meta'     => array(
 					'activitypub_status' => 'federated',
 				),

--- a/tests/includes/scheduler/class-test-comment.php
+++ b/tests/includes/scheduler/class-test-comment.php
@@ -179,49 +179,4 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$this->assertEquals( $activitypub_id, \get_post_meta( $outbox_post->ID, '_activitypub_object_id', true ) );
 		$this->assertEquals( self::$user_id, $outbox_post->post_author );
 	}
-
-	/**
-	 * Test that non-federated comments don't create Delete activities.
-	 *
-	 * @covers ::schedule_comment_delete_activity
-	 */
-	public function test_no_delete_activity_for_non_federated_comment() {
-		// Create a comment that was NOT federated.
-		$comment_id = self::factory()->comment->create(
-			array(
-				'comment_post_ID'  => self::$comment_post_ID,
-				'user_id'          => self::$user_id,
-				'comment_approved' => 1,
-			)
-		);
-
-		$activitypub_id = Comment::generate_id( $comment_id );
-
-		// Ensure this comment is NOT marked as sent.
-		\delete_comment_meta( $comment_id, 'activitypub_status' );
-
-		// Permanently delete the comment.
-		\wp_delete_comment( $comment_id, true );
-
-		// Check that no Delete activity was created for this specific comment.
-		$outbox_posts = \get_posts(
-			array(
-				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
-				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
-				'numberposts' => 1,
-				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					array(
-						'key'   => '_activitypub_object_id',
-						'value' => $activitypub_id,
-					),
-					array(
-						'key'   => '_activitypub_activity_type',
-						'value' => 'Delete',
-					),
-				),
-			)
-		);
-
-		$this->assertEmpty( $outbox_posts, 'Should not create Delete activity for non-federated comment deletion' );
-	}
 }

--- a/tests/includes/scheduler/class-test-comment.php
+++ b/tests/includes/scheduler/class-test-comment.php
@@ -126,4 +126,118 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		wp_delete_comment( $comment_id, true );
 	}
+
+	/**
+	 * Test scheduling Delete activity when comment is permanently deleted.
+	 *
+	 * @covers ::schedule_comment_delete_activity
+	 */
+	public function test_schedule_comment_delete_activity() {
+		// Create a comment that gets federated.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$comment_post_ID,
+				'user_id'          => self::$user_id,
+				'comment_approved' => 1,
+			)
+		);
+
+		// Mark the comment as sent (federated).
+		\add_comment_meta( $comment_id, 'activitypub_status', 'federated' );
+
+		$comment        = \get_comment( $comment_id );
+		$activitypub_id = \Activitypub\Comment::generate_id( $comment );
+
+		// Permanently delete the comment - this should trigger a Delete activity.
+		\wp_delete_comment( $comment_id, true );
+
+		// Check if a Delete activity was created.
+		$outbox_posts = \get_posts(
+			array(
+				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
+				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
+				'numberposts' => -1,
+				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					array(
+						'key'   => '_activitypub_object_id',
+						'value' => $activitypub_id,
+					),
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Delete',
+					),
+				),
+			)
+		);
+
+		$this->assertCount( 1, $outbox_posts, 'Should create exactly one Delete activity for permanently deleted federated comment' );
+
+		// Verify the outbox post has correct metadata.
+		$outbox_post = $outbox_posts[0];
+		$this->assertEquals( 'Delete', \get_post_meta( $outbox_post->ID, '_activitypub_activity_type', true ) );
+		$this->assertEquals( $activitypub_id, \get_post_meta( $outbox_post->ID, '_activitypub_object_id', true ) );
+		$this->assertEquals( self::$user_id, $outbox_post->post_author );
+	}
+
+	/**
+	 * Test that non-federated comments don't create Delete activities.
+	 *
+	 * @covers ::schedule_comment_delete_activity
+	 */
+	public function test_no_delete_activity_for_non_federated_comment() {
+		// Create a comment that was NOT federated.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$comment_post_ID,
+				'user_id'          => self::$user_id,
+				'comment_approved' => 1,
+			)
+		);
+
+		$comment        = \get_comment( $comment_id );
+		$activitypub_id = \Activitypub\Comment::generate_id( $comment );
+
+		// Ensure this comment is NOT marked as sent.
+		\delete_comment_meta( $comment_id, 'activitypub_status' );
+
+		// Count existing Delete activities before deletion.
+		$outbox_posts_before = \get_posts(
+			array(
+				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
+				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
+				'numberposts' => -1,
+				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Delete',
+					),
+				),
+			)
+		);
+
+		// Permanently delete the comment.
+		\wp_delete_comment( $comment_id, true );
+
+		// Check that no new Delete activity was created for this specific comment.
+		$outbox_posts_after = \get_posts(
+			array(
+				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
+				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
+				'numberposts' => -1,
+				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					array(
+						'key'   => '_activitypub_object_id',
+						'value' => $activitypub_id,
+					),
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Delete',
+					),
+				),
+			)
+		);
+
+		$this->assertEmpty( $outbox_posts_after, 'Should not create Delete activity for non-federated comment deletion' );
+		$this->assertCount( count( $outbox_posts_before ), $outbox_posts_after, 'Number of Delete activities should remain unchanged' );
+	}
 }

--- a/tests/includes/scheduler/class-test-comment.php
+++ b/tests/includes/scheduler/class-test-comment.php
@@ -7,6 +7,8 @@
 
 namespace Activitypub\Tests\Scheduler;
 
+use Activitypub\Comment;
+
 /**
  * Test Comment scheduler class.
  *
@@ -41,7 +43,7 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				'comment_approved' => 0,
 			)
 		);
-		$activitpub_id = \Activitypub\Comment::generate_id( $comment_id );
+		$activitpub_id = Comment::generate_id( $comment_id );
 
 		wp_set_comment_status( $comment_id, 'approve' );
 
@@ -49,7 +51,7 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$id   = \get_post_meta( $post->ID, '_activitypub_object_id', true );
 		$this->assertSame( $activitpub_id, $id );
 
-		wp_delete_comment( $comment_id, true );
+		\wp_delete_comment( $comment_id, true );
 	}
 
 	/**
@@ -63,13 +65,13 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 				'comment_approved' => 1,
 			)
 		);
-		$activitpub_id = \Activitypub\Comment::generate_id( $comment_id );
+		$activitpub_id = Comment::generate_id( $comment_id );
 
 		$post = $this->get_latest_outbox_item( $activitpub_id );
 		$id   = \get_post_meta( $post->ID, '_activitypub_object_id', true );
 		$this->assertSame( $activitpub_id, $id );
 
-		wp_delete_comment( $comment_id, true );
+		\wp_delete_comment( $comment_id, true );
 	}
 
 	/**
@@ -120,11 +122,11 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		}
 
 		$comment_id    = self::factory()->comment->create( $comment_data );
-		$activitpub_id = \Activitypub\Comment::generate_id( $comment_id );
+		$activitpub_id = Comment::generate_id( $comment_id );
 
 		$this->assertNull( $this->get_latest_outbox_item( $activitpub_id ) );
 
-		wp_delete_comment( $comment_id, true );
+		\wp_delete_comment( $comment_id, true );
 	}
 
 	/**
@@ -145,8 +147,7 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Mark the comment as sent (federated).
 		\add_comment_meta( $comment_id, 'activitypub_status', 'federated' );
 
-		$comment        = \get_comment( $comment_id );
-		$activitypub_id = \Activitypub\Comment::generate_id( $comment );
+		$activitypub_id = Comment::generate_id( $comment_id );
 
 		// Permanently delete the comment - this should trigger a Delete activity.
 		\wp_delete_comment( $comment_id, true );
@@ -156,7 +157,7 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			array(
 				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
 				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
-				'numberposts' => -1,
+				'numberposts' => 1,
 				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					array(
 						'key'   => '_activitypub_object_id',
@@ -171,9 +172,9 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		);
 
 		$this->assertCount( 1, $outbox_posts, 'Should create exactly one Delete activity for permanently deleted federated comment' );
+		$outbox_post = $outbox_posts[0];
 
 		// Verify the outbox post has correct metadata.
-		$outbox_post = $outbox_posts[0];
 		$this->assertEquals( 'Delete', \get_post_meta( $outbox_post->ID, '_activitypub_activity_type', true ) );
 		$this->assertEquals( $activitypub_id, \get_post_meta( $outbox_post->ID, '_activitypub_object_id', true ) );
 		$this->assertEquals( self::$user_id, $outbox_post->post_author );
@@ -194,51 +195,20 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			)
 		);
 
-		$comment        = \get_comment( $comment_id );
-		$activitypub_id = \Activitypub\Comment::generate_id( $comment );
+		$activitypub_id = Comment::generate_id( $comment_id );
 
 		// Ensure this comment is NOT marked as sent.
 		\delete_comment_meta( $comment_id, 'activitypub_status' );
 
-		// Count existing Delete activities before deletion.
-		$outbox_posts_before = \get_posts(
-			array(
-				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
-				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
-				'numberposts' => -1,
-				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					array(
-						'key'   => '_activitypub_activity_type',
-						'value' => 'Delete',
-					),
-				),
-			)
-		);
-
 		// Permanently delete the comment.
 		\wp_delete_comment( $comment_id, true );
 
-		// Count all Delete activities after deletion to ensure no new ones were created.
-		$outbox_posts_after = \get_posts(
+		// Check that no Delete activity was created for this specific comment.
+		$outbox_posts = \get_posts(
 			array(
 				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
 				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
-				'numberposts' => -1,
-				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					array(
-						'key'   => '_activitypub_activity_type',
-						'value' => 'Delete',
-					),
-				),
-			)
-		);
-
-		// Check that no new Delete activity was created for this specific comment.
-		$specific_comment_activities = \get_posts(
-			array(
-				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
-				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
-				'numberposts' => -1,
+				'numberposts' => 1,
 				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					array(
 						'key'   => '_activitypub_object_id',
@@ -252,7 +222,6 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			)
 		);
 
-		$this->assertEmpty( $specific_comment_activities, 'Should not create Delete activity for non-federated comment deletion' );
-		$this->assertCount( count( $outbox_posts_before ), $outbox_posts_after, 'Number of Delete activities should remain unchanged' );
+		$this->assertEmpty( $outbox_posts, 'Should not create Delete activity for non-federated comment deletion' );
 	}
 }

--- a/tests/includes/scheduler/class-test-comment.php
+++ b/tests/includes/scheduler/class-test-comment.php
@@ -218,8 +218,23 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Permanently delete the comment.
 		\wp_delete_comment( $comment_id, true );
 
-		// Check that no new Delete activity was created for this specific comment.
+		// Count all Delete activities after deletion to ensure no new ones were created.
 		$outbox_posts_after = \get_posts(
+			array(
+				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
+				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
+				'numberposts' => -1,
+				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Delete',
+					),
+				),
+			)
+		);
+
+		// Check that no new Delete activity was created for this specific comment.
+		$specific_comment_activities = \get_posts(
 			array(
 				'post_type'   => \Activitypub\Collection\Outbox::POST_TYPE,
 				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
@@ -237,7 +252,7 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			)
 		);
 
-		$this->assertEmpty( $outbox_posts_after, 'Should not create Delete activity for non-federated comment deletion' );
+		$this->assertEmpty( $specific_comment_activities, 'Should not create Delete activity for non-federated comment deletion' );
 		$this->assertCount( count( $outbox_posts_before ), $outbox_posts_after, 'Number of Delete activities should remain unchanged' );
 	}
 }


### PR DESCRIPTION
See https://github.com/Automattic/wordpress-activitypub/issues/2065.

## Summary

When a federated comment is permanently deleted using `wp_delete_comment()`, the plugin now creates a Delete activity and sends it to the appropriate ActivityPub inboxes. This ensures that remote servers are notified when comments they sent are deleted.

## Changes

- Added new hook `delete_comment` in `Comment` scheduler class
- Added `schedule_comment_delete_activity()` method that:
  - Checks if comment was previously federated using `\Activitypub\Comment::was_sent()`
  - Only creates Delete activities for federated comments
  - Ignores non-federated comments to avoid unnecessary federation traffic
- Added comprehensive tests with both positive and negative test cases
- Tests verify exact outbox post creation and metadata validation

## Testing instructions

1. Create a comment on a post by a registered user
2. Mark the comment as federated: `add_comment_meta( $comment_id, 'activitypub_status', 'federated' )`
3. Permanently delete the comment: `wp_delete_comment( $comment_id, true )`
4. Verify a Delete activity is created in the outbox with correct metadata
5. Test that non-federated comments do not create Delete activities

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Added - for new features

#### Message
Add Delete activity support for permanently deleted federated comments.

</details>