### PR TITLE
Add immediate Accept activity dispatch to outbox

### DIFF
--- a/.github/changelog/2301-from-description
+++ b/.github/changelog/2301-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added immediate dispatch for Accept activities to speed up quoted posts while keeping scheduled processing for compatibility with other instances.


### PR DESCRIPTION
This PR adds immediate Accept activity dispatch functionality to the outbox system by registering a new action hook that triggers when activities are added to the outbox. The implementation specifically targets Accept activities and sends them to additional inboxes (mentioned users and replied-to users) outside of the normal follower distribution.

The scheduled Accept takes a considerable amount of time, which makes Quoted Posts very slow. This serves as a workaround that could help speed up the Accept process. However, we should still keep the scheduled item, since sending an immediate response before the original request completes could cause issues for some instances (for example, NodeBB has had problems with this).

## Proposed changes:
- Registers a new action hook `post_activitypub_add_to_outbox` for immediate Accept activity processing
- Implements `send_immediate_accept` method to handle Accept activity dispatch to additional inboxes

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try to follow a blog user on mastodon or quote a blog post and check if they were accepted immediately.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added immediate dispatch for Accept activities to speed up quoted posts while keeping scheduled processing for compatibility with other instances.

</details>
