### PR TITLE
Move `Activity-Object-Type` setting to advanced settings

### DIFF
--- a/.github/changelog/2148-from-description
+++ b/.github/changelog/2148-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+ActivityPub now defaults to automated object type selection, with the old manual option moved to Advanced settings for compatibility.

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -26,6 +26,7 @@ class Options {
 
 		\add_filter( 'default_option_activitypub_negotiate_content', array( self::class, 'default_option_activitypub_negotiate_content' ) );
 		\add_filter( 'option_activitypub_max_image_attachments', array( self::class, 'default_max_image_attachments' ) );
+		\add_filter( 'option_activitypub_object_type', array( self::class, 'default_object_type' ) );
 	}
 
 	/**
@@ -134,21 +135,6 @@ class Options {
 	}
 
 	/**
-	 * Default max image attachments.
-	 *
-	 * @param string $value The value of the option.
-	 *
-	 * @return string|int The value of the option.
-	 */
-	public static function default_max_image_attachments( $value ) {
-		if ( ! \is_numeric( $value ) ) {
-			$value = ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS;
-		}
-
-		return $value;
-	}
-
-	/**
 	 * Default option filter for the Content-Negotiation.
 	 *
 	 * @see https://github.com/Automattic/wordpress-activitypub/wiki/Caching
@@ -173,5 +159,35 @@ class Options {
 		}
 
 		return $default_value;
+	}
+
+	/**
+	 * Default max image attachments.
+	 *
+	 * @param string $value The value of the option.
+	 *
+	 * @return string|int The value of the option.
+	 */
+	public static function default_max_image_attachments( $value ) {
+		if ( ! \is_numeric( $value ) ) {
+			$value = ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Default object type.
+	 *
+	 * @param string $value The value of the option.
+	 *
+	 * @return string The value of the option.
+	 */
+	public static function default_object_type( $value ) {
+		if ( ! $value ) {
+			$value = ACTIVITYPUB_DEFAULT_OBJECT_TYPE;
+		}
+
+		return $value;
 	}
 }

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -108,9 +108,9 @@ class Advanced_Settings_Fields {
 			array( 'label_for' => 'activitypub_persist_inbox' )
 		);
 
-		add_settings_field(
+		\add_settings_field(
 			'activitypub_object_type',
-			__( 'Activity-Object-Type', 'activitypub' ),
+			\__( 'Activity-Object-Type', 'activitypub' ),
 			array( self::class, 'render_object_type_field' ),
 			'activitypub_advanced_settings',
 			'activitypub_advanced_settings',
@@ -293,16 +293,16 @@ class Advanced_Settings_Fields {
 	 * Render object type field.
 	 */
 	public static function render_object_type_field() {
-		$value = get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
+		$value = \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
 		?>
 		<p>
 			<label>
-				<input type="checkbox" name="activitypub_object_type" value="note" <?php checked( 'note', $value ); ?> />
-				<?php esc_html_e( 'Use Template Tags instead of letting the plugin choose the best possible format for you.', 'activitypub' ); ?>
+				<input type="checkbox" name="activitypub_object_type" value="note" <?php \checked( 'note', $value ); ?> />
+				<?php \esc_html_e( 'Use Template Tags instead of letting the plugin choose the best possible format for you.', 'activitypub' ); ?>
 			</label>
 		</p>
 		<p class="description">
-			<?php esc_html_e( 'This is mainly for backwards compatibility. It is not recommended to use the Template Tags, because it might not be supported in future versions.', 'activitypub' ); ?>
+			<?php \esc_html_e( 'This is mainly for backwards compatibility. It is not recommended to use the Template Tags, because it might not be supported in future versions.', 'activitypub' ); ?>
 		</p>
 		<?php
 	}

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -298,11 +298,11 @@ class Advanced_Settings_Fields {
 		<p>
 			<label>
 				<input type="checkbox" name="activitypub_object_type" value="note" <?php checked( 'note', $value ); ?> />
-				<?php esc_html_e( 'Use Template Tags (not recommended)', 'activitypub' ); ?>
+				<?php esc_html_e( 'Use Template Tags instead of letting the plugin choose the best possible format for you.', 'activitypub' ); ?>
 			</label>
 		</p>
 		<p class="description">
-			<?php esc_html_e( 'This is mainly for backward compatibility. It is not recommended to use this feature, because it might not be supported in future versions.', 'activitypub' ); ?>
+			<?php esc_html_e( 'This is mainly for backwards compatibility. It is not recommended to use the Template Tags, because it might not be supported in future versions.', 'activitypub' ); ?>
 		</p>
 		<?php
 	}

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -107,6 +107,15 @@ class Advanced_Settings_Fields {
 			'activitypub_advanced_settings',
 			array( 'label_for' => 'activitypub_persist_inbox' )
 		);
+
+		add_settings_field(
+			'activitypub_object_type',
+			__( 'Activity-Object-Type', 'activitypub' ),
+			array( self::class, 'render_object_type_field' ),
+			'activitypub_advanced_settings',
+			'activitypub_advanced_settings',
+			array( 'label_for' => 'activitypub_object_type' )
+		);
 	}
 
 	/**
@@ -276,6 +285,24 @@ class Advanced_Settings_Fields {
 		</p>
 		<p class="description">
 			For now, this is only used for debugging purposes. If you have no actual need for this, please keep it disabled to avoid unnecessary database writes. Future versions may enable this feature by default.
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render object type field.
+	 */
+	public static function render_object_type_field() {
+		$value = get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
+		?>
+		<p>
+			<label>
+				<input type="checkbox" name="activitypub_object_type" value="note" <?php checked( 'note', $value ); ?> />
+				<?php esc_html_e( 'Use Template Tags (not recommended)', 'activitypub' ); ?>
+			</label>
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'This is mainly for backward compatibility. It is not recommended to use this feature, because it might not be supported in future versions.', 'activitypub' ); ?>
 		</p>
 		<?php
 	}

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -71,14 +71,6 @@ class Settings_Fields {
 			'activitypub_profiles'
 		);
 
-		add_settings_field(
-			'activitypub_object_type',
-			__( 'Activity-Object-Type', 'activitypub' ),
-			array( self::class, 'render_object_type_field' ),
-			'activitypub_settings',
-			'activitypub_activities'
-		);
-
 		$object_type = \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
 		if ( 'note' === $object_type ) {
 			add_settings_field(
@@ -230,35 +222,6 @@ class Settings_Fields {
 			</div>
 		</div>
 	</fieldset>
-		<?php
-	}
-
-	/**
-	 * Render object type field.
-	 */
-	public static function render_object_type_field() {
-		$value = get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
-		?>
-		<p>
-			<label>
-				<input type="radio" name="activitypub_object_type" value="wordpress-post-format" <?php checked( 'wordpress-post-format', $value ); ?> />
-				<?php esc_html_e( 'Automatic (default)', 'activitypub' ); ?>
-				-
-				<span class="description">
-					<?php esc_html_e( 'Let the plugin choose the best possible format for you.', 'activitypub' ); ?>
-				</span>
-			</label>
-		</p>
-		<p>
-			<label>
-				<input type="radio" name="activitypub_object_type" value="note" <?php checked( 'note', $value ); ?> />
-				<?php esc_html_e( 'Note', 'activitypub' ); ?>
-				-
-				<span class="description">
-					<?php esc_html_e( 'Should work with most platforms.', 'activitypub' ); ?>
-				</span>
-			</label>
-		</p>
 		<?php
 	}
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -71,21 +71,6 @@ class Settings {
 
 		\register_setting(
 			'activitypub',
-			'activitypub_object_type',
-			array(
-				'type'         => 'string',
-				'description'  => \__( 'The Activity-Object-Type', 'activitypub' ),
-				'show_in_rest' => array(
-					'schema' => array(
-						'enum' => array( 'note', 'wordpress-post-format' ),
-					),
-				),
-				'default'      => ACTIVITYPUB_DEFAULT_OBJECT_TYPE,
-			)
-		);
-
-		\register_setting(
-			'activitypub',
 			'activitypub_use_hashtags',
 			array(
 				'type'        => 'boolean',
@@ -257,6 +242,21 @@ class Settings {
 				'type'        => 'boolean',
 				'description' => 'Enable inbox collection persistence.',
 				'default'     => false,
+			)
+		);
+
+		\register_setting(
+			'activitypub_advanced',
+			'activitypub_object_type',
+			array(
+				'type'         => 'string',
+				'description'  => \__( 'The Activity-Object-Type', 'activitypub' ),
+				'show_in_rest' => array(
+					'schema' => array(
+						'enum' => array( 'note', 'wordpress-post-format' ),
+					),
+				),
+				'default'      => ACTIVITYPUB_DEFAULT_OBJECT_TYPE,
 			)
 		);
 
@@ -498,14 +498,18 @@ class Settings {
 			)
 		);
 
-		// Template Tags.
-		\get_current_screen()->add_help_tab(
-			array(
-				'id'      => 'template-tags',
-				'title'   => \__( 'Template Tags', 'activitypub' ),
-				'content' => self::get_help_tab_template( 'template-tags' ),
-			)
-		);
+		// Show only if templating is enabled.
+		$object_type = \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
+		if ( 'note' === $object_type ) {
+			// Template Tags.
+			\get_current_screen()->add_help_tab(
+				array(
+					'id'      => 'template-tags',
+					'title'   => \__( 'Template Tags', 'activitypub' ),
+					'content' => self::get_help_tab_template( 'template-tags' ),
+				)
+			);
+		}
 
 		// Recommended Plugins.
 		if ( ! empty( self::get_recommended_plugins() ) ) {


### PR DESCRIPTION
The `Activity-Object-Type` option and its field have been relocated from the main settings to the advanced settings section. Registration of the option is now under `activitypub_advanced`, and the UI has been simplified to a single checkbox for backward compatibility. Help tab for template tags is now conditionally shown only when `note` is selected.

I think we should hide this feature for new Users, to push the automated mode a bit more.

## Proposed changes:
- Move `activitypub_object_type` setting registration from main to advanced settings group
- Simplify UI from radio buttons to a single checkbox for enabling template tags
- Add conditional display of template tags help tab based on object type selection
- Show template tags help only if activated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check for the settings under the Advanced Tab
* The Template form is still in the main settings, to not confuse existing customers/users.
* Check if checking/unchecking the settings will have the expected results.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [X] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

ActivityPub now defaults to automated object type selection, with the old manual option moved to Advanced settings for compatibility.

</details>
