### PR TITLE
Fix flaky test_handle_create_check_multiple_comments test

### DIFF
--- a/tests/includes/handler/class-test-create.php
+++ b/tests/includes/handler/class-test-create.php
@@ -271,6 +271,8 @@ class Test_Create extends \WP_UnitTestCase {
 		$args = array(
 			'type'    => 'comment',
 			'post_id' => $this->post_id,
+			'orderby' => 'comment_ID',
+			'order'   => 'ASC',
 		);
 
 		$query  = new \WP_Comment_Query( $args );


### PR DESCRIPTION
See https://github.com/Automattic/wordpress-activitypub/actions/runs/18168625887/job/51717475283?pr=2261
See https://github.com/Automattic/wordpress-activitypub/actions/runs/18168066690/job/51715526960

Not sure if this will actually fix it but worth a try.

## Proposed changes:
* Fixed flaky `test_handle_create_check_multiple_comments` test by adding explicit comment ordering

The test was failing intermittently because `WP_Comment_Query` doesn't guarantee ordering when no `orderby` parameter is specified. This caused `$result[1]` to sometimes contain 'example' instead of 'example2' when comments were returned in reverse order.

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A - fixing existing test

## Testing instructions:

* Run `npm run env-test` multiple times to verify the test no longer fails intermittently
* The test should consistently pass with the second comment having content 'example2'