### PR TITLE
Add following meta key to Jetpack sync allowlist

### DIFF
--- a/.github/changelog/2226-from-description
+++ b/.github/changelog/2226-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync following meta to enable RSS feed subscriptions for ActivityPub actors in WordPress.com Reader

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Integration;
 
 use Activitypub\Collection\Followers;
+use Activitypub\Collection\Following;
 use Activitypub\Comment;
 
 /**
@@ -32,14 +33,11 @@ class Jetpack {
 	 * @return array The Jetpack sync allow list with ActivityPub meta keys.
 	 */
 	public static function add_sync_meta( $allow_list ) {
-		if ( ! is_array( $allow_list ) ) {
-			return $allow_list;
-		}
-		$activitypub_meta_keys = array(
-			Followers::FOLLOWER_META_KEY,
-			'_activitypub_inbox',
-		);
-		return \array_merge( $allow_list, $activitypub_meta_keys );
+		$allow_list[] = '_activitypub_user_id';
+		$allow_list[] = Followers::FOLLOWER_META_KEY;
+		$allow_list[] = Following::FOLLOWING_META_KEY;
+
+		return $allow_list;
 	}
 
 	/**

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -33,7 +33,6 @@ class Jetpack {
 	 * @return array The Jetpack sync allow list with ActivityPub meta keys.
 	 */
 	public static function add_sync_meta( $allow_list ) {
-		$allow_list[] = '_activitypub_user_id';
 		$allow_list[] = Followers::FOLLOWER_META_KEY;
 		$allow_list[] = Following::FOLLOWING_META_KEY;
 


### PR DESCRIPTION
See #2155.

## Proposed changes:
* Add `_activitypub_user_id` meta key to Jetpack sync allowlist
* Add following information (`Following::FOLLOWING_META_KEY`) to sync allowlist
* Simplify the allowlist logic by removing unnecessary array check and intermediate array creation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Set up a Jetpack-connected WordPress site with ActivityPub plugin
* Follow some ActivityPub accounts to populate following data
* Verify that the following meta keys are synced to WordPress.com:
  * `_activitypub_followers`
  * `_activitypub_following`
* Test RSS feed functionality in WordPress.com Reader for the connected site

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Added - for new features

#### Message

Sync following meta to enable RSS feed subscriptions for ActivityPub actors in WordPress.com Reader

</details>