### PR TITLE
Add external link icon to Jetpack reader feed link

### DIFF
--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -176,6 +176,11 @@ summary {
 	transform: translateY(-30%) rotate(-135deg);
 }
 
+table.followings .dashicons {
+	font-size: 1em;
+	line-height: 1.7;
+}
+
 .activitypub-settings-accordion-trigger:active,
 .activitypub-settings-accordion-trigger:hover {
 	background: #f6f7f7;

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -176,14 +176,6 @@ summary {
 	transform: translateY(-30%) rotate(-135deg);
 }
 
-
-.activitypub-external:after {
-	font-family: dashicons;
-	vertical-align: baseline;
-	font-size: 0.9em;
-	content: " \f504";
-}
-
 .activitypub-settings-accordion-trigger:active,
 .activitypub-settings-accordion-trigger:hover {
 	background: #f6f7f7;

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -176,6 +176,14 @@ summary {
 	transform: translateY(-30%) rotate(-135deg);
 }
 
+
+.activitypub-external:after {
+	font-family: dashicons;
+	vertical-align: baseline;
+	font-size: 0.9em;
+	content: " \f504";
+}
+
 .activitypub-settings-accordion-trigger:active,
 .activitypub-settings-accordion-trigger:hover {
 	background: #f6f7f7;

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -10,6 +10,7 @@ namespace Activitypub\Integration;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
 use Activitypub\Comment;
+use Automattic\Jetpack\Connection\Manager;
 
 /**
  * Jetpack integration class.
@@ -30,7 +31,7 @@ class Jetpack {
 
 		if (
 			( \defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
-			( \class_exists( '\Jetpack' ) && \Jetpack::is_connection_ready() )
+			( \class_exists( 'Automattic\Jetpack\Connection\Manager' ) && ( new Manager() )->is_user_connected() )
 		) {
 			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
 			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
@@ -104,7 +105,7 @@ class Jetpack {
 		return array_merge(
 			array(
 				'reader' => sprintf(
-					'<a href="%s" target="_blank">%s</a>',
+					'<a href="%s" target="_blank" class="activitypub-external">%s</a>',
 					esc_url( $url ),
 					esc_html__( 'View Feed', 'activitypub' )
 				),

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -10,7 +10,6 @@ namespace Activitypub\Integration;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
 use Activitypub\Comment;
-use Automattic\Jetpack\Connection\Manager;
 
 /**
  * Jetpack integration class.
@@ -31,7 +30,7 @@ class Jetpack {
 
 		if (
 			( \defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
-			( \class_exists( 'Automattic\Jetpack\Connection\Manager' ) && ( new Manager() )->is_user_connected() )
+			( \class_exists( '\Jetpack' ) && \Jetpack::is_connection_ready() )
 		) {
 			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
 			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -104,10 +104,11 @@ class Jetpack {
 		return array_merge(
 			array(
 				'reader' => sprintf(
-					'<a href="%s" target="_blank" class="activitypub-external" aria-label="%s">%s</a>',
+					'<a href="%1$s" target="_blank">%2$s<span class="screen-reader-text"> %3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
 					esc_url( $url ),
-					esc_html__( 'View feed in the WordPress.com Reader', 'activitypub' ),
-					esc_html__( 'View Feed', 'activitypub' )
+					esc_html__( 'View Feed', 'activitypub' ),
+					/* translators: Hidden accessibility text. */
+					esc_html__( '(opens in a new tab)', 'activitypub' )
 				),
 			),
 			$actions

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -104,8 +104,9 @@ class Jetpack {
 		return array_merge(
 			array(
 				'reader' => sprintf(
-					'<a href="%s" target="_blank" class="activitypub-external">%s</a>',
+					'<a href="%s" target="_blank" class="activitypub-external" aria-label="%s">%s</a>',
 					esc_url( $url ),
+					esc_html__( 'View feed in the WordPress.com Reader', 'activitypub' ),
 					esc_html__( 'View Feed', 'activitypub' )
 				),
 			),


### PR DESCRIPTION
Updated the Jetpack integration to add the 'activitypub-external' class to the reader feed link, and added CSS to display a dashicon after external links. This visually indicates external links in the admin interface.

<img width="817" height="327" alt="Screenshot 2025-09-30 at 13 30 44" src="https://github.com/user-attachments/assets/a3f8546f-6c8b-42f6-8f18-366e7269f50f" />

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
