### PR TITLE
Apply formatting baseline across all PHP files

### DIFF
--- a/build/followers/render.php
+++ b/build/followers/render.php
@@ -8,6 +8,7 @@
 use Activitypub\Blocks;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+
 use function Activitypub\is_activitypub_request;
 use function Activitypub\object_to_uri;
 

--- a/build/reactions/render.php
+++ b/build/reactions/render.php
@@ -5,8 +5,9 @@
  * @package ActivityPub
  */
 
-use Activitypub\Comment;
 use Activitypub\Blocks;
+use Activitypub\Comment;
+
 use function Activitypub\is_activitypub_request;
 
 if ( is_activitypub_request() || is_feed() ) {

--- a/build/remote-reply/render.php
+++ b/build/remote-reply/render.php
@@ -6,6 +6,7 @@
  */
 
 use Activitypub\Blocks;
+
 use function Activitypub\is_activitypub_request;
 
 if ( is_activitypub_request() || is_feed() ) {

--- a/includes/class-http.php
+++ b/includes/class-http.php
@@ -8,7 +8,6 @@
 namespace Activitypub;
 
 use Activitypub\Collection\Actors;
-use WP_Error;
 
 /**
  * ActivityPub HTTP Class
@@ -23,7 +22,7 @@ class Http {
 	 * @param string $body    The Post Body.
 	 * @param int    $user_id The WordPress User-ID.
 	 *
-	 * @return array|WP_Error The POST Response or an WP_Error.
+	 * @return array|\WP_Error The POST Response or an WP_Error.
 	 */
 	public static function post( $url, $body, $user_id ) {
 		/**
@@ -60,7 +59,7 @@ class Http {
 		$code     = \wp_remote_retrieve_response_code( $response );
 
 		if ( $code >= 400 ) {
-			$response = new WP_Error(
+			$response = new \WP_Error(
 				$code,
 				__( 'Failed HTTP Request', 'activitypub' ),
 				array(
@@ -73,10 +72,10 @@ class Http {
 		/**
 		 * Action to save the response of the remote POST request.
 		 *
-		 * @param array|WP_Error $response The response of the remote POST request.
-		 * @param string         $url      The URL endpoint.
-		 * @param string         $body     The Post Body.
-		 * @param int            $user_id  The WordPress User-ID.
+		 * @param array|\WP_Error $response The response of the remote POST request.
+		 * @param string          $url      The URL endpoint.
+		 * @param string          $body     The Post Body.
+		 * @param int             $user_id  The WordPress User-ID.
 		 */
 		\do_action( 'activitypub_safe_remote_post_response', $response, $url, $body, $user_id );
 
@@ -89,7 +88,7 @@ class Http {
 	 * @param string   $url    The URL endpoint.
 	 * @param bool|int $cached Optional. Whether the result should be cached, or its duration. Default false.
 	 *
-	 * @return array|WP_Error The GET Response or a WP_Error.
+	 * @return array|\WP_Error The GET Response or a WP_Error.
 	 */
 	public static function get( $url, $cached = false ) {
 		/**
@@ -108,8 +107,8 @@ class Http {
 				/**
 				 * Action to save the response of the remote GET request.
 				 *
-				 * @param array|WP_Error $response The response of the remote GET request.
-				 * @param string         $url      The URL endpoint.
+				 * @param array|\WP_Error $response The response of the remote GET request.
+				 * @param string          $url      The URL endpoint.
 				 */
 				\do_action( 'activitypub_safe_remote_get_response', $response, $url );
 
@@ -152,14 +151,14 @@ class Http {
 		$code     = \wp_remote_retrieve_response_code( $response );
 
 		if ( $code >= 400 ) {
-			$response = new WP_Error( $code, __( 'Failed HTTP Request', 'activitypub' ), array( 'status' => $code ) );
+			$response = new \WP_Error( $code, __( 'Failed HTTP Request', 'activitypub' ), array( 'status' => $code ) );
 		}
 
 		/**
 		 * Action to save the response of the remote GET request.
 		 *
-		 * @param array|WP_Error $response The response of the remote GET request.
-		 * @param string         $url      The URL endpoint.
+		 * @param array|\WP_Error $response The response of the remote GET request.
+		 * @param string          $url      The URL endpoint.
 		 */
 		\do_action( 'activitypub_safe_remote_get_response', $response, $url );
 
@@ -204,7 +203,7 @@ class Http {
 	 * @param array|string $url_or_object The Object or the Object URL.
 	 * @param bool         $cached        Optional. Whether the result should be cached. Default true.
 	 *
-	 * @return array|WP_Error The Object data as array or WP_Error on failure.
+	 * @return array|\WP_Error The Object data as array or WP_Error on failure.
 	 */
 	public static function get_remote_object( $url_or_object, $cached = true ) {
 		/**
@@ -225,7 +224,7 @@ class Http {
 		}
 
 		if ( ! $url ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'activitypub_no_valid_actor_identifier',
 				\__( 'The "actor" identifier is not valid', 'activitypub' ),
 				array(
@@ -251,7 +250,7 @@ class Http {
 		}
 
 		if ( ! \wp_http_validate_url( $url ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'activitypub_no_valid_object_url',
 				\__( 'The "object" is/has no valid URL', 'activitypub' ),
 				array(
@@ -271,7 +270,7 @@ class Http {
 		$data = \json_decode( $data, true );
 
 		if ( ! $data ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'activitypub_invalid_json',
 				\__( 'No valid JSON data', 'activitypub' ),
 				array(

--- a/includes/class-http.php
+++ b/includes/class-http.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub;
 
-use WP_Error;
 use Activitypub\Collection\Actors;
+use WP_Error;
 
 /**
  * ActivityPub HTTP Class

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub;
 
-use Activitypub\Activity\Actor;
 use Activitypub\Activity\Activity;
+use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
 use Activitypub\Model\Blog;
 use Activitypub\Model\User;

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -9,11 +9,11 @@ namespace Activitypub;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
-use Activitypub\Scheduler\Post;
-use Activitypub\Scheduler\Actor;
-use Activitypub\Scheduler\Comment;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
+use Activitypub\Scheduler\Actor;
+use Activitypub\Scheduler\Comment;
+use Activitypub\Scheduler\Post;
 
 /**
  * Scheduler class.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -8,8 +8,8 @@
 namespace Activitypub;
 
 use Activitypub\Collection\Actors;
-use Activitypub\Signature\Http_Signature_Draft;
 use Activitypub\Signature\Http_Message_Signature;
+use Activitypub\Signature\Http_Signature_Draft;
 
 /**
  * ActivityPub Signature Class.

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -9,7 +9,6 @@ namespace Activitypub;
 
 use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
-use WP_Error;
 
 /**
  * ActivityPub WebFinger Class.
@@ -40,7 +39,7 @@ class Webfinger {
 	 *
 	 * @param string $uri The WebFinger Resource.
 	 *
-	 * @return string|WP_Error The URL or WP_Error.
+	 * @return string|\WP_Error The URL or WP_Error.
 	 */
 	public static function resolve( $uri ) {
 		$data = self::get_data( $uri );
@@ -50,7 +49,7 @@ class Webfinger {
 		}
 
 		if ( ! is_array( $data ) || empty( $data['links'] ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'webfinger_missing_links',
 				__( 'No valid Link elements found.', 'activitypub' ),
 				array(
@@ -73,7 +72,7 @@ class Webfinger {
 			}
 		}
 
-		return new WP_Error(
+		return new \WP_Error(
 			'webfinger_url_no_activitypub',
 			__( 'The Site supports WebFinger but not ActivityPub', 'activitypub' ),
 			array(
@@ -90,7 +89,7 @@ class Webfinger {
 	 *
 	 * @param string $uri The URI (acct:, mailto:, http:, https:).
 	 *
-	 * @return string|WP_Error Error or acct URI.
+	 * @return string|\WP_Error Error or acct URI.
 	 */
 	public static function uri_to_acct( $uri ) {
 		$data = self::get_data( $uri );
@@ -116,7 +115,7 @@ class Webfinger {
 			}
 		}
 
-		return new WP_Error(
+		return new \WP_Error(
 			'webfinger_url_no_acct',
 			__( 'No acct URI found.', 'activitypub' ),
 			array(
@@ -132,11 +131,11 @@ class Webfinger {
 	 *
 	 * @param string $url The URI (acct:, mailto:, http:, https:).
 	 *
-	 * @return WP_Error|array Error reaction or array with identifier and host as values.
+	 * @return \WP_Error|array Error reaction or array with identifier and host as values.
 	 */
 	public static function get_identifier_and_host( $url ) {
 		if ( ! $url ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'webfinger_invalid_identifier',
 				__( 'Invalid Identifier', 'activitypub' ),
 				array(
@@ -173,7 +172,7 @@ class Webfinger {
 		}
 
 		if ( empty( $host ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'webfinger_invalid_identifier',
 				__( 'Invalid Identifier', 'activitypub' ),
 				array(
@@ -191,7 +190,7 @@ class Webfinger {
 	 *
 	 * @param string $uri The Identifier: <identifier>@<host> or URI.
 	 *
-	 * @return WP_Error|array Error reaction or array with identifier and host as values.
+	 * @return \WP_Error|array Error reaction or array with identifier and host as values.
 	 */
 	public static function get_data( $uri ) {
 		$identifier_and_host = self::get_identifier_and_host( $uri );
@@ -223,7 +222,7 @@ class Webfinger {
 		);
 
 		if ( \is_wp_error( $response ) || \wp_remote_retrieve_response_code( $response ) >= 400 ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'webfinger_url_not_accessible',
 				__( 'The WebFinger Resource is not accessible.', 'activitypub' ),
 				array(
@@ -246,7 +245,7 @@ class Webfinger {
 	 *
 	 * @param string $uri The WebFinger Resource URI.
 	 *
-	 * @return string|WP_Error Error or the Remote-Follow endpoint URI.
+	 * @return string|\WP_Error Error or the Remote-Follow endpoint URI.
 	 */
 	public static function get_remote_follow_endpoint( $uri ) {
 		$data = self::get_data( $uri );
@@ -256,7 +255,7 @@ class Webfinger {
 		}
 
 		if ( empty( $data['links'] ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'webfinger_missing_links',
 				__( 'No valid Link elements found.', 'activitypub' ),
 				array(
@@ -272,7 +271,7 @@ class Webfinger {
 			}
 		}
 
-		return new WP_Error(
+		return new \WP_Error(
 			'webfinger_missing_remote_follow_endpoint',
 			__( 'No valid Remote-Follow endpoint found.', 'activitypub' ),
 			array(

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -7,9 +7,9 @@
 
 namespace Activitypub;
 
-use WP_Error;
 use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
+use WP_Error;
 
 /**
  * ActivityPub WebFinger Class.

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -7,11 +7,11 @@
 
 namespace Activitypub\Collection;
 
-use Activitypub\Http;
-use Activitypub\Model\User;
-use Activitypub\Model\Blog;
-use Activitypub\Model\Application;
 use Activitypub\Activity\Actor;
+use Activitypub\Http;
+use Activitypub\Model\Application;
+use Activitypub\Model\Blog;
+use Activitypub\Model\User;
 
 use function Activitypub\get_remote_metadata_by_actor;
 use function Activitypub\is_actor;

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -10,8 +10,8 @@ namespace Activitypub\Collection;
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
 
-use function Activitypub\object_to_uri;
 use function Activitypub\is_activity_public;
+use function Activitypub\object_to_uri;
 
 /**
  * ActivityPub Inbox Collection

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -7,15 +7,15 @@
 
 namespace Activitypub\Collection;
 
+use Activitypub\Comment;
 use Activitypub\Webfinger;
 use WP_Comment_Query;
-use Activitypub\Comment;
 
-use function Activitypub\object_to_uri;
-use function Activitypub\is_post_disabled;
-use function Activitypub\url_to_commentid;
-use function Activitypub\object_id_to_comment;
 use function Activitypub\get_remote_metadata_by_actor;
+use function Activitypub\is_post_disabled;
+use function Activitypub\object_id_to_comment;
+use function Activitypub\object_to_uri;
+use function Activitypub\url_to_commentid;
 
 /**
  * ActivityPub Interactions Collection.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\Collection;
 
-use Activitypub\Scheduler;
-use Activitypub\Webfinger;
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
+use Activitypub\Scheduler;
+use Activitypub\Webfinger;
 
 use function Activitypub\add_to_outbox;
 

--- a/includes/collection/class-replies.php
+++ b/includes/collection/class-replies.php
@@ -9,11 +9,8 @@ namespace Activitypub\Collection;
 
 use Activitypub\Comment;
 use Activitypub\Model\Blog;
-use Activitypub\Transformer\Comment as CommentTransformer;
-use Activitypub\Transformer\Post as PostTransformer;
-use WP_Comment;
-use WP_Error;
-use WP_Post;
+use Activitypub\Transformer\Comment as Comment_Transformer;
+use Activitypub\Transformer\Post as Post_Transformer;
 
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\is_local_comment;
@@ -27,7 +24,7 @@ class Replies {
 	/**
 	 * Build base arguments for fetching the comments of either a WordPress post or comment.
 	 *
-	 * @param WP_Post|WP_Comment|WP_Error $wp_object The post or comment to fetch replies for on success.
+	 * @param \WP_Post|\WP_Comment|\WP_Error $wp_object The post or comment to fetch replies for on success.
 	 */
 	private static function build_args( $wp_object ) {
 		$args = array(
@@ -37,13 +34,13 @@ class Replies {
 			'type'    => 'comment',
 		);
 
-		if ( $wp_object instanceof WP_Post ) {
+		if ( $wp_object instanceof \WP_Post ) {
 			$args['parent']  = 0; // TODO: maybe this is unnecessary.
 			$args['post_id'] = $wp_object->ID;
-		} elseif ( $wp_object instanceof WP_Comment ) {
+		} elseif ( $wp_object instanceof \WP_Comment ) {
 			$args['parent'] = $wp_object->comment_ID;
 		} else {
-			return new WP_Error();
+			return new \WP_Error();
 		}
 
 		return $args;
@@ -52,24 +49,24 @@ class Replies {
 	/**
 	 * Get the replies collections ID.
 	 *
-	 * @param WP_Post|WP_Comment $wp_object The post or comment to fetch replies for.
+	 * @param \WP_Post|\WP_Comment $wp_object The post or comment to fetch replies for.
 	 *
-	 * @return string|WP_Error The rest URL of the replies collection or WP_Error if the object is not a post or comment.
+	 * @return string|\WP_Error The rest URL of the replies collection or WP_Error if the object is not a post or comment.
 	 */
 	private static function get_id( $wp_object ) {
-		if ( $wp_object instanceof WP_Post ) {
+		if ( $wp_object instanceof \WP_Post ) {
 			return get_rest_url_by_path( sprintf( 'posts/%d/replies', $wp_object->ID ) );
-		} elseif ( $wp_object instanceof WP_Comment ) {
+		} elseif ( $wp_object instanceof \WP_Comment ) {
 			return get_rest_url_by_path( sprintf( 'comments/%d/replies', $wp_object->comment_ID ) );
 		} else {
-			return new WP_Error( 'unsupported_object', 'The object is not a post or comment.' );
+			return new \WP_Error( 'unsupported_object', 'The object is not a post or comment.' );
 		}
 	}
 
 	/**
 	 * Get the Replies collection.
 	 *
-	 * @param WP_Post|WP_Comment $wp_object The post or comment to fetch replies for.
+	 * @param \WP_Post|\WP_Comment $wp_object The post or comment to fetch replies for.
 	 *
 	 * @return array|\WP_Error|null An associative array containing the replies collection without JSON-LD context on success.
 	 */
@@ -95,11 +92,11 @@ class Replies {
 	 *
 	 * @link https://www.w3.org/TR/activitystreams-vocabulary/#dfn-collectionpage
 	 *
-	 * @param WP_Post|WP_Comment $wp_object The post of comment the replies are for.
-	 * @param int                $page      The current pagination page.
-	 * @param string             $part_of   Optional. The collection id/url the returned CollectionPage belongs to. Default null.
+	 * @param \WP_Post|\WP_Comment $wp_object The post of comment the replies are for.
+	 * @param int                  $page      The current pagination page.
+	 * @param string               $part_of   Optional. The collection id/url the returned CollectionPage belongs to. Default null.
 	 *
-	 * @return array|WP_Error|null A CollectionPage as an associative array on success, WP_Error or null on failure.
+	 * @return array|\WP_Error|null A CollectionPage as an associative array on success, WP_Error or null on failure.
 	 */
 	public static function get_collection_page( $wp_object, $page, $part_of = null ) {
 		// Build initial arguments for fetching approved comments.
@@ -169,7 +166,7 @@ class Replies {
 			)
 		);
 		$ids      = self::get_reply_ids( $comments, true );
-		$post_uri = ( new PostTransformer( $post ) )->to_id();
+		$post_uri = ( new Post_Transformer( $post ) )->to_id();
 		\array_unshift( $ids, $post_uri );
 
 		$author = Actors::get_by_id( $post->post_author );
@@ -196,8 +193,8 @@ class Replies {
 	 * It takes only federated/non-local comments into account, others also do not have an
 	 * ActivityPub ID available.
 	 *
-	 * @param WP_Comment[] $comments              The comments to retrieve the ActivityPub ids from.
-	 * @param boolean      $include_blog_comments Optional. Include blog comments in the returned array. Default false.
+	 * @param \WP_Comment[] $comments              The comments to retrieve the ActivityPub ids from.
+	 * @param boolean       $include_blog_comments Optional. Include blog comments in the returned array. Default false.
 	 *
 	 * @return string[] A list of the ActivityPub ID's.
 	 */
@@ -216,7 +213,7 @@ class Replies {
 			}
 
 			if ( $include_blog_comments ) {
-				$comment_ids[] = ( new CommentTransformer( $comment ) )->to_id();
+				$comment_ids[] = ( new Comment_Transformer( $comment ) )->to_id();
 			}
 		}
 

--- a/includes/collection/class-replies.php
+++ b/includes/collection/class-replies.php
@@ -7,18 +7,17 @@
 
 namespace Activitypub\Collection;
 
-use WP_Post;
-use WP_Comment;
-use WP_Error;
-
 use Activitypub\Comment;
 use Activitypub\Model\Blog;
-use Activitypub\Transformer\Post as PostTransformer;
 use Activitypub\Transformer\Comment as CommentTransformer;
+use Activitypub\Transformer\Post as PostTransformer;
+use WP_Comment;
+use WP_Error;
+use WP_Post;
 
-use function Activitypub\is_post_disabled;
-use function Activitypub\is_local_comment;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_local_comment;
+use function Activitypub\is_post_disabled;
 use function Activitypub\is_user_type_disabled;
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -11,11 +11,11 @@ use Activitypub\Activity\Activity;
 use Activitypub\Activity\Actor;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
-use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
-use Activitypub\Transformer\Post;
+use Activitypub\Collection\Outbox;
 use Activitypub\Transformer\Factory as Transformer_Factory;
+use Activitypub\Transformer\Post;
 
 /**
  * Returns the ActivityPub default JSON-context.

--- a/includes/handler/class-accept.php
+++ b/includes/handler/class-accept.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\Handler;
 
-use Activitypub\Notification;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Following;
 use Activitypub\Collection\Outbox;
+use Activitypub\Notification;
 
 use function Activitypub\object_to_uri;
 

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -7,13 +7,13 @@
 
 namespace Activitypub\Handler;
 
-use Activitypub\Http;
-use Activitypub\Comment;
 use Activitypub\Collection\Interactions;
+use Activitypub\Comment;
+use Activitypub\Http;
 
 use function Activitypub\is_activity;
-use function Activitypub\object_to_uri;
 use function Activitypub\is_activity_public;
+use function Activitypub\object_to_uri;
 
 /**
  * Handle Create requests.

--- a/includes/handler/class-create.php
+++ b/includes/handler/class-create.php
@@ -9,9 +9,9 @@ namespace Activitypub\Handler;
 
 use Activitypub\Collection\Interactions;
 
-use function Activitypub\is_self_ping;
-use function Activitypub\is_activity_reply;
 use function Activitypub\is_activity_public;
+use function Activitypub\is_activity_reply;
+use function Activitypub\is_self_ping;
 use function Activitypub\object_id_to_comment;
 
 /**

--- a/includes/handler/class-delete.php
+++ b/includes/handler/class-delete.php
@@ -7,9 +7,9 @@
 
 namespace Activitypub\Handler;
 
-use Activitypub\Tombstone;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Interactions;
+use Activitypub\Tombstone;
 
 use function Activitypub\object_to_uri;
 

--- a/includes/handler/class-follow.php
+++ b/includes/handler/class-follow.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\Handler;
 
-use Activitypub\Notification;
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use Activitypub\Notification;
 
 use function Activitypub\add_to_outbox;
 

--- a/includes/handler/class-like.php
+++ b/includes/handler/class-like.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Handler;
 
-use Activitypub\Comment;
 use Activitypub\Collection\Interactions;
+use Activitypub\Comment;
 
 use function Activitypub\object_to_uri;
 

--- a/includes/handler/class-move.php
+++ b/includes/handler/class-move.php
@@ -7,9 +7,9 @@
 
 namespace Activitypub\Handler;
 
-use Activitypub\Http;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use Activitypub\Http;
 
 use function Activitypub\object_to_uri;
 

--- a/includes/handler/class-reject.php
+++ b/includes/handler/class-reject.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\Handler;
 
-use Activitypub\Notification;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Following;
 use Activitypub\Collection\Outbox;
+use Activitypub\Notification;
 
 use function Activitypub\object_to_uri;
 

--- a/includes/model/class-application.php
+++ b/includes/model/class-application.php
@@ -10,8 +10,8 @@ namespace Activitypub\Model;
 use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
 
-use function Activitypub\home_host;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\home_host;
 
 /**
  * Application class.

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -12,10 +12,10 @@ use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 
 use function Activitypub\esc_hashtag;
-use function Activitypub\is_single_user;
-use function Activitypub\is_blog_public;
-use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_attribution_domains;
+use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_blog_public;
+use function Activitypub\is_single_user;
 
 /**
  * Blog class.

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -11,9 +11,9 @@ use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 
-use function Activitypub\is_blog_public;
-use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_attribution_domains;
+use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_blog_public;
 use function Activitypub\user_can_activitypub;
 
 /**

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -8,13 +8,11 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Activity\Activity;
-use Activitypub\Collection\Actors;
-use Activitypub\Debug;
 use Activitypub\Moderation;
 
 use function Activitypub\get_context;
-use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_masked_wp_version;
+use function Activitypub\get_rest_url_by_path;
 
 /**
  * Actors_Inbox_Controller class.

--- a/includes/rest/class-collections-controller.php
+++ b/includes/rest/class-collections-controller.php
@@ -9,14 +9,11 @@ namespace Activitypub\Rest;
 
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
-use Activitypub\Model\Application;
-use Activitypub\Model\Blog;
-use Activitypub\Model\User;
 use Activitypub\Transformer\Factory;
 
 use function Activitypub\esc_hashtag;
-use function Activitypub\is_single_user;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_single_user;
 
 /**
  * Collections_Controller class.

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -11,9 +11,8 @@ use Activitypub\Collection\Actors;
 use Activitypub\Collection\Following;
 
 use function Activitypub\get_context;
-use function Activitypub\is_single_user;
-use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_masked_wp_version;
+use function Activitypub\get_rest_url_by_path;
 
 /**
  * Following_Controller class.

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -9,11 +9,10 @@ namespace Activitypub\Rest;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
-use Activitypub\Debug;
 use Activitypub\Moderation;
 
-use function Activitypub\is_same_domain;
 use function Activitypub\extract_recipients_from_activity;
+use function Activitypub\is_same_domain;
 use function Activitypub\user_can_activitypub;
 
 /**

--- a/includes/rest/class-nodeinfo-controller.php
+++ b/includes/rest/class-nodeinfo-controller.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\Rest;
 
-use function Activitypub\get_masked_wp_version;
-use function Activitypub\get_total_users;
 use function Activitypub\get_active_users;
+use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\get_total_users;
 
 /**
  * ActivityPub NodeInfo Controller.

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -10,6 +10,7 @@ namespace Activitypub\Rest;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
+
 use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_rest_url_by_path;
 

--- a/includes/rest/class-post-controller.php
+++ b/includes/rest/class-post-controller.php
@@ -7,9 +7,9 @@
 
 namespace Activitypub\Rest;
 
-use Activitypub\Comment;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Replies;
+use Activitypub\Comment;
 
 use function Activitypub\get_rest_url_by_path;
 

--- a/includes/rest/class-replies-controller.php
+++ b/includes/rest/class-replies-controller.php
@@ -8,8 +8,8 @@
 namespace Activitypub\Rest;
 
 use Activitypub\Activity\Base_Object;
-use Activitypub\Collection\Replies;
 use Activitypub\Collection\Interactions;
+use Activitypub\Collection\Replies;
 
 use function Activitypub\get_rest_url_by_path;
 

--- a/includes/rest/class-url-validator-controller.php
+++ b/includes/rest/class-url-validator-controller.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Rest;
 
-use Activitypub\Http;
 use Activitypub\Embed;
+use Activitypub\Http;
 
 /**
  * URL Validator Controller Class.

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\Transformer;
 
-use Activitypub\Http;
 use Activitypub\Activity\Activity;
-use Activitypub\Collection\Actors;
 use Activitypub\Activity\Base_Object;
+use Activitypub\Collection\Actors;
+use Activitypub\Http;
 
 use function Activitypub\get_upload_baseurl;
 use function Activitypub\object_to_uri;

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -7,16 +7,16 @@
 
 namespace Activitypub\Transformer;
 
-use Activitypub\Webfinger;
-use Activitypub\Comment as Comment_Utils;
-use Activitypub\Model\Blog;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Replies;
+use Activitypub\Comment as Comment_Utils;
+use Activitypub\Model\Blog;
+use Activitypub\Webfinger;
 
-use function Activitypub\is_single_user;
-use function Activitypub\get_rest_url_by_path;
-use function Activitypub\was_comment_received;
 use function Activitypub\get_comment_ancestors;
+use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_single_user;
+use function Activitypub\was_comment_received;
 
 /**
  * WordPress Comment Transformer.

--- a/includes/transformer/class-json.php
+++ b/includes/transformer/class-json.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Transformer;
 
-use function Activitypub\is_actor;
 use function Activitypub\is_activity;
+use function Activitypub\is_actor;
 
 /**
  * String Transformer Class file.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -8,20 +8,20 @@
 namespace Activitypub\Transformer;
 
 use Activitypub\Collection\Actors;
-use Activitypub\Collection\Replies;
 use Activitypub\Collection\Interactions;
+use Activitypub\Collection\Replies;
 use Activitypub\Http;
 use Activitypub\Model\Blog;
 use Activitypub\Shortcodes;
 
 use function Activitypub\esc_hashtag;
-use function Activitypub\is_single_user;
-use function Activitypub\get_enclosures;
-use function Activitypub\get_content_warning;
-use function Activitypub\get_rest_url_by_path;
-use function Activitypub\site_supports_blocks;
 use function Activitypub\generate_post_summary;
 use function Activitypub\get_content_visibility;
+use function Activitypub\get_content_warning;
+use function Activitypub\get_enclosures;
+use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_single_user;
+use function Activitypub\site_supports_blocks;
 
 /**
  * WordPress Post Transformer.

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\WP_Admin;
 
-use Activitypub\Webfinger;
-use Activitypub\Http;
 use Activitypub\Collection\Actors;
+use Activitypub\Http;
 use Activitypub\Sanitize;
+use Activitypub\Webfinger;
 
 use function Activitypub\user_can_activitypub;
 

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -10,6 +10,7 @@ namespace Activitypub\WP_Admin;
 use Activitypub\Collection\Actors;
 use Activitypub\Model\Blog;
 use Activitypub\Sanitize;
+
 use function Activitypub\user_can_activitypub;
 
 /**

--- a/includes/wp-admin/import/class-starter-kit.php
+++ b/includes/wp-admin/import/class-starter-kit.php
@@ -8,8 +8,8 @@
 namespace Activitypub\WP_Admin\Import;
 
 use function Activitypub\follow;
-use function Activitypub\object_to_uri;
 use function Activitypub\is_user_type_disabled;
+use function Activitypub\object_to_uri;
 
 /**
  * Starter Kit importer class.

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -14,7 +14,6 @@ use Activitypub\Http;
 use Activitypub\Mention;
 use Activitypub\Transformer\Factory;
 use Activitypub\Webfinger as Webfinger_Util;
-use DateTime;
 use Enable_Mastodon_Apps\Entity\Account;
 use Enable_Mastodon_Apps\Entity\Media_Attachment;
 use Enable_Mastodon_Apps\Entity\Status;
@@ -205,8 +204,8 @@ class Enable_Mastodon_Apps {
 				$account->url             = $actor->get_url();
 				$account->avatar          = $actor->get_icon_url();
 				$account->avatar_static   = $actor->get_icon_url();
-				$account->created_at      = new DateTime( $actor->get_published() );
-				$account->last_status_at  = new DateTime( $actor->get_published() );
+				$account->created_at      = new \DateTime( $actor->get_published() );
+				$account->last_status_at  = new \DateTime( $actor->get_published() );
 				$account->note            = $actor->get_summary();
 				$account->header          = $actor->get_image_url();
 				$account->header_static   = $actor->get_image_url();
@@ -300,7 +299,7 @@ class Enable_Mastodon_Apps {
 			$account->header_static = $account->header;
 		}
 
-		$account->created_at = new DateTime( $user->get_published() );
+		$account->created_at = new \DateTime( $user->get_published() );
 
 		$post_types = \get_option( 'activitypub_support_post_types', array( 'post' ) );
 		$query_args = array(
@@ -311,7 +310,7 @@ class Enable_Mastodon_Apps {
 			$query_args['author'] = $user_id;
 		}
 		$posts                   = \get_posts( $query_args );
-		$account->last_status_at = ! empty( $posts ) ? new DateTime( $posts[0]->post_date_gmt ) : $account->created_at;
+		$account->last_status_at = ! empty( $posts ) ? new \DateTime( $posts[0]->post_date_gmt ) : $account->created_at;
 
 		$account->fields = self::get_extra_fields( $user_id_to_use );
 		// Now do it in source['fields'] with stripped tags.
@@ -419,7 +418,7 @@ class Enable_Mastodon_Apps {
 		if ( ! isset( $data['published'] ) ) {
 			$data['published'] = 'now';
 		}
-		$account->created_at = new DateTime( $data['published'] );
+		$account->created_at = new \DateTime( $data['published'] );
 
 		return $account;
 	}
@@ -500,8 +499,8 @@ class Enable_Mastodon_Apps {
 			$account->uri            = $actor->get_id();
 			$account->avatar         = $actor->get_icon_url();
 			$account->avatar_static  = $actor->get_icon_url();
-			$account->created_at     = new DateTime( $actor->get_published() );
-			$account->last_status_at = new DateTime( $actor->get_published() );
+			$account->created_at     = new \DateTime( $actor->get_published() );
+			$account->last_status_at = new \DateTime( $actor->get_published() );
 			$account->note           = $actor->get_summary();
 			$account->header         = $actor->get_image_url();
 			$account->header_static  = $actor->get_image_url();
@@ -553,7 +552,7 @@ class Enable_Mastodon_Apps {
 
 		$status             = new Status();
 		$status->id         = $post_id ?? $object['id'];
-		$status->created_at = new DateTime( $object['published'] );
+		$status->created_at = new \DateTime( $object['published'] );
 		$status->content    = $object['content'];
 		$status->account    = $account;
 

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -7,17 +7,17 @@
 
 namespace Activitypub\Integration;
 
-use DateTime;
-use Activitypub\Webfinger as Webfinger_Util;
+use Activitypub\Collection\Actors;
+use Activitypub\Collection\Extra_Fields;
+use Activitypub\Collection\Followers;
 use Activitypub\Http;
 use Activitypub\Mention;
-use Activitypub\Collection\Actors;
-use Activitypub\Collection\Followers;
-use Activitypub\Collection\Extra_Fields;
 use Activitypub\Transformer\Factory;
+use Activitypub\Webfinger as Webfinger_Util;
+use DateTime;
 use Enable_Mastodon_Apps\Entity\Account;
-use Enable_Mastodon_Apps\Entity\Status;
 use Enable_Mastodon_Apps\Entity\Media_Attachment;
+use Enable_Mastodon_Apps\Entity\Status;
 
 use function Activitypub\get_remote_metadata_by_actor;
 use function Activitypub\is_user_type_disabled;

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Integration;
 
-use Activitypub\Comment;
 use Activitypub\Collection\Followers;
+use Activitypub\Comment;
 
 /**
  * Jetpack integration class.

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -7,9 +7,9 @@
 
 namespace Activitypub\Integration;
 
-use function Activitypub\get_total_users;
 use function Activitypub\get_active_users;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\get_total_users;
 
 /**
  * Compatibility with the NodeInfo plugin.

--- a/integration/class-opengraph.php
+++ b/integration/class-opengraph.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Integration;
 
-use Activitypub\Model\Blog;
 use Activitypub\Collection\Actors;
+use Activitypub\Model\Blog;
 
 use function Activitypub\is_single_user;
 use function Activitypub\is_user_type_disabled;

--- a/integration/class-seriously-simple-podcasting.php
+++ b/integration/class-seriously-simple-podcasting.php
@@ -9,8 +9,8 @@ namespace Activitypub\Integration;
 
 use Activitypub\Transformer\Post;
 
-use function Activitypub\object_to_uri;
 use function Activitypub\generate_post_summary;
+use function Activitypub\object_to_uri;
 
 /**
  * Compatibility with the Seriously Simple Podcasting plugin.

--- a/integration/class-stream-connector.php
+++ b/integration/class-stream-connector.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Integration;
 
 use Activitypub\Collection\Actors;
+
 use function Activitypub\url_to_authorid;
 use function Activitypub\url_to_commentid;
 

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -11,8 +11,8 @@ use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
 use Activitypub\Comment;
 
-use function WP_CLI\Utils\make_progress_bar;
 use function WP_CLI\Utils\get_flag_value;
+use function WP_CLI\Utils\make_progress_bar;
 
 /**
  * WP-CLI commands.

--- a/src/followers/render.php
+++ b/src/followers/render.php
@@ -8,6 +8,7 @@
 use Activitypub\Blocks;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+
 use function Activitypub\is_activitypub_request;
 use function Activitypub\object_to_uri;
 

--- a/src/reactions/render.php
+++ b/src/reactions/render.php
@@ -5,8 +5,9 @@
  * @package ActivityPub
  */
 
-use Activitypub\Comment;
 use Activitypub\Blocks;
+use Activitypub\Comment;
+
 use function Activitypub\is_activitypub_request;
 
 if ( is_activitypub_request() || is_feed() ) {

--- a/src/remote-reply/render.php
+++ b/src/remote-reply/render.php
@@ -6,6 +6,7 @@
  */
 
 use Activitypub\Blocks;
+
 use function Activitypub\is_activitypub_request;
 
 if ( is_activitypub_request() || is_feed() ) {

--- a/templates/help-tab/account-migration.php
+++ b/templates/help-tab/account-migration.php
@@ -7,6 +7,7 @@
 
 use Activitypub\Collection\Actors;
 use Activitypub\Model\Blog;
+
 use function Activitypub\user_can_activitypub;
 
 if ( user_can_activitypub( get_current_user_id() ) ) {

--- a/templates/help-tab/core-features.php
+++ b/templates/help-tab/core-features.php
@@ -6,6 +6,7 @@
  */
 
 use Activitypub\Collection\Actors;
+
 use function Activitypub\user_can_activitypub;
 
 $host   = wp_parse_url( home_url(), PHP_URL_HOST );

--- a/tests/class-activitypub-testcase-timer.php
+++ b/tests/class-activitypub-testcase-timer.php
@@ -9,9 +9,9 @@
 
 namespace Activitypub\Tests;
 
+use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
-use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestSuite;
 
 /**

--- a/tests/includes/class-test-activitypub.php
+++ b/tests/includes/class-test-activitypub.php
@@ -8,8 +8,8 @@
 namespace Activitypub\Tests;
 
 use Activitypub\Activitypub;
-use Activitypub\Query;
 use Activitypub\Collection\Outbox;
+use Activitypub\Query;
 
 /**
  * Test class for Activitypub.

--- a/tests/includes/class-test-dispatcher.php
+++ b/tests/includes/class-test-dispatcher.php
@@ -9,8 +9,8 @@ namespace Activitypub\Tests;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
-use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Followers;
+use Activitypub\Collection\Outbox;
 use Activitypub\Dispatcher;
 
 /**

--- a/tests/includes/class-test-mailer.php
+++ b/tests/includes/class-test-mailer.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Tests;
 
-use Activitypub\Mailer;
 use Activitypub\Collection\Actors;
+use Activitypub\Mailer;
 use WP_UnitTestCase;
 
 /**

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -7,13 +7,13 @@
 
 namespace Activitypub\Tests;
 
-use Activitypub\Migration;
-use Activitypub\Comment;
 use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Outbox;
+use Activitypub\Comment;
+use Activitypub\Migration;
 
 /**
  * Test class for Activitypub Migrate.

--- a/tests/includes/class-test-signature.php
+++ b/tests/includes/class-test-signature.php
@@ -9,9 +9,9 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Collection\Actors;
 use Activitypub\Http;
 use Activitypub\Signature;
-use Activitypub\Collection\Actors;
 
 /**
  * Test class for Signature.

--- a/tests/includes/collection/class-test-inbox.php
+++ b/tests/includes/collection/class-test-inbox.php
@@ -9,9 +9,8 @@ namespace Activitypub\Tests\Collection;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
-use Activitypub\Collection\Actors;
-use Activitypub\Collection\Inbox;
 use Activitypub\Activitypub;
+use Activitypub\Collection\Inbox;
 
 /**
  * Test class for Inbox collection.

--- a/tests/includes/collection/class-test-outbox.php
+++ b/tests/includes/collection/class-test-outbox.php
@@ -9,9 +9,7 @@ namespace Activitypub\Tests\Collection;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
-use Activitypub\Activity\Generic_Object;
 use Activitypub\Activity\Extended_Object\Event;
-use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
 
 /**

--- a/tests/includes/handler/class-test-accept.php
+++ b/tests/includes/handler/class-test-accept.php
@@ -7,9 +7,9 @@
 
 namespace Activitypub\Tests\Handler;
 
-use Activitypub\Handler\Accept;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Following;
+use Activitypub\Handler\Accept;
 
 /**
  * Class Test_Accept

--- a/tests/includes/handler/class-test-reject.php
+++ b/tests/includes/handler/class-test-reject.php
@@ -7,10 +7,10 @@
 
 namespace Activitypub\Tests\Handler;
 
-use Activitypub\Handler\Reject;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Following;
 use Activitypub\Collection\Outbox;
+use Activitypub\Handler\Reject;
 
 /**
  * Class Test_Reject

--- a/tests/includes/handler/class-test-update.php
+++ b/tests/includes/handler/class-test-update.php
@@ -8,9 +8,9 @@
 namespace Activitypub\Tests\Handler;
 
 use Activitypub\Activity\Actor;
-use Activitypub\Handler\Update;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
+use Activitypub\Handler\Update;
 
 /**
  * Update Handler Test Class.

--- a/tests/includes/model/class-test-follower.php
+++ b/tests/includes/model/class-test-follower.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Tests\Model;
 
-use Activitypub\Model\Follower;
 use Activitypub\Collection\Actors;
+use Activitypub\Model\Follower;
 
 /**
  * Tests the Follower class.

--- a/tests/includes/rest/class-test-post-controller.php
+++ b/tests/includes/rest/class-test-post-controller.php
@@ -11,7 +11,6 @@ use Activitypub\Rest\Post;
 use WP_REST_Request;
 use WP_REST_Server;
 use WP_UnitTestCase;
-use WP_REST_Response;
 
 /**
  * Test Post REST Endpoints.

--- a/tests/includes/transformer/class-test-activity-object.php
+++ b/tests/includes/transformer/class-test-activity-object.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Tests\Transformer;
 
-use Activitypub\Transformer\Activity_Object;
 use Activitypub\Activity\Base_Object;
+use Activitypub\Transformer\Activity_Object;
 use WP_UnitTestCase;
 
 /**

--- a/tests/includes/transformer/class-test-base.php
+++ b/tests/includes/transformer/class-test-base.php
@@ -7,7 +7,6 @@
 
 namespace Activitypub\Tests\Transformer;
 
-use Activitypub\Http;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Activity\Generic_Object;
 use Activitypub\Transformer\Base;

--- a/tests/includes/transformer/class-test-factory.php
+++ b/tests/includes/transformer/class-test-factory.php
@@ -7,13 +7,13 @@
 
 namespace Activitypub\Tests\Transformer;
 
-use WP_UnitTestCase;
-use Activitypub\Transformer\Factory;
-use Activitypub\Transformer\Post;
-use Activitypub\Transformer\Comment;
-use Activitypub\Transformer\Attachment;
-use Activitypub\Transformer\Json;
 use Activitypub\Transformer\Activity_Object;
+use Activitypub\Transformer\Attachment;
+use Activitypub\Transformer\Comment;
+use Activitypub\Transformer\Factory;
+use Activitypub\Transformer\Json;
+use Activitypub\Transformer\Post;
+use WP_UnitTestCase;
 
 /**
  * Test class for Transformer Factory.

--- a/tests/includes/transformer/class-test-json.php
+++ b/tests/includes/transformer/class-test-json.php
@@ -7,8 +7,8 @@
 
 namespace Activitypub\Tests\Transformer;
 
-use Activitypub\Transformer\Json;
 use Activitypub\Activity\Base_Object;
+use Activitypub\Transformer\Json;
 use WP_UnitTestCase;
 
 /**


### PR DESCRIPTION
Follow-up to #2122.

<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Apply consistent formatting baseline across all PHP files in the codebase
* Sort PHP imports using precommit tooling
* Remove unused imports discovered during formatting process
* Apply PHPCS formatting rules repository-wide
* Apply Prettier formatting to JS/CSS files

### Other information:

- [ ] Have you written new tests for your changes, if applicable? (Not applicable - formatting only)

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify no syntax errors by running `composer lint` 
* Run test suite with `npm run env-test` to ensure no functional regressions
* Check that precommit hook still works correctly on future changes
* Spot check a few files to verify consistent import sorting and formatting