### PR TITLE
Add row action filters and Jetpack Reader link integration

### DIFF
--- a/.github/changelog/2241-from-description
+++ b/.github/changelog/2241-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+You can now follow people and see their updates right in the WordPress.com Reader when using Jetpack or WordPress.com.

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -82,6 +82,7 @@ class Admin {
 	 */
 	public static function admin_notices() {
 		$current_screen = get_current_screen();
+
 		if ( ! $current_screen ) {
 			return;
 		}

--- a/includes/wp-admin/table/class-blocked-actors.php
+++ b/includes/wp-admin/table/class-blocked-actors.php
@@ -402,7 +402,7 @@ class Blocked_Actors extends \WP_List_Table {
 		 *
 		 * This filter is evaluated for each blocked actor item in the list table.
 		 *
-		 * @since 2.8.0
+		 * @since unreleased
 		 *
 		 * @param string[] $actions An array of row action links. Defaults are
 		 *                          'Unblock'.

--- a/includes/wp-admin/table/class-blocked-actors.php
+++ b/includes/wp-admin/table/class-blocked-actors.php
@@ -400,13 +400,12 @@ class Blocked_Actors extends \WP_List_Table {
 		/**
 		 * Filters the array of row action links on the Blocked Actors list table.
 		 *
-		 * The filter is evaluated only for non-hierarchical post types.
+		 * This filter is evaluated for each blocked actor item in the list table.
 		 *
 		 * @since 2.8.0
 		 *
 		 * @param string[] $actions An array of row action links. Defaults are
-		 *                          'Edit', 'Quick Edit', 'Restore', 'Trash',
-		 *                          'Delete Permanently', 'Preview', and 'View'.
+		 *                          'Unblock'.
 		 * @param array    $item    The current blocked actor item.
 		 */
 		$actions = apply_filters( 'activitypub_blocked_actors_row_actions', $actions, $item );

--- a/includes/wp-admin/table/class-blocked-actors.php
+++ b/includes/wp-admin/table/class-blocked-actors.php
@@ -397,6 +397,20 @@ class Blocked_Actors extends \WP_List_Table {
 			),
 		);
 
+		/**
+		 * Filters the array of row action links on the Blocked Actors list table.
+		 *
+		 * The filter is evaluated only for non-hierarchical post types.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param string[] $actions An array of row action links. Defaults are
+		 *                          'Edit', 'Quick Edit', 'Restore', 'Trash',
+		 *                          'Delete Permanently', 'Preview', and 'View'.
+		 * @param array    $item    The current blocked actor item.
+		 */
+		$actions = apply_filters( 'activitypub_blocked_actors_row_actions', $actions, $item );
+
 		return $this->row_actions( $actions );
 	}
 }

--- a/includes/wp-admin/table/class-followers.php
+++ b/includes/wp-admin/table/class-followers.php
@@ -483,7 +483,7 @@ class Followers extends \WP_List_Table {
 		 * This filter allows you to modify the available row actions (such as Delete, Block, or Follow back)
 		 * for each follower item displayed in the table.
 		 *
-		 * @since 2.8.0
+		 * @since unreleased
 		 *
 		 * @param string[] $actions An array of row action links. Defaults are
 		 *                          'Delete', 'Block', and optionally 'Follow back'.

--- a/includes/wp-admin/table/class-followers.php
+++ b/includes/wp-admin/table/class-followers.php
@@ -478,15 +478,15 @@ class Followers extends \WP_List_Table {
 		}
 
 		/**
-		 * Filters the array of row action links on the Followers list table.
+		 * Filters the array of row action links for each follower in the Followers list table.
 		 *
-		 * The filter is evaluated only for non-hierarchical post types.
+		 * This filter allows you to modify the available row actions (such as Delete, Block, or Follow back)
+		 * for each follower item displayed in the table.
 		 *
 		 * @since 2.8.0
 		 *
 		 * @param string[] $actions An array of row action links. Defaults are
-		 *                          'Edit', 'Quick Edit', 'Restore', 'Trash',
-		 *                          'Delete Permanently', 'Preview', and 'View'.
+		 *                          'Delete', 'Block', and optionally 'Follow back'.
 		 * @param array    $item    The current follower item.
 		 */
 		$actions = apply_filters( 'activitypub_followers_row_actions', $actions, $item );

--- a/includes/wp-admin/table/class-followers.php
+++ b/includes/wp-admin/table/class-followers.php
@@ -477,6 +477,20 @@ class Followers extends \WP_List_Table {
 			}
 		}
 
+		/**
+		 * Filters the array of row action links on the Followers list table.
+		 *
+		 * The filter is evaluated only for non-hierarchical post types.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param string[] $actions An array of row action links. Defaults are
+		 *                          'Edit', 'Quick Edit', 'Restore', 'Trash',
+		 *                          'Delete Permanently', 'Preview', and 'View'.
+		 * @param array    $item    The current follower item.
+		 */
+		$actions = apply_filters( 'activitypub_followers_row_actions', $actions, $item );
+
 		return $this->row_actions( $actions );
 	}
 

