### PR TITLE
Fix HTML entity encoding in extra field names

### DIFF
--- a/.github/changelog/2261-from-description
+++ b/.github/changelog/2261-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed HTML entity encoding in extra field names when displayed on ActivityPub platforms

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -107,10 +107,11 @@ class Extra_Fields {
 		\add_filter( 'activitypub_link_rel', array( self::class, 'add_rel_me' ) );
 
 		foreach ( $fields as $post ) {
+			$title         = \html_entity_decode( \get_the_title( $post ), \ENT_QUOTES, 'UTF-8' );
 			$content       = self::get_formatted_content( $post );
 			$attachments[] = array(
 				'type'  => 'PropertyValue',
-				'name'  => \html_entity_decode( \get_the_title( $post ), \ENT_QUOTES, 'UTF-8' ),
+				'name'  => $title,
 				'value' => \html_entity_decode( $content, \ENT_QUOTES, 'UTF-8' ),
 			);
 
@@ -130,7 +131,7 @@ class Extra_Fields {
 				if ( 'A' === $tags->get_tag() ) {
 					$attachment = array(
 						'type' => 'Link',
-						'name' => \get_the_title( $post ),
+						'name' => $title,
 						'href' => \esc_url( $tags->get_attribute( 'href' ) ),
 					);
 
@@ -145,12 +146,8 @@ class Extra_Fields {
 			if ( ! $attachment ) {
 				$attachment = array(
 					'type'    => 'Note',
-					'name'    => \get_the_title( $post ),
-					'content' => \html_entity_decode(
-						$content,
-						\ENT_QUOTES,
-						'UTF-8'
-					),
+					'name'    => $title,
+					'content' => \html_entity_decode( $content, \ENT_QUOTES, 'UTF-8' ),
 				);
 			}
 

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -110,12 +110,8 @@ class Extra_Fields {
 			$content       = self::get_formatted_content( $post );
 			$attachments[] = array(
 				'type'  => 'PropertyValue',
-				'name'  => \get_the_title( $post ),
-				'value' => \html_entity_decode(
-					$content,
-					\ENT_QUOTES,
-					'UTF-8'
-				),
+				'name'  => \html_entity_decode( \get_the_title( $post ), \ENT_QUOTES, 'UTF-8' ),
+				'value' => \html_entity_decode( $content, \ENT_QUOTES, 'UTF-8' ),
 			);
 
 			$attachment = false;

--- a/tests/includes/collection/class-test-extra-fields.php
+++ b/tests/includes/collection/class-test-extra-fields.php
@@ -38,4 +38,29 @@ class Test_Extra_Fields extends \WP_UnitTestCase {
 
 		$this->assertEquals( 1, $value_count['me'] );
 	}
+
+	/**
+	 * Test that HTML entities are decoded in field names and values.
+	 *
+	 * @covers ::fields_to_attachments
+	 */
+	public function test_html_entities_decoded() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => Extra_Fields::BLOG_POST_TYPE,
+				'post_content' => 'Test content with &quot;quotes&quot; and &amp; ampersands',
+				'post_title'   => 'Void&#8217;s Profile',
+			)
+		);
+
+		$attachments = Extra_Fields::fields_to_attachments( array( $post ) );
+
+		// Check PropertyValue has decoded entities in both name and value.
+		$this->assertEquals( 'PropertyValue', $attachments[0]['type'] );
+		// WordPress converts the HTML entity &#8217; to the UTF-8 right single quotation mark character.
+		$expected_name = "Void\u{2019}s Profile";
+		$this->assertEquals( $expected_name, $attachments[0]['name'] );
+		$this->assertStringContainsString( '"quotes"', $attachments[0]['value'] );
+		$this->assertStringContainsString( '& ampersands', $attachments[0]['value'] );
+	}
 }


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/apostrophe-in-extra-field/

## Proposed changes:
* Apply `html_entity_decode()` to extra field names (from `get_the_title()`) to properly decode HTML entities like `&#8217;` and `&amp;`
* Apply `html_entity_decode()` to extra field values to ensure consistent decoding
* Add unit test to verify HTML entities are properly decoded in both field names and values

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create an extra field with a title containing HTML entities (e.g., "Void&#8217;s Profile" or "Company &amp; Partners")
* View the actor profile on Mastodon or another ActivityPub platform
* Verify that the field name displays correctly with proper characters instead of HTML entities

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed HTML entity encoding in extra field names when displayed on ActivityPub platforms

</details>