### PR TITLE
Fix PHP warning in bulk edit scenario when post_author is missing

### DIFF
--- a/.github/changelog/2230-from-description
+++ b/.github/changelog/2230-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP warning in bulk edit scenario when post_author is missing from $_REQUEST

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -46,7 +46,7 @@ class Post {
 		}
 
 		// Bail on bulk edits, unless post author or post status changed.
-		if ( isset( $_REQUEST['bulk_edit'] ) && -1 === (int) $_REQUEST['post_author'] && -1 === (int) $_REQUEST['_status'] ) { // phpcs:ignore WordPress
+		if ( isset( $_REQUEST['bulk_edit'] ) && ( ! isset( $_REQUEST['post_author'] ) || -1 === (int) $_REQUEST['post_author'] ) && -1 === (int) $_REQUEST['_status'] ) { // phpcs:ignore WordPress
 			return;
 		}
 

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -117,8 +117,9 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$post_id        = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
 		$activitypub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
 
-		// Test bulk edit with missing post_author and _status (should not generate PHP warnings).
+		// Test bulk edit with missing post_author (should not generate PHP warnings).
 		$_REQUEST['bulk_edit'] = 1;
+		$_REQUEST['_status']   = -1;
 		$_REQUEST['post']      = array( $post_id );
 
 		bulk_edit_posts( $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification

--- a/tests/includes/scheduler/class-test-post.php
+++ b/tests/includes/scheduler/class-test-post.php
@@ -117,6 +117,15 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$post_id        = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
 		$activitypub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
 
+		// Test bulk edit with missing post_author and _status (should not generate PHP warnings).
+		$_REQUEST['bulk_edit'] = 1;
+		$_REQUEST['post']      = array( $post_id );
+
+		bulk_edit_posts( $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		$outbox_item = $this->get_latest_outbox_item( $activitypub_id );
+		$this->assertNotSame( 'Update', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
+
 		// Test bulk edit that should bail (no author or status change).
 		$_REQUEST['bulk_edit']   = 1;
 		$_REQUEST['post_author'] = -1;
@@ -152,7 +161,7 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$this->assertSame( 'Delete', \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true ) );
 
 		// Clean up.
-		unset( $_REQUEST['bulk_edit'], $_REQUEST['post_author'], $_REQUEST['post_status'] );
+		unset( $_REQUEST['bulk_edit'], $_REQUEST['post_author'], $_REQUEST['_status'], $_REQUEST['post'] );
 		\wp_delete_post( $post_id, true );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes PHP warning that occurs during bulk edit operations when post_author key is missing from $_REQUEST.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add proper `isset()` check for `$_REQUEST['post_author']` before accessing it in Post scheduler class
* Add test case to demonstrate the issue and prevent regression
* Fix PHP warning: "Undefined array key 'post_author'" that occurs in bulk edit scenarios

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `npm run env-test -- --filter=test_schedule_post_activity_bulk_edit` to verify the test passes without PHP warnings
* Run `npm run env-test` to ensure no regressions in other tests
* The fix prevents PHP warnings when bulk editing posts without changing the post author

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix PHP warning in bulk edit scenario when post_author is missing from $_REQUEST

</details>