### PR TITLE
Enhance Jetpack integration for comment meta sync

### DIFF
--- a/.github/changelog/2233-from-description
+++ b/.github/changelog/2233-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated sync allowlist to add support for Jetpack notifications of likes and reposts.

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -21,6 +21,8 @@ class Jetpack {
 	 */
 	public static function init() {
 		\add_filter( 'jetpack_sync_post_meta_whitelist', array( self::class, 'add_sync_meta' ) );
+		\add_filter( 'jetpack_sync_comment_meta_whitelist', array( self::class, 'add_sync_comment_meta' ) );
+		\add_filter( 'jetpack_sync_whitelisted_comment_types', array( self::class, 'add_comment_types' ) );
 		\add_filter( 'jetpack_json_api_comment_types', array( self::class, 'add_comment_types' ) );
 		\add_filter( 'jetpack_api_include_comment_types_count', array( self::class, 'add_comment_types' ) );
 	}
@@ -40,12 +42,30 @@ class Jetpack {
 	}
 
 	/**
+	 * Add ActivityPub comment meta keys to the Jetpack sync allow list.
+	 *
+	 * @param array $allow_list The Jetpack sync allow list.
+	 *
+	 * @return array The Jetpack sync allow list with ActivityPub comment meta keys.
+	 */
+	public static function add_sync_comment_meta( $allow_list ) {
+		$allow_list[] = 'avatar_url';
+
+		return $allow_list;
+	}
+
+	/**
 	 * Add custom comment types to the list of comment types.
 	 *
 	 * @param array $comment_types Default comment types.
 	 * @return array
 	 */
 	public static function add_comment_types( $comment_types ) {
+		// jetpack_sync_whitelisted_comment_types runs on plugins_loaded, before comment types are registered.
+		if ( 'jetpack_sync_whitelisted_comment_types' === current_filter() ) {
+			Comment::register_comment_types();
+		}
+
 		return array_unique( \array_merge( $comment_types, Comment::get_comment_type_slugs() ) );
 	}
 }


### PR DESCRIPTION
Fixes #1059.

Adds the required sync information to make like and repost notifications work for Jetpack and WoA sites.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds filters to include ActivityPub comment meta keys and custom comment types in Jetpack sync. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Can only be tested in conjunction with changes on WordPress.com.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Updated sync allowlist to add support for Jetpack notifications of likes and reposts.

</details>
