### PR TITLE
Add health check for active Captcha plugins

### DIFF
--- a/.github/changelog/2231-from-description
+++ b/.github/changelog/2231-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+New site health check warns if active Captcha plugins may block ActivityPub comments.

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -104,6 +104,11 @@ class Health_Check {
 			'test'  => array( self::class, 'test_pretty_permalinks' ),
 		);
 
+		$tests['direct']['activitypub_check_for_captcha_plugins'] = array(
+			'label' => \__( 'Check for Captcha Plugins', 'activitypub' ),
+			'test'  => array( self::class, 'test_check_for_captcha_plugins' ),
+		);
+
 		return $tests;
 	}
 
@@ -463,6 +468,66 @@ class Health_Check {
 					/* translators: %s: Permalink settings URL. */
 					\__( 'Your current permalink structure includes <code>/index.php</code> which is not compatible with ActivityPub. Please <a href="%s">update your permalink settings</a> to use a standard format without <code>/index.php</code>.', 'activitypub' ),
 					esc_url( admin_url( 'options-permalink.php' ) )
+				)
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Check for Captcha Plugins.
+	 *
+	 * @return array The test result.
+	 */
+	public static function test_check_for_captcha_plugins() {
+		$result = array(
+			'label'       => \__( 'Check for Captcha Plugins', 'activitypub' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => \__( 'ActivityPub', 'activitypub' ),
+				'color' => 'green',
+			),
+			'description' => \sprintf(
+				'<p>%s</p>',
+				\__( 'No known Captcha plugins detected that might interfere with ActivityPub functionality.', 'activitypub' )
+			),
+			'actions'     => '',
+			'test'        => 'test_check_for_captcha_plugins',
+		);
+
+		$active_plugins = (array) get_option( 'active_plugins', array() );
+
+		// search for the word 'captcha' in the list of active plugins.
+		$captcha_plugins = array_filter(
+			$active_plugins,
+			function ( $plugin ) {
+				return str_contains( strtolower( $plugin ), 'captcha' );
+			}
+		);
+
+		if ( ! empty( $captcha_plugins ) ) {
+			// Get nice plugin names instead of file paths.
+			$captcha_plugin_names = array_map(
+				function ( $plugin_file ) {
+					$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false, false );
+					if ( ! empty( $plugin_data['Name'] ) ) {
+						return $plugin_data['Name'];
+					}
+					return false;
+				},
+				$captcha_plugins
+			);
+
+			$result['status']         = 'recommended';
+			$result['label']          = \__( 'Captcha plugins detected', 'activitypub' );
+			$result['badge']['color'] = 'orange';
+			$result['description']    = \sprintf(
+				'<p>%s</p>',
+				sprintf(
+					/* translators: %s: List of captcha plugins. */
+					\esc_html__( 'The following Captcha plugins are active and may interfere with ActivityPub functionality: %s.', 'activitypub' ),
+					implode( ', ', array_map( 'esc_html', array_filter( $captcha_plugin_names ) ) )
 				)
 			);
 		}

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -490,7 +490,7 @@ class Health_Check {
 			),
 			'description' => \sprintf(
 				'<p>%s</p>',
-				\__( 'No known Captcha plugins detected that might interfere with ActivityPub functionality.', 'activitypub' )
+				\__( 'No Captcha plugins were found that could interfere with ActivityPub functionality.', 'activitypub' )
 			),
 			'actions'     => '',
 			'test'        => 'test_check_for_captcha_plugins',
@@ -506,31 +506,42 @@ class Health_Check {
 			}
 		);
 
-		if ( ! empty( $captcha_plugins ) ) {
-			// Get nice plugin names instead of file paths.
-			$captcha_plugin_names = array_map(
-				function ( $plugin_file ) {
-					$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false, false );
-					if ( ! empty( $plugin_data['Name'] ) ) {
-						return $plugin_data['Name'];
-					}
-					return false;
-				},
-				$captcha_plugins
-			);
-
-			$result['status']         = 'recommended';
-			$result['label']          = \__( 'Captcha plugins detected', 'activitypub' );
-			$result['badge']['color'] = 'orange';
-			$result['description']    = \sprintf(
-				'<p>%s</p>',
-				sprintf(
-					/* translators: %s: List of captcha plugins. */
-					\esc_html__( 'The following Captcha plugins are active and may interfere with ActivityPub functionality: %s.', 'activitypub' ),
-					implode( ', ', array_map( 'esc_html', array_filter( $captcha_plugin_names ) ) )
-				)
-			);
+		if ( ! $captcha_plugins ) {
+			return $result;
 		}
+
+		// Get nice plugin names instead of file paths.
+		$captcha_plugin_names = array_map(
+			function ( $plugin_file ) {
+				$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false, false );
+				if ( ! empty( $plugin_data['Name'] ) ) {
+					return $plugin_data['Name'];
+				}
+				return false;
+			},
+			$captcha_plugins
+		);
+
+		$result['status']         = 'recommended';
+		$result['label']          = \__( 'Captcha plugins detected', 'activitypub' );
+		$result['badge']['color'] = 'orange';
+		$result['description']    = \sprintf(
+			'<p>%s</p><p>%s</p>',
+			sprintf(
+				/* translators: %s: List of captcha plugins. */
+				\esc_html__( 'The following Captcha plugins are active and may interfere with ActivityPub functionality: %s', 'activitypub' ),
+				implode( ', ', array_map( 'esc_html', array_filter( $captcha_plugin_names ) ) )
+			),
+			__( 'Captcha plugins require verification for comment submissions, but some may not distinguish between regular comments and those sent via an API (such as from ActivityPub). As a result, federated comments might be blocked because they cannot provide a Captcha response. If you experience missing comments, try disabling the Captcha plugin to determine if it resolves the issue.', 'activitypub' )
+		);
+		$result['actions'] = sprintf(
+			'<p>%s</p>',
+			sprintf(
+				// translators: %s: Plugin page URL.
+				\__( 'They can be disabled from the <a href="%s">Plugin Page</a>.', 'activitypub' ),
+				esc_url( admin_url( 'plugins.php?s=captcha&plugin_status=all' ) )
+			)
+		);
 
 		return $result;
 	}

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -496,13 +496,13 @@ class Health_Check {
 			'test'        => 'test_check_for_captcha_plugins',
 		);
 
-		$active_plugins = (array) get_option( 'active_plugins', array() );
+		$active_plugins = (array) \get_option( 'active_plugins', array() );
 
 		// search for the word 'captcha' in the list of active plugins.
 		$captcha_plugins = array_filter(
 			$active_plugins,
 			function ( $plugin ) {
-				return str_contains( strtolower( $plugin ), 'captcha' );
+				return \str_contains( strtolower( $plugin ), 'captcha' );
 			}
 		);
 
@@ -510,12 +510,12 @@ class Health_Check {
 			return $result;
 		}
 
