### PR TITLE
Improve user ID fallback and transformer logic

### DIFF
--- a/.github/changelog/2246-from-description
+++ b/.github/changelog/2246-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Posts now only fall back to the blog user when blog mode is enabled and no valid author exists, ensuring content negotiation only runs if an Actor is available.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1313,10 +1313,10 @@ function get_user_id( $id ) {
 		$user = Actors::get_by_id( Actors::BLOG_USER_ID );
 	} else {
 		$user = Actors::get_by_id( $id );
-	}
 
-	if ( \is_wp_error( $user ) ) {
-		$user = Actors::get_by_id( Actors::BLOG_USER_ID );
+		if ( \is_wp_error( $user ) ) {
+			$user = Actors::get_by_id( Actors::BLOG_USER_ID );
+		}
 	}
 
 	if ( \is_wp_error( $user ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1300,12 +1300,24 @@ function get_content_warning( $post_id ) {
 /**
  * Get the ActivityPub ID of a User by the WordPress User ID.
  *
+ * Fall back to blog user if in blog mode or if user is not found.
+ *
  * @param int $id The WordPress User ID.
  *
- * @return string The ActivityPub ID (a URL) of the User.
+ * @return string|false The ActivityPub ID (a URL) of the User or false if not found.
  */
 function get_user_id( $id ) {
-	$user = Actors::get_by_id( $id );
+	$mode = \get_option( 'activitypub_actor_mode', 'default' );
+
+	if ( ACTIVITYPUB_BLOG_MODE === $mode ) {
+		$user = Actors::get_by_id( 0 );
+	} else {
+		$user = Actors::get_by_id( $id );
+	}
+
+	if ( \is_wp_error( $user ) ) {
+		$user = Actors::get_by_id( 0 );
+	}
 
 	if ( \is_wp_error( $user ) ) {
 		return false;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1310,7 +1310,7 @@ function get_user_id( $id ) {
 	$mode = \get_option( 'activitypub_actor_mode', 'default' );
 
 	if ( ACTIVITYPUB_BLOG_MODE === $mode ) {
-		$user = Actors::get_by_id( 0 );
+		$user = Actors::get_by_id( Actors::BLOG_USER_ID );
 	} else {
 		$user = Actors::get_by_id( $id );
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1316,7 +1316,7 @@ function get_user_id( $id ) {
 	}
 
 	if ( \is_wp_error( $user ) ) {
-		$user = Actors::get_by_id( 0 );
+		$user = Actors::get_by_id( Actors::BLOG_USER_ID );
 	}
 
 	if ( \is_wp_error( $user ) ) {

--- a/includes/transformer/class-factory.php
+++ b/includes/transformer/class-factory.php
@@ -11,6 +11,7 @@ use Activitypub\Activity\Base_Object;
 use Activitypub\Comment as Comment_Helper;
 use Activitypub\Http;
 
+use function Activitypub\get_user_id;
 use function Activitypub\is_post_disabled;
 use function Activitypub\user_can_activitypub;
 
@@ -90,7 +91,7 @@ class Factory {
 			case 'WP_Post':
 				if ( 'attachment' === $data->post_type && ! is_post_disabled( $data ) ) {
 					return new Attachment( $data );
-				} elseif ( ! is_post_disabled( $data ) ) {
+				} elseif ( ! is_post_disabled( $data ) && get_user_id( $data->post_author ) ) {
 					return new Post( $data );
 				}
 				break;

--- a/tests/includes/class-test-functions.php
+++ b/tests/includes/class-test-functions.php
@@ -712,6 +712,17 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 		$user->add_cap( 'activitypub' );
 
 		$this->assertIsString( \Activitypub\get_user_id( $user->ID ) );
+
+		\add_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		$this->assertIsString( \Activitypub\get_user_id( $user->ID ) );
+
+		$user->remove_cap( 'activitypub' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+		$this->assertIsString( \Activitypub\get_user_id( $user->ID ) );
+
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+		$this->assertFalse( \Activitypub\get_user_id( $user->ID ) );
 	}
 
 	/**

--- a/tests/includes/transformer/class-test-factory.php
+++ b/tests/includes/transformer/class-test-factory.php
@@ -13,14 +13,13 @@ use Activitypub\Transformer\Comment;
 use Activitypub\Transformer\Factory;
 use Activitypub\Transformer\Json;
 use Activitypub\Transformer\Post;
-use WP_UnitTestCase;
 
 /**
  * Test class for Transformer Factory.
  *
  * @coversDefaultClass \Activitypub\Transformer\Factory
  */
-class Test_Factory extends WP_UnitTestCase {
+class Test_Factory extends \WP_UnitTestCase {
 	/**
 	 * Test post ID.
 	 *
@@ -110,6 +109,20 @@ class Test_Factory extends WP_UnitTestCase {
 	 * @covers ::get_transformer
 	 */
 	public function test_get_transformer_post() {
+		$post        = get_post( self::$post_id );
+		$transformer = Factory::get_transformer( $post );
+
+		$this->assertInstanceOf( \WP_Error::class, $transformer );
+
+		\add_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$post        = get_post( self::$post_id );
+		$transformer = Factory::get_transformer( $post );
+
+		$this->assertInstanceOf( Post::class, $transformer );
+
+		\add_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
 		$post        = get_post( self::$post_id );
 		$transformer = Factory::get_transformer( $post );
 


### PR DESCRIPTION
Updated `get_user_id` to fall back to the blog user in blog mode or when the user is not found. Adjusted transformer factory to only create Post transformers if a valid user ID exists. Added and updated tests to cover new fallback and mode logic.

Atm. the post author always falls back to the Blog-User, if enabled or not. With this change, the transformer also checks if there is an Actor enabled before starting content-negotiation.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Implement proper fallback for `get_user_id`
* Check if there is a valid user before transforming object

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before PR:

* Remove `activitypub` cap from all Blog-Users
* Set Actor mode to "Author Profiles Only"
* Load post JSON (`https://example.org/?p=123&activitypub`)
* The JSON loads with the Blog-User as `attributedTo`

After PR:

* HTML loads instead of JSON

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Posts now only fall back to the blog user when blog mode is enabled and no valid author exists, ensuring content negotiation only runs if an Actor is available.

</details>
