### PR TITLE
Add `fetch_by_acct` and `fetch_by_various` methods to Remote_Actors

### DIFF
--- a/.github/changelog/2235-from-description
+++ b/.github/changelog/2235-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added support for fetching actors by account identifiers and improved reliability of actor retrieval.

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -203,6 +203,21 @@ class Remote_Actors {
 	}
 
 	/**
+	 * Fetch a remote actor post by either actor URI or acct, fetching from remote if not found locally.
+	 *
+	 * @param string $uri_or_acct The actor URI or acct identifier.
+	 *
+	 * @return \WP_Post|\WP_Error Post object or WP_Error if not found.
+	 */
+	public static function fetch_by_various( $uri_or_acct ) {
+		if ( \filter_var( $uri_or_acct, FILTER_VALIDATE_URL ) ) {
+			return self::fetch_by_uri( $uri_or_acct );
+		}
+
+		return self::fetch_by_acct( $uri_or_acct );
+	}
+
+	/**
 	 * Lookup a remote actor post by actor URI (guid), fetching from remote if not found locally.
 	 *
 	 * @param string $actor_uri The actor URI.
@@ -237,6 +252,45 @@ class Remote_Actors {
 		}
 
 		return \get_post( $post_id );
+	}
+
+	/**
+	 * Fetch a remote actor post by acct, fetching from remote if not found locally.
+	 *
+	 * @param string $acct The acct identifier.
+	 *
+	 * @return \WP_Post|\WP_Error Post object or WP_Error if not found.
+	 */
+	public static function fetch_by_acct( $acct ) {
+		$acct = Sanitize::webfinger( $acct );
+
+		// Check local DB for acct post meta.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$post_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key='_activitypub_acct' AND meta_value=%s",
+				esc_sql( $acct )
+			)
+		);
+
+		if ( $post_id ) {
+			return \get_post( $post_id );
+		}
+
+		$profile_uri = Webfinger::resolve( $acct );
+
+		if ( \is_wp_error( $profile_uri ) ) {
+			return $profile_uri;
+		}
+
+		$post = self::fetch_by_uri( $profile_uri );
+
+		if ( ! \is_wp_error( $post ) ) {
+			\update_post_meta( $post->ID, '_activitypub_acct', $acct );
+		}
+
+		return $post;
 	}
 
 	/**

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -278,7 +278,7 @@ class Remote_Actors {
 		$post_id = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key='_activitypub_acct' AND meta_value=%s",
-				esc_sql( $acct )
+				$acct
 			)
 		);
 

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -214,7 +214,15 @@ class Remote_Actors {
 			return self::fetch_by_uri( $uri_or_acct );
 		}
 
-		return self::fetch_by_acct( $uri_or_acct );
+		if ( preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $uri_or_acct ) ) {
+			return self::fetch_by_acct( $uri_or_acct );
+		}
+
+		return new \WP_Error(
+			'activitypub_invalid_actor_identifier',
+			'The actor identifier is not supported',
+			array( 'status' => 400 )
+		);
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -85,7 +85,7 @@ function get_webfinger_resource( $user_id ) {
  *
  * @return array|\WP_Error The Actor profile as array or WP_Error on failure.
  */
-function get_remote_metadata_by_actor( $actor, $cached = true ) {
+function get_remote_metadata_by_actor( $actor, $cached = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable, Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	/**
 	 * Filters the metadata before it is retrieved from a remote actor.
 	 *
@@ -101,7 +101,13 @@ function get_remote_metadata_by_actor( $actor, $cached = true ) {
 		return $pre;
 	}
 
-	return Http::get_remote_object( $actor, $cached );
+	$remote_actor = Remote_Actors::fetch_by_various( $actor );
+
+	if ( is_wp_error( $remote_actor ) ) {
+		return $remote_actor;
+	}
+
+	return json_decode( $remote_actor->post_content, true );
 }
 
 /**


### PR DESCRIPTION
Introduces `fetch_by_acct` to retrieve remote actor posts by acct identifier, resolving via Webfinger and fetching remotely if not found locally. Adds `fetch_by_various` to select between URI and acct-based fetching. Comprehensive tests for both methods are included, covering local, remote, and error scenarios.

<!--- Provide a general summary of your changes in the Title above -->

In preparation to #2225

This PR introduces the least invasive change needed to cache all Actors in the ap_actor post type. It also adds the necessary functions to update the rest of the code and deprecates `get_remote_metadata_by_actor`.

## Proposed changes:

- Introduces `fetch_by_acct` method to retrieve actors via webfinger resolution of acct identifiers
- Adds `fetch_by_various` method as a unified interface to select between URI and acct-based fetching
- Updates `get_remote_metadata_by_actor` to use the new `fetch_by_various` method instead of direct HTTP calls

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check unit tests

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added support for fetching actors by account identifiers and improved reliability of actor retrieval.

</details>
