### PR TITLE
Integrate Federated Reply block with Reader post share

### DIFF
--- a/.github/changelog/2302-from-description
+++ b/.github/changelog/2302-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Integrate Federated Reply block with WP.com Reader's post share functionality, allowing users to reply to ActivityPub posts directly from the Reader.

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -24,11 +24,6 @@ class Jetpack {
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
-		// Replace the Reader's "Share Post" with the Federated Reply block.
-		if ( isset( $_GET['is_post_share'], $_GET['url'] ) && $_GET['is_post_share'] ) { // phpcs:ignore WordPress.Security
-			self::adapt_post_share();
-		}
-
 		if ( ! \defined( 'IS_WPCOM' ) ) {
 			\add_filter( 'jetpack_sync_post_meta_whitelist', array( self::class, 'add_sync_meta' ) );
 			\add_filter( 'jetpack_sync_comment_meta_whitelist', array( self::class, 'add_sync_comment_meta' ) );
@@ -44,6 +39,8 @@ class Jetpack {
 			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
 			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
 		}
+
+		\add_action( 'load-post-new.php', array( self::class, 'adapt_post_share' ) );
 	}
 
 	/**
@@ -141,7 +138,11 @@ class Jetpack {
 	 * Adapt the parameters for a post share request to be compatible with the Federated Reply block.
 	 */
 	public static function adapt_post_share() {
-		$url = \sanitize_url( \wp_unslash( $_GET['url'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! isset( $_GET['is_post_share'], $_GET['url'] ) || ! $_GET['is_post_share'] ) { // phpcs:ignore WordPress.Security
+			return;
+		}
+
+		$url = \sanitize_url( \wp_unslash( $_GET['url'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		if ( is_activity_object( Http::get_remote_object( $url ) ) ) {
 			$args = array(

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -144,10 +144,13 @@ class Jetpack {
 		$url = \sanitize_url( \wp_unslash( $_GET['url'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		if ( is_activity_object( Http::get_remote_object( $url ) ) ) {
-			$_GET['in_reply_to'] = $url;
-			unset( $_GET['is_post_share'], $_GET['url'] );
+			$args = array(
+				'post_type'   => 'post',
+				'in_reply_to' => $url,
+			);
 
-			\wp_safe_redirect( \add_query_arg( $_GET, \admin_url( 'post-new.php' ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			\wp_safe_redirect( \add_query_arg( $args, \admin_url( 'post-new.php' ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			exit;
 		}
 	}
 }

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -149,7 +149,7 @@ class Jetpack {
 				'in_reply_to' => $url,
 			);
 
-			\wp_safe_redirect( \add_query_arg( $args, \admin_url( 'post-new.php' ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			\wp_safe_redirect( \add_query_arg( $args, \admin_url( 'post-new.php' ) ) );
 			exit;
 		}
 	}

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -10,7 +10,10 @@ namespace Activitypub\Integration;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
 use Activitypub\Comment;
+use Activitypub\Http;
 use Automattic\Jetpack\Connection\Manager;
+
+use function Activitypub\is_activity_object;
 
 /**
  * Jetpack integration class.
@@ -35,6 +38,11 @@ class Jetpack {
 		) {
 			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
 			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
+
+			// Replace the Reader's "Share Post" with the Federated Reply block.
+			if ( isset( $_GET['is_post_share'], $_GET['url'] ) && $_GET['is_post_share'] ) { // phpcs:ignore WordPress.Security
+				\add_action( 'load-post-new.php', array( self::class, 'adapt_post_share' ), 9 ); // Before Blocks::handle_in_reply_to_get_param().
+			}
 		}
 	}
 
@@ -127,5 +135,19 @@ class Jetpack {
 	 */
 	public static function pre_option_activitypub_following_ui() {
 		return '1';
+	}
+
+	/**
+	 * Adapt the parameters for a post share request to be compatible with the Federated Reply block.
+	 */
+	public static function adapt_post_share() {
+		$url = \sanitize_url( \wp_unslash( $_GET['url'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		if ( is_activity_object( Http::get_remote_object( $url ) ) ) {
+			$_GET['in_reply_to'] = $url;
+			unset( $_GET['is_post_share'], $_GET['url'] );
+
+			\remove_action( 'wp_insert_post', 'wpcomsh_insert_shared_post_data' );
+		}
 	}
 }

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -24,6 +24,11 @@ class Jetpack {
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
+		// Replace the Reader's "Share Post" with the Federated Reply block.
+		if ( isset( $_GET['is_post_share'], $_GET['url'] ) && $_GET['is_post_share'] ) { // phpcs:ignore WordPress.Security
+			self::adapt_post_share();
+		}
+
 		if ( ! \defined( 'IS_WPCOM' ) ) {
 			\add_filter( 'jetpack_sync_post_meta_whitelist', array( self::class, 'add_sync_meta' ) );
 			\add_filter( 'jetpack_sync_comment_meta_whitelist', array( self::class, 'add_sync_comment_meta' ) );
@@ -38,11 +43,6 @@ class Jetpack {
 		) {
 			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
 			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
-
-			// Replace the Reader's "Share Post" with the Federated Reply block.
-			if ( isset( $_GET['is_post_share'], $_GET['url'] ) && $_GET['is_post_share'] ) { // phpcs:ignore WordPress.Security
-				\add_action( 'load-post-new.php', array( self::class, 'adapt_post_share' ), 9 ); // Before Blocks::handle_in_reply_to_get_param().
-			}
 		}
 	}
 
@@ -147,7 +147,7 @@ class Jetpack {
 			$_GET['in_reply_to'] = $url;
 			unset( $_GET['is_post_share'], $_GET['url'] );
 
-			\remove_action( 'wp_insert_post', 'wpcomsh_insert_shared_post_data' );
+			\wp_safe_redirect( \add_query_arg( $_GET, \admin_url( 'post-new.php' ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/df766cd8-afa5-45f2-aecc-951c6affa886

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds logic to replace WP.com Reader's 'Share Post' feature with the Federated Reply block when sharing posts. 
* Adapts post share parameters and redirects the request.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to a WP.com-connected test site.
* Follow a Federated account in the WP.com reader and pull up their feed.
* On a post, click "Repost" and select your test site.
* Make sure it correctly redirects to the Editor with the Reply block added.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Integrate Federated Reply block with WP.com Reader's post share functionality, allowing users to reply to ActivityPub posts directly from the Reader.

</details>
