### PR TITLE
Add FEP-3b86 Activity Intents support to WebFinger

### DIFF
--- a/.github/changelog/2256-from-description
+++ b/.github/changelog/2256-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added support for FEP-3b86 Activity Intents, extending WebFinger and REST interactions with new Create and Follow intent links.

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -22,6 +22,7 @@ The WordPress plugin largely follows ActivityPub's server-to-server specificatio
 - [FEP-7888: Demystifying the context property](https://codeberg.org/fediverse/fep/src/branch/main/fep/7888/fep-7888.md)
 - [FEP-844e: Capability discovery](https://codeberg.org/fediverse/fep/src/branch/main/fep/844e/fep-844e.md)
 - [FEP-044f: Consent-respecting quote posts](https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md)
+- [FEP-3b86: Activity Intents](https://codeberg.org/fediverse/fep/src/branch/main/fep/3b86/fep-3b86.md)
 
 Partially supported FEPs
 

--- a/includes/rest/class-interaction-controller.php
+++ b/includes/rest/class-interaction-controller.php
@@ -50,10 +50,8 @@ class Interaction_Controller extends \WP_REST_Controller {
 							'sanitize_callback' => array( $this, 'sanitize_uri' ),
 						),
 						'intent' => array(
-							'default'     => '',
 							'description' => 'The intent of the interaction, e.g., follow, reply, import.',
 							'type'        => 'string',
-							'required'    => false,
 						),
 					),
 				),

--- a/includes/rest/class-interaction-controller.php
+++ b/includes/rest/class-interaction-controller.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Rest;
 
+use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
 use Activitypub\Http;
 
@@ -52,6 +53,7 @@ class Interaction_Controller extends \WP_REST_Controller {
 						'intent' => array(
 							'description' => 'The intent of the interaction, e.g., follow, reply, import.',
 							'type'        => 'string',
+							'enum'        => array_map( 'Activitypub\camel_to_snake_case', Activity::TYPES ),
 						),
 					),
 				),