-		// Get nice plugin names instead of file paths.
+		// Get nice plugin names instead of file paths using WordPress built-in functions.
+		$all_plugins          = \get_plugins();
 		$captcha_plugin_names = array_map(
-			function ( $plugin_file ) {
-				$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false, false );
-				if ( ! empty( $plugin_data['Name'] ) ) {
-					return $plugin_data['Name'];
+			function ( $plugin_file ) use ( $all_plugins ) {
+				if ( isset( $all_plugins[ $plugin_file ]['Name'] ) ) {
+					return $all_plugins[ $plugin_file ]['Name'];
 				}
 				return false;
 			},
@@ -527,16 +527,16 @@ class Health_Check {
 		$result['badge']['color'] = 'orange';
 		$result['description']    = \sprintf(
 			'<p>%s</p><p>%s</p>',
-			sprintf(
+			\sprintf(
 				/* translators: %s: List of captcha plugins. */
 				\esc_html__( 'The following Captcha plugins are active and may interfere with ActivityPub functionality: %s', 'activitypub' ),
 				implode( ', ', array_map( 'esc_html', array_filter( $captcha_plugin_names ) ) )
 			),
-			__( 'Captcha plugins require verification for comment submissions, but some may not distinguish between regular comments and those sent via an API (such as from ActivityPub). As a result, federated comments might be blocked because they cannot provide a Captcha response. If you experience missing comments, try disabling the Captcha plugin to determine if it resolves the issue.', 'activitypub' )
+			\__( 'Captcha plugins require verification for comment submissions, but some may not distinguish between regular comments and those sent via an API (such as from ActivityPub). As a result, federated comments might be blocked because they cannot provide a Captcha response. If you experience missing comments, try disabling the Captcha plugin to determine if it resolves the issue.', 'activitypub' )
 		);
-		$result['actions'] = sprintf(
+		$result['actions'] = \sprintf(
 			'<p>%s</p>',
-			sprintf(
+			\sprintf(
 				// translators: %s: Plugin page URL.
 				\__( 'They can be disabled from the <a href="%s">Plugin Page</a>.', 'activitypub' ),
 				esc_url( admin_url( 'plugins.php?s=captcha&plugin_status=all' ) )

--- a/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/includes/wp-admin/class-test-health-check.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Test Health_Check class.
+ *
+ * @package Activitypub
+ */
+
+use Activitypub\WP_Admin\Health_Check;
+
+/**
+ * Test Health_Check class.
+ */
+class Test_Health_Check extends WP_UnitTestCase {
+
+	/**
+	 * Test that health check tests are properly registered.
+	 */
+	public function test_add_tests() {
+		$tests  = array();
+		$result = Health_Check::add_tests( $tests );
+
+		// Check that the captcha test is registered.
+		$this->assertArrayHasKey( 'direct', $result );
+		$this->assertArrayHasKey( 'activitypub_check_for_captcha_plugins', $result['direct'] );
+
+		// Verify test structure.
+		$captcha_test = $result['direct']['activitypub_check_for_captcha_plugins'];
+		$this->assertArrayHasKey( 'label', $captcha_test );
+		$this->assertArrayHasKey( 'test', $captcha_test );
+		$this->assertEquals( array( Health_Check::class, 'test_check_for_captcha_plugins' ), $captcha_test['test'] );
+	}
+
+	/**
+	 * Mock function to return active plugins without captcha.
+	 *
+	 * @return array List of active plugins.
+	 */
+	public function mock_active_plugins_no_captcha() {
+		return array( 'some-other-plugin/plugin.php', 'another-plugin/main.php' );
+	}
+
+	/**
+	 * Mock function to return active plugins with captcha.
+	 *
+	 * @return array List of active plugins.
+	 */
+	public function mock_active_plugins_with_captcha() {
+		return array(
+			'really-simple-captcha/really-simple-captcha.php',
+			'some-other-plugin/plugin.php',
+			'recaptcha-for-woocommerce/recaptcha.php',
+		);
+	}
+
+	/**
+	 * Mock function to return active plugins with mixed case captcha.
+	 *
+	 * @return array List of active plugins.
+	 */
+	public function mock_active_plugins_mixed_case() {
+		return array(
+			'CAPTCHA-plugin/captcha.php',
+			'some-plugin-with-CaPtChA/main.php',
+			'regular-plugin/plugin.php',
+		);
+	}
+
+	/**
+	 * Test captcha plugin detection when no captcha plugins are active.
+	 */
+	public function test_check_for_captcha_plugins_none_found() {
+		// Mock empty active plugins.
+		add_filter(
+			'option_active_plugins',
+			array( $this, 'mock_active_plugins_no_captcha' )
+		);
+
+		$result = Health_Check::test_check_for_captcha_plugins();
+
+		$this->assertEquals( 'good', $result['status'] );
+		$this->assertEquals( 'Check for Captcha Plugins', $result['label'] );
+		$this->assertEquals( 'green', $result['badge']['color'] );
+		$this->assertStringContainsString( 'No Captcha plugins were found', $result['description'] );
+
+		remove_all_filters( 'option_active_plugins' );
+	}
+
+	/**
+	 * Test captcha plugin detection when captcha plugins are found.
+	 * This test focuses on the core detection logic rather than plugin name extraction.
+	 */
+	public function test_check_for_captcha_plugins_found() {
+		// Mock active plugins with captcha plugins.
+		add_filter(
+			'option_active_plugins',
+			array( $this, 'mock_active_plugins_with_captcha' )
+		);
+
+		$result = Health_Check::test_check_for_captcha_plugins();
+
+		// Test the core functionality - captcha plugins should be detected.
+		$this->assertEquals( 'recommended', $result['status'] );
+		$this->assertEquals( 'Captcha plugins detected', $result['label'] );
+		$this->assertEquals( 'orange', $result['badge']['color'] );
+		$this->assertStringContainsString( 'The following Captcha plugins are active', $result['description'] );
+		$this->assertStringContainsString( 'may interfere with ActivityPub functionality', $result['description'] );
+		$this->assertStringContainsString( 'Plugin Page', $result['actions'] );
+
+		// Clean up.
+		remove_all_filters( 'option_active_plugins' );
+	}
+
+	/**
+	 * Test captcha plugin detection with case-insensitive matching.
+	 * This test focuses on the case-insensitive detection logic.
+	 */
+	public function test_check_for_captcha_plugins_case_insensitive() {
+		// Mock active plugins with mixed case captcha plugins.
+		add_filter(
+			'option_active_plugins',
+			array( $this, 'mock_active_plugins_mixed_case' )
+		);
+
+		$result = Health_Check::test_check_for_captcha_plugins();
+
+		// Test that case-insensitive matching works.
+		$this->assertEquals( 'recommended', $result['status'] );
+		$this->assertEquals( 'Captcha plugins detected', $result['label'] );
+		$this->assertEquals( 'orange', $result['badge']['color'] );
+
+		remove_all_filters( 'option_active_plugins' );
+	}
+
+	/**
+	 * Test count_results method.
+	 */
+	public function test_count_results() {
+		// Test counting all results.
+		$all_results = Health_Check::count_results( 'all' );
+		$this->assertIsArray( $all_results );
+		$this->assertArrayHasKey( 'good', $all_results );
+		$this->assertArrayHasKey( 'critical', $all_results );
+		$this->assertArrayHasKey( 'recommended', $all_results );
+
+		// Test counting specific result types.
+		$good_count = Health_Check::count_results( 'good' );
+		$this->assertIsInt( $good_count );
+
+		$critical_count = Health_Check::count_results( 'critical' );
+		$this->assertIsInt( $critical_count );
+
+		$recommended_count = Health_Check::count_results( 'recommended' );
+		$this->assertIsInt( $recommended_count );
+	}
+
+	/**
+	 * Test that the actions link points to the correct plugin page.
+	 * This test focuses on the action link generation.
+	 */
+	public function test_captcha_plugins_actions_link() {
+		// Mock active plugins with captcha plugin.
+		add_filter(
+			'option_active_plugins',
+			array( $this, 'mock_active_plugins_with_captcha' )
+		);
+
+		$result = Health_Check::test_check_for_captcha_plugins();
+
+		// Test that the actions contain the correct plugin management link.
+		// WordPress encodes & as &#038; for security, so we check for the encoded version.
+		$this->assertStringContainsString( 'plugins.php?s=captcha&#038;plugin_status=all', $result['actions'] );
+		$this->assertStringContainsString( 'Plugin Page', $result['actions'] );
+
+		remove_all_filters( 'option_active_plugins' );
+	}
+
+	/**
+	 * Test debug_information method includes ActivityPub fields.
+	 */
+	public function test_debug_information() {
+		$info   = array();
+		$result = Health_Check::debug_information( $info );
+
+		$this->assertArrayHasKey( 'activitypub', $result );
+		$this->assertArrayHasKey( 'label', $result['activitypub'] );
+		$this->assertArrayHasKey( 'fields', $result['activitypub'] );
+		$this->assertEquals( 'ActivityPub', $result['activitypub']['label'] );
+	}
+
+	/**
+	 * Test captcha plugin array filtering functionality.
+	 * This tests the array_filter behavior used in the health check.
+	 */
+	public function test_captcha_plugin_array_filtering() {
+		// Test the array filtering used in the health check to remove empty plugin names.
+		$captcha_plugins = array( 'really-simple-captcha/captcha.php', 'another-captcha/main.php' );
+
+		// Simulate the array_filter operation from the health check.
+		$filtered_plugins = array_filter(
+			$captcha_plugins,
+			function ( $plugin ) {
+				return str_contains( strtolower( $plugin ), 'captcha' );
+			}
+		);
+
+		$this->assertCount( 2, $filtered_plugins );
+		$this->assertContains( 'really-simple-captcha/captcha.php', $filtered_plugins );
+		$this->assertContains( 'another-captcha/main.php', $filtered_plugins );
+	}
+
+	/**
+	 * Test that array_filter works correctly to remove false values.
+	 */
+	public function test_array_filter_removes_false_values() {
+		$plugin_names = array( 'Really Simple CAPTCHA', false, 'Another Plugin', false );
+		$filtered     = array_filter( $plugin_names );
+
+		$this->assertCount( 2, $filtered );
+		$this->assertContains( 'Really Simple CAPTCHA', $filtered );
+		$this->assertContains( 'Another Plugin', $filtered );
+		$this->assertNotContains( false, $filtered );
+	}
+}


### PR DESCRIPTION
Introduces a new site health test to detect active Captcha plugins that may interfere with ActivityPub functionality. The test notifies administrators if any such plugins are found, listing their names for easier identification.

<img width="1053" height="457" alt="Screenshot 2025-09-25 at 11 14 55" src="https://github.com/user-attachments/assets/eac3aac0-cd88-4857-b4e7-70c618b3ed64" />

See:

* https://github.com/Automattic/wordpress-activitypub/issues?q=captcha
* https://wordpress.org/search/captcha+activitypub/
* https://wordpress.org/support/topic/technical-docs-2/

## Proposed changes:

- Adds a health check test to identify Captcha plugins by searching for "captcha" in active plugin filenames
- Provides user-friendly notifications with plugin names and explanatory messages
- Includes actionable guidance directing users to the plugins page to disable problematic plugins


### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install a Captcha plugin and check the Site-Health page.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

New site health check warns if active Captcha plugins may block ActivityPub comments.

</details>
