### PR TITLE
Add init check to get_comment_type_slugs

### DIFF
--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -561,7 +561,7 @@ class Comment {
 	 */
 	public static function get_comment_type_slugs() {
 		if ( ! did_action( 'init' ) ) {
-			_doing_it_wrong( __METHOD__, 'This function should not be called before register_comment_types() has run.', 'unreleased' );
+			_doing_it_wrong( __METHOD__, 'This function should not be called before the init action has run. Comment types are only available after init.', 'unreleased' );
 
 			return array();
 		}

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -560,6 +560,12 @@ class Comment {
 	 * @return array The registered custom comment type slugs.
 	 */
 	public static function get_comment_type_slugs() {
+		if ( ! did_action( 'init' ) ) {
+			_doing_it_wrong( __METHOD__, 'This function should not be called before register_comment_types() has run.', 'unreleased' );
+
+			return array();
+		}
+
 		return array_keys( self::get_comment_types() );
 	}
 


### PR DESCRIPTION
While working on sync on Dotcom I encountered a few circumstances where `get_comment_type_slugs()` was called on `plugins_loaded` and caused a PHP error because `self::get_comment_types()` returned `null`. These should be edge cases, but with this change at least it's failing more gracefully.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a check to ensure get_comment_type_slugs() is not called before the 'init' action has run. This prevents usage before comment types are registered and improves error handling.