--- a/includes/rest/class-interaction-controller.php
+++ b/includes/rest/class-interaction-controller.php
@@ -43,11 +43,17 @@ class Interaction_Controller extends \WP_REST_Controller {
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => '__return_true',
 					'args'                => array(
-						'uri' => array(
+						'uri'    => array(
 							'description'       => 'The URI or webfinger ID of the object to interact with.',
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => array( $this, 'sanitize_uri' ),
+						),
+						'intent' => array(
+							'default'     => '',
+							'description' => 'The intent of the interaction, e.g., follow, reply, import.',
+							'type'        => 'string',
+							'required'    => false,
 						),
 					),
 				),

--- a/integration/class-webfinger.php
+++ b/integration/class-webfinger.php
@@ -130,10 +130,12 @@ class Webfinger {
 			'template' => get_rest_url_by_path( 'interactions?uri={uri}' ),
 		);
 
-		// Note: The parameter name `{inReplyTo}` is used here for all 'Create' intents,
-		// not just replies, to maintain compatibility with existing implementations and
-		// the FEP-3b86 specification. If a more generic parameter name is adopted in the
-		// future, this should be updated accordingly.
+		/*
+		 * Note: The parameter name `{inReplyTo}` is used here for all 'Create' intents,
+		 * not just replies, to maintain compatibility with existing implementations and
+		 * the FEP-3b86 specification. If a more generic parameter name is adopted in the
+		 * future, this should be updated accordingly.
+		 */
 		$jrd['links'][] = array(
 			'rel'      => 'https://w3id.org/fep/3b86/Create',
 			'template' => get_rest_url_by_path( 'interactions?uri={inReplyTo}&intent=create' ),

--- a/integration/class-webfinger.php
+++ b/integration/class-webfinger.php
@@ -24,8 +24,8 @@ class Webfinger {
 		\add_filter( 'webfinger_user_data', array( self::class, 'add_user_discovery' ), 1, 3 );
 		\add_filter( 'webfinger_data', array( self::class, 'add_pseudo_user_discovery' ), 1, 2 );
 
-		\add_filter( 'webfinger_user_data', array( self::class, 'add_interaction_links' ), 11, 2 );
-		\add_filter( 'webfinger_data', array( self::class, 'add_interaction_links' ), 11, 2 );
+		\add_filter( 'webfinger_user_data', array( self::class, 'add_interaction_links' ), 11 );
+		\add_filter( 'webfinger_data', array( self::class, 'add_interaction_links' ), 11 );
 	}
 
 	/**
@@ -116,12 +116,11 @@ class Webfinger {
 	 *
 	 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/3b86/fep-3b86.md
 	 *
-	 * @param array  $jrd  The jrd array.
-	 * @param string $uri  The WebFinger resource.
+	 * @param array $jrd  The jrd array.
 	 *
 	 * @return array The jrd array.
 	 */
-	public static function add_interaction_links( $jrd, $uri ) {
+	public static function add_interaction_links( $jrd ) {
 		if ( ! is_array( $jrd ) ) {
 			return $jrd;
 		}

--- a/integration/class-webfinger.php
+++ b/integration/class-webfinger.php
@@ -131,6 +131,10 @@ class Webfinger {
 			'template' => get_rest_url_by_path( 'interactions?uri={uri}' ),
 		);
 
+		// Note: The parameter name `{inReplyTo}` is used here for all 'Create' intents,
+		// not just replies, to maintain compatibility with existing implementations and
+		// the FEP-3b86 specification. If a more generic parameter name is adopted in the
+		// future, this should be updated accordingly.
 		$jrd['links'][] = array(
 			'rel'      => 'https://w3id.org/fep/3b86/Create',
 			'template' => get_rest_url_by_path( 'interactions?uri={inReplyTo}&intent=create' ),

--- a/integration/class-webfinger.php
+++ b/integration/class-webfinger.php
@@ -23,6 +23,9 @@ class Webfinger {
 	public static function init() {
 		\add_filter( 'webfinger_user_data', array( self::class, 'add_user_discovery' ), 1, 3 );
 		\add_filter( 'webfinger_data', array( self::class, 'add_pseudo_user_discovery' ), 1, 2 );
+
+		\add_filter( 'webfinger_user_data', array( self::class, 'add_interaction_links' ), 11, 2 );
+		\add_filter( 'webfinger_data', array( self::class, 'add_interaction_links' ), 11, 2 );
 	}
 
 	/**
@@ -53,11 +56,6 @@ class Webfinger {
 			'rel'  => 'self',
 			'type' => 'application/activity+json',
 			'href' => $user->get_id(),
-		);
-
-		$jrd['links'][] = array(
-			'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
-			'template' => get_rest_url_by_path( 'interactions?uri={uri}' ),
 		);
 
 		return $jrd;
@@ -101,10 +99,6 @@ class Webfinger {
 					'type' => 'text/html',
 					'href' => $user->get_id(),
 				),
-				array(
-					'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
-					'template' => get_rest_url_by_path( 'interactions?uri={uri}' ),
-				),
 			),
 		);
 
@@ -115,5 +109,38 @@ class Webfinger {
 		}
 
 		return $profile;
+	}
+
+	/**
+	 * Add interaction links to the WebFinger data.
+	 *
+	 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/3b86/fep-3b86.md
+	 *
+	 * @param array  $jrd  The jrd array.
+	 * @param string $uri  The WebFinger resource.
+	 *
+	 * @return array The jrd array.
+	 */
+	public static function add_interaction_links( $jrd, $uri ) {
+		if ( ! is_array( $jrd ) ) {
+			return $jrd;
+		}
+
+		$jrd['links'][] = array(
+			'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+			'template' => get_rest_url_by_path( 'interactions?uri={uri}' ),
+		);
+
+		$jrd['links'][] = array(
+			'rel'      => 'https://w3id.org/fep/3b86/Create',
+			'template' => get_rest_url_by_path( 'interactions?uri={inReplyTo}&intent=create' ),
+		);
+
+		$jrd['links'][] = array(
+			'rel'      => 'https://w3id.org/fep/3b86/Follow',
+			'template' => get_rest_url_by_path( 'interactions?uri={object}&intent=follow' ),
+		);
+
+		return $jrd;
 	}
 }

--- a/tests/includes/rest/class-test-webfinger-controller.php
+++ b/tests/includes/rest/class-test-webfinger-controller.php
@@ -146,7 +146,7 @@ class Test_Webfinger_Controller extends \Activitypub\Tests\Test_REST_Controller_
 				$this->assertEquals( 'acct:test_user@' . WP_TESTS_DOMAIN, $webfinger );
 				return $test_data;
 			},
-			10,
+			20,
 			2
 		);
 

--- a/tests/integration/class-test-webfinger.php
+++ b/tests/integration/class-test-webfinger.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * Test file for WebFinger integration.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Integration;
+
+use Activitypub\Collection\Actors;
+use Activitypub\Integration\Webfinger;
+
+/**
+ * Test class for WebFinger integration.
+ *
+ * @coversDefaultClass \Activitypub\Integration\Webfinger
+ */
+class Test_Webfinger extends \WP_UnitTestCase {
+	/**
+	 * Test user IDs.
+	 *
+	 * @var array
+	 */
+	protected static $user_ids = array();
+
+	/**
+	 * Create fake data before tests run.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Helper that creates fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		// Create test users with different roles.
+		self::$user_ids['author'] = $factory->user->create(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'testauthor',
+				'display_name' => 'Test Author',
+			)
+		);
+
+		self::$user_ids['admin'] = $factory->user->create(
+			array(
+				'role'         => 'administrator',
+				'user_login'   => 'testadmin',
+				'display_name' => 'Test Admin',
+			)
+		);
+
+		// Give users activitypub capability.
+		$author = get_user_by( 'id', self::$user_ids['author'] );
+		$author->add_cap( 'activitypub' );
+
+		$admin = get_user_by( 'id', self::$user_ids['admin'] );
+		$admin->add_cap( 'activitypub' );
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		// Remove filters that may have been added during tests.
+		remove_filter( 'webfinger_user_data', array( Webfinger::class, 'add_user_discovery' ), 1 );
+		remove_filter( 'webfinger_data', array( Webfinger::class, 'add_pseudo_user_discovery' ), 1 );
+		remove_filter( 'webfinger_user_data', array( Webfinger::class, 'add_interaction_links' ), 1 );
+		remove_filter( 'webfinger_data', array( Webfinger::class, 'add_interaction_links' ), 1 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test init method registers hooks correctly.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_registers_hooks() {
+		// Initialize WebFinger integration.
+		Webfinger::init();
+
+		// Check that hooks are registered.
+		$this->assertNotFalse( has_filter( 'webfinger_user_data', array( Webfinger::class, 'add_user_discovery' ) ) );
+		$this->assertNotFalse( has_filter( 'webfinger_data', array( Webfinger::class, 'add_pseudo_user_discovery' ) ) );
+		$this->assertNotFalse( has_filter( 'webfinger_user_data', array( Webfinger::class, 'add_interaction_links' ) ) );
+		$this->assertNotFalse( has_filter( 'webfinger_data', array( Webfinger::class, 'add_interaction_links' ) ) );
+	}
+
+	/**
+	 * Test add_user_discovery method.
+	 *
+	 * @covers ::add_user_discovery
+	 */
+	public function test_add_user_discovery() {
+		$user        = get_user_by( 'id', self::$user_ids['author'] );
+		$actor       = Actors::get_by_id( $user->ID );
+		$uri         = 'acct:' . $user->user_login . '@' . wp_parse_url( home_url(), PHP_URL_HOST );
+		$initial_jrd = array(
+			'subject' => $uri,
+			'aliases' => array(),
+			'links'   => array(),
+		);
+
+		$result = Webfinger::add_user_discovery( $initial_jrd, $uri, $user );
+
+		// Check subject is set correctly.
+		$this->assertArrayHasKey( 'subject', $result );
+		$this->assertStringContains( 'acct:', $result['subject'] );
+		$this->assertStringContains( $user->user_login, $result['subject'] );
+
+		// Check aliases are added.
+		$this->assertArrayHasKey( 'aliases', $result );
+		$this->assertIsArray( $result['aliases'] );
+		$this->assertContains( $actor->get_id(), $result['aliases'] );
+		$this->assertContains( $actor->get_url(), $result['aliases'] );
+
+		// Check that aliases are unique.
+		$this->assertCount( count( $result['aliases'] ), array_unique( $result['aliases'] ) );
+
+		// Check that ActivityPub self link is added.
+		$self_link = null;
+		foreach ( $result['links'] as $link ) {
+			if ( 'self' === $link['rel'] && 'application/activity+json' === $link['type'] ) {
+				$self_link = $link;
+				break;
+			}
+		}
+		$this->assertNotNull( $self_link, 'Should have ActivityPub self link' );
+		$this->assertEquals( $actor->get_id(), $self_link['href'] );
+	}
+
+	/**
+	 * Test add_user_discovery with invalid user.
+	 *
+	 * @covers ::add_user_discovery
+	 */
+	public function test_add_user_discovery_with_invalid_user() {
+		$user = get_user_by( 'id', 99999 ); // Non-existent user.
+		if ( ! $user ) {
+			$user = new \WP_User();
+		}
+
+		$initial_jrd = array(
+			'subject' => 'acct:invalid@example.com',
+			'aliases' => array(),
+			'links'   => array(),
+		);
+
+		$result = Webfinger::add_user_discovery( $initial_jrd, 'acct:invalid@example.com', $user );
+
+		// Should return original jrd unchanged.
+		$this->assertEquals( $initial_jrd, $result );
+	}
+
+	/**
+	 * Test add_pseudo_user_discovery method.
+	 *
+	 * @covers ::add_pseudo_user_discovery
+	 */
+	public function test_add_pseudo_user_discovery() {
+		$user = get_user_by( 'id', self::$user_ids['author'] );
+		$uri  = 'acct:' . $user->user_login . '@' . wp_parse_url( home_url(), PHP_URL_HOST );
+
+		$initial_jrd = array(
+			'subject' => $uri,
+			'aliases' => array(),
+			'links'   => array(),
+		);
+
+		$result = Webfinger::add_pseudo_user_discovery( $initial_jrd, $uri );
+
+		// Check that result is an array (not WP_Error).
+		$this->assertIsArray( $result );
+
+		// Check subject is set.
+		$this->assertArrayHasKey( 'subject', $result );
+		$this->assertStringContains( 'acct:', $result['subject'] );
+
+		// Check aliases are set.
+		$this->assertArrayHasKey( 'aliases', $result );
+		$this->assertIsArray( $result['aliases'] );
+		$this->assertGreaterThan( 0, count( $result['aliases'] ) );
+
+		// Check links are set.
+		$this->assertArrayHasKey( 'links', $result );
+		$this->assertIsArray( $result['links'] );
+		$this->assertGreaterThan( 0, count( $result['links'] ) );
+
+		// Check for ActivityPub self link.
+		$has_activitypub_link = false;
+		foreach ( $result['links'] as $link ) {
+			if ( 'self' === $link['rel'] && 'application/activity+json' === $link['type'] ) {
+				$has_activitypub_link = true;
+				break;
+			}
+		}
+		$this->assertTrue( $has_activitypub_link, 'Should have ActivityPub self link' );
+
+		// Check for profile page link.
+		$has_profile_link = false;
+		foreach ( $result['links'] as $link ) {
+			if ( 'http://webfinger.net/rel/profile-page' === $link['rel'] ) {
+				$has_profile_link = true;
+				break;
+			}
+		}
+		$this->assertTrue( $has_profile_link, 'Should have profile page link' );
+	}
+
+	/**
+	 * Test add_pseudo_user_discovery with invalid resource.
+	 *
+	 * @covers ::add_pseudo_user_discovery
+	 */
+	public function test_add_pseudo_user_discovery_with_invalid_resource() {
+		$initial_jrd = array(
+			'subject' => 'acct:invalid@invalid.example',
+			'aliases' => array(),
+			'links'   => array(),
+		);
+
+		$result = Webfinger::add_pseudo_user_discovery( $initial_jrd, 'acct:invalid@invalid.example' );
+
+		// Should return WP_Error for invalid resource.
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * Test add_interaction_links method.
+	 *
+	 * @covers ::add_interaction_links
+	 */
+	public function test_add_interaction_links() {
+		$user = get_user_by( 'id', self::$user_ids['author'] );
+		$uri  = 'acct:' . $user->user_login . '@' . wp_parse_url( home_url(), PHP_URL_HOST );
+
+		$initial_jrd = array(
+			'subject' => $uri,
+			'aliases' => array(),
+			'links'   => array(),
+		);
+
+		$result = Webfinger::add_interaction_links( $initial_jrd, $uri );
+
+		// Check that links were added.
+		$this->assertArrayHasKey( 'links', $result );
+		$this->assertIsArray( $result['links'] );
+
+		// Count interaction links added.
+		$interaction_link_count = 0;
+		$found_rels             = array();
+
+		foreach ( $result['links'] as $link ) {
+			if ( isset( $link['template'] ) ) {
+				++$interaction_link_count;
+				$found_rels[] = $link['rel'];
+			}
+		}
+
+		// Should have added 3 interaction links.
+		$this->assertEquals( 3, $interaction_link_count );
+
+		// Check for OStatus subscribe link.
+		$this->assertContains( 'http://ostatus.org/schema/1.0/subscribe', $found_rels );
+
+		// Check for FEP-3b86 Create link.
+		$this->assertContains( 'https://w3id.org/fep/3b86/Create', $found_rels );
+
+		// Check for FEP-3b86 Follow link.
+		$this->assertContains( 'https://w3id.org/fep/3b86/Follow', $found_rels );
+	}
+
+	/**
+	 * Test interaction links have correct templates.
+	 *
+	 * @covers ::add_interaction_links
+	 */
+	public function test_add_interaction_links_templates() {
+		$user = get_user_by( 'id', self::$user_ids['author'] );
+		$uri  = 'acct:' . $user->user_login . '@' . wp_parse_url( home_url(), PHP_URL_HOST );
+
+		$initial_jrd = array( 'links' => array() );
+		$result      = Webfinger::add_interaction_links( $initial_jrd, $uri );
+
+		// Check templates contain required placeholders.
+		foreach ( $result['links'] as $link ) {
+			if ( ! isset( $link['template'] ) ) {
+				continue;
+			}
+
+			$this->assertIsString( $link['template'] );
+			$this->assertStringContains( 'interactions', $link['template'] );
+
+			// Check that template has the right placeholder based on rel.
+			if ( 'http://ostatus.org/schema/1.0/subscribe' === $link['rel'] ) {
+				$this->assertStringContains( '{uri}', $link['template'] );
+			} elseif ( 'https://w3id.org/fep/3b86/Create' === $link['rel'] ) {
+				$this->assertStringContains( '{inReplyTo}', $link['template'] );
+				$this->assertStringContains( 'intent=create', $link['template'] );
+			} elseif ( 'https://w3id.org/fep/3b86/Follow' === $link['rel'] ) {
+				$this->assertStringContains( '{object}', $link['template'] );
+				$this->assertStringContains( 'intent=follow', $link['template'] );
+			}
+		}
+	}
+
+	/**
+	 * Test that methods are static.
+	 *
+	 * @covers ::init
+	 * @covers ::add_user_discovery
+	 * @covers ::add_pseudo_user_discovery
+	 * @covers ::add_interaction_links
+	 */
+	public function test_methods_are_static() {
+		$reflection = new \ReflectionClass( Webfinger::class );
+
+		$methods = array( 'init', 'add_user_discovery', 'add_pseudo_user_discovery', 'add_interaction_links' );
+
+		foreach ( $methods as $method_name ) {
+			$method = $reflection->getMethod( $method_name );
+			$this->assertTrue( $method->isStatic(), "Method {$method_name} should be static" );
+		}
+	}
+
+	/**
+	 * Test integration with actual WordPress hooks.
+	 *
+	 * @covers ::init
+	 * @covers ::add_user_discovery
+	 * @covers ::add_pseudo_user_discovery
+	 * @covers ::add_interaction_links
+	 */
+	public function test_integration_with_hooks() {
+		// Initialize the integration.
+		Webfinger::init();
+
+		$user = get_user_by( 'id', self::$user_ids['author'] );
+		$uri  = 'acct:' . $user->user_login . '@' . wp_parse_url( home_url(), PHP_URL_HOST );
+
+		$initial_jrd = array(
+			'subject' => $uri,
+			'aliases' => array(),
+			'links'   => array(),
+		);
+
+		// Test webfinger_user_data filter.
+		$user_data = apply_filters( 'webfinger_user_data', $initial_jrd, $uri, $user );
+		$this->assertArrayHasKey( 'subject', $user_data );
+		$this->assertArrayHasKey( 'aliases', $user_data );
+		$this->assertArrayHasKey( 'links', $user_data );
+
+		// Test webfinger_data filter.
+		$data = apply_filters( 'webfinger_data', $initial_jrd, $uri );
+		if ( ! is_wp_error( $data ) ) {
+			$this->assertArrayHasKey( 'links', $data );
+		}
+	}
+
+	/**
+	 * Helper method to check if string contains substring.
+	 *
+	 * @param string $needle   The substring to search for.
+	 * @param string $haystack The string to search in.
+	 */
+	private function assertStringContains( $needle, $haystack ) {
+		$this->assertTrue(
+			false !== strpos( $haystack, $needle ),
+			sprintf( 'Failed asserting that "%s" contains "%s"', $haystack, $needle )
+		);
+	}
+}

--- a/tests/integration/class-test-webfinger.php
+++ b/tests/integration/class-test-webfinger.php
@@ -246,7 +246,7 @@ class Test_Webfinger extends \WP_UnitTestCase {
 			'links'   => array(),
 		);
 
-		$result = Webfinger::add_interaction_links( $initial_jrd, $uri );
+		$result = Webfinger::add_interaction_links( $initial_jrd );
 
 		// Check that links were added.
 		$this->assertArrayHasKey( 'links', $result );
@@ -282,11 +282,8 @@ class Test_Webfinger extends \WP_UnitTestCase {
 	 * @covers ::add_interaction_links
 	 */
 	public function test_add_interaction_links_templates() {
-		$user = get_user_by( 'id', self::$user_ids['author'] );
-		$uri  = 'acct:' . $user->user_login . '@' . wp_parse_url( home_url(), PHP_URL_HOST );
-
 		$initial_jrd = array( 'links' => array() );
-		$result      = Webfinger::add_interaction_links( $initial_jrd, $uri );
+		$result      = Webfinger::add_interaction_links( $initial_jrd );
 
 		// Check templates contain required placeholders.
 		foreach ( $result['links'] as $link ) {

--- a/tests/integration/class-test-webfinger.php
+++ b/tests/integration/class-test-webfinger.php
@@ -362,5 +362,4 @@ class Test_Webfinger extends \WP_UnitTestCase {
 			$this->assertArrayHasKey( 'links', $data );
 		}
 	}
-
 }

--- a/tests/integration/class-test-webfinger.php
+++ b/tests/integration/class-test-webfinger.php
@@ -363,16 +363,4 @@ class Test_Webfinger extends \WP_UnitTestCase {
 		}
 	}
 
-	/**
-	 * Helper method to check if string contains substring.
-	 *
-	 * @param string $needle   The substring to search for.
-	 * @param string $haystack The string to search in.
-	 */
-	private function assertStringContains( $needle, $haystack ) {
-		$this->assertTrue(
-			false !== strpos( $haystack, $needle ),
-			sprintf( 'Failed asserting that "%s" contains "%s"', $haystack, $needle )
-		);
-	}
 }

--- a/tests/integration/class-test-webfinger.php
+++ b/tests/integration/class-test-webfinger.php
@@ -111,8 +111,8 @@ class Test_Webfinger extends \WP_UnitTestCase {
 
 		// Check subject is set correctly.
 		$this->assertArrayHasKey( 'subject', $result );
-		$this->assertStringContains( 'acct:', $result['subject'] );
-		$this->assertStringContains( $user->user_login, $result['subject'] );
+		$this->assertStringContainsString( 'acct:', $result['subject'] );
+		$this->assertStringContainsString( $user->user_login, $result['subject'] );
 
 		// Check aliases are added.
 		$this->assertArrayHasKey( 'aliases', $result );
@@ -180,7 +180,7 @@ class Test_Webfinger extends \WP_UnitTestCase {
 
 		// Check subject is set.
 		$this->assertArrayHasKey( 'subject', $result );
-		$this->assertStringContains( 'acct:', $result['subject'] );
+		$this->assertStringContainsString( 'acct:', $result['subject'] );
 
 		// Check aliases are set.
 		$this->assertArrayHasKey( 'aliases', $result );
@@ -295,17 +295,17 @@ class Test_Webfinger extends \WP_UnitTestCase {
 			}
 
 			$this->assertIsString( $link['template'] );
-			$this->assertStringContains( 'interactions', $link['template'] );
+			$this->assertStringContainsString( 'interactions', $link['template'] );
 
 			// Check that template has the right placeholder based on rel.
 			if ( 'http://ostatus.org/schema/1.0/subscribe' === $link['rel'] ) {
-				$this->assertStringContains( '{uri}', $link['template'] );
+				$this->assertStringContainsString( '{uri}', $link['template'] );
 			} elseif ( 'https://w3id.org/fep/3b86/Create' === $link['rel'] ) {
-				$this->assertStringContains( '{inReplyTo}', $link['template'] );
-				$this->assertStringContains( 'intent=create', $link['template'] );
+				$this->assertStringContainsString( '{inReplyTo}', $link['template'] );
+				$this->assertStringContainsString( 'intent=create', $link['template'] );
 			} elseif ( 'https://w3id.org/fep/3b86/Follow' === $link['rel'] ) {
-				$this->assertStringContains( '{object}', $link['template'] );
-				$this->assertStringContains( 'intent=follow', $link['template'] );
+				$this->assertStringContainsString( '{object}', $link['template'] );
+				$this->assertStringContainsString( 'intent=follow', $link['template'] );
 			}
 		}
 	}


### PR DESCRIPTION
This commit adds support for FEP-3b86 Activity Intents by updating the WebFinger integration to include new interaction links for Create and Follow intents, and updates the REST interaction controller to accept an 'intent' parameter. Documentation and tests are updated to reflect these changes, including a new integration test for WebFinger.

## Proposed changes:
- Refactored WebFinger interaction links into a dedicated method for better maintainability
- Added FEP-3b86 Activity Intent links for Create and Follow operations to WebFinger responses
- Enhanced REST interaction controller to accept an 'intent' parameter for different interaction types

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load some WebFinger profiles and check the JSON.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added support for FEP-3b86 Activity Intents, extending WebFinger and REST interactions with new Create and Follow intent links.

</details>
