### PR TITLE
Register post types and meta on 'init' action

### DIFF
--- a/.github/changelog/2232-from-description
+++ b/.github/changelog/2232-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where post metadata in the block editor was missing or failed to update.

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -22,11 +22,11 @@ class Post_Types {
 	 * Initialize the class, registering all custom post types and post meta.
 	 */
 	public static function init() {
-		self::register_remote_actors_post_type();
-		self::register_inbox_post_type();
-		self::register_outbox_post_type();
-		self::register_extra_fields_post_types();
-		self::register_activitypub_post_meta();
+		\add_action( 'init', array( self::class, 'register_remote_actors_post_type' ), 11 );
+		\add_action( 'init', array( self::class, 'register_inbox_post_type' ), 11 );
+		\add_action( 'init', array( self::class, 'register_outbox_post_type' ), 11 );
+		\add_action( 'init', array( self::class, 'register_extra_fields_post_types' ), 11 );
+		\add_action( 'init', array( self::class, 'register_activitypub_post_meta' ), 11 );
 
 		\add_action( 'rest_api_init', array( self::class, 'register_ap_actor_rest_field' ) );
 
@@ -529,13 +529,13 @@ class Post_Types {
 		}
 
 		// If meta value is already explicitly set, respect the author's choice.
-		if ( null !== $meta_value ) {
+		if ( $meta_value ) {
 			return $meta_value;
 		}
 
 		// If the post is federated, return the default visibility.
 		if ( 'federated' === \get_post_meta( $object_id, 'activitypub_status', true ) ) {
-			return null;
+			return $meta_value;
 		}
 
 		// If the post is not federated and older than a month, return local visibility.
@@ -543,6 +543,6 @@ class Post_Types {
 			return ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL;
 		}
 
-		return null;
+		return $meta_value;
 	}
 }

--- a/tests/includes/class-test-post-types.php
+++ b/tests/includes/class-test-post-types.php
@@ -85,8 +85,8 @@ class Test_Post_Types extends \WP_UnitTestCase {
 
 		// Test 5: When meta value is already set (not null), should respect author's explicit choice.
 		\update_post_meta( $post_id, 'activitypub_status', 'pending' ); // Ensure not federated.
-		$result = Post_Types::default_post_meta_data( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, $post_id, 'activitypub_content_visibility' );
-		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, $result, 'Should respect explicitly set public visibility even for old unfederated posts.' );
+		$result = Post_Types::default_post_meta_data( ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC, $post_id, 'activitypub_content_visibility' );
+		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC, $result, 'Should respect explicitly set public visibility even for old unfederated posts.' );
 
 		// Test 6: Only apply local visibility when meta value is null (no explicit setting).
 		$result = Post_Types::default_post_meta_data( null, $post_id, 'activitypub_content_visibility' );


### PR DESCRIPTION
Moved custom post type and post meta registration to the 'init' action hook with priority 11 for better compatibility with WordPress initialization. Also updated the get_content_visibility_meta_value logic to consistently return the meta value when set or when the post is federated or not older than a month.

It looks like a race condition is causing metas in the block editor to go missing and preventing them from being updated.

<img width="347" height="492" alt="Screenshot 2025-09-24 at 19 57 21" src="https://github.com/user-attachments/assets/73ce0d9f-ff58-43fa-a18f-812539445af7" />

Also fixes #2228 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Call the register_* functions in a later hook (calling the full class in a later hook won't work)
* Changed the check for the default content-visibility from `null !== $meta_value` to `! empty( $meta_value )` because it is never `null` but empty string by default.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check Block-Editor for defaults
* Try to change defaults and save them

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed an issue where post metadata in the block editor was missing or failed to update.

</details>