--- a/includes/wp-admin/table/class-following.php
+++ b/includes/wp-admin/table/class-following.php
@@ -481,6 +481,7 @@ class Following extends \WP_List_Table {
 	 * @param array  $item        The current following item.
 	 * @param string $column_name The current column name.
 	 * @param string $primary     The primary column name.
+	 *
 	 * @return string HTML for the row actions.
 	 */
 	protected function handle_row_actions( $item, $column_name, $primary ) {
@@ -497,6 +498,20 @@ class Following extends \WP_List_Table {
 				\esc_html__( 'Unfollow', 'activitypub' )
 			),
 		);
+
+		/**
+		 * Filters the array of row action links on the Following list table.
+		 *
+		 * The filter is evaluated only for non-hierarchical post types.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param string[] $actions An array of row action links. Defaults are
+		 *                          'Edit', 'Quick Edit', 'Restore', 'Trash',
+		 *                          'Delete Permanently', 'Preview', and 'View'.
+		 * @param array    $item    The current following item.
+		 */
+		$actions = apply_filters( 'activitypub_following_row_actions', $actions, $item );
 
 		return $this->row_actions( $actions );
 	}

--- a/includes/wp-admin/table/class-following.php
+++ b/includes/wp-admin/table/class-following.php
@@ -504,7 +504,7 @@ class Following extends \WP_List_Table {
 		 *
 		 * This filter allows you to modify the row actions for each following item in the Following list table.
 		 *
-		 * @since 2.8.0
+		 * @since unreleased
 		 *
 		 * @param string[] $actions An array of row action links. Defaults include 'Unfollow'.
 		 * @param array    $item    The current following item.

--- a/includes/wp-admin/table/class-following.php
+++ b/includes/wp-admin/table/class-following.php
@@ -502,13 +502,11 @@ class Following extends \WP_List_Table {
 		/**
 		 * Filters the array of row action links on the Following list table.
 		 *
-		 * The filter is evaluated only for non-hierarchical post types.
+		 * This filter allows you to modify the row actions for each following item in the Following list table.
 		 *
 		 * @since 2.8.0
 		 *
-		 * @param string[] $actions An array of row action links. Defaults are
-		 *                          'Edit', 'Quick Edit', 'Restore', 'Trash',
-		 *                          'Delete Permanently', 'Preview', and 'View'.
+		 * @param string[] $actions An array of row action links. Defaults include 'Unfollow'.
 		 * @param array    $item    The current following item.
 		 */
 		$actions = apply_filters( 'activitypub_following_row_actions', $actions, $item );

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -99,7 +99,7 @@ class Jetpack {
 		$actions['reader'] = sprintf(
 			'<a href="%s" target="_blank">%s</a>',
 			esc_url( $url ),
-			esc_html__( 'Open in Reader', 'activitypub' )
+			esc_html__( 'View Feed', 'activitypub' )
 		);
 
 		return $actions;

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -93,7 +93,7 @@ class Jetpack {
 		if ( isset( $feed['feed_id'] ) ) {
 			$url = sprintf( 'https://wordpress.com/reader/feed/%d', (int) $feed['feed_id'] );
 		} else {
-			$url = sprintf( 'https://wordpress.com/reader/feeds/lookup/%s', $item['identifier'] );
+			$url = sprintf( 'https://wordpress.com/reader/feeds/lookup/%s', rawurlencode( $item['identifier'] ) );
 		}
 
 		$actions['reader'] = sprintf(

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -28,7 +28,10 @@ class Jetpack {
 			\add_filter( 'jetpack_api_include_comment_types_count', array( self::class, 'add_comment_types' ) );
 		}
 
-		if ( ( \defined( 'IS_WPCOM' ) && IS_WPCOM ) || \Jetpack::is_connection_ready() ) {
+		if (
+			( \defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
+			( \class_exists( '\Jetpack' ) && \Jetpack::is_connection_ready() )
+		) {
 			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
 			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
 		}

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -20,11 +20,16 @@ class Jetpack {
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
-		\add_filter( 'jetpack_sync_post_meta_whitelist', array( self::class, 'add_sync_meta' ) );
-		\add_filter( 'jetpack_sync_comment_meta_whitelist', array( self::class, 'add_sync_comment_meta' ) );
-		\add_filter( 'jetpack_sync_whitelisted_comment_types', array( self::class, 'add_comment_types' ) );
-		\add_filter( 'jetpack_json_api_comment_types', array( self::class, 'add_comment_types' ) );
-		\add_filter( 'jetpack_api_include_comment_types_count', array( self::class, 'add_comment_types' ) );
+		if ( ! \defined( 'IS_WPCOM' ) ) {
+			\add_filter( 'jetpack_sync_post_meta_whitelist', array( self::class, 'add_sync_meta' ) );
+			\add_filter( 'jetpack_sync_comment_meta_whitelist', array( self::class, 'add_sync_comment_meta' ) );
+			\add_filter( 'jetpack_sync_whitelisted_comment_types', array( self::class, 'add_comment_types' ) );
+			\add_filter( 'jetpack_json_api_comment_types', array( self::class, 'add_comment_types' ) );
+			\add_filter( 'jetpack_api_include_comment_types_count', array( self::class, 'add_comment_types' ) );
+		}
+
+		\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
+		\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
 	}
 
 	/**
@@ -67,5 +72,45 @@ class Jetpack {
 		}
 
 		return array_unique( \array_merge( $comment_types, Comment::get_comment_type_slugs() ) );
+	}
+
+	/**
+	 * Add a "Reader" link to the bulk actions dropdown on the following list screen.
+	 *
+	 * @param array $actions The bulk actions.
+	 * @param array $item    The current following item.
+	 *
+	 * @return array The bulk actions with the "Reader" link.
+	 */
+	public static function add_reader_link( $actions, $item ) {
+		// Do not show the link for pending follow requests.
+		if ( 'pending' === $item['status'] ) {
+			return $actions;
+		}
+
+		$reader_id = \get_post_meta( $item['id'], '_activitypub_actor_feed', true );
+
+		if ( $reader_id ) {
+			$url = sprintf( 'https://wordpress.com/reader/feed/%d', (int) $reader_id );
+		} else {
+			$url = sprintf( 'https://wordpress.com/reader/feeds/lookup/%s', $item['identifier'] );
+		}
+
+		$actions['reader'] = sprintf(
+			'<a href="%s" target="_blank">%s</a>',
+			esc_url( $url ),
+			esc_html__( 'Open in Reader', 'activitypub' )
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * Force the ActivityPub Following UI to be enabled when Jetpack is active.
+	 *
+	 * @return string '1' to enable the ActivityPub Following UI.
+	 */
+	public static function pre_option_activitypub_following_ui() {
+		return '1';
 	}
 }

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -28,8 +28,10 @@ class Jetpack {
 			\add_filter( 'jetpack_api_include_comment_types_count', array( self::class, 'add_comment_types' ) );
 		}
 
-		\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
-		\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
+		if ( ( \defined( 'IS_WPCOM' ) && IS_WPCOM ) || \Jetpack::is_connection_ready() ) {
+			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
+			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
+		}
 	}
 
 	/**

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -96,13 +96,16 @@ class Jetpack {
 			$url = sprintf( 'https://wordpress.com/reader/feeds/lookup/%s', rawurlencode( $item['identifier'] ) );
 		}
 
-		$actions['reader'] = sprintf(
-			'<a href="%s" target="_blank">%s</a>',
-			esc_url( $url ),
-			esc_html__( 'View Feed', 'activitypub' )
+		return array_merge(
+			array(
+				'reader' => sprintf(
+					'<a href="%s" target="_blank">%s</a>',
+					esc_url( $url ),
+					esc_html__( 'View Feed', 'activitypub' )
+				),
+			),
+			$actions
 		);
-
-		return $actions;
 	}
 
 	/**

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -88,10 +88,10 @@ class Jetpack {
 			return $actions;
 		}
 
-		$reader_id = \get_post_meta( $item['id'], '_activitypub_actor_feed', true );
+		$feed = \get_post_meta( $item['id'], '_activitypub_actor_feed', true );
 
-		if ( $reader_id ) {
-			$url = sprintf( 'https://wordpress.com/reader/feed/%d', (int) $reader_id );
+		if ( isset( $feed['feed_id'] ) ) {
+			$url = sprintf( 'https://wordpress.com/reader/feed/%d', (int) $feed['feed_id'] );
 		} else {
 			$url = sprintf( 'https://wordpress.com/reader/feeds/lookup/%s', $item['identifier'] );
 		}

--- a/integration/load.php
+++ b/integration/load.php
@@ -62,7 +62,7 @@ function plugin_init() {
 	 *
 	 * @see https://jetpack.com/
 	 */
-	if ( \defined( 'JETPACK__VERSION' ) && ! \defined( 'IS_WPCOM' ) ) {
+	if ( \defined( 'JETPACK__VERSION' ) ) {
 		Jetpack::init();
 	}
 

--- a/tests/integration/class-test-jetpack.php
+++ b/tests/integration/class-test-jetpack.php
@@ -240,7 +240,7 @@ class Test_Jetpack extends \WP_UnitTestCase {
 					'identifier' => 'https://example.com/feed',
 				),
 				'feed_id'                 => false,
-				'expected_url'            => 'https://wordpress.com/reader/feeds/lookup/https://example.com/feed',
+				'expected_url'            => 'https://wordpress.com/reader/feeds/lookup/https%3A%2F%2Fexample.com%2Ffeed',
 				'should_have_reader_link' => true,
 			),
 			'pending following should not have reader link' => array(
@@ -276,7 +276,8 @@ class Test_Jetpack extends \WP_UnitTestCase {
 				'get_post_metadata',
 				function ( $value, $object_id, $meta_key ) use ( $item, $feed_id ) {
 					if ( $object_id === $item['id'] && '_activitypub_actor_feed' === $meta_key ) {
-						return $feed_id;
+						// Return as array of values (WordPress expects this format).
+						return array( array( 'feed_id' => $feed_id ) );
 					}
 					return $value;
 				},
@@ -301,7 +302,7 @@ class Test_Jetpack extends \WP_UnitTestCase {
 			$this->assertArrayNotHasKey( 'reader', $updated_actions );
 		}
 
-		// Clean up filter.
+		// Clean up filters.
 		remove_all_filters( 'get_post_metadata' );
 	}
 

--- a/tests/integration/class-test-jetpack.php
+++ b/tests/integration/class-test-jetpack.php
@@ -294,7 +294,7 @@ class Test_Jetpack extends \WP_UnitTestCase {
 			// Check that reader link is added.
 			$this->assertArrayHasKey( 'reader', $updated_actions );
 			$this->assertStringContainsString( $expected_url, $updated_actions['reader'] );
-			$this->assertStringContainsString( 'Open in Reader', $updated_actions['reader'] );
+			$this->assertStringContainsString( 'View Feed', $updated_actions['reader'] );
 			$this->assertStringContainsString( 'target="_blank"', $updated_actions['reader'] );
 		} else {
 			// Check that reader link is not added for pending items.

--- a/tests/integration/class-test-jetpack.php
+++ b/tests/integration/class-test-jetpack.php
@@ -71,27 +71,42 @@ class Test_Jetpack extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test init method registers hooks correctly.
+	 * Test init method registers sync hooks correctly.
 	 *
 	 * @covers ::init
 	 */
-	public function test_init_registers_hooks() {
+	public function test_init_registers_sync_hooks() {
 		// Ensure hooks are not already registered.
 		$this->assertFalse( has_filter( 'jetpack_sync_post_meta_whitelist' ) );
+
+		// Initialize Jetpack integration.
+		Jetpack::init();
+
+		// Check that sync hooks are registered (when not on WordPress.com).
+		$this->assertTrue( has_filter( 'jetpack_sync_post_meta_whitelist' ) );
+		$this->assertTrue( has_filter( 'jetpack_sync_comment_meta_whitelist' ) );
+		$this->assertTrue( has_filter( 'jetpack_sync_whitelisted_comment_types' ) );
+		$this->assertTrue( has_filter( 'jetpack_json_api_comment_types' ) );
+		$this->assertTrue( has_filter( 'jetpack_api_include_comment_types_count' ) );
+	}
+
+	/**
+	 * Test that following UI hooks are not registered without proper conditions.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_skips_following_ui_hooks_without_conditions() {
+		// Ensure hooks are not already registered.
 		$this->assertFalse( has_filter( 'activitypub_following_row_actions' ) );
 		$this->assertFalse( has_filter( 'pre_option_activitypub_following_ui' ) );
 
 		// Initialize Jetpack integration.
 		Jetpack::init();
 
-		// Check that hooks are registered.
-		$this->assertTrue( has_filter( 'jetpack_sync_post_meta_whitelist' ) );
-		$this->assertTrue( has_filter( 'jetpack_sync_comment_meta_whitelist' ) );
-		$this->assertTrue( has_filter( 'jetpack_sync_whitelisted_comment_types' ) );
-		$this->assertTrue( has_filter( 'jetpack_json_api_comment_types' ) );
-		$this->assertTrue( has_filter( 'jetpack_api_include_comment_types_count' ) );
-		$this->assertTrue( has_filter( 'activitypub_following_row_actions' ) );
-		$this->assertTrue( has_filter( 'pre_option_activitypub_following_ui' ) );
+		// Following UI hooks should NOT be registered in test environment
+		// because neither IS_WPCOM is defined nor is Jetpack connected.
+		$this->assertFalse( has_filter( 'activitypub_following_row_actions' ) );
+		$this->assertFalse( has_filter( 'pre_option_activitypub_following_ui' ) );
 	}
 
 	/**
@@ -122,9 +137,9 @@ class Test_Jetpack extends \WP_UnitTestCase {
 			$this->assertTrue( has_filter( 'jetpack_json_api_comment_types' ) );
 			$this->assertTrue( has_filter( 'jetpack_api_include_comment_types_count' ) );
 
-			// Following UI hooks should also be registered.
-			$this->assertTrue( has_filter( 'activitypub_following_row_actions' ) );
-			$this->assertTrue( has_filter( 'pre_option_activitypub_following_ui' ) );
+			// Following UI hooks should NOT be registered in normal test environment.
+			$this->assertFalse( has_filter( 'activitypub_following_row_actions' ) );
+			$this->assertFalse( has_filter( 'pre_option_activitypub_following_ui' ) );
 
 			// Clear hooks again for the WPCOM simulation.
 			remove_all_filters( 'jetpack_sync_post_meta_whitelist' );
@@ -151,7 +166,7 @@ class Test_Jetpack extends \WP_UnitTestCase {
 		$this->assertFalse( has_filter( 'jetpack_json_api_comment_types' ) );
 		$this->assertFalse( has_filter( 'jetpack_api_include_comment_types_count' ) );
 
-		// But following UI hooks should still be registered.
+		// But following UI hooks should be registered when IS_WPCOM is true.
 		$this->assertTrue( has_filter( 'activitypub_following_row_actions' ) );
 		$this->assertTrue( has_filter( 'pre_option_activitypub_following_ui' ) );
 	}
@@ -351,17 +366,18 @@ class Test_Jetpack extends \WP_UnitTestCase {
 			$this->assertNotContains( 'avatar_url', $comment_meta );
 		}
 
-		// Test following UI filter integration (always available).
-		$ui_enabled = apply_filters( 'pre_option_activitypub_following_ui', '0' );
-		$this->assertEquals( '1', $ui_enabled );
+		// Test following UI filter integration - test direct method calls.
+		$ui_result = Jetpack::pre_option_activitypub_following_ui();
+		$this->assertEquals( '1', $ui_result );
 
-		// Test reader link filter integration (always available).
-		$test_item = array(
+		// Test reader link method directly.
+		$test_item        = array(
 			'id'         => 123,
 			'status'     => 'active',
 			'identifier' => 'https://example.com/feed',
 		);
-		$actions   = apply_filters( 'activitypub_following_row_actions', array(), $test_item );
-		$this->assertArrayHasKey( 'reader', $actions );
+		$original_actions = array( 'edit' => '<a href="#">Edit</a>' );
+		$updated_actions  = Jetpack::add_reader_link( $original_actions, $test_item );
+		$this->assertArrayHasKey( 'reader', $updated_actions );
 	}
 }

--- a/tests/integration/class-test-jetpack.php
+++ b/tests/integration/class-test-jetpack.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Test file for Jetpack integration.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Integration;
+
+use Activitypub\Collection\Followers;
+use Activitypub\Collection\Following;
+use Activitypub\Comment;
+use Activitypub\Integration\Jetpack;
+
+/**
+ * Test class for Jetpack integration.
+ *
+ * @coversDefaultClass \Activitypub\Integration\Jetpack
+ */
+class Test_Jetpack extends \WP_UnitTestCase {
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Test post ID.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Create fake data before tests run.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Helper that creates fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		self::$post_id = $factory->post->create(
+			array(
+				'post_author'  => self::$user_id,
+				'post_content' => 'Test post content',
+				'post_title'   => 'Test Post',
+				'post_status'  => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tear_down() {
+		// Remove any filters that may have been added during tests.
+		remove_all_filters( 'jetpack_sync_post_meta_whitelist' );
+		remove_all_filters( 'jetpack_sync_comment_meta_whitelist' );
+		remove_all_filters( 'jetpack_sync_whitelisted_comment_types' );
+		remove_all_filters( 'jetpack_json_api_comment_types' );
+		remove_all_filters( 'jetpack_api_include_comment_types_count' );
+		remove_all_filters( 'activitypub_following_row_actions' );
+		remove_all_filters( 'pre_option_activitypub_following_ui' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test init method registers hooks correctly.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_registers_hooks() {
+		// Ensure hooks are not already registered.
+		$this->assertFalse( has_filter( 'jetpack_sync_post_meta_whitelist' ) );
+		$this->assertFalse( has_filter( 'activitypub_following_row_actions' ) );
+		$this->assertFalse( has_filter( 'pre_option_activitypub_following_ui' ) );
+
+		// Initialize Jetpack integration.
+		Jetpack::init();
+
+		// Check that hooks are registered.
+		$this->assertTrue( has_filter( 'jetpack_sync_post_meta_whitelist' ) );
+		$this->assertTrue( has_filter( 'jetpack_sync_comment_meta_whitelist' ) );
+		$this->assertTrue( has_filter( 'jetpack_sync_whitelisted_comment_types' ) );
+		$this->assertTrue( has_filter( 'jetpack_json_api_comment_types' ) );
+		$this->assertTrue( has_filter( 'jetpack_api_include_comment_types_count' ) );
+		$this->assertTrue( has_filter( 'activitypub_following_row_actions' ) );
+		$this->assertTrue( has_filter( 'pre_option_activitypub_following_ui' ) );
+	}
+
+	/**
+	 * Test init method skips sync hooks when IS_WPCOM is defined.
+	 *
+	 * @covers ::init
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_init_skips_sync_hooks_on_wpcom() {
+		// Clear any existing hooks first.
+		remove_all_filters( 'jetpack_sync_post_meta_whitelist' );
+		remove_all_filters( 'jetpack_sync_comment_meta_whitelist' );
+		remove_all_filters( 'jetpack_sync_whitelisted_comment_types' );
+		remove_all_filters( 'jetpack_json_api_comment_types' );
+		remove_all_filters( 'jetpack_api_include_comment_types_count' );
+		remove_all_filters( 'activitypub_following_row_actions' );
+		remove_all_filters( 'pre_option_activitypub_following_ui' );
+
+		// Test the normal case first (IS_WPCOM not defined).
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			Jetpack::init();
+
+			// Sync hooks should be registered when IS_WPCOM is not defined.
+			$this->assertTrue( has_filter( 'jetpack_sync_post_meta_whitelist' ) );
+			$this->assertTrue( has_filter( 'jetpack_sync_comment_meta_whitelist' ) );
+			$this->assertTrue( has_filter( 'jetpack_sync_whitelisted_comment_types' ) );
+			$this->assertTrue( has_filter( 'jetpack_json_api_comment_types' ) );
+			$this->assertTrue( has_filter( 'jetpack_api_include_comment_types_count' ) );
+
+			// Following UI hooks should also be registered.
+			$this->assertTrue( has_filter( 'activitypub_following_row_actions' ) );
+			$this->assertTrue( has_filter( 'pre_option_activitypub_following_ui' ) );
+
+			// Clear hooks again for the WPCOM simulation.
+			remove_all_filters( 'jetpack_sync_post_meta_whitelist' );
+			remove_all_filters( 'jetpack_sync_comment_meta_whitelist' );
+			remove_all_filters( 'jetpack_sync_whitelisted_comment_types' );
+			remove_all_filters( 'jetpack_json_api_comment_types' );
+			remove_all_filters( 'jetpack_api_include_comment_types_count' );
+			remove_all_filters( 'activitypub_following_row_actions' );
+			remove_all_filters( 'pre_option_activitypub_following_ui' );
+		}
+
+		// Now simulate IS_WPCOM behavior by defining the constant temporarily.
+		// We use a runInSeparateProcess annotation to isolate this test.
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			define( 'IS_WPCOM', true );
+		}
+
+		Jetpack::init();
+
+		// When IS_WPCOM is defined, sync hooks should NOT be registered.
+		$this->assertFalse( has_filter( 'jetpack_sync_post_meta_whitelist' ) );
+		$this->assertFalse( has_filter( 'jetpack_sync_comment_meta_whitelist' ) );
+		$this->assertFalse( has_filter( 'jetpack_sync_whitelisted_comment_types' ) );
+		$this->assertFalse( has_filter( 'jetpack_json_api_comment_types' ) );
+		$this->assertFalse( has_filter( 'jetpack_api_include_comment_types_count' ) );
+
+		// But following UI hooks should still be registered.
+		$this->assertTrue( has_filter( 'activitypub_following_row_actions' ) );
+		$this->assertTrue( has_filter( 'pre_option_activitypub_following_ui' ) );
+	}
+
+	/**
+	 * Test add_sync_meta method adds ActivityPub meta keys.
+	 *
+	 * @covers ::add_sync_meta
+	 */
+	public function test_add_sync_meta() {
+		$original_list = array( 'existing_meta_key' );
+
+		$updated_list = Jetpack::add_sync_meta( $original_list );
+
+		// Check that original keys are preserved.
+		$this->assertContains( 'existing_meta_key', $updated_list );
+
+		// Check that ActivityPub meta keys are added.
+		$this->assertContains( Followers::FOLLOWER_META_KEY, $updated_list );
+		$this->assertContains( Following::FOLLOWING_META_KEY, $updated_list );
+	}
+
+	/**
+	 * Test add_sync_comment_meta method adds ActivityPub comment meta keys.
+	 *
+	 * @covers ::add_sync_comment_meta
+	 */
+	public function test_add_sync_comment_meta() {
+		$original_list = array( 'existing_comment_meta' );
+
+		$updated_list = Jetpack::add_sync_comment_meta( $original_list );
+
+		// Check that original keys are preserved.
+		$this->assertContains( 'existing_comment_meta', $updated_list );
+
+		// Check that ActivityPub comment meta keys are added.
+		$this->assertContains( 'avatar_url', $updated_list );
+	}
+
+	/**
+	 * Test add_comment_types method adds ActivityPub comment types.
+	 *
+	 * @covers ::add_comment_types
+	 */
+	public function test_add_comment_types() {
+		$original_types = array( 'comment', 'pingback', 'trackback' );
+
+		$updated_types = Jetpack::add_comment_types( $original_types );
+
+		// Check that original types are preserved.
+		$this->assertContains( 'comment', $updated_types );
+		$this->assertContains( 'pingback', $updated_types );
+		$this->assertContains( 'trackback', $updated_types );
+
+		// Check that ActivityPub comment types are added.
+		$expected_ap_types = Comment::get_comment_type_slugs();
+		foreach ( $expected_ap_types as $type ) {
+			$this->assertContains( $type, $updated_types );
+		}
+
+		// Check that duplicates are removed.
+		$this->assertEquals( $updated_types, array_unique( $updated_types ) );
+	}
+
+	/**
+	 * Data provider for Reader link test scenarios.
+	 *
+	 * @return array Test cases with different following item configurations.
+	 */
+	public function reader_link_data() {
+		return array(
+			'active following with feed ID'    => array(
+				'item'                    => array(
+					'id'         => 123,
+					'status'     => 'active',
+					'identifier' => 'https://example.com/feed',
+				),
+				'feed_id'                 => 456,
+				'expected_url'            => 'https://wordpress.com/reader/feed/456',
+				'should_have_reader_link' => true,
+			),
+			'active following without feed ID' => array(
+				'item'                    => array(
+					'id'         => 123,
+					'status'     => 'active',
+					'identifier' => 'https://example.com/feed',
+				),
+				'feed_id'                 => false,
+				'expected_url'            => 'https://wordpress.com/reader/feeds/lookup/https://example.com/feed',
+				'should_have_reader_link' => true,
+			),
+			'pending following should not have reader link' => array(
+				'item'                    => array(
+					'id'         => 123,
+					'status'     => 'pending',
+					'identifier' => 'https://example.com/feed',
+				),
+				'feed_id'                 => 456,
+				'expected_url'            => null,
+				'should_have_reader_link' => false,
+			),
+		);
+	}
+
+	/**
+	 * Test add_reader_link method adds correct Reader links.
+	 *
+	 * @dataProvider reader_link_data
+	 * @covers ::add_reader_link
+	 *
+	 * @param array       $item                    The following item.
+	 * @param int|false   $feed_id                 The feed ID or false.
+	 * @param string|null $expected_url            Expected URL or null.
+	 * @param bool        $should_have_reader_link Whether reader link should be added.
+	 */
+	public function test_add_reader_link( $item, $feed_id, $expected_url, $should_have_reader_link ) {
+		$original_actions = array( 'edit' => '<a href="#">Edit</a>' );
+
+		// Mock the feed ID meta if provided.
+		if ( false !== $feed_id ) {
+			add_filter(
+				'get_post_metadata',
+				function ( $value, $object_id, $meta_key ) use ( $item, $feed_id ) {
+					if ( $object_id === $item['id'] && '_activitypub_actor_feed' === $meta_key ) {
+						return $feed_id;
+					}
+					return $value;
+				},
+				10,
+				3
+			);
+		}
+
+		$updated_actions = Jetpack::add_reader_link( $original_actions, $item );
+
+		// Check that original actions are preserved.
+		$this->assertArrayHasKey( 'edit', $updated_actions );
+
+		if ( $should_have_reader_link ) {
+			// Check that reader link is added.
+			$this->assertArrayHasKey( 'reader', $updated_actions );
+			$this->assertStringContainsString( $expected_url, $updated_actions['reader'] );
+			$this->assertStringContainsString( 'Open in Reader', $updated_actions['reader'] );
+			$this->assertStringContainsString( 'target="_blank"', $updated_actions['reader'] );
+		} else {
+			// Check that reader link is not added for pending items.
+			$this->assertArrayNotHasKey( 'reader', $updated_actions );
+		}
+
+		// Clean up filter.
+		remove_all_filters( 'get_post_metadata' );
+	}
+
+	/**
+	 * Test pre_option_activitypub_following_ui method forces UI to be enabled.
+	 *
+	 * @covers ::pre_option_activitypub_following_ui
+	 */
+	public function test_pre_option_activitypub_following_ui() {
+		$result = Jetpack::pre_option_activitypub_following_ui();
+
+		$this->assertEquals( '1', $result );
+	}
+
+	/**
+	 * Test integration with actual WordPress filters.
+	 */
+	public function test_filter_integration() {
+		// Initialize Jetpack integration.
+		Jetpack::init();
+
+		// Test sync meta filter integration (only if not on WordPress.com).
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			$sync_meta = apply_filters( 'jetpack_sync_post_meta_whitelist', array() );
+			$this->assertContains( Followers::FOLLOWER_META_KEY, $sync_meta );
+			$this->assertContains( Following::FOLLOWING_META_KEY, $sync_meta );
+
+			// Test comment meta filter integration.
+			$comment_meta = apply_filters( 'jetpack_sync_comment_meta_whitelist', array() );
+			$this->assertContains( 'avatar_url', $comment_meta );
+
+			// Test comment types filter integration.
+			$comment_types     = apply_filters( 'jetpack_sync_whitelisted_comment_types', array() );
+			$expected_ap_types = Comment::get_comment_type_slugs();
+			foreach ( $expected_ap_types as $type ) {
+				$this->assertContains( $type, $comment_types );
+			}
+		} else {
+			// On WordPress.com, sync filters should not be registered.
+			// Test that they are indeed not registered.
+			$sync_meta = apply_filters( 'jetpack_sync_post_meta_whitelist', array() );
+			$this->assertNotContains( Followers::FOLLOWER_META_KEY, $sync_meta );
+			$this->assertNotContains( Following::FOLLOWING_META_KEY, $sync_meta );
+
+			$comment_meta = apply_filters( 'jetpack_sync_comment_meta_whitelist', array() );
+			$this->assertNotContains( 'avatar_url', $comment_meta );
+		}
+
+		// Test following UI filter integration (always available).
+		$ui_enabled = apply_filters( 'pre_option_activitypub_following_ui', '0' );
+		$this->assertEquals( '1', $ui_enabled );
+
+		// Test reader link filter integration (always available).
+		$test_item = array(
+			'id'         => 123,
+			'status'     => 'active',
+			'identifier' => 'https://example.com/feed',
+		);
+		$actions   = apply_filters( 'activitypub_following_row_actions', array(), $test_item );
+		$this->assertArrayHasKey( 'reader', $actions );
+	}
+}


### PR DESCRIPTION
Introduces new filters for customizing row actions in the Blocked Actors, Followers, and Following admin tables. Enhances Jetpack integration by conditionally registering hooks, adding a 'Reader' link to the Following list actions, and ensuring the ActivityPub Following UI is enabled when Jetpack is active. Also updates the Jetpack initialization condition in the integration loader.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #2156

## Proposed changes:
- Added filter hooks to all ActivityPub admin table classes for customizable row actions
- Enhanced Jetpack integration with a Reader link feature for the Following table
- Updated Jetpack initialization logic to support WordPress.com environments

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Configure Jetpack or run on WP.com
* Check if Following is enabled
* Follow an Actor
* Check that Reader link is not shown when state is pending
* Check if Reader link is visible when state is no longer pending
* Click on reader link and check redirect

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

You can now follow people and see their updates right in the WordPress.com Reader when using Jetpack or WordPress.com.

</details>
