### PR TITLE
Ignore package-lock.json in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ coverage
 node_modules
 tests/fixtures
 vendor
+package-lock.json
 
 # Temporary ignores while breaking out each component.
 assets


### PR DESCRIPTION
Added package-lock.json to the .prettierignore file to prevent Prettier from formatting or processing this dependency lock file.
