### PR TITLE
Improve NodeInfo handling and add support for FEP-0151

### DIFF
--- a/.github/changelog/2255-from-description
+++ b/.github/changelog/2255-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added support for the latest NodeInfo (FEP-0151), with improved federation details, staff info, and software metadata for better ActivityPub compliance.

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -13,6 +13,7 @@ The WordPress plugin largely follows ActivityPub's server-to-server specificatio
 ## Supported FEPs
 
 - [FEP-f1d5: NodeInfo in Fediverse Software](https://codeberg.org/fediverse/fep/src/branch/main/fep/f1d5/fep-f1d5.md)
+- [FEP-0151: NodeInfo in Fediverse Software (2025 edition)](https://codeberg.org/fediverse/fep/src/branch/main/fep/0151/fep-0151.md)
 - [FEP-67ff: FEDERATION.md](https://codeberg.org/fediverse/fep/src/branch/main/fep/67ff/fep-67ff.md)
 - [FEP-5feb: Search indexing consent for actors](https://codeberg.org/fediverse/fep/src/branch/main/fep/5feb/fep-5feb.md)
 - [FEP-2677: Identifying the Application Actor](https://codeberg.org/fediverse/fep/src/branch/main/fep/2677/fep-2677.md)

--- a/includes/rest/class-nodeinfo-controller.php
+++ b/includes/rest/class-nodeinfo-controller.php
@@ -88,7 +88,15 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 					'href' => get_rest_url_by_path( '/nodeinfo/2.0' ),
 				),
 				array(
+					'rel'  => 'https://nodeinfo.diaspora.software/ns/schema/2.0',
+					'href' => get_rest_url_by_path( '/nodeinfo/2.0' ),
+				),
+				array(
 					'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/2.1',
+					'href' => get_rest_url_by_path( '/nodeinfo/2.1' ),
+				),
+				array(
+					'rel'  => 'https://nodeinfo.diaspora.software/ns/schema/2.1',
 					'href' => get_rest_url_by_path( '/nodeinfo/2.1' ),
 				),
 				array(
@@ -108,7 +116,7 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response Response object.
 	 */
 	public function get_item( $request ) {
-		$version = $request->get_param( 'version', '2.1' );
+		$version = $request->get_param( 'version', '2.0' );
 
 		/**
 		 * Fires before the NodeInfo data is created and sent to the client.

--- a/includes/rest/class-nodeinfo-controller.php
+++ b/includes/rest/class-nodeinfo-controller.php
@@ -7,10 +7,8 @@
 
 namespace Activitypub\Rest;
 
-use function Activitypub\get_active_users;
 use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_rest_url_by_path;
-use function Activitypub\get_total_users;
 
 /**
  * ActivityPub NodeInfo Controller.
@@ -90,8 +88,8 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 					'href' => get_rest_url_by_path( '/nodeinfo/2.0' ),
 				),
 				array(
-					'rel'  => 'https://nodeinfo.diaspora.software/ns/schema/2.0',
-					'href' => get_rest_url_by_path( '/nodeinfo/2.0' ),
+					'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/2.1',
+					'href' => get_rest_url_by_path( '/nodeinfo/2.1' ),
 				),
 				array(
 					'rel'  => 'https://www.w3.org/ns/activitystreams#Application',
@@ -110,7 +108,7 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response Response object.
 	 */
 	public function get_item( $request ) {
-		$version = $request->get_param( 'version' );
+		$version = $request->get_param( 'version', '2.1' );
 
 		/**
 		 * Fires before the NodeInfo data is created and sent to the client.
@@ -121,7 +119,8 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 
 		switch ( $version ) {
 			case '2.0':
-				$response = $this->get_version_2_0();
+			case '2.1':
+				$response = $this->get_version_2_X( $version );
 				break;
 
 			default:
@@ -135,30 +134,22 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 	/**
 	 * Get the NodeInfo 2.0 data.
 	 *
-	 * @return array
+	 * @param string $version The NodeInfo version.
+	 *
+	 * @return array The NodeInfo data.
 	 */
-	public function get_version_2_0() {
+	public function get_version_2_X( $version ) {
 		$posts    = \wp_count_posts();
 		$comments = \wp_count_comments();
 
-		return array(
-			'version'           => '2.0',
+		$nodeinfo = array(
+			'version'           => $version,
 			'software'          => array(
 				'name'    => 'wordpress',
 				'version' => get_masked_wp_version(),
 			),
-			'protocols'         => array( 'activitypub' ),
-			'services'          => array(
-				'inbound'  => array(),
-				'outbound' => array(),
-			),
 			'openRegistrations' => (bool) get_option( 'users_can_register' ),
 			'usage'             => array(
-				'users'         => array(
-					'total'          => get_total_users(),
-					'activeHalfyear' => get_active_users( 6 ),
-					'activeMonth'    => get_active_users(),
-				),
 				'localPosts'    => (int) $posts->publish,
 				'localComments' => $comments->approved,
 			),
@@ -168,5 +159,13 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 				'nodeIcon'        => \get_site_icon_url(),
 			),
 		);
+
+		/**
+		 * Filter the NodeInfo data.
+		 *
+		 * @param array  $nodeinfo The NodeInfo data.
+		 * @param string $version  The NodeInfo version.
+		 */
+		return \apply_filters( 'nodeinfo_data', $nodeinfo, $version );
 	}
 }

--- a/includes/rest/class-nodeinfo-controller.php
+++ b/includes/rest/class-nodeinfo-controller.php
@@ -116,7 +116,7 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response Response object.
 	 */
 	public function get_item( $request ) {
-		$version = $request->get_param( 'version', '2.0' );
+		$version = $request->get_param( 'version' );
 
 		/**
 		 * Fires before the NodeInfo data is created and sent to the client.

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -117,9 +117,9 @@ class Nodeinfo {
 	}
 
 	/**
-	 * Get all admin users with the cap activitypub.
+	 * Get all staff accounts (admin users with the "activitypub" capability) and return them in WebFinger resource format.
 	 *
-	 * @return array The list of staff accounts.
+	 * @return array List of staff accounts in WebFinger resource format.
 	 */
 	private static function get_staff() {
 		// Get all admin users with the cap activitypub.

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -38,12 +38,33 @@ class Nodeinfo {
 	 * @return array The extended array.
 	 */
 	public static function add_nodeinfo_data( $nodeinfo, $version ) {
-		if ( \version_compare( $version, '2.0', '>=' ) ) {
-			$nodeinfo['protocols'][] = 'activitypub';
-		} else {
-			$nodeinfo['protocols']['inbound'][]  = 'activitypub';
-			$nodeinfo['protocols']['outbound'][] = 'activitypub';
+		$nodeinfo = wp_parse_args(
+			$nodeinfo,
+			array(
+				'version'   => $version,
+				'software'  => array(),
+				'usage'     => array(
+					'users' => array(
+						'total'          => 0,
+						'activeMonth'    => 0,
+						'activeHalfyear' => 0,
+					),
+				),
+				'protocols' => array(),
+				'services'  => array(
+					'inbound'  => array(),
+					'outbound' => array(),
+				),
+				'metadata'  => array(),
+			)
+		);
+
+		if ( \version_compare( $version, '2.1', '>=' ) ) {
+			$nodeinfo['software']['homepage']   = 'https://wordpress.org/plugins/activitypub/';
+			$nodeinfo['software']['repository'] = 'https://github.com/Automattic/wordpress-activitypub';
 		}
+
+		$nodeinfo['protocols'][] = 'activitypub';
 
 		$nodeinfo['usage']['users'] = array(
 			'total'          => get_total_users(),
@@ -53,13 +74,6 @@ class Nodeinfo {
 
 		$nodeinfo['metadata']['federation']    = array( 'enabled' => true );
 		$nodeinfo['metadata']['staffAccounts'] = self::get_staff();
-
-		if ( empty( $nodeinfo['services'] ) ) {
-			$nodeinfo['services'] = array(
-				'inbound'  => array(),
-				'outbound' => array(),
-			);
-		}
 
 		$nodeinfo['services']['inbound'][]  = 'activitypub';
 		$nodeinfo['services']['outbound'][] = 'activitypub';

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -7,6 +7,8 @@
 
 namespace Activitypub\Integration;
 
+use Activitypub\Webfinger;
+
 use function Activitypub\get_active_users;
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\get_total_users;
@@ -36,7 +38,7 @@ class Nodeinfo {
 	 * @return array The extended array.
 	 */
 	public static function add_nodeinfo_data( $nodeinfo, $version ) {
-		if ( $version >= '2.0' ) {
+		if ( \version_compare( $version, '2.0', '>=' ) ) {
 			$nodeinfo['protocols'][] = 'activitypub';
 		} else {
 			$nodeinfo['protocols']['inbound'][]  = 'activitypub';
@@ -48,6 +50,9 @@ class Nodeinfo {
 			'activeMonth'    => get_active_users(),
 			'activeHalfyear' => get_active_users( 6 ),
 		);
+
+		$nodeinfo['metadata']['federation']    = array( 'enabled' => true );
+		$nodeinfo['metadata']['staffAccounts'] = self::get_staff();
 
 		return $nodeinfo;
 	}
@@ -85,5 +90,30 @@ class Nodeinfo {
 		);
 
 		return $data;
+	}
+
+	/**
+	 * Get all admin users with the cap activitypub.
+	 *
+	 * @return array The list of staff accounts.
+	 */
+	private static function get_staff() {
+		// Get all admin users with the cap activitypub.
+		$admins = get_users(
+			array(
+				'role'    => 'administrator',
+				'orderby' => 'ID',
+				'order'   => 'ASC',
+				'cap'     => 'activitypub',
+				'fields'  => array( 'ID' ),
+			)
+		);
+
+		return array_map(
+			function ( $user ) {
+				return Webfinger::get_user_resource( $user->ID );
+			},
+			$admins
+		);
 	}
 }

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -54,6 +54,16 @@ class Nodeinfo {
 		$nodeinfo['metadata']['federation']    = array( 'enabled' => true );
 		$nodeinfo['metadata']['staffAccounts'] = self::get_staff();
 
+		if ( empty( $nodeinfo['services'] ) ) {
+			$nodeinfo['services'] = array(
+				'inbound'  => array(),
+				'outbound' => array(),
+			);
+		}
+
+		$nodeinfo['services']['inbound'][]  = 'activitypub';
+		$nodeinfo['services']['outbound'][] = 'activitypub';
+
 		return $nodeinfo;
 	}
 

--- a/tests/includes/rest/class-test-nodeinfo-controller.php
+++ b/tests/includes/rest/class-test-nodeinfo-controller.php
@@ -38,7 +38,7 @@ class Test_Nodeinfo_Controller extends \Activitypub\Tests\Test_REST_Controller_T
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertArrayHasKey( 'links', $data );
-		$this->assertCount( 3, $data['links'] );
+		$this->assertCount( 5, $data['links'] );
 
 		/*
 		 * Test first link.
@@ -53,8 +53,16 @@ class Test_Nodeinfo_Controller extends \Activitypub\Tests\Test_REST_Controller_T
 		$this->assertStringEndsWith( '/nodeinfo/2.0', $data['links'][1]['href'] );
 
 		// Test third link.
-		$this->assertEquals( 'https://www.w3.org/ns/activitystreams#Application', $data['links'][2]['rel'] );
-		$this->assertStringEndsWith( '/application', $data['links'][2]['href'] );
+		$this->assertEquals( 'http://nodeinfo.diaspora.software/ns/schema/2.1', $data['links'][2]['rel'] );
+		$this->assertStringEndsWith( '/nodeinfo/2.1', $data['links'][2]['href'] );
+
+		// Test forth link.
+		$this->assertEquals( 'https://nodeinfo.diaspora.software/ns/schema/2.1', $data['links'][3]['rel'] );
+		$this->assertStringEndsWith( '/nodeinfo/2.1', $data['links'][3]['href'] );
+
+		// Test fifth link.
+		$this->assertEquals( 'https://www.w3.org/ns/activitystreams#Application', $data['links'][4]['rel'] );
+		$this->assertStringEndsWith( '/application', $data['links'][4]['href'] );
 
 		// Make sure the links work.
 		$request  = new \WP_REST_Request( 'GET', str_replace( \get_rest_url(), '/', $data['links'][0]['href'] ) );

--- a/tests/includes/rest/class-test-nodeinfo-controller.php
+++ b/tests/includes/rest/class-test-nodeinfo-controller.php
@@ -78,7 +78,7 @@ class Test_Nodeinfo_Controller extends \Activitypub\Tests\Test_REST_Controller_T
 	 * Test get_item method with valid version.
 	 *
 	 * @covers ::get_item
-	 * @covers ::get_version_2_0
+	 * @covers ::get_version_2_X
 	 */
 	public function test_get_item() {
 		self::factory()->post->create();

--- a/tests/integration/class-test-nodeinfo.php
+++ b/tests/integration/class-test-nodeinfo.php
@@ -1,0 +1,413 @@
+<?php
+/**
+ * Test file for NodeInfo integration.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Integration;
+
+use Activitypub\Integration\Nodeinfo;
+
+/**
+ * Test class for NodeInfo integration.
+ *
+ * @coversDefaultClass \Activitypub\Integration\Nodeinfo
+ */
+class Test_Nodeinfo extends \WP_UnitTestCase {
+	/**
+	 * Test user IDs.
+	 *
+	 * @var array
+	 */
+	protected static $user_ids = array();
+
+	/**
+	 * Create fake data before tests run.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Helper that creates fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		// Create test users with different roles.
+		self::$user_ids['admin'] = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		self::$user_ids['author'] = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		self::$user_ids['subscriber'] = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+
+		// Give the admin user activitypub capability.
+		$admin_user = get_user_by( 'id', self::$user_ids['admin'] );
+		$admin_user->add_cap( 'activitypub' );
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		// Remove filters that may have been added during tests.
+		remove_filter( 'nodeinfo_data', array( Nodeinfo::class, 'add_nodeinfo_data' ), 10 );
+		remove_filter( 'nodeinfo2_data', array( Nodeinfo::class, 'add_nodeinfo2_data' ) );
+		remove_filter( 'wellknown_nodeinfo_data', array( Nodeinfo::class, 'add_wellknown_nodeinfo_data' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test init method registers hooks correctly.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_registers_hooks() {
+		// Initialize NodeInfo integration.
+		Nodeinfo::init();
+
+		// Check that hooks are registered.
+		$this->assertTrue( has_filter( 'nodeinfo_data' ) );
+		$this->assertTrue( has_filter( 'nodeinfo2_data' ) );
+		$this->assertTrue( has_filter( 'wellknown_nodeinfo_data' ) );
+	}
+
+	/**
+	 * Data provider for NodeInfo version testing.
+	 *
+	 * @return array Test cases with different NodeInfo versions.
+	 */
+	public function nodeinfo_version_data() {
+		return array(
+			'version 1.0' => array(
+				'version'            => '1.0',
+				'expected_protocols' => array(
+					'inbound'  => array( 'activitypub' ),
+					'outbound' => array( 'activitypub' ),
+				),
+			),
+			'version 1.1' => array(
+				'version'            => '1.1',
+				'expected_protocols' => array(
+					'inbound'  => array( 'activitypub' ),
+					'outbound' => array( 'activitypub' ),
+				),
+			),
+			'version 2.0' => array(
+				'version'            => '2.0',
+				'expected_protocols' => array( 'activitypub' ),
+			),
+			'version 2.1' => array(
+				'version'            => '2.1',
+				'expected_protocols' => array( 'activitypub' ),
+			),
+		);
+	}
+
+	/**
+	 * Test add_nodeinfo_data method with different versions.
+	 *
+	 * @dataProvider nodeinfo_version_data
+	 * @covers ::add_nodeinfo_data
+	 *
+	 * @param string $version           The NodeInfo version.
+	 * @param array  $expected_protocols The expected protocol structure.
+	 */
+	public function test_add_nodeinfo_data_with_versions( $version, $expected_protocols ) {
+		$original_nodeinfo = array(
+			'version'   => $version,
+			'software'  => array(
+				'name'    => 'wordpress',
+				'version' => get_bloginfo( 'version' ),
+			),
+			'protocols' => array(),
+			'usage'     => array(),
+			'metadata'  => array(),
+		);
+
+		$result = Nodeinfo::add_nodeinfo_data( $original_nodeinfo, $version );
+
+		// Check protocols are added correctly based on version.
+		$this->assertEquals( $expected_protocols, $result['protocols'] );
+
+		// Check usage data is added.
+		$this->assertArrayHasKey( 'users', $result['usage'] );
+		$this->assertArrayHasKey( 'total', $result['usage']['users'] );
+		$this->assertArrayHasKey( 'activeMonth', $result['usage']['users'] );
+		$this->assertArrayHasKey( 'activeHalfyear', $result['usage']['users'] );
+
+		// Check metadata is added.
+		$this->assertArrayHasKey( 'federation', $result['metadata'] );
+		$this->assertArrayHasKey( 'staffAccounts', $result['metadata'] );
+		$this->assertTrue( $result['metadata']['federation']['enabled'] );
+	}
+
+	/**
+	 * Test add_nodeinfo_data preserves existing data.
+	 *
+	 * @covers ::add_nodeinfo_data
+	 */
+	public function test_add_nodeinfo_data_preserves_existing_data() {
+		$original_nodeinfo = array(
+			'version'   => '2.0',
+			'software'  => array(
+				'name'    => 'wordpress',
+				'version' => get_bloginfo( 'version' ),
+			),
+			'protocols' => array( 'existing-protocol' ),
+			'usage'     => array(
+				'localPosts' => 10,
+			),
+			'metadata'  => array(
+				'existing' => 'data',
+			),
+		);
+
+		$result = Nodeinfo::add_nodeinfo_data( $original_nodeinfo, '2.0' );
+
+		// Check that existing data is preserved.
+		$this->assertEquals( get_bloginfo( 'version' ), $result['software']['version'] );
+		$this->assertEquals( 10, $result['usage']['localPosts'] );
+		$this->assertEquals( 'data', $result['metadata']['existing'] );
+
+		// Check that new data is added.
+		$this->assertContains( 'existing-protocol', $result['protocols'] );
+		$this->assertContains( 'activitypub', $result['protocols'] );
+	}
+
+	/**
+	 * Test add_nodeinfo2_data method.
+	 *
+	 * @covers ::add_nodeinfo2_data
+	 */
+	public function test_add_nodeinfo2_data() {
+		$original_nodeinfo = array(
+			'version'   => '1.0',
+			'server'    => array(
+				'baseUrl' => home_url(),
+				'name'    => get_bloginfo( 'name' ),
+			),
+			'protocols' => array(),
+			'usage'     => array(),
+		);
+
+		$result = Nodeinfo::add_nodeinfo2_data( $original_nodeinfo );
+
+		// Check that activitypub protocol is added.
+		$this->assertContains( 'activitypub', $result['protocols'] );
+
+		// Check usage data is added.
+		$this->assertArrayHasKey( 'users', $result['usage'] );
+		$this->assertArrayHasKey( 'total', $result['usage']['users'] );
+		$this->assertArrayHasKey( 'activeMonth', $result['usage']['users'] );
+		$this->assertArrayHasKey( 'activeHalfyear', $result['usage']['users'] );
+
+		// Check that original data is preserved.
+		$this->assertEquals( home_url(), $result['server']['baseUrl'] );
+		$this->assertEquals( get_bloginfo( 'name' ), $result['server']['name'] );
+	}
+
+	/**
+	 * Test add_nodeinfo2_data preserves existing protocols.
+	 *
+	 * @covers ::add_nodeinfo2_data
+	 */
+	public function test_add_nodeinfo2_data_preserves_existing_protocols() {
+		$original_nodeinfo = array(
+			'protocols' => array( 'existing-protocol' ),
+			'usage'     => array(),
+		);
+
+		$result = Nodeinfo::add_nodeinfo2_data( $original_nodeinfo );
+
+		// Check that both existing and new protocols are present.
+		$this->assertContains( 'existing-protocol', $result['protocols'] );
+		$this->assertContains( 'activitypub', $result['protocols'] );
+	}
+
+	/**
+	 * Test add_wellknown_nodeinfo_data method.
+	 *
+	 * @covers ::add_wellknown_nodeinfo_data
+	 */
+	public function test_add_wellknown_nodeinfo_data() {
+		$original_data = array(
+			'links' => array(
+				array(
+					'rel'  => 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+					'href' => home_url( '/.well-known/nodeinfo/2.0' ),
+				),
+			),
+		);
+
+		$result = Nodeinfo::add_wellknown_nodeinfo_data( $original_data );
+
+		// Check that original links are preserved.
+		$this->assertCount( 2, $result['links'] );
+		$this->assertEquals( 'http://nodeinfo.diaspora.software/ns/schema/2.0', $result['links'][0]['rel'] );
+
+		// Check that ActivityStreams Application link is added.
+		$activitystreams_link = null;
+		foreach ( $result['links'] as $link ) {
+			if ( 'https://www.w3.org/ns/activitystreams#Application' === $link['rel'] ) {
+				$activitystreams_link = $link;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $activitystreams_link, 'ActivityStreams Application link should be added' );
+		$this->assertTrue( false !== strpos( $activitystreams_link['href'], '/application' ), 'Link should contain /application' );
+	}
+
+	/**
+	 * Test add_wellknown_nodeinfo_data handles empty data.
+	 *
+	 * @covers ::add_wellknown_nodeinfo_data
+	 */
+	public function test_add_wellknown_nodeinfo_data_handles_empty_data() {
+		$original_data = array();
+
+		$result = Nodeinfo::add_wellknown_nodeinfo_data( $original_data );
+
+		// Check that links array is created.
+		$this->assertArrayHasKey( 'links', $result );
+		$this->assertCount( 1, $result['links'] );
+
+		// Check that ActivityStreams Application link is added.
+		$this->assertEquals( 'https://www.w3.org/ns/activitystreams#Application', $result['links'][0]['rel'] );
+		$this->assertTrue( false !== strpos( $result['links'][0]['href'], '/application' ), 'Link should contain /application' );
+	}
+
+	/**
+	 * Test user statistics in NodeInfo data.
+	 *
+	 * @covers ::add_nodeinfo_data
+	 */
+	public function test_nodeinfo_user_statistics() {
+		$original_nodeinfo = array(
+			'protocols' => array(),
+			'usage'     => array(),
+			'metadata'  => array(),
+		);
+
+		$result = Nodeinfo::add_nodeinfo_data( $original_nodeinfo, '2.0' );
+
+		// Check that user statistics are numeric.
+		$this->assertIsNumeric( $result['usage']['users']['total'] );
+		$this->assertIsNumeric( $result['usage']['users']['activeMonth'] );
+		$this->assertIsNumeric( $result['usage']['users']['activeHalfyear'] );
+
+		// Check that the values are reasonable (not negative).
+		$this->assertGreaterThanOrEqual( 0, $result['usage']['users']['total'] );
+		$this->assertGreaterThanOrEqual( 0, $result['usage']['users']['activeMonth'] );
+		$this->assertGreaterThanOrEqual( 0, $result['usage']['users']['activeHalfyear'] );
+	}
+
+	/**
+	 * Test staff accounts in NodeInfo metadata.
+	 *
+	 * @covers ::add_nodeinfo_data
+	 */
+	public function test_nodeinfo_staff_accounts() {
+		$original_nodeinfo = array(
+			'protocols' => array(),
+			'usage'     => array(),
+			'metadata'  => array(),
+		);
+
+		$result = Nodeinfo::add_nodeinfo_data( $original_nodeinfo, '2.0' );
+
+		// Check that staffAccounts is an array.
+		$this->assertIsArray( $result['metadata']['staffAccounts'] );
+
+		// Check that staff accounts contain the admin user we created.
+		$this->assertGreaterThanOrEqual( 1, count( $result['metadata']['staffAccounts'] ) );
+
+		// Check that staff account entries look like WebFinger resources.
+		foreach ( $result['metadata']['staffAccounts'] as $staff_account ) {
+			$this->assertIsString( $staff_account );
+			// WebFinger resources typically contain @ symbol.
+			$this->assertTrue( false !== strpos( $staff_account, '@' ), 'Staff account should contain @ symbol' );
+		}
+	}
+
+	/**
+	 * Test federation metadata.
+	 *
+	 * @covers ::add_nodeinfo_data
+	 */
+	public function test_nodeinfo_federation_metadata() {
+		$original_nodeinfo = array(
+			'protocols' => array(),
+			'usage'     => array(),
+			'metadata'  => array(),
+		);
+
+		$result = Nodeinfo::add_nodeinfo_data( $original_nodeinfo, '2.0' );
+
+		// Check that federation is enabled.
+		$this->assertArrayHasKey( 'federation', $result['metadata'] );
+		$this->assertArrayHasKey( 'enabled', $result['metadata']['federation'] );
+		$this->assertTrue( $result['metadata']['federation']['enabled'] );
+	}
+
+	/**
+	 * Test that the class methods are static.
+	 *
+	 * @covers ::init
+	 * @covers ::add_nodeinfo_data
+	 * @covers ::add_nodeinfo2_data
+	 * @covers ::add_wellknown_nodeinfo_data
+	 */
+	public function test_methods_are_static() {
+		$reflection = new \ReflectionClass( Nodeinfo::class );
+
+		$methods = array( 'init', 'add_nodeinfo_data', 'add_nodeinfo2_data', 'add_wellknown_nodeinfo_data' );
+
+		foreach ( $methods as $method_name ) {
+			$method = $reflection->getMethod( $method_name );
+			$this->assertTrue( $method->isStatic(), "Method {$method_name} should be static" );
+		}
+	}
+
+	/**
+	 * Test integration with actual WordPress hooks.
+	 *
+	 * @covers ::init
+	 * @covers ::add_nodeinfo_data
+	 * @covers ::add_nodeinfo2_data
+	 * @covers ::add_wellknown_nodeinfo_data
+	 */
+	public function test_integration_with_hooks() {
+		// Initialize the integration.
+		Nodeinfo::init();
+
+		// Test nodeinfo_data filter.
+		$nodeinfo_data = apply_filters( 'nodeinfo_data', array( 'protocols' => array() ), '2.0' );
+		$this->assertContains( 'activitypub', $nodeinfo_data['protocols'] );
+
+		// Test nodeinfo2_data filter.
+		$nodeinfo2_data = apply_filters( 'nodeinfo2_data', array( 'protocols' => array() ) );
+		$this->assertContains( 'activitypub', $nodeinfo2_data['protocols'] );
+
+		// Test wellknown_nodeinfo_data filter.
+		$wellknown_data = apply_filters( 'wellknown_nodeinfo_data', array() );
+		$this->assertArrayHasKey( 'links', $wellknown_data );
+	}
+}

--- a/tests/integration/class-test-nodeinfo.php
+++ b/tests/integration/class-test-nodeinfo.php
@@ -95,20 +95,6 @@ class Test_Nodeinfo extends \WP_UnitTestCase {
 	 */
 	public function nodeinfo_version_data() {
 		return array(
-			'version 1.0' => array(
-				'version'            => '1.0',
-				'expected_protocols' => array(
-					'inbound'  => array( 'activitypub' ),
-					'outbound' => array( 'activitypub' ),
-				),
-			),
-			'version 1.1' => array(
-				'version'            => '1.1',
-				'expected_protocols' => array(
-					'inbound'  => array( 'activitypub' ),
-					'outbound' => array( 'activitypub' ),
-				),
-			),
 			'version 2.0' => array(
 				'version'            => '2.0',
 				'expected_protocols' => array( 'activitypub' ),


### PR DESCRIPTION
This PR improves NodeInfo handling and adds support for FEP-0151 (NodeInfo in Fediverse Software 2025 edition), enhancing the plugin's ActivityPub federation compliance.

## Proposed changes:
- Added support for NodeInfo version 2.1 with enhanced software metadata
- Expanded NodeInfo data with federation metadata and staff accounts
- Added comprehensive test coverage for NodeInfo integration

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load NodeInfo endpoints and check output

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added support for the latest NodeInfo (FEP-0151), with improved federation details, staff info, and software metadata for better ActivityPub compliance.

</details>
