### PR TITLE
Prevent duplicate checkstyle annotations in PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -115,22 +115,25 @@ jobs:
           EOF
 
           # Check for PHPUnit warnings and process them
-          if grep -q "WARNINGS!\|There was.*warning" coverage-output.log; then
+          if grep -q "WARNINGS!" coverage-output.log; then
             echo "Processing coverage warnings for checkstyle report..."
 
             # Show warnings section for debugging
             echo "--- Warnings Found ---"
-            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log | head -10
+            sed -n '/There w.*warning/,/WARNINGS!/p' coverage-output.log | head -10
             echo "--- End Warnings ---"
 
             # Extract warnings to temporary file to avoid subshell issues
-            sed -n '/There was.*warning/,/WARNINGS!/p' coverage-output.log > temp-warnings.txt
+            sed -n '/There w.*warning/,/WARNINGS!/p' coverage-output.log > temp-warnings.txt
+
+            # Track processed file:line combinations to avoid duplicates
+            declare -A processed_annotations
 
             # Process each line
             while IFS= read -r line; do
               echo "Processing line: $line"
               # Look for @covers warnings
-              if [[ "$line" =~ \"@covers.*\"\ is\ invalid ]]; then
+              if [[ "$line" =~ \"@covers[^\"]*\"\ is\ invalid ]]; then
                 echo "Found @covers warning line: $line"
                 # Extract the @covers target - everything between quotes
                 if [[ "$line" =~ \"@covers\ ([^\"]+)\" ]]; then
@@ -146,13 +149,25 @@ jobs:
                     echo "Found test file: $TEST_FILE"
                     if LINE_NUM=$(grep -n "@covers.*$METHOD_NAME" "$TEST_FILE" | head -1 | cut -d: -f1); then
                       echo "Found line number: $LINE_NUM"
-                      # Escape XML characters and add checkstyle entry
-                      MESSAGE=$(echo "Invalid @covers annotation: $COVERS_TARGET" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
-                      cat >> coverage-warnings.xml << EOF
+
+                      # Create unique key for this file:line combination
+                      FILE_LINE_KEY="$TEST_FILE:$LINE_NUM"
+
+                      # Only process if we haven't seen this file:line before
+                      if [[ -z "${processed_annotations[$FILE_LINE_KEY]}" ]]; then
+                        echo "Adding annotation for $FILE_LINE_KEY"
+                        processed_annotations[$FILE_LINE_KEY]=1
+
+                        # Escape XML characters and add checkstyle entry
+                        MESSAGE=$(echo "Invalid @covers annotation: $COVERS_TARGET" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
+                        cat >> coverage-warnings.xml << EOF
           <file name="$TEST_FILE">
             <error line="$LINE_NUM" column="1" severity="warning" message="$MESSAGE" source="phpunit.coverage"/>
           </file>
           EOF
+                      else
+                        echo "Skipping duplicate annotation for $FILE_LINE_KEY"
+                      fi
                     fi
                   fi
                 fi


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refines warning detection and improves robustness of the annotation extraction.
* Adds logic to track processed file:line combinations and avoid generating duplicate checkstyle annotations for the same `@covers` warning in the GitHub Actions PHPUnit workflow. 

Extracted from #2215.