### PR TITLE
Refine handling of local content visibility for posts

### DIFF
--- a/.github/changelog/2236-from-description
+++ b/.github/changelog/2236-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Improved handling of posts switched to 'local' visibility so they update correctly and can be re-enabled by changing visibility again.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -337,13 +337,10 @@ function is_post_disabled( $post ) {
 
 	if (
 		! $disabled &&
-		\in_array( $visibility, array( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE ), true )
+		\in_array( $visibility, array( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE ), true ) &&
+		'federated' !== \get_post_meta( $post->ID, 'activitypub_status', true )
 	) {
-		if ( 'federated' === \get_post_meta( $post->ID, 'activitypub_status', true ) ) {
-			// If post was already federated, we need to send an update with the new visibility.
-			$disabled = false;
-
-		} else {
+			// If post wasn't federated, we don't need to send an update with the new visibility.
 			$disabled = true;
 		}
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -325,16 +325,27 @@ function is_post_disabled( $post ) {
 		return true;
 	}
 
-	$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
-
 	if (
-		ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL === $visibility ||
-		ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE === $visibility ||
 		! \post_type_supports( $post->post_type, 'activitypub' ) ||
 		'private' === $post->post_status ||
 		! empty( $post->post_password )
 	) {
 		$disabled = true;
+	}
+
+	$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
+
+	if (
+		! $disabled &&
+		\in_array( $visibility, array( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE ), true )
+	) {
+		if ( 'federated' === \get_post_meta( $post->ID, 'activitypub_status', true ) ) {
+			// If post was already federated, we need to send an update with the new visibility.
+			$disabled = false;
+
+		} else {
+			$disabled = true;
+		}
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -340,9 +340,8 @@ function is_post_disabled( $post ) {
 		\in_array( $visibility, array( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE ), true ) &&
 		'federated' !== \get_post_meta( $post->ID, 'activitypub_status', true )
 	) {
-			// If post wasn't federated, we don't need to send an update with the new visibility.
-			$disabled = true;
-		}
+		// If post wasn't federated, we don't need to send an update with the new visibility.
+		$disabled = true;
 	}
 
 	/**

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -208,8 +208,8 @@ abstract class Base {
 				$activity_object->add_to( $replied_to );
 				break;
 			case ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL:
-				$activity_object->set_to( array() );
-				$activity_object->set_cc( array() );
+				$activity_object->add_to( $actor->get_id() );
+				$activity_object->add_cc( $actor->get_id() );
 		}
 
 		return $activity_object;

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -206,6 +206,10 @@ abstract class Base {
 			case ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE:
 				$activity_object->add_to( $mentions );
 				$activity_object->add_to( $replied_to );
+				break;
+			case ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL:
+				$activity_object->add_to( $actor->get_id() );
+				$activity_object->add_cc( $actor->get_id() );
 		}
 
 		return $activity_object;

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -208,8 +208,8 @@ abstract class Base {
 				$activity_object->add_to( $replied_to );
 				break;
 			case ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL:
-				$activity_object->add_to( $actor->get_id() );
-				$activity_object->add_cc( $actor->get_id() );
+				$activity_object->set_to( array() );
+				$activity_object->set_cc( array() );
 		}
 
 		return $activity_object;

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -578,10 +578,6 @@ class Post extends Base {
 	 * @return string|array|null The in-reply-to URL of the post.
 	 */
 	protected function get_in_reply_to() {
-		if ( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL === $this->get_content_visibility() ) {
-			return null;
-		}
-
 		if ( ! site_supports_blocks() ) {
 			return null;
 		}

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -578,6 +578,10 @@ class Post extends Base {
 	 * @return string|array|null The in-reply-to URL of the post.
 	 */
 	protected function get_in_reply_to() {
+		if ( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL === $this->get_content_visibility() ) {
+			return null;
+		}
+
 		if ( ! site_supports_blocks() ) {
 			return null;
 		}

--- a/tests/includes/class-test-query.php
+++ b/tests/includes/class-test-query.php
@@ -320,6 +320,11 @@ class Test_Query extends \WP_UnitTestCase {
 		Query::get_instance()->__destruct();
 		add_post_meta( self::$post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
 		$this->go_to( get_permalink( self::$post_id ) );
+		$this->assertNotNull( Query::get_instance()->get_activitypub_object() );
+
+		Query::get_instance()->__destruct();
+		delete_post_meta( self::$post_id, 'activitypub_status' );
+		$this->go_to( get_permalink( self::$post_id ) );
 		$this->assertNull( Query::get_instance()->get_activitypub_object() );
 
 		Query::get_instance()->__destruct();

--- a/tests/includes/collection/class-test-replies.php
+++ b/tests/includes/collection/class-test-replies.php
@@ -72,6 +72,7 @@ class Test_Replies extends \WP_UnitTestCase {
 		);
 
 		// Test with disabled post.
+		delete_post_meta( $context_post_id, 'activitypub_status' );
 		add_post_meta( $context_post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
 		$this->assertFalse( Replies::get_context_collection( $context_post_id ), 'Should return false for disabled posts' );
 		delete_post_meta( $context_post_id, 'activitypub_content_visibility' );

--- a/tests/includes/transformer/class-test-post.php
+++ b/tests/includes/transformer/class-test-post.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Tests\Transformer;
 
 use Activitypub\Activity\Base_Object;
+use Activitypub\Collection\Actors;
 use Activitypub\Transformer\Post;
 
 /**
@@ -286,12 +287,15 @@ class Test_Post extends \WP_UnitTestCase {
 		$object = Post::transform( get_post( $post_id ) )->to_object();
 		$this->assertContains( 'https://www.w3.org/ns/activitystreams#Public', $object->get_cc() );
 
+		\delete_post_meta( $post_id, 'activitypub_status' );
 		\update_post_meta( $post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
+
+		$actor = Actors::get_by_id( 1 );
 
 		$this->assertTrue( \Activitypub\is_post_disabled( $post_id ) );
 		$object = Post::transform( get_post( $post_id ) )->to_object();
-		$this->assertEmpty( $object->get_to() );
-		$this->assertEmpty( $object->get_cc() );
+		$this->assertEquals( array( $actor->get_id() ), $object->get_to() );
+		$this->assertEquals( array( $actor->get_id() ), $object->get_cc() );
 	}
 
 	/**


### PR DESCRIPTION
This PR aims to send an `Update` activity when a previously federated post is later set to local, reflecting changes to the audience (`to`, `cc` fields) and `in_reply_to`.

The benefit of this change (if it works as intended) over sending a `Delete` is that the post can be reactivated by simply changing its visibility.

Improves logic for 'activitypub_content_visibility' set to 'local', ensuring posts are only disabled if not already federated. Updates transformer logic to set correct recipients for local posts, prevents in-reply-to for local visibility, and adds/updates related unit tests to cover these scenarios.

<!--- Provide a general summary of your changes in the Title above -->

For reference https://wordpress.org/support/topic/how-to-delete-federated-posts/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Send Updates when a post was published before and set to `local` afterwards
* Clear `in_reply_to` (not sure if that is needed)
* Only set Post-Author to `to` and `cc` (not if that is needed or if empty arrays would also do the job)

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish a `public` post
* Change visibility to `local`
* Check Outbox if `Update` is properly created

* Write new post and set to `local` before publishing
* Check that no `Update` / `Create` Activities were created

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Improved handling of posts switched to 'local' visibility so they update correctly and can be re-enabled by changing visibility again.

</details>
