### PR TITLE
Add QuoteRequest activity handler support

### DIFF
--- a/.github/changelog/2240-from-description
+++ b/.github/changelog/2240-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added support for QuoteRequest activities (FEP-044f), enabling proper handling, validation, and policy-based acceptance or rejection of quote requests.

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -21,6 +21,7 @@ The WordPress plugin largely follows ActivityPub's server-to-server specificatio
 - [FEP-b2b8: Long-form Text](https://codeberg.org/fediverse/fep/src/branch/main/fep/b2b8/fep-b2b8.md)
 - [FEP-7888: Demystifying the context property](https://codeberg.org/fediverse/fep/src/branch/main/fep/7888/fep-7888.md)
 - [FEP-844e: Capability discovery](https://codeberg.org/fediverse/fep/src/branch/main/fep/844e/fep-844e.md)
+- [FEP-044f: Consent-respecting quote posts](https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md)
 
 Partially supported FEPs
 

--- a/includes/activity/class-activity.php
+++ b/includes/activity/class-activity.php
@@ -22,6 +22,10 @@ use Activitypub\Activity\Extended_Object\Place;
 class Activity extends Base_Object {
 	const JSON_LD_CONTEXT = array(
 		'https://www.w3.org/ns/activitystreams',
+		array(
+			'toot'         => 'http://joinmastodon.org/ns#',
+			'QuoteRequest' => 'toot:QuoteRequest',
+		),
 	);
 
 	/**
@@ -50,6 +54,7 @@ class Activity extends Base_Object {
 		'Listen',
 		'Move',
 		'Offer',
+		'QuoteRequest', // @see https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md
 		'Read',
 		'Reject',
 		'Remove',

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -39,6 +39,7 @@ use function Activitypub\snake_to_camel_case;
  * @method string|string[]|null          get_origin()             Gets the origin property of the object.
  * @method string|null                   get_preferred_username() Gets the preferred username of the object.
  * @method string|null                   get_published()          Gets the date and time the object was published in ISO 8601 format.
+ * @method string|null                   get_result()             Gets the result property of the object.
  * @method bool|null                     get_sensitive()          Gets the sensitive property of the object.
  * @method string|null                   get_summary()            Gets the natural language summary of the object.
  * @method string[]|null                 get_summary_map()        Gets the summary map property of the object.
@@ -70,6 +71,7 @@ use function Activitypub\snake_to_camel_case;
  * @method Base_Object set_object( string|array|Base_Object|null $data ) Sets the direct object of the activity.
  * @method Base_Object set_origin( string|array|null $origin )           Sets the origin property of the object.
  * @method Base_Object set_published( string|null $published )           Sets the date and time the object was published in ISO 8601 format.
+ * @method Base_Object set_result( string|null $result )                 Sets the result property of the object.
  * @method Base_Object set_sensitive( bool|null $sensitive )             Sets the sensitive property of the object.
  * @method Base_Object set_summary( string $summary )                    Sets the natural language summary of the object.
  * @method Base_Object set_summary_map( array|null $summary_map )        Sets the summary property of the object.

--- a/includes/activity/extended-object/class-quote-authorization.php
+++ b/includes/activity/extended-object/class-quote-authorization.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Event is an implementation of one of the
+ * Activity Streams Event object type
+ *
+ * @package activity-event-transformers
+ */
+
+namespace Activitypub\Activity\Extended_Object;
+
+use Activitypub\Activity\Base_Object;
+
+/**
+ * Class representing a QuoteAuthorization activity.
+ *
+ * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md#quoteauthorization
+ */
+class Quote_Authorization extends Base_Object {
+	/**
+	 * The JSON-LD context for the object.
+	 *
+	 * @var array
+	 */
+	const JSON_LD_CONTEXT = array(
+		'https://www.w3.org/ns/activitystreams',
+		array(
+			'QuoteAuthorization' => 'https://w3id.org/fep/044f#QuoteAuthorization',
+			'gts'                => 'https://gotosocial.org/ns#',
+			'interactingObject'  => array(
+				'@id'   => 'gts:interactingObject',
+				'@type' => '@id',
+			),
+			'interactionTarget'  => array(
+				'@id'   => 'gts:interactionTarget',
+				'@type' => '@id',
+			),
+		),
+	);
+
+	/**
+	 * The type of the object.
+	 *
+	 * @var string
+	 */
+	protected $type = 'QuoteAuthorization';
+
+	/**
+	 * The object that is being interacted with.
+	 *
+	 * @var mixed
+	 */
+	protected $interacting_object;
+
+	/**
+	 * The target of the interaction.
+	 *
+	 * @var mixed
+	 */
+	protected $interaction_target;
+}

--- a/includes/activity/extended-object/class-quote-authorization.php
+++ b/includes/activity/extended-object/class-quote-authorization.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Event is an implementation of one of the
- * Activity Streams Event object type
+ * Quote_Authorization is an implementation of the QuoteAuthorization activity type,
+ * as defined in FEP-044f (https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md#quoteauthorization).
  *
- * @package activity-event-transformers
+ * This class represents a QuoteAuthorization activity for ActivityPub implementations.
  */
 
 namespace Activitypub\Activity\Extended_Object;

--- a/includes/activity/extended-object/class-quote-authorization.php
+++ b/includes/activity/extended-object/class-quote-authorization.php
@@ -16,6 +16,14 @@ use Activitypub\Activity\Base_Object;
  * Class representing a QuoteAuthorization activity.
  *
  * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md#quoteauthorization
+ *
+ * @since unreleased
+ *
+ * @method Base_Object|string|array|null get_interacting_object() Gets the interacting object property of the object.
+ * @method Base_Object|string|array|null get_interaction_target() Gets the interaction target property of the object.
+ *
+ * @method Quote_Authorization set_interacting_object( string|array|Base_Object|null $data ) Sets the interacting object property of the object.
+ * @method Quote_Authorization set_interaction_target( string|array|Base_Object|null $data ) Sets the interaction target property of the object.
  */
 class Quote_Authorization extends Base_Object {
 	/**
@@ -49,14 +57,14 @@ class Quote_Authorization extends Base_Object {
 	/**
 	 * The object that is being interacted with.
 	 *
-	 * @var mixed
+	 * @var string|Base_Object|array|null
 	 */
 	protected $interacting_object;
 
 	/**
 	 * The target of the interaction.
 	 *
-	 * @var mixed
+	 * @var string|Base_Object|array|null
 	 */
 	protected $interaction_target;
 }

--- a/includes/activity/extended-object/class-quote-authorization.php
+++ b/includes/activity/extended-object/class-quote-authorization.php
@@ -4,6 +4,8 @@
  * as defined in FEP-044f (https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md#quoteauthorization).
  *
  * This class represents a QuoteAuthorization activity for ActivityPub implementations.
+ *
+ * @package Activitypub
  */
 
 namespace Activitypub\Activity\Extended_Object;

--- a/includes/activity/extended-object/class-quote-authorization.php
+++ b/includes/activity/extended-object/class-quote-authorization.php
@@ -57,14 +57,14 @@ class Quote_Authorization extends Base_Object {
 	/**
 	 * The object that is being interacted with.
 	 *
-	 * @var string|Base_Object|array|null
+	 * @var Base_Object|string|array|null
 	 */
 	protected $interacting_object;
 
 	/**
 	 * The target of the interaction.
 	 *
-	 * @var string|Base_Object|array|null
+	 * @var Base_Object|string|array|null
 	 */
 	protected $interaction_target;
 }

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -238,6 +238,7 @@ class Activitypub {
 
 		$query_params = \wp_parse_args( $query );
 		unset( $query_params['activitypub'] );
+		unset( $query_params['stamp'] );
 
 		if ( 1 !== count( $query_params ) ) {
 			return $redirect_url;
@@ -312,6 +313,7 @@ class Activitypub {
 		$vars[] = 'preview';
 		$vars[] = 'author';
 		$vars[] = 'actor';
+		$vars[] = 'stamp';
 		$vars[] = 'type';
 		$vars[] = 'c';
 		$vars[] = 'p';

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -473,7 +473,7 @@ class Comment {
 		}
 
 		// Generate URI based on comment ID.
-		return \add_query_arg( 'c', $comment->comment_ID, \trailingslashit( \home_url() ) );
+		return \add_query_arg( 'c', $comment->comment_ID, \home_url( '/' ) );
 	}
 
 	/**

--- a/includes/class-handler.php
+++ b/includes/class-handler.php
@@ -15,6 +15,7 @@ use Activitypub\Handler\Follow;
 use Activitypub\Handler\Inbox;
 use Activitypub\Handler\Like;
 use Activitypub\Handler\Move;
+use Activitypub\Handler\Quote_Request;
 use Activitypub\Handler\Reject;
 use Activitypub\Handler\Undo;
 use Activitypub\Handler\Update;

--- a/includes/class-handler.php
+++ b/includes/class-handler.php
@@ -42,6 +42,7 @@ class Handler {
 		Inbox::init();
 		Like::init();
 		Move::init();
+		Quote_Request::init();
 		Reject::init();
 		Undo::init();
 		Update::init();

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -404,7 +404,7 @@ class Query {
 				'p'     => $post->ID,
 				'stamp' => $meta->meta_id,
 			),
-			\trailingslashit( \home_url() )
+			\home_url( '/' )
 		);
 
 		$activitypub_object = new Quote_Authorization();

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -7,9 +7,13 @@
 
 namespace Activitypub;
 
+use Activitypub\Activity\Extended_Object\Quote_Authorization;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
 use Activitypub\Transformer\Factory;
+
+use function Activitypub\get_post_id;
+use function Activitypub\get_user_id;
 
 /**
  * Singleton class to handle and store the ActivityPub query.
@@ -137,6 +141,10 @@ class Query {
 	 */
 	private function prepare_activitypub_data() {
 		$queried_object = $this->get_queried_object();
+
+		if ( $queried_object instanceof \WP_Post && \get_query_var( 'stamp' ) ) {
+			return $this->maybe_get_stamp();
+		}
 
 		// Check for Outbox Activity.
 		if (
@@ -311,7 +319,7 @@ class Query {
 	 */
 	public function should_negotiate_content() {
 		$return           = false;
-		$always_negotiate = array( 'p', 'c', 'author', 'actor', 'preview', 'activitypub' );
+		$always_negotiate = array( 'p', 'c', 'author', 'actor', 'stamp', 'preview', 'activitypub' );
 		$url              = \wp_parse_url( $this->get_request_url(), PHP_URL_QUERY );
 		$query            = array();
 		\wp_parse_str( $url, $query );
@@ -367,5 +375,47 @@ class Query {
 	 */
 	public function set_old_host_request( $state = true ) {
 		$this->is_old_host_request = $state;
+	}
+
+	/**
+	 * Maybe get a QuoteAuthorization object from a stamp.
+	 *
+	 * @return bool True if the object was prepared, false otherwise.
+	 */
+	private function maybe_get_stamp() {
+		require_once ABSPATH . 'wp-admin/includes/post.php';
+
+		$stamp = \get_query_var( 'stamp' );
+		$meta  = \get_post_meta_by_id( (int) $stamp );
+
+		if ( ! $meta ) {
+			return false;
+		}
+
+		$post     = $this->get_queried_object();
+		$user_uri = get_user_id( $post->post_author );
+
+		if ( ! $user_uri ) {
+			return false;
+		}
+
+		$stamp_uri = \add_query_arg(
+			array(
+				'p'     => $post->ID,
+				'stamp' => $meta->meta_id,
+			),
+			\trailingslashit( \home_url() )
+		);
+
+		$activitypub_object = new Quote_Authorization();
+		$activitypub_object->set_id( $stamp_uri );
+		$activitypub_object->set_attributed_to( $user_uri );
+		$activitypub_object->set_interacting_object( $meta->meta_value );
+		$activitypub_object->set_interaction_target( get_post_id( $post->ID ) );
+
+		$this->activitypub_object    = $activitypub_object;
+		$this->activitypub_object_id = $activitypub_object->get_id();
+
+		return true;
 	}
 }

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -12,9 +12,6 @@ use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
 use Activitypub\Transformer\Factory;
 
-use function Activitypub\get_post_id;
-use function Activitypub\get_user_id;
-
 /**
  * Singleton class to handle and store the ActivityPub query.
  */

--- a/includes/class-router.php
+++ b/includes/class-router.php
@@ -199,6 +199,7 @@ class Router {
 
 		$query_params = \wp_parse_args( $query );
 		unset( $query_params['activitypub'] );
+		unset( $query_params['stamp'] );
 
 		if ( 1 !== count( $query_params ) ) {
 			return $redirect_url;
@@ -273,6 +274,7 @@ class Router {
 		$vars[] = 'preview';
 		$vars[] = 'author';
 		$vars[] = 'actor';
+		$vars[] = 'stamp';
 		$vars[] = 'type';
 		$vars[] = 'c';
 		$vars[] = 'p';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1300,15 +1300,27 @@ function get_content_warning( $post_id ) {
 /**
  * Get the ActivityPub ID of a User by the WordPress User ID.
  *
+ * If
+ *
  * @param int $id The WordPress User ID.
  *
  * @return string The ActivityPub ID (a URL) of the User.
  */
 function get_user_id( $id ) {
-	$user = Actors::get_by_id( $id );
+	$mode = \get_option( 'activitypub_actor_mode', 'default' );
+
+	if ( ACTIVITYPUB_BLOG_MODE === $mode ) {
+		$user = Actors::get_by_id( 0 );
+	} else {
+		$user = Actors::get_by_id( $id );
+	}
 
 	if ( \is_wp_error( $user ) ) {
-		return false;
+		if ( ! is_user_type_disabled( 'blog' ) ) {
+			$user = Actors::get_by_id( 0 );
+		} else {
+			return false;
+		}
 	}
 
 	return $user->get_id();
@@ -1322,14 +1334,15 @@ function get_user_id( $id ) {
  * @return string The ActivityPub ID (a URL) of the Post.
  */
 function get_post_id( $id ) {
-	$post = get_post( $id );
+	$last_legacy_id = (int) \get_option( 'activitypub_last_post_with_permalink_as_id', 0 );
+	$post_id        = (int) $id;
 
-	if ( ! $post ) {
-		return false;
+	if ( $post_id > $last_legacy_id ) {
+		// Generate URI based on post ID.
+		return \add_query_arg( 'p', $post_id, \trailingslashit( \home_url() ) );
 	}
 
-	$transformer = new Post( $post );
-	return $transformer->get_id();
+	return \get_permalink( $post_id );
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1308,17 +1308,17 @@ function get_user_id( $id ) {
 	$mode = \get_option( 'activitypub_actor_mode', 'default' );
 
 	if ( ACTIVITYPUB_BLOG_MODE === $mode ) {
-		$user = Actors::get_by_id( 0 );
+		$user = Actors::get_by_id( Actors::BLOG_USER_ID );
 	} else {
 		$user = Actors::get_by_id( $id );
+
+		if ( \is_wp_error( $user ) ) {
+			$user = Actors::get_by_id( Actors::BLOG_USER_ID );
+		}
 	}
 
 	if ( \is_wp_error( $user ) ) {
-		if ( ! is_user_type_disabled( 'blog' ) ) {
-			$user = Actors::get_by_id( 0 );
-		} else {
-			return false;
-		}
+		return false;
 	}
 
 	return $user->get_id();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1300,8 +1300,6 @@ function get_content_warning( $post_id ) {
 /**
  * Get the ActivityPub ID of a User by the WordPress User ID.
  *
- * If
- *
  * @param int $id The WordPress User ID.
  *
  * @return string The ActivityPub ID (a URL) of the User.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1337,7 +1337,7 @@ function get_post_id( $id ) {
 
 	if ( $post_id > $last_legacy_id ) {
 		// Generate URI based on post ID.
-		return \add_query_arg( 'p', $post_id, \trailingslashit( \home_url() ) );
+		return \add_query_arg( 'p', $post_id, \home_url( '/' ) );
 	}
 
 	return \get_permalink( $post_id );

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -38,8 +38,14 @@ class Quote_Request {
 	 * @param int   $user_id  The user ID.
 	 */
 	public static function handle_quote_request( $activity, $user_id ) {
-		$post           = \get_post( object_to_uri( $activity['object'] ) );
-		$content_policy = \get_post_meta( $post->ID, 'activitypub_interaction_policy_quote', true );
+		$post_id = \url_to_postid( object_to_uri( $activity['object'] ) );
+
+		if ( ! $post_id ) {
+			self::queue_reject( $activity, $user_id );
+			return;
+		}
+
+		$content_policy = \get_post_meta( $post_id, 'activitypub_interaction_policy_quote', true );
 
 		switch ( $content_policy ) {
 			case ACTIVITYPUB_INTERACTION_POLICY_ME:
@@ -84,6 +90,12 @@ class Quote_Request {
 	 * @param int   $user_id         The user ID.
 	 */
 	public static function queue_accept( $activity_object, $user_id ) {
+		$actor = Actors::get_by_id( $user_id );
+
+		if ( \is_wp_error( $actor ) ) {
+			return;
+		}
+
 		$activity_object['instrument'] = object_to_uri( $activity_object['instrument'] );
 
 		// Only send minimal data.
@@ -100,7 +112,7 @@ class Quote_Request {
 
 		$activity = new Activity();
 		$activity->set_type( 'Accept' );
-		$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
+		$activity->set_actor( $actor->get_id() );
 		$activity->set_object( $activity_object );
 		$activity->add_to( object_to_uri( $activity_object['actor'] ) );
 
@@ -116,6 +128,12 @@ class Quote_Request {
 	 * @param int   $user_id  The user ID.
 	 */
 	public static function queue_reject( $activity_object, $user_id ) {
+		$actor = Actors::get_by_id( $user_id );
+
+		if ( \is_wp_error( $actor ) ) {
+			return;
+		}
+
 		$activity_object['instrument'] = object_to_uri( $activity_object['instrument'] );
 
 		// Only send minimal data.
@@ -132,7 +150,7 @@ class Quote_Request {
 
 		$activity = new Activity();
 		$activity->set_type( 'Reject' );
-		$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
+		$activity->set_actor( $actor->get_id() );
 		$activity->set_object( $activity_object );
 		$activity->add_to( object_to_uri( $activity_object['actor'] ) );
 
@@ -149,16 +167,17 @@ class Quote_Request {
 	 * @return bool The validation state: true if valid, false if not.
 	 */
 	public static function validate_object( $valid, $param, $request ) {
+		if ( \is_wp_error( $request ) ) {
+			return $valid;
+		}
+
 		$json_params = $request->get_json_params();
 
 		if ( empty( $json_params['type'] ) ) {
 			return false;
 		}
 
-		if (
-			'QuoteRequest' !== $json_params['type'] ||
-			\is_wp_error( $request )
-		) {
+		if ( 'QuoteRequest' !== $json_params['type'] ) {
 			return $valid;
 		}
 

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -68,12 +68,12 @@ class Quote_Request {
 		}
 
 		/**
-		 * Fires after an ActivityPub Announce activity has been handled.
+		 * Fires after an ActivityPub QuoteRequest activity has been handled.
 		 *
-		 * @param array                            $activity The ActivityPub activity data.
-		 * @param int                              $user_id  The local user ID.
-		 * @param bool                             $success  True on success, false otherwise.
-		 * @param array|string|int|\WP_Error|false $result   The WP_Comment object of the created announce/repost comment, or null if creation failed.
+		 * @param array $activity The ActivityPub activity data.
+		 * @param int   $user_id  The local user ID.
+		 * @param bool  $success  True on success, false otherwise.
+		 * @param null  $result   Reserved for future use. Currently always null for QuoteRequest activities.
 		 */
 		\do_action( 'activitypub_handled_quoterequest', $activity, $user_id, $state, null );
 	}

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -41,19 +41,19 @@ class Quote_Request {
 
 		switch ( $content_policy ) {
 			case ACTIVITYPUB_INTERACTION_POLICY_ANYONE:
-				self::send_accept( $activity, $user_id );
+				self::queue_accept( $activity, $user_id );
 				break;
 			case ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS:
 				$follower = Remote_Actors::get_by_uri( object_to_uri( $activity['actor'] ) );
 				if ( ! \is_wp_error( $follower ) && Followers::follows( $follower->ID, $user_id ) ) {
-					self::send_accept( $activity, $user_id );
+					self::queue_accept( $activity, $user_id );
 				} else {
-					self::send_reject( $activity, $user_id );
+					self::queue_reject( $activity, $user_id );
 				}
 				break;
 			case ACTIVITYPUB_INTERACTION_POLICY_ME:
 			default:
-				self::send_reject( $activity, $user_id );
+				self::queue_reject( $activity, $user_id );
 				break;
 		}
 	}
@@ -76,25 +76,61 @@ class Quote_Request {
 	/**
 	 * Send an Accept activity in response to the QuoteRequest.
 	 *
-	 * @param array $activity The activity object.
-	 * @param int   $user_id  The user ID.
+	 * @param array $activity_object The activity object.
+	 * @param int   $user_id         The user ID.
 	 */
-	public static function send_accept( $activity, $user_id ) {
-		$activity = self::normalize_activity( $activity );
+	public static function queue_accept( $activity_object, $user_id ) {
+		$activity_object['instrument'] = object_to_uri( $activity_object['instrument'] );
 
-		add_to_outbox( $activity, 'Accept', $user_id );
+		// Only send minimal data.
+		$activity_object = array_intersect_key(
+			$activity_object,
+			array(
+				'id'         => 1,
+				'type'       => 1,
+				'actor'      => 1,
+				'object'     => 1,
+				'instrument' => 1,
+			)
+		);
+
+		$activity = new Activity();
+		$activity->set_type( 'Accept' );
+		$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
+		$activity->set_object( $activity_object );
+		$activity->add_to( object_to_uri( $activity_object['actor'] ) );
+
+		add_to_outbox( $activity, null, $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 	}
 
 	/**
 	 * Send a Reject activity in response to the QuoteRequest.
 	 *
-	 * @param array $activity The activity object.
+	 * @param array $activity_object The activity object.
 	 * @param int   $user_id  The user ID.
 	 */
-	public static function send_reject( $activity, $user_id ) {
-		$activity = self::normalize_activity( $activity );
+	public static function queue_reject( $activity_object, $user_id ) {
+		$activity_object['instrument'] = object_to_uri( $activity_object['instrument'] );
 
-		add_to_outbox( $activity, 'Reject', $user_id );
+		// Only send minimal data.
+		$activity_object = array_intersect_key(
+			$activity_object,
+			array(
+				'id'         => 1,
+				'type'       => 1,
+				'actor'      => 1,
+				'object'     => 1,
+				'instrument' => 1,
+			)
+		);
+
+		$activity = new Activity();
+		$activity->set_type( 'Reject' );
+		$activity->set_actor( Actors::get_by_id( $user_id )->get_id() );
+		$activity->set_object( $activity_object );
+		$activity->add_to( object_to_uri( $activity_object['actor'] ) );
+
+		add_to_outbox( $activity, null, $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 	}
 
 	/**
@@ -142,24 +178,5 @@ class Quote_Request {
 		}
 
 		return $valid;
-	}
-
-	/**
-	 * Normalize the activity.
-	 *
-	 * @param array $activity The activity object.
-	 *
-	 * @return array The normalized activity object.
-	 */
-	private static function normalize_activity( $activity ) {
-		if ( empty( $activity['type'] ) ) {
-			$activity['type'] = 'QuoteRequest';
-		}
-
-		if ( empty( $activity['id'] ) ) {
-			$activity['id'] = \wp_generate_uuid4();
-		}
-
-		return $activity;
 	}
 }

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -146,7 +146,7 @@ class Quote_Request {
 				'p'     => $post_id,
 				'stamp' => $meta_id,
 			),
-			\trailingslashit( \home_url() )
+			\home_url( '/' )
 		);
 
 		$activity = new Activity();

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Move handler file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Handler;
+
+use Activitypub\Collection\Followers;
+use Activitypub\Collection\Remote_Actors;
+
+use function Activitypub\add_to_outbox;
+use function Activitypub\object_to_uri;
+
+/**
+ * Handler for QuoteRequest activities.
+ *
+ * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md
+ */
+class Quote_Request {
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_action( 'activitypub_inbox_quoterequest', array( self::class, 'handle_quote_request' ), 10, 2 );
+		\add_action( 'activitypub_rest_inbox_disallowed', array( self::class, 'handle_blocked_request' ), 10, 4 );
+
+		\add_filter( 'activitypub_validate_object', array( self::class, 'validate_object' ), 10, 3 );
+	}
+
+	/**
+	 * Handle QuoteRequest activities.
+	 *
+	 * @param array $activity The activity object.
+	 * @param int   $user_id  The user ID.
+	 */
+	public static function handle_quote_request( $activity, $user_id ) {
+		$post           = \get_post( object_to_uri( $activity['object'] ) );
+		$content_policy = \get_post_meta( $post->ID, 'activitypub_interaction_policy_quote', true );
+
+		switch ( $content_policy ) {
+			case ACTIVITYPUB_INTERACTION_POLICY_ANYONE:
+				self::send_accept( $activity, $user_id );
+				break;
+			case ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS:
+				$follower = Remote_Actors::get_by_uri( object_to_uri( $activity['actor'] ) );
+				if ( ! \is_wp_error( $follower ) && Followers::follows( $follower->ID, $user_id ) ) {
+					self::send_accept( $activity, $user_id );
+				} else {
+					self::send_reject( $activity, $user_id );
+				}
+				break;
+			case ACTIVITYPUB_INTERACTION_POLICY_ME:
+			default:
+				self::send_reject( $activity, $user_id );
+				break;
+		}
+	}
+
+	/**
+	 * ActivityPub inbox disallowed activity.
+	 *
+	 * @param array  $activity The activity array.
+	 * @param null   $user_id  The user ID.
+	 * @param string $type     The type of the activity.
+	 */
+	public static function handle_blocked_request( $activity, $user_id, $type ) {
+		if ( 'quoterequest' !== \strtolower( $type ) ) {
+			return;
+		}
+
+		self::send_reject( $activity, $user_id );
+	}
+
+	/**
+	 * Send an Accept activity in response to the QuoteRequest.
+	 *
+	 * @param array $activity The activity object.
+	 * @param int   $user_id  The user ID.
+	 */
+	public static function send_accept( $activity, $user_id ) {
+		$activity = self::normalize_activity( $activity );
+
+		add_to_outbox( $activity, 'Accept', $user_id );
+	}
+
+	/**
+	 * Send a Reject activity in response to the QuoteRequest.
+	 *
+	 * @param array $activity The activity object.
+	 * @param int   $user_id  The user ID.
+	 */
+	public static function send_reject( $activity, $user_id ) {
+		$activity = self::normalize_activity( $activity );
+
+		add_to_outbox( $activity, 'Reject', $user_id );
+	}
+
+	/**
+	 * Validate the object.
+	 *
+	 * @param bool             $valid   The validation state.
+	 * @param string           $param   The object parameter.
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return bool The validation state: true if valid, false if not.
+	 */
+	public static function validate_object( $valid, $param, $request ) {
+		$json_params = $request->get_json_params();
+
+		if ( empty( $json_params['type'] ) ) {
+			return false;
+		}
+
+		if (
+			'QuoteRequest' !== $json_params['type'] ||
+			\is_wp_error( $request )
+		) {
+			return $valid;
+		}
+
+		$required_attributes = array(
+			'actor',
+			'object',
+		);
+
+		if ( ! empty( \array_diff( $required_attributes, \array_keys( $json_params ) ) ) ) {
+			return false;
+		}
+
+		$required_object_attributes = array(
+			'id',
+			'type',
+			'actor',
+			'object',
+			'instrument',
+		);
+
+		if ( ! empty( \array_diff( $required_object_attributes, \array_keys( $json_params['object'] ) ) ) ) {
+			return false;
+		}
+
+		return $valid;
+	}
+
+	/**
+	 * Normalize the activity.
+	 *
+	 * @param array $activity The activity object.
+	 *
+	 * @return array The normalized activity object.
+	 */
+	private static function normalize_activity( $activity ) {
+		if ( empty( $activity['type'] ) ) {
+			$activity['type'] = 'QuoteRequest';
+		}
+
+		if ( empty( $activity['id'] ) ) {
+			$activity['id'] = \wp_generate_uuid4();
+		}
+
+		return $activity;
+	}
+}

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -82,9 +82,9 @@ class Quote_Request {
 	/**
 	 * ActivityPub inbox disallowed activity.
 	 *
-	 * @param array  $activity The activity array.
-	 * @param null   $user_id  The user ID.
-	 * @param string $type     The type of the activity.
+	 * @param array    $activity The activity array.
+	 * @param int|null $user_id  The user ID.
+	 * @param string   $type     The type of the activity.
 	 */
 	public static function handle_blocked_request( $activity, $user_id, $type ) {
 		if ( 'quoterequest' !== \strtolower( $type ) ) {

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -78,6 +78,8 @@ class Quote_Request {
 	/**
 	 * Send an Accept activity in response to the QuoteRequest.
 	 *
+	 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md#example-accept
+	 *
 	 * @param array $activity_object The activity object.
 	 * @param int   $user_id         The user ID.
 	 */
@@ -107,6 +109,8 @@ class Quote_Request {
 
 	/**
 	 * Send a Reject activity in response to the QuoteRequest.
+	 *
+	 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md#example-reject
 	 *
 	 * @param array $activity_object The activity object.
 	 * @param int   $user_id  The user ID.

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -42,8 +42,8 @@ class Quote_Request {
 		$content_policy = \get_post_meta( $post->ID, 'activitypub_interaction_policy_quote', true );
 
 		switch ( $content_policy ) {
-			case ACTIVITYPUB_INTERACTION_POLICY_ANYONE:
-				self::queue_accept( $activity, $user_id );
+			case ACTIVITYPUB_INTERACTION_POLICY_ME:
+				self::queue_reject( $activity, $user_id );
 				break;
 			case ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS:
 				$follower = Remote_Actors::get_by_uri( object_to_uri( $activity['actor'] ) );
@@ -53,9 +53,9 @@ class Quote_Request {
 					self::queue_reject( $activity, $user_id );
 				}
 				break;
-			case ACTIVITYPUB_INTERACTION_POLICY_ME:
+			case ACTIVITYPUB_INTERACTION_POLICY_ANYONE:
 			default:
-				self::queue_reject( $activity, $user_id );
+				self::queue_accept( $activity, $user_id );
 				break;
 		}
 	}

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -7,6 +7,8 @@
 
 namespace Activitypub\Handler;
 
+use Activitypub\Activity\Activity;
+use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Remote_Actors;
 
@@ -70,7 +72,7 @@ class Quote_Request {
 			return;
 		}
 
-		self::send_reject( $activity, $user_id );
+		self::queue_reject( $activity, $user_id );
 	}
 
 	/**

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -71,12 +71,12 @@ class Quote_Request {
 		/**
 		 * Fires after an ActivityPub QuoteRequest activity has been handled.
 		 *
-		 * @param array $activity The ActivityPub activity data.
-		 * @param int   $user_id  The local user ID.
-		 * @param bool  $success  True on success, false otherwise.
-		 * @param null  $result   Reserved for future use. Currently always null for QuoteRequest activities.
+		 * @param array  $activity       The ActivityPub activity data.
+		 * @param int    $user_id        The local user ID.
+		 * @param bool   $success        True on success, false otherwise.
+		 * @param string $content_policy The content policy for the quoted post.
 		 */
-		\do_action( 'activitypub_handled_quote_request', $activity, $user_id, $state, null );
+		\do_action( 'activitypub_handled_quote_request', $activity, $user_id, $state, $content_policy );
 	}
 
 	/**

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -51,6 +51,7 @@ class Quote_Request {
 		switch ( $content_policy ) {
 			case ACTIVITYPUB_INTERACTION_POLICY_ME:
 				self::queue_reject( $activity, $user_id, $post_id );
+				$state = false;
 				break;
 			case ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS:
 				$follower = Remote_Actors::get_by_uri( object_to_uri( $activity['actor'] ) );

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -24,7 +24,7 @@ class Quote_Request {
 	 */
 	public static function init() {
 		\add_action( 'activitypub_inbox_quoterequest', array( self::class, 'handle_quote_request' ), 10, 2 );
-		\add_action( 'activitypub_rest_inbox_disallowed', array( self::class, 'handle_blocked_request' ), 10, 4 );
+		\add_action( 'activitypub_rest_inbox_disallowed', array( self::class, 'handle_blocked_request' ), 10, 3 );
 
 		\add_filter( 'activitypub_validate_object', array( self::class, 'validate_object' ), 10, 3 );
 	}

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -50,7 +50,7 @@ class Quote_Request {
 
 		switch ( $content_policy ) {
 			case ACTIVITYPUB_INTERACTION_POLICY_ME:
-				self::queue_reject( $activity, $user_id, $post_id );
+				self::queue_reject( $activity, $user_id );
 				$state = false;
 				break;
 			case ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS:

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -25,7 +25,7 @@ class Quote_Request {
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
-		\add_action( 'activitypub_inbox_quoterequest', array( self::class, 'handle_quote_request' ), 10, 2 );
+		\add_action( 'activitypub_inbox_quote_request', array( self::class, 'handle_quote_request' ), 10, 2 );
 		\add_action( 'activitypub_rest_inbox_disallowed', array( self::class, 'handle_blocked_request' ), 10, 3 );
 
 		\add_filter( 'activitypub_validate_object', array( self::class, 'validate_object' ), 10, 3 );

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -76,7 +76,7 @@ class Quote_Request {
 		 * @param bool  $success  True on success, false otherwise.
 		 * @param null  $result   Reserved for future use. Currently always null for QuoteRequest activities.
 		 */
-		\do_action( 'activitypub_handled_quoterequest', $activity, $user_id, $state, null );
+		\do_action( 'activitypub_handled_quote_request', $activity, $user_id, $state, null );
 	}
 
 	/**

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -159,21 +159,10 @@ class Quote_Request {
 		$required_attributes = array(
 			'actor',
 			'object',
-		);
-
-		if ( ! empty( \array_diff( $required_attributes, \array_keys( $json_params ) ) ) ) {
-			return false;
-		}
-
-		$required_object_attributes = array(
-			'id',
-			'type',
-			'actor',
-			'object',
 			'instrument',
 		);
 
-		if ( ! empty( \array_diff( $required_object_attributes, \array_keys( $json_params['object'] ) ) ) ) {
+		if ( ! empty( \array_diff( $required_attributes, \array_keys( $json_params ) ) ) ) {
 			return false;
 		}
 

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Move handler file.
+ * Handler for QuoteRequest activities.
  *
  * @package Activitypub
  */

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -38,6 +38,7 @@ class Quote_Request {
 	 * @param int   $user_id  The user ID.
 	 */
 	public static function handle_quote_request( $activity, $user_id ) {
+		$state   = true;
 		$post_id = \url_to_postid( object_to_uri( $activity['object'] ) );
 
 		if ( ! $post_id ) {
@@ -49,21 +50,32 @@ class Quote_Request {
 
 		switch ( $content_policy ) {
 			case ACTIVITYPUB_INTERACTION_POLICY_ME:
-				self::queue_reject( $activity, $user_id );
+				self::queue_reject( $activity, $user_id, $post_id );
 				break;
 			case ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS:
 				$follower = Remote_Actors::get_by_uri( object_to_uri( $activity['actor'] ) );
 				if ( ! \is_wp_error( $follower ) && Followers::follows( $follower->ID, $user_id ) ) {
-					self::queue_accept( $activity, $user_id );
+					self::queue_accept( $activity, $user_id, $post_id );
 				} else {
 					self::queue_reject( $activity, $user_id );
+					$state = false;
 				}
 				break;
 			case ACTIVITYPUB_INTERACTION_POLICY_ANYONE:
 			default:
-				self::queue_accept( $activity, $user_id );
+				self::queue_accept( $activity, $user_id, $post_id );
 				break;
 		}
+
+		/**
+		 * Fires after an ActivityPub Announce activity has been handled.
+		 *
+		 * @param array                            $activity The ActivityPub activity data.
+		 * @param int                              $user_id  The local user ID.
+		 * @param bool                             $success  True on success, false otherwise.
+		 * @param array|string|int|\WP_Error|false $result   The WP_Comment object of the created announce/repost comment, or null if creation failed.
+		 */
+		\do_action( 'activitypub_handled_quoterequest', $activity, $user_id, $state, null );
 	}
 
 	/**
@@ -88,8 +100,9 @@ class Quote_Request {
 	 *
 	 * @param array $activity_object The activity object.
 	 * @param int   $user_id         The user ID.
+	 * @param int   $post_id         The post ID.
 	 */
-	public static function queue_accept( $activity_object, $user_id ) {
+	public static function queue_accept( $activity_object, $user_id, $post_id ) {
 		$actor = Actors::get_by_id( $user_id );
 
 		if ( \is_wp_error( $actor ) ) {
@@ -97,6 +110,23 @@ class Quote_Request {
 		}
 
 		$activity_object['instrument'] = object_to_uri( $activity_object['instrument'] );
+
+		$post_meta = \get_post_meta( $post_id, '_activitypub_quoted_by', false );
+		if ( in_array( $activity_object['instrument'], $post_meta, true ) ) {
+			global $wpdb;
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$meta_id = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s AND meta_value = %s LIMIT 1",
+					$post_id,
+					'_activitypub_quoted_by',
+					$activity_object['instrument']
+				)
+			);
+		} else {
+			$meta_id = \add_post_meta( $post_id, '_activitypub_quoted_by', $activity_object['instrument'] );
+		}
 
 		// Only send minimal data.
 		$activity_object = array_intersect_key(
@@ -110,10 +140,19 @@ class Quote_Request {
 			)
 		);
 
+		$url = \add_query_arg(
+			array(
+				'p'     => $post_id,
+				'stamp' => $meta_id,
+			),
+			\trailingslashit( \home_url() )
+		);
+
 		$activity = new Activity();
 		$activity->set_type( 'Accept' );
 		$activity->set_actor( $actor->get_id() );
 		$activity->set_object( $activity_object );
+		$activity->set_result( $url );
 		$activity->add_to( object_to_uri( $activity_object['actor'] ) );
 
 		add_to_outbox( $activity, null, $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -96,7 +96,7 @@ class Blog extends Actor {
 			return \esc_url( \trailingslashit( get_home_url() ) . '@' . $this->get_preferred_username() );
 		}
 
-		return \add_query_arg( 'author', $this->_id, \trailingslashit( \home_url() ) );
+		return \add_query_arg( 'author', $this->_id, \home_url( '/' ) );
 	}
 
 	/**

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -122,7 +122,7 @@ class User extends Actor {
 			return $this->get_url();
 		}
 
-		return \add_query_arg( 'author', $this->_id, \trailingslashit( \home_url() ) );
+		return \add_query_arg( 'author', $this->_id, \home_url( '/' ) );
 	}
 
 	/**

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -10,6 +10,7 @@ namespace Activitypub\Rest;
 use Activitypub\Activity\Activity;
 use Activitypub\Moderation;
 
+use function Activitypub\camel_to_snake_case;
 use function Activitypub\get_context;
 use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_rest_url_by_path;
@@ -160,7 +161,7 @@ class Actors_Inbox_Controller extends Actors_Controller {
 	public function create_item( $request ) {
 		$user_id = $request->get_param( 'user_id' );
 		$data    = $request->get_json_params();
-		$type    = \strtolower( $request->get_param( 'type' ) );
+		$type    = camel_to_snake_case( $request->get_param( 'type' ) );
 
 		/* @var Activity $activity Activity object.*/
 		$activity = Activity::init_from_array( $data );

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -11,6 +11,7 @@ use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
 use Activitypub\Moderation;
 
+use function Activitypub\camel_to_snake_case;
 use function Activitypub\extract_recipients_from_activity;
 use function Activitypub\is_same_domain;
 use function Activitypub\user_can_activitypub;
@@ -132,7 +133,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 	 */
 	public function create_item( $request ) {
 		$data = $request->get_json_params();
-		$type = \strtolower( $request->get_param( 'type' ) );
+		$type = camel_to_snake_case( $request->get_param( 'type' ) );
 
 		/* @var Activity $activity Activity object.*/
 		$activity = Activity::init_from_array( $data );

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -130,7 +130,7 @@ class Post extends Base {
 
 		if ( $post_id > $last_legacy_id ) {
 			// Generate URI based on post ID.
-			return \add_query_arg( 'p', $post_id, \trailingslashit( \home_url() ) );
+			return \add_query_arg( 'p', $post_id, \home_url( '/' ) );
 		}
 
 		return $this->get_url();

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -1361,4 +1361,50 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 		$result = \Activitypub\get_activity_visibility( $activity );
 		$this->assertSame( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, $result, 'Should work with minimal activity data' );
 	}
+
+	/**
+	 * Data provider for camel to snake case and snake to camel case tests.
+	 *
+	 * @return array
+	 */
+	public function camel_snake_case_provider() {
+		return array(
+			'SimpleCamelCase'    => array( 'SimpleCamelCase', 'simple_camel_case' ),
+			'camelCase'          => array( 'camelCase', 'camel_case' ),
+			'XMLHttpRequest'     => array( 'XMLHttpRequest', 'x_m_l_http_request' ),
+			'already_snake_case' => array( 'already_snake_case', 'already_snake_case' ),
+			'with_numbers123'    => array( 'withNumbers123', 'with_numbers123' ),
+			'leadingUpperCase'   => array( 'LeadingUpperCase', 'leading_upper_case' ),
+			'singleletter'       => array( 'a', 'a' ),
+			'emptyString'        => array( '', '' ),
+			'nonStringInput'     => array( 12345, '12345' ),
+			'CreateActivity'     => array( 'CreateActivity', 'create_activity' ),
+			'Follow'             => array( 'Follow', 'follow' ),
+			'QuoteRequest'       => array( 'QuoteRequest', 'quote_request' ),
+		);
+	}
+
+	/**
+	 * Test camel_to_snake_case function.
+	 *
+	 * @dataProvider camel_snake_case_provider
+	 *
+	 * @param string $original The original string.
+	 * @param string $expected The expected result.
+	 */
+	public function test_camel_to_snake_case( $original, $expected ) {
+		$this->assertSame( $expected, \Activitypub\camel_to_snake_case( $original ) );
+	}
+
+	/**
+	 * Test snake_to_camel_case function.
+	 *
+	 * @dataProvider camel_snake_case_provider
+	 *
+	 * @param string $expected The expected result.
+	 * @param string $original The original string.
+	 */
+	public function test_snake_to_camel_case( $expected, $original ) {
+		$this->assertSame( $expected, \Activitypub\snake_to_camel_case( $original ) );
+	}
 }

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -1395,16 +1395,4 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 	public function test_camel_to_snake_case( $original, $expected ) {
 		$this->assertSame( $expected, \Activitypub\camel_to_snake_case( $original ) );
 	}
-
-	/**
-	 * Test snake_to_camel_case function.
-	 *
-	 * @dataProvider camel_snake_case_provider
-	 *
-	 * @param string $expected The expected result.
-	 * @param string $original The original string.
-	 */
-	public function test_snake_to_camel_case( $expected, $original ) {
-		$this->assertSame( $expected, \Activitypub\snake_to_camel_case( $original ) );
-	}
 }

--- a/tests/includes/class-test-query.php
+++ b/tests/includes/class-test-query.php
@@ -429,7 +429,7 @@ class Test_Query extends \WP_UnitTestCase {
 				'p'     => self::$post_id,
 				'stamp' => $meta_id,
 			),
-			\trailingslashit( \home_url() )
+			\home_url( '/' )
 		);
 		$this->assertEquals( $expected_id, $object->get_id(), 'Should have correct stamp URI as ID' );
 

--- a/tests/includes/class-test-query.php
+++ b/tests/includes/class-test-query.php
@@ -399,4 +399,123 @@ class Test_Query extends \WP_UnitTestCase {
 		\delete_option( 'activitypub_content_negotiation' );
 		\delete_option( 'permalink_structure' );
 	}
+
+	/**
+	 * Test maybe_get_stamp method for QuoteAuthorization objects.
+	 *
+	 * @covers ::maybe_get_stamp
+	 * @covers ::get_activitypub_object
+	 * @covers ::get_activitypub_object_id
+	 */
+	public function test_maybe_get_stamp() {
+		// Create a post meta entry to simulate a quote authorization stamp.
+		$meta_id = \add_post_meta( self::$post_id, '_activitypub_quoted_by', 'https://remote.example.com/posts/456' );
+
+		// Test with valid stamp query parameter.
+		Query::get_instance()->__destruct();
+		$this->go_to( home_url( '/?p=' . self::$post_id . '&stamp=' . $meta_id ) );
+		\set_query_var( 'stamp', $meta_id );
+
+		$query  = Query::get_instance();
+		$object = $query->get_activitypub_object();
+
+		// Test that we get a QuoteAuthorization object.
+		$this->assertNotNull( $object, 'Should create QuoteAuthorization object for valid stamp' );
+		$this->assertEquals( 'QuoteAuthorization', $object->get_type(), 'Should be QuoteAuthorization type' );
+
+		// Test the object properties.
+		$expected_id = \add_query_arg(
+			array(
+				'p'     => self::$post_id,
+				'stamp' => $meta_id,
+			),
+			\trailingslashit( \home_url() )
+		);
+		$this->assertEquals( $expected_id, $object->get_id(), 'Should have correct stamp URI as ID' );
+
+		// Test object ID separately.
+		$this->assertEquals( $expected_id, $query->get_activitypub_object_id(), 'Should return correct object ID' );
+
+		// Test with invalid stamp.
+		Query::get_instance()->__destruct();
+		$this->go_to( home_url( '/?p=' . self::$post_id . '&stamp=999999' ) );
+		\set_query_var( 'stamp', '999999' );
+
+		$query  = Query::get_instance();
+		$object = $query->get_activitypub_object();
+
+		// Should fall back to regular post object.
+		$this->assertNotNull( $object, 'Should fall back to post object for invalid stamp' );
+		$this->assertNotEquals( 'QuoteAuthorization', $object->get_type(), 'Should not be QuoteAuthorization for invalid stamp' );
+
+		// Test without stamp parameter.
+		Query::get_instance()->__destruct();
+		$this->go_to( home_url( '/?p=' . self::$post_id ) );
+
+		$query  = Query::get_instance();
+		$object = $query->get_activitypub_object();
+
+		// Should get regular post object.
+		$this->assertNotNull( $object, 'Should get post object without stamp parameter' );
+		$this->assertNotEquals( 'QuoteAuthorization', $object->get_type(), 'Should not be QuoteAuthorization without stamp parameter' );
+
+		// Clean up.
+		\delete_post_meta( self::$post_id, '_activitypub_quoted_by' );
+	}
+
+	/**
+	 * Test maybe_get_stamp with non-existent meta ID.
+	 *
+	 * @covers ::maybe_get_stamp
+	 */
+	public function test_maybe_get_stamp_invalid_meta() {
+		// Test with non-existent meta ID.
+		Query::get_instance()->__destruct();
+		$this->go_to( home_url( '/?p=' . self::$post_id . '&stamp=999999' ) );
+		\set_query_var( 'stamp', '999999' );
+
+		$reflection = new \ReflectionClass( Query::class );
+		$method     = $reflection->getMethod( 'maybe_get_stamp' );
+		$method->setAccessible( true );
+
+		$query  = Query::get_instance();
+		$result = $method->invoke( $query );
+
+		$this->assertFalse( $result, 'Should return false for non-existent meta ID' );
+	}
+
+	/**
+	 * Test maybe_get_stamp with invalid post author.
+	 *
+	 * @covers ::maybe_get_stamp
+	 */
+	public function test_maybe_get_stamp_invalid_author() {
+		// Create a post with invalid author.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author'  => 999999, // Non-existent user ID.
+				'post_title'   => 'Test Post Invalid Author',
+				'post_content' => 'Test Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$meta_id = \add_post_meta( $post_id, '_activitypub_quoted_by', 'https://remote.example.com/posts/456' );
+
+		Query::get_instance()->__destruct();
+		$this->go_to( home_url( '/?p=' . $post_id . '&stamp=' . $meta_id ) );
+		\set_query_var( 'stamp', $meta_id );
+
+		$reflection = new \ReflectionClass( Query::class );
+		$method     = $reflection->getMethod( 'maybe_get_stamp' );
+		$method->setAccessible( true );
+
+		$query  = Query::get_instance();
+		$result = $method->invoke( $query );
+
+		$this->assertFalse( $result, 'Should return false for invalid post author' );
+
+		// Clean up.
+		\wp_delete_post( $post_id, true );
+	}
 }

--- a/tests/includes/handler/class-test-quote-request.php
+++ b/tests/includes/handler/class-test-quote-request.php
@@ -466,7 +466,7 @@ class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase 
 	 */
 	public function test_init_registers_hooks() {
 		// Remove existing hooks first.
-		remove_all_actions( 'activitypub_inbox_quoterequest' );
+		remove_all_actions( 'activitypub_inbox_quote_request' );
 		remove_all_actions( 'activitypub_rest_inbox_disallowed' );
 		remove_all_filters( 'activitypub_validate_object' );
 
@@ -474,7 +474,7 @@ class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase 
 		Quote_Request::init();
 
 		// Check that hooks are registered.
-		$this->assertTrue( has_action( 'activitypub_inbox_quoterequest' ) );
+		$this->assertTrue( has_action( 'activitypub_inbox_quote_request' ) );
 		$this->assertTrue( has_action( 'activitypub_rest_inbox_disallowed' ) );
 		$this->assertTrue( has_filter( 'activitypub_validate_object' ) );
 	}

--- a/tests/includes/handler/class-test-quote-request.php
+++ b/tests/includes/handler/class-test-quote-request.php
@@ -284,7 +284,7 @@ class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase 
 	public function test_queue_accept() {
 		$activity = $this->create_quote_request_activity();
 
-		Quote_Request::queue_accept( $activity, self::$user_id );
+		Quote_Request::queue_accept( $activity, self::$user_id, self::$post_id );
 
 		// Check outbox for Accept response.
 		$outbox_posts = get_posts(

--- a/tests/includes/handler/class-test-quote-request.php
+++ b/tests/includes/handler/class-test-quote-request.php
@@ -1,0 +1,487 @@
+<?php
+/**
+ * Test file for Quote Request handler.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Handler;
+
+use Activitypub\Collection\Followers;
+use Activitypub\Collection\Outbox;
+use Activitypub\Handler\Quote_Request;
+
+/**
+ * Test class for Quote Request Handler.
+ *
+ * @coversDefaultClass \Activitypub\Handler\Quote_Request
+ */
+class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
+	/**
+	 * Test post ID.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Test remote actor.
+	 *
+	 * @var object
+	 */
+	protected static $remote_actor;
+
+	/**
+	 * Set up the test case.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Mock remote actor.
+		self::$remote_actor = (object) array(
+			'ID'       => 999,
+			'user_url' => 'https://remote.example.com/users/remote_user',
+		);
+	}
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Create a fresh post for each test since parent::tear_down() deletes all posts.
+		self::$post_id = self::factory()->post->create(
+			array(
+				'post_author'  => self::$user_id,
+				'post_content' => 'Test post content',
+				'post_title'   => 'Test Post',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Initialize the Quote Request handler.
+		Quote_Request::init();
+	}
+
+	/**
+	 * Create a sample QuoteRequest activity.
+	 *
+	 * @param string $actor_uri The actor URI.
+	 * @return array The activity array.
+	 */
+	private function create_quote_request_activity( $actor_uri = 'https://remote.example.com/users/remote_user' ) {
+		return array(
+			'id'         => 'https://remote.example.com/activities/123',
+			'type'       => 'QuoteRequest',
+			'actor'      => $actor_uri,
+			'object'     => \get_permalink( self::$post_id ),
+			'instrument' => 'https://remote.example.com/posts/456',
+		);
+	}
+
+	/**
+	 * Data provider for quote request policy tests.
+	 *
+	 * @return array Test cases with policy, setup callback, and expected response type.
+	 */
+	public function policy_test_data() {
+		return array(
+			'default (no policy) - should accept' => array(
+				'policy'          => '',
+				'setup_callback'  => null,
+				'expected_type'   => 'Accept',
+				'expected_result' => true,
+			),
+			'anyone policy - should accept'       => array(
+				'policy'          => ACTIVITYPUB_INTERACTION_POLICY_ANYONE,
+				'setup_callback'  => null,
+				'expected_type'   => 'Accept',
+				'expected_result' => true,
+			),
+			'me policy - should reject'           => array(
+				'policy'          => ACTIVITYPUB_INTERACTION_POLICY_ME,
+				'setup_callback'  => null,
+				'expected_type'   => 'Reject',
+				'expected_result' => true,
+			),
+			'followers policy with follower - should accept' => array(
+				'policy'          => ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS,
+				'setup_callback'  => 'add_follower',
+				'expected_type'   => 'Accept',
+				'expected_result' => true,
+			),
+			'followers policy with non-follower - should reject' => array(
+				'policy'          => ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS,
+				'setup_callback'  => null,
+				'expected_type'   => 'Reject',
+				'expected_result' => true,
+			),
+			'followers policy with actor error - should reject' => array(
+				'policy'          => ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS,
+				'setup_callback'  => 'mock_actor_error',
+				'expected_type'   => 'Reject',
+				'expected_result' => true,
+			),
+		);
+	}
+
+	/**
+	 * Test QuoteRequest handling with various policies.
+	 *
+	 * @dataProvider policy_test_data
+	 * @covers ::handle_quote_request
+	 *
+	 * @param string      $policy          The interaction policy to set.
+	 * @param string|null $setup_callback  Optional setup callback method name.
+	 * @param string      $expected_type   Expected activity type (Accept/Reject).
+	 * @param bool        $expected_result Expected test result.
+	 */
+	public function test_handle_quote_request_policies( $policy, $setup_callback, $expected_type, $expected_result ) {
+		// Set policy if provided.
+		if ( ! empty( $policy ) ) {
+			update_post_meta( self::$post_id, 'activitypub_interaction_policy_quote', $policy );
+		}
+
+		$activity  = $this->create_quote_request_activity();
+		$actor_url = $activity['actor'];
+
+		// Mock HTTP requests for actor metadata.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function () use ( $actor_url ) {
+				return array(
+					'id'    => $actor_url,
+					'actor' => $actor_url,
+					'type'  => 'Person',
+					'inbox' => str_replace( '/users/', '/inbox/', $actor_url ),
+				);
+			}
+		);
+
+		$remote_actor_id = false;
+
+		// Run setup callback if provided.
+		if ( 'add_follower' === $setup_callback ) {
+			$remote_actor_id = Followers::add_follower( self::$user_id, $actor_url );
+			$this->assertNotFalse( $remote_actor_id, 'Should successfully add follower' );
+		} elseif ( 'mock_actor_error' === $setup_callback ) {
+			// Override the actor metadata filter to return an error.
+			remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+			add_filter(
+				'pre_get_remote_metadata_by_actor',
+				function () {
+					return new \WP_Error( 'not_found', 'Actor not found' );
+				}
+			);
+		}
+
+		// Handle the quote request.
+		Quote_Request::handle_quote_request( $activity, self::$user_id );
+
+		// Check outbox for expected response.
+		$outbox_posts = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				'author'      => self::$user_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => $expected_type,
+					),
+				),
+			)
+		);
+
+		if ( $expected_result ) {
+			$this->assertNotEmpty( $outbox_posts, "{$expected_type} activity should be queued" );
+
+			$outbox_post   = $outbox_posts[0];
+			$activity_json = json_decode( $outbox_post->post_content, true );
+
+			$this->assertEquals( $expected_type, $activity_json['type'] );
+			$this->assertContains( $activity['actor'], $activity_json['to'] );
+		} else {
+			$this->assertEmpty( $outbox_posts, "No {$expected_type} activity should be queued" );
+		}
+
+		// Clean up follower if created.
+		if ( $remote_actor_id ) {
+			wp_delete_post( $remote_actor_id, true );
+		}
+	}
+
+	/**
+	 * Test handling of blocked QuoteRequest activities.
+	 *
+	 * @covers ::handle_blocked_request
+	 */
+	public function test_handle_blocked_request() {
+		$activity = $this->create_quote_request_activity();
+
+		Quote_Request::handle_blocked_request( $activity, self::$user_id, 'QuoteRequest' );
+
+		// Check outbox for Reject response.
+		$outbox_posts = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				'author'      => self::$user_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Reject',
+					),
+				),
+			)
+		);
+
+		$this->assertNotEmpty( $outbox_posts, 'Reject activity should be queued for blocked request' );
+
+		$outbox_post   = $outbox_posts[0];
+		$activity_json = json_decode( $outbox_post->post_content, true );
+
+		$this->assertEquals( 'Reject', $activity_json['type'] );
+	}
+
+	/**
+	 * Test that non-QuoteRequest types are ignored by handle_blocked_request.
+	 *
+	 * @covers ::handle_blocked_request
+	 */
+	public function test_handle_blocked_request_ignores_other_types() {
+		$activity = $this->create_quote_request_activity();
+
+		Quote_Request::handle_blocked_request( $activity, self::$user_id, 'Follow' );
+
+		// Check that no outbox activity was created.
+		$outbox_posts = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				'author'      => self::$user_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Follow',
+					),
+				),
+			)
+		);
+
+		$this->assertEmpty( $outbox_posts, 'Should not handle non-QuoteRequest activities' );
+	}
+
+	/**
+	 * Test queue_accept method creates correct Accept activity.
+	 *
+	 * @covers ::queue_accept
+	 */
+	public function test_queue_accept() {
+		$activity = $this->create_quote_request_activity();
+
+		Quote_Request::queue_accept( $activity, self::$user_id );
+
+		// Check outbox for Accept response.
+		$outbox_posts = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				'author'      => self::$user_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Accept',
+					),
+				),
+			)
+		);
+
+		$this->assertNotEmpty( $outbox_posts, 'Accept activity should be created' );
+
+		$outbox_post   = $outbox_posts[0];
+		$activity_json = json_decode( $outbox_post->post_content, true );
+		$visibility    = get_post_meta( $outbox_post->ID, 'activitypub_content_visibility', true );
+
+		$this->assertEquals( 'Accept', $activity_json['type'] );
+		$this->assertEquals( 'private', $visibility );
+		$this->assertContains( $activity['actor'], $activity_json['to'] );
+
+		// Check that the activity object contains only minimal data.
+		$expected_keys = array( 'id', 'type', 'object', 'actor', 'instrument' );
+		$this->assertEquals( $expected_keys, array_keys( $activity_json['object'] ) );
+	}
+
+	/**
+	 * Test queue_reject method creates correct Reject activity.
+	 *
+	 * @covers ::queue_reject
+	 */
+	public function test_queue_reject() {
+		$activity = $this->create_quote_request_activity();
+
+		Quote_Request::queue_reject( $activity, self::$user_id );
+
+		// Check outbox for Reject response.
+		$outbox_posts = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				'author'      => self::$user_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Reject',
+					),
+				),
+			)
+		);
+
+		$this->assertNotEmpty( $outbox_posts, 'Reject activity should be created' );
+
+		$outbox_post   = $outbox_posts[0];
+		$activity_json = json_decode( $outbox_post->post_content, true );
+		$visibility    = get_post_meta( $outbox_post->ID, 'activitypub_content_visibility', true );
+
+		$this->assertEquals( 'Reject', $activity_json['type'] );
+		$this->assertEquals( 'private', $visibility );
+		$this->assertContains( $activity['actor'], $activity_json['to'] );
+
+		// Check that the activity object contains only minimal data.
+		$expected_keys = array( 'id', 'type', 'object', 'actor', 'instrument' );
+		$this->assertEquals( $expected_keys, array_keys( $activity_json['object'] ) );
+	}
+
+	/**
+	 * Test validate_object with valid QuoteRequest.
+	 *
+	 * @covers ::validate_object
+	 */
+	public function test_validate_object_valid_quote_request() {
+		$request_data = array(
+			'type'       => 'QuoteRequest',
+			'actor'      => 'https://remote.example.com/users/remote_user',
+			'object'     => get_permalink( self::$post_id ),
+			'instrument' => 'https://remote.example.com/posts/456',
+		);
+
+		$request = new \WP_REST_Request();
+		$request->set_body( \wp_json_encode( $request_data ) );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$result = Quote_Request::validate_object( true, 'object', $request );
+
+		$this->assertTrue( $result, 'Valid QuoteRequest should pass validation' );
+	}
+
+	/**
+	 * Test validate_object with missing required attributes.
+	 *
+	 * @covers ::validate_object
+	 */
+	public function test_validate_object_missing_required_attributes() {
+		$request_data = array(
+			'type'  => 'QuoteRequest',
+			'actor' => 'https://remote.example.com/users/remote_user',
+			// Missing 'object' and 'instrument'.
+		);
+
+		$request = new \WP_REST_Request();
+		$request->set_body( \wp_json_encode( $request_data ) );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$result = Quote_Request::validate_object( true, 'object', $request );
+
+		$this->assertFalse( $result, 'QuoteRequest missing required attributes should fail validation' );
+	}
+
+	/**
+	 * Test validate_object with non-QuoteRequest type.
+	 *
+	 * @covers ::validate_object
+	 */
+	public function test_validate_object_non_quote_request_type() {
+		$request_data = array(
+			'type'   => 'Follow',
+			'actor'  => 'https://remote.example.com/users/remote_user',
+			'object' => get_permalink( self::$post_id ),
+		);
+
+		$request = new \WP_REST_Request();
+		$request->set_body( \wp_json_encode( $request_data ) );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$result = Quote_Request::validate_object( true, 'object', $request );
+
+		$this->assertTrue( $result, 'Non-QuoteRequest types should pass through unchanged' );
+	}
+
+	/**
+	 * Test validate_object with no type specified.
+	 *
+	 * @covers ::validate_object
+	 */
+	public function test_validate_object_no_type() {
+		$request_data = array(
+			'actor'  => 'https://remote.example.com/users/remote_user',
+			'object' => get_permalink( self::$post_id ),
+		);
+
+		$request = new \WP_REST_Request();
+		$request->set_body( \wp_json_encode( $request_data ) );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$result = Quote_Request::validate_object( true, 'object', $request );
+
+		$this->assertFalse( $result, 'Request without type should fail validation' );
+	}
+
+	/**
+	 * Test validate_object with WP_Error request.
+	 *
+	 * @covers ::validate_object
+	 */
+	public function test_validate_object_with_wp_error() {
+		$request = new \WP_Error( 'invalid_request', 'Invalid request' );
+
+		$result = Quote_Request::validate_object( true, 'object', $request );
+
+		$this->assertTrue( $result, 'Should pass through original validation result when request is WP_Error' );
+	}
+
+	/**
+	 * Test that init method properly registers hooks.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_registers_hooks() {
+		// Remove existing hooks first.
+		remove_all_actions( 'activitypub_inbox_quoterequest' );
+		remove_all_actions( 'activitypub_rest_inbox_disallowed' );
+		remove_all_filters( 'activitypub_validate_object' );
+
+		// Call init.
+		Quote_Request::init();
+
+		// Check that hooks are registered.
+		$this->assertTrue( has_action( 'activitypub_inbox_quoterequest' ) );
+		$this->assertTrue( has_action( 'activitypub_rest_inbox_disallowed' ) );
+		$this->assertTrue( has_filter( 'activitypub_validate_object' ) );
+	}
+
+	/**
+	 * Clean up filters after each test.
+	 */
+	public function tear_down() {
+		// Remove all the filters we added during tests.
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+
+		parent::tear_down();
+	}
+}

--- a/tests/includes/handler/class-test-quote-request.php
+++ b/tests/includes/handler/class-test-quote-request.php
@@ -314,7 +314,9 @@ class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase 
 
 		// Check that the activity object contains only minimal data.
 		$expected_keys = array( 'id', 'type', 'object', 'actor', 'instrument' );
-		$this->assertEquals( $expected_keys, array_keys( $activity_json['object'] ) );
+		$actual_keys   = array_keys( $activity_json['object'] );
+		$this->assertEmpty( array_diff( $expected_keys, $actual_keys ), 'All expected keys should be present' );
+		$this->assertEmpty( array_diff( $actual_keys, $expected_keys ), 'No unexpected keys should be present' );
 	}
 
 	/**
@@ -355,7 +357,9 @@ class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase 
 
 		// Check that the activity object contains only minimal data.
 		$expected_keys = array( 'id', 'type', 'object', 'actor', 'instrument' );
-		$this->assertEquals( $expected_keys, array_keys( $activity_json['object'] ) );
+		$actual_keys   = array_keys( $activity_json['object'] );
+		$this->assertEmpty( array_diff( $expected_keys, $actual_keys ), 'All expected keys should be present' );
+		$this->assertEmpty( array_diff( $actual_keys, $expected_keys ), 'No unexpected keys should be present' );
 	}
 
 	/**


### PR DESCRIPTION
Introduces a new handler for QuoteRequest activities as defined in FEP-044f, including registration in the handler initialization and updates to the activity class to support the new activity type and context. This enables processing and validation of QuoteRequest activities according to interaction policies.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #2239

Here is an example:

1. Quoted Post on Mastodon

<img width="627" height="513" alt="Screenshot 2025-09-30 at 14 02 05" src="https://github.com/user-attachments/assets/1a4c2146-58ca-43c8-948d-45a0e305f63c" />

2. The `Accept` response

<img width="910" height="206" alt="Screenshot 2025-09-30 at 14 02 39" src="https://github.com/user-attachments/assets/e134c2e8-1233-4db2-9b62-f5e9181ad36c" />

3. The `QuoteAuthorization` object https://pfefferle.org/?p=4047&stamp=17034&activitypub

## Proposed changes:
- Adds a new QuoteRequest handler class with policy-based acceptance/rejection logic
- Registers the QuoteRequest activity type in the Activity class and handler initialization
- Creates a QuoteAuthorization extended object class for the activity context

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this PR on one of your Blogs
* Publish a post
* Quote this post on Mastodon

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added support for QuoteRequest activities (FEP-044f), enabling proper handling, validation, and policy-based acceptance or rejection of quote requests.

</details>
