### PR TITLE
Add upgrade routine to enable ActivityPub feeds in WordPress.com Reader

### DIFF
--- a/.github/changelog/2243-from-description
+++ b/.github/changelog/2243-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add upgrade routine to enable ActivityPub feeds in WordPress.com Reader

--- a/tests/data/class-jetpack.php
+++ b/tests/data/class-jetpack.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Mock Jetpack class for testing.
+ *
+ * @package Activitypub
+ */
+
+if ( ! class_exists( 'Jetpack' ) ) {
+	/**
+	 * Mock Jetpack class for testing purposes.
+	 */
+	class Jetpack {
+		/**
+		 * Mock method to simulate Jetpack connection status.
+		 *
+		 * @return bool Always returns true for testing.
+		 */
+		public static function is_connection_ready() {
+			return true;
+		}
+	}
+}

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -1157,7 +1157,6 @@ class Test_Migration extends \WP_UnitTestCase {
 		// Track action calls for the specific meta key we care about.
 		$following_actions = array();
 		$capture_action    = function ( $meta_id, $post_id, $meta_key, $meta_value ) use ( &$following_actions ) {
-			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 			if ( Following::FOLLOWING_META_KEY === $meta_key ) {
 				$following_actions[] = array( $meta_id, $post_id, $meta_key, $meta_value );
 			}

--- a/tests/includes/class-test-migration.php
+++ b/tests/includes/class-test-migration.php
@@ -11,6 +11,7 @@ use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 use Activitypub\Collection\Followers;
+use Activitypub\Collection\Following;
 use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Comment;
@@ -35,6 +36,11 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * Set up the test.
 	 */
 	public static function set_up_before_class() {
+		// Mock Jetpack class if it doesn't exist.
+		if ( ! class_exists( 'Jetpack' ) ) {
+			require_once AP_TESTS_DIR . '/data/class-jetpack.php';
+		}
+
 		\remove_action( 'wp_after_insert_post', array( \Activitypub\Scheduler\Post::class, 'schedule_post_activity' ), 33 );
 		\remove_action( 'transition_comment_status', array( \Activitypub\Scheduler\Comment::class, 'schedule_comment_activity' ), 20 );
 		\remove_action( 'wp_insert_comment', array( \Activitypub\Scheduler\Comment::class, 'schedule_comment_activity_on_insert' ) );
@@ -1096,5 +1102,76 @@ class Test_Migration extends \WP_UnitTestCase {
 
 		// Clean up.
 		\wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test sync_jetpack_following_meta triggers actions correctly.
+	 *
+	 * @covers ::sync_jetpack_following_meta
+	 */
+	public function test_sync_jetpack_following_meta() {
+		// Create test posts with following meta.
+		$posts = self::factory()->post->create_many( 3, array( 'post_type' => Remote_Actors::POST_TYPE ) );
+
+		// Add following meta to each post.
+		\add_post_meta( $posts[0], Following::FOLLOWING_META_KEY, '123' );
+		\add_post_meta( $posts[1], Following::FOLLOWING_META_KEY, '456' );
+		\add_post_meta( $posts[2], Following::FOLLOWING_META_KEY, '789' );
+
+		// Track action calls.
+		$action_calls   = array();
+		$capture_action = function () use ( &$action_calls ) {
+			$action_calls[] = func_get_args();
+		};
+
+		\add_action( 'added_post_meta', $capture_action, 10, 4 );
+
+		// Run the migration with Jetpack available.
+		Migration::sync_jetpack_following_meta();
+
+		// Verify the correct actions were triggered.
+		$this->assertCount( 3, $action_calls, 'Should trigger action for each following meta entry' );
+
+		// Check the first action call structure.
+		$this->assertCount( 4, $action_calls[0], 'Action should be called with 4 parameters' );
+		list( $meta_id, $post_id, $meta_key, $meta_value ) = $action_calls[0];
+
+		$this->assertEquals( Following::FOLLOWING_META_KEY, $meta_key, 'Meta key should be Following::FOLLOWING_META_KEY' );
+		$this->assertIsNumeric( $meta_id, 'Meta ID should be numeric' );
+		$this->assertIsNumeric( $post_id, 'Post ID should be numeric' );
+		$this->assertContains( $meta_value, array( '123', '456', '789' ), 'Meta value should be one of the test values' );
+
+		// Clean up.
+		\remove_action( 'added_post_meta', $capture_action, 10 );
+		foreach ( $posts as $post ) {
+			\wp_delete_post( $post, true );
+		}
+	}
+
+	/**
+	 * Test sync_jetpack_following_meta with no following meta.
+	 *
+	 * @covers ::sync_jetpack_following_meta
+	 */
+	public function test_sync_jetpack_following_meta_no_entries() {
+		// Track action calls for the specific meta key we care about.
+		$following_actions = array();
+		$capture_action    = function ( $meta_id, $post_id, $meta_key, $meta_value ) use ( &$following_actions ) {
+			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+			if ( Following::FOLLOWING_META_KEY === $meta_key ) {
+				$following_actions[] = array( $meta_id, $post_id, $meta_key, $meta_value );
+			}
+		};
+
+		\add_action( 'added_post_meta', $capture_action, 10, 4 );
+
+		// Run migration with no following meta (should not trigger our specific actions).
+		Migration::sync_jetpack_following_meta();
+
+		// Verify no following-specific actions were triggered.
+		$this->assertEmpty( $following_actions, 'No following-specific actions should be triggered when no following meta exists' );
+
+		// Clean up.
+		\remove_action( 'added_post_meta', $capture_action, 10 );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add upgrade routine to enable ActivityPub following feeds in WordPress.com Reader
* Add `sync_jetpack_following_meta()` method in migration class that replays `added_post_meta` actions
* Ensures existing following relationships are properly synced to WordPress.com for RSS feed functionality
* Uses spread operator with `ARRAY_N` for clean parameter passing
* Includes comprehensive test coverage with Jetpack mock

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `npm run env-test` to verify all tests pass
* Run `composer lint` to verify code standards compliance
* Run `npm run build` to ensure build succeeds
* Check that new tests `test_sync_jetpack_following_meta` and `test_sync_jetpack_following_meta_no_entries` pass
* Verify the upgrade routine only runs when Jetpack is available and connected

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

Add upgrade routine to enable ActivityPub feeds in WordPress.com Reader

</details>