### PR TITLE
Fix Jetpack reader feed URL path

### DIFF
--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -101,7 +101,7 @@ class Jetpack {
 			if ( empty( $feed['feed_id'] ) ) {
 				return $actions; // No feed_id available on WPCOM.
 			}
-			$url = sprintf( 'https://wordpress.com/reader/feed/%d', (int) $feed['feed_id'] );
+			$url = sprintf( 'https://wordpress.com/reader/feeds/%d', (int) $feed['feed_id'] );
 		} else {
 			$url = sprintf( 'https://wordpress.com/reader/feeds/lookup/%s', rawurlencode( $item['identifier'] ) );
 		}

--- a/tests/integration/class-test-jetpack.php
+++ b/tests/integration/class-test-jetpack.php
@@ -292,7 +292,7 @@ class Test_Jetpack extends \WP_UnitTestCase {
 					'identifier' => 'https://example.com/feed',
 				),
 				'feed_id'                 => 456,
-				'expected_url'            => 'https://wordpress.com/reader/feed/456',
+				'expected_url'            => 'https://wordpress.com/reader/feeds/456',
 				'should_have_reader_link' => true,
 			),
 			'active following without feed ID' => array(
@@ -335,7 +335,7 @@ class Test_Jetpack extends \WP_UnitTestCase {
 		$original_actions = array( 'edit' => '<a href="#">Edit</a>' );
 
 		// Set up WPCOM environment if expecting WPCOM-style URL.
-		$is_wpcom_test = $expected_url && strpos( $expected_url, '/reader/feed/' ) !== false;
+		$is_wpcom_test = $expected_url && strpos( $expected_url, '/reader/feeds/lookup/' ) === false;
 		if ( $is_wpcom_test && ! defined( 'IS_WPCOM' ) ) {
 			define( 'IS_WPCOM', true );
 		}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Corrects the URL path from '/reader/feed/' to '/reader/feeds/' when generating the WordPress.com reader feed link. This ensures the link points to the correct location.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to https://wordpress.com/reader/feed/173037843
* Go to https://wordpress.com/reader/feeds/173037843
