### PR TITLE
Add email notifications for new quote events

### DIFF
--- a/.github/changelog/2303-from-description
+++ b/.github/changelog/2303-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added email notifications for quoted posts, with user and blog-level settings and a new customizable email template.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -342,6 +342,18 @@ class Activitypub {
 
 		\register_meta(
 			'user',
+			$blog_prefix . 'activitypub_mailer_new_quote',
+			array(
+				'type'              => 'integer',
+				'description'       => 'Send a notification when someone quotes this user.',
+				'single'            => true,
+				'sanitize_callback' => 'absint',
+			)
+		);
+		\add_filter( 'get_user_option_activitypub_mailer_new_quote', array( self::class, 'user_options_default' ) );
+
+		\register_meta(
+			'user',
 			'activitypub_show_welcome_tab',
 			array(
 				'type'              => 'integer',

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -22,8 +22,8 @@ class Mailer {
 
 		\add_action( 'activitypub_inbox_follow', array( self::class, 'new_follower' ), 10, 2 );
 		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		/** After @see \Activitypub\Handler\Create::handle_create() */
-		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );
+		
+		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 ); // After @see \Activitypub\Handler\Create::handle_create()
 
 		\add_action( 'activitypub_handled_quote_request', array( self::class, 'quote' ), 10, 3 );
 	}

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -420,6 +420,10 @@ class Mailer {
 			$quoted_url = object_to_uri( $activity['object']['quoteUrl'] );
 		}
 
+		if ( ! $quoted_url ) {
+			return;
+		}
+
 		$template_args = array(
 			'activity'   => $activity,
 			'actor'      => $actor,

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -424,11 +424,19 @@ class Mailer {
 			return;
 		}
 
+		// Try to get the quoted post title.
+		$quoted_title = null;
+		$post_id      = \url_to_postid( $quoted_url );
+		if ( $post_id ) {
+			$quoted_title = \get_the_title( $post_id );
+		}
+
 		$template_args = array(
-			'activity'   => $activity,
-			'actor'      => $actor,
-			'user_id'    => $user_id,
-			'quoted_url' => $quoted_url,
+			'activity'     => $activity,
+			'actor'        => $actor,
+			'user_id'      => $user_id,
+			'quoted_url'   => $quoted_url,
+			'quoted_title' => $quoted_title,
 		);
 
 		/* translators: 1: Blog name, 2: Actor name */

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -22,7 +22,10 @@ class Mailer {
 
 		\add_action( 'activitypub_inbox_follow', array( self::class, 'new_follower' ), 10, 2 );
 		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );  /** After @see \Activitypub\Handler\Create::handle_create() */
+		/** After @see \Activitypub\Handler\Create::handle_create() */
+		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );
+
+		\add_action( 'activitypub_handled_quote_request', array( self::class, 'quote' ), 10, 3 );
 	}
 
 	/**
@@ -350,6 +353,112 @@ class Mailer {
 			$message .= \sprintf( \esc_html__( 'From: %s', 'activitypub' ), \esc_html( $actor['name'] ) ) . "\r\n";
 			/* translators: Message URL */
 			$message .= \sprintf( \esc_html__( 'URL: %s', 'activitypub' ), \esc_url( $activity['object']['id'] ) ) . "\r\n\r\n";
+
+			$mailer->{'AltBody'} = $message;
+		};
+		\add_action( 'phpmailer_init', $alt_function );
+
+		\wp_mail( $email, $subject, $html_message, array( 'Content-type: text/html' ) );
+
+		\remove_action( 'phpmailer_init', $alt_function );
+	}
+
+	/**
+	 * Send a quoted notification.
+	 *
+	 * @param array $activity The ActivityPub activity data.
+	 * @param int   $user_id  The local user ID.
+	 * @param bool  $state    True on success, false otherwise.
+	 */
+	public static function quote( $activity, $user_id, $state ) {
+		if ( ! $state ) {
+			return;
+		}
+
+		// Do not send notifications to the Application user.
+		if ( Actors::APPLICATION_USER_ID === $user_id ) {
+			return;
+		}
+
+		if ( $user_id > Actors::BLOG_USER_ID ) {
+			if ( ! \get_user_option( 'activitypub_mailer_new_quote', $user_id ) ) {
+				return;
+			}
+
+			$email = \get_userdata( $user_id )->user_email;
+		} else {
+			if ( '1' !== \get_option( 'activitypub_blog_user_mailer_new_quote', '1' ) ) {
+				return;
+			}
+
+			$email = \get_option( 'admin_email' );
+		}
+
+		$actor = get_remote_metadata_by_actor( $activity['actor'] );
+		if ( ! $actor || \is_wp_error( $actor ) ) {
+			return;
+		}
+
+		$actor = self::normalize_actor( $actor );
+
+		// Get the quoted post/object.
+		// For QuoteRequest activities, object is the quoted URL string.
+		// For regular quote posts, object.quoteUrl contains the quoted URL.
+		$quoted_url = null;
+		if ( is_string( $activity['object'] ) ) {
+			// QuoteRequest format.
+			$quoted_url = $activity['object'];
+		} elseif ( ! empty( $activity['object']['quoteUrl'] ) ) {
+			// Regular quote post format.
+			$quoted_url = $activity['object']['quoteUrl'];
+		}
+
+		$template_args = array(
+			'activity'   => $activity,
+			'actor'      => $actor,
+			'user_id'    => $user_id,
+			'quoted_url' => $quoted_url,
+		);
+
+		/* translators: 1: Blog name, 2: Actor name */
+		$subject = \sprintf( \esc_html__( '[%1$s] Quote from: %2$s', 'activitypub' ), \esc_html( \get_option( 'blogname' ) ), \esc_html( $actor['name'] ) );
+
+		\ob_start();
+		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/emails/new-quote.php', false, $template_args );
+		$html_message = \ob_get_clean();
+
+		$alt_function = function ( $mailer ) use ( $actor, $activity, $quoted_url ) {
+			$content = '';
+			// For QuoteRequest, instrument contains the quote post URL.
+			// For regular quotes, object contains the quote post.
+			$quote_object = $activity['instrument'] ?? $activity['object'];
+			if ( is_array( $quote_object ) && ! empty( $quote_object['content'] ) ) {
+				$content = \html_entity_decode(
+					\wp_strip_all_tags(
+						str_replace( '</p>', PHP_EOL . PHP_EOL, $quote_object['content'] )
+					),
+					ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+				);
+			}
+
+			/* translators: Actor name */
+			$message = \sprintf( \esc_html__( '%1$s quoted your post:', 'activitypub' ), \esc_html( $actor['name'] ) ) . "\r\n\r\n";
+
+			if ( $content ) {
+				$message .= $content . "\r\n\r\n";
+			}
+
+			if ( $quoted_url ) {
+				/* translators: Quoted post URL */
+				$message .= \sprintf( \esc_html__( 'Your post: %s', 'activitypub' ), \esc_url( $quoted_url ) ) . "\r\n";
+			}
+
+			// Get the quote post URL.
+			$quote_url = is_array( $quote_object ) && ! empty( $quote_object['id'] ) ? $quote_object['id'] : ( $activity['instrument'] ?? '' );
+			if ( $quote_url ) {
+				/* translators: Quote post URL */
+				$message .= \sprintf( \esc_html__( 'Quote URL: %s', 'activitypub' ), \esc_url( $quote_url ) ) . "\r\n\r\n";
+			}
 
 			$mailer->{'AltBody'} = $message;
 		};

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -430,7 +430,7 @@ class Mailer {
 			// For QuoteRequest, instrument contains the quote post URL.
 			// For regular quotes, object contains the quote post.
 			$quote_object = $activity['instrument'] ?? $activity['object'];
-			if ( is_array( $quote_object ) && ! empty( $quote_object['content'] ) ) {
+			if ( ! empty( $quote_object['content'] ) ) {
 				$content = \html_entity_decode(
 					\wp_strip_all_tags(
 						str_replace( '</p>', PHP_EOL . PHP_EOL, $quote_object['content'] )

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -409,26 +409,24 @@ class Mailer {
 		/*
 		 * Get the quoted post/object.
 		 * For QuoteRequest activities, object is the quoted URL string.
-		 * For regular quote posts, object.quoteUrl contains the quoted URL.
+		 * For regular quote posts, check both 'quote' (FEP-044f) and 'quoteUrl' properties.
 		*/
-		$quoted_url = null;
 		if ( is_string( $activity['object'] ) ) {
 			// QuoteRequest format.
-			$quoted_url = $activity['object'];
-		} elseif ( ! empty( $activity['object']['quoteUrl'] ) ) {
-			// Regular quote post format.
-			$quoted_url = object_to_uri( $activity['object']['quoteUrl'] );
+			$quoted_url   = $activity['object'];
+			$quote_object = $activity['instrument'] ?? null;
+		} else {
+			$quoted_url   = object_to_uri( $activity['object']['quote'] ?? $activity['object']['quoteUrl'] ?? '' );
+			$quote_object = $activity['object'];
 		}
 
 		if ( ! $quoted_url ) {
 			return;
 		}
 
-		// Try to get the quoted post title.
-		$quoted_title = null;
-		$post_id      = \url_to_postid( $quoted_url );
-		if ( $post_id ) {
-			$quoted_title = \get_the_title( $post_id );
+		$fetched = Http::get_remote_object( $quote_object );
+		if ( ! \is_wp_error( $fetched ) && is_array( $fetched ) ) {
+			$quote_object = $fetched;
 		}
 
 		$template_args = array(
@@ -436,7 +434,8 @@ class Mailer {
 			'actor'        => $actor,
 			'user_id'      => $user_id,
 			'quoted_url'   => $quoted_url,
-			'quoted_title' => $quoted_title,
+			'quoted_title' => \get_the_title( \url_to_postid( $quoted_url ) ),
+			'quote_object' => $quote_object,
 		);
 
 		/* translators: 1: Blog name, 2: Actor name */
@@ -446,15 +445,11 @@ class Mailer {
 		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/emails/new-quote.php', false, $template_args );
 		$html_message = \ob_get_clean();
 
-		$alt_function = function ( $mailer ) use ( $actor, $activity, $quoted_url ) {
+		$alt_function = function ( $mailer ) use ( $actor, $activity, $quoted_url, $quote_object ) {
 			$content = '';
 
-			/*
-			 * For QuoteRequest, instrument contains the quote post URL.
-			 * For regular quotes, object contains the quote post.
-			 */
-			$quote_object = $activity['instrument'] ?? $activity['object'];
-			if ( ! empty( $quote_object['content'] ) ) {
+			// Extract content from the quote object if available.
+			if ( is_array( $quote_object ) && ! empty( $quote_object['content'] ) ) {
 				$content = \html_entity_decode(
 					\wp_strip_all_tags(
 						str_replace( '</p>', PHP_EOL . PHP_EOL, $quote_object['content'] )

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -410,7 +410,7 @@ class Mailer {
 		 * Get the quoted post/object.
 		 * For QuoteRequest activities, object is the quoted URL string.
 		 * For regular quote posts, check both 'quote' (FEP-044f) and 'quoteUrl' properties.
-		*/
+		 */
 		if ( is_string( $activity['object'] ) ) {
 			// QuoteRequest format.
 			$quoted_url   = $activity['object'];

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -22,9 +22,7 @@ class Mailer {
 
 		\add_action( 'activitypub_inbox_follow', array( self::class, 'new_follower' ), 10, 2 );
 		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		
-		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 ); // After @see \Activitypub\Handler\Create::handle_create()
-
+		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 ); /** After {@see \Activitypub\Handler\Create::handle_create()}. */
 		\add_action( 'activitypub_handled_quote_request', array( self::class, 'quote' ), 10, 3 );
 	}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -399,9 +399,11 @@ class Mailer {
 
 		$actor = self::normalize_actor( $actor );
 
-		// Get the quoted post/object.
-		// For QuoteRequest activities, object is the quoted URL string.
-		// For regular quote posts, object.quoteUrl contains the quoted URL.
+		/*
+		 * Get the quoted post/object.
+		 * For QuoteRequest activities, object is the quoted URL string.
+		 * For regular quote posts, object.quoteUrl contains the quoted URL.
+		*/
 		$quoted_url = null;
 		if ( is_string( $activity['object'] ) ) {
 			// QuoteRequest format.
@@ -427,8 +429,11 @@ class Mailer {
 
 		$alt_function = function ( $mailer ) use ( $actor, $activity, $quoted_url ) {
 			$content = '';
-			// For QuoteRequest, instrument contains the quote post URL.
-			// For regular quotes, object contains the quote post.
+
+			/*
+			 * For QuoteRequest, instrument contains the quote post URL.
+			 * For regular quotes, object contains the quote post.
+			 */
 			$quote_object = $activity['instrument'] ?? $activity['object'];
 			if ( ! empty( $quote_object['content'] ) ) {
 				$content = \html_entity_decode(
@@ -452,7 +457,7 @@ class Mailer {
 			}
 
 			// Get the quote post URL.
-			$quote_url = is_array( $quote_object ) && ! empty( $quote_object['id'] ) ? $quote_object['id'] : ( $activity['instrument'] ?? '' );
+			$quote_url = $quote_object['id'] ?? $activity['instrument'] ?? '';
 			if ( $quote_url ) {
 				/* translators: Quote post URL */
 				$message .= \sprintf( \esc_html__( 'Quote URL: %s', 'activitypub' ), \esc_url( $quote_url ) ) . "\r\n\r\n";

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -410,7 +410,7 @@ class Mailer {
 			$quoted_url = $activity['object'];
 		} elseif ( ! empty( $activity['object']['quoteUrl'] ) ) {
 			// Regular quote post format.
-			$quoted_url = $activity['object']['quoteUrl'];
+			$quoted_url = object_to_uri( $activity['object']['quoteUrl'] );
 		}
 
 		$template_args = array(

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -249,6 +249,7 @@ class Admin {
 			'activitypub_mailer_new_dm',
 			'activitypub_mailer_new_follower',
 			'activitypub_mailer_new_mention',
+			'activitypub_mailer_new_quote',
 		);
 
 		foreach ( $required_user_options as $option ) {

--- a/includes/wp-admin/class-blog-settings-fields.php
+++ b/includes/wp-admin/class-blog-settings-fields.php
@@ -236,6 +236,12 @@ class Blog_Settings_Fields {
 					<?php \esc_html_e( 'New Mentions', 'activitypub' ); ?>
 				</label>
 			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_blog_user_mailer_new_quote" id="activitypub_blog_user_mailer_new_quote" value="1" <?php \checked( '1', \get_option( 'activitypub_blog_user_mailer_new_quote', '1' ) ); ?> />
+					<?php \esc_html_e( 'New Quotes', 'activitypub' ); ?>
+				</label>
+			</p>
 		</fieldset>
 		<?php
 	}

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -327,6 +327,16 @@ class Settings {
 
 		\register_setting(
 			'activitypub_blog',
+			'activitypub_blog_user_mailer_new_quote',
+			array(
+				'type'        => 'integer',
+				'description' => 'Send a notification when someone quotes a user of the blog.',
+				'default'     => 1,
+			)
+		);
+
+		\register_setting(
+			'activitypub_blog',
 			'activitypub_blog_user_also_known_as',
 			array(
 				'type'              => 'array',

--- a/includes/wp-admin/class-user-settings-fields.php
+++ b/includes/wp-admin/class-user-settings-fields.php
@@ -250,6 +250,12 @@ class User_Settings_Fields {
 					<?php \esc_html_e( 'New Mentions', 'activitypub' ); ?>
 				</label>
 			</p>
+			<p>
+				<label>
+					<input type="checkbox" name="activitypub_mailer_new_quote" id="activitypub_mailer_new_quote" value="1" <?php \checked( 1, \get_user_option( 'activitypub_mailer_new_quote' ) ); ?> />
+					<?php \esc_html_e( 'New Quotes', 'activitypub' ); ?>
+				</label>
+			</p>
 		</fieldset>
 		<?php
 	}

--- a/templates/emails/new-quote.php
+++ b/templates/emails/new-quote.php
@@ -5,7 +5,6 @@
  * @package Activitypub
  */
 
-use Activitypub\Collection\Actors;
 use Activitypub\Embed;
 
 use function Activitypub\site_supports_blocks;
@@ -22,7 +21,7 @@ require __DIR__ . '/parts/header.php';
 <p>
 	<?php
 	/* translators: %s: The name of the person who quoted the post. */
-	$message = __( 'Looks like someone&#8217;s shared one of your posts! Your post was just quoted by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
+	$message = __( 'Your post was shared by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
 
 	printf( esc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
 	?>

--- a/templates/emails/new-quote.php
+++ b/templates/emails/new-quote.php
@@ -22,7 +22,7 @@ require __DIR__ . '/parts/header.php';
 <p>
 	<?php
 	/* translators: %s: The name of the person who quoted the post. */
-	$message = __( 'Looks like someone&#8217;s sharing one of your posts! Your post was just quoted by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
+	$message = __( 'Looks like someone&#8217;s shared one of your posts! Your post was just quoted by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
 
 	printf( esc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
 	?>

--- a/templates/emails/new-quote.php
+++ b/templates/emails/new-quote.php
@@ -21,13 +21,8 @@ require __DIR__ . '/parts/header.php';
 
 <p>
 	<?php
-	if ( Actors::BLOG_USER_ID === $args['user_id'] ) :
-		/* translators: %s: The name of the person who quoted the blog. */
-		$message = __( 'Looks like someone&#8217;s sharing one of your posts! Your post was just quoted by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
-	else :
-		/* translators: %s: The name of the person who quoted the user. */
-		$message = __( 'Looks like someone&#8217;s sharing one of your posts! Your post was just quoted by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
-	endif;
+	/* translators: %s: The name of the person who quoted the post. */
+	$message = __( 'Looks like someone&#8217;s sharing one of your posts! Your post was just quoted by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
 
 	printf( esc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
 	?>

--- a/templates/emails/new-quote.php
+++ b/templates/emails/new-quote.php
@@ -7,31 +7,26 @@
 
 use Activitypub\Embed;
 
+use function Activitypub\object_to_uri;
 use function Activitypub\site_supports_blocks;
 
 /* @var array $args Template arguments. */
 $args = wp_parse_args( $args ?? array() );
 
-// For QuoteRequest activities, the instrument contains the quote post URL.
-$quote_object = $args['activity']['instrument'] ?? $args['activity']['object'];
+$quote_object = $args['quote_object'];
+$quote_url    = object_to_uri( $quote_object );
 
 $comment_author = esc_html( $args['actor']['webfinger'] );
 if ( ! empty( $args['actor']['url'] ) ) {
 	$comment_author = sprintf( '<a href="%s">%s</a>', esc_url( $args['actor']['url'] ), esc_html( $args['actor']['webfinger'] ) );
 }
 
-/* translators: %s: The name of the person who quoted the post. */
-$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %s just shared one of your posts.', 'activitypub' );
-
-// Determine the message based on available data.
-if ( ! empty( $args['quoted_url'] ) ) {
-	if ( ! empty( $args['quoted_title'] ) ) {
-		/* translators: 1: actor name/link, 2: quoted post URL, 3: quoted post title */
-		$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">%3$s</a>.', 'activitypub' );
-	} else {
-		/* translators: 1: actor name/link, 2: quoted post URL */
-		$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">your post</a>.', 'activitypub' );
-	}
+if ( ! empty( $args['quoted_title'] ) ) {
+	/* translators: 1: actor name/link, 2: quoted post URL, 3: quoted post title */
+	$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">%3$s</a>.', 'activitypub' );
+} else {
+	/* translators: 1: actor name/link, 2: quoted post URL */
+	$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">your post</a>.', 'activitypub' );
 }
 
 // Load header.
@@ -65,20 +60,17 @@ if ( is_array( $quote_object ) ) :
 		echo Embed::get_html_for_object( $quote_object );
 		?>
 	</div>
+<?php endif; ?>
 
+<p>
 	<?php if ( site_supports_blocks() && ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) : ?>
-	<p>
-		<a class="button" href="<?php echo esc_url( admin_url( 'post-new.php?in_reply_to=' . $quote_object['id'] ) ); ?>">
+		<a class="button" href="<?php echo esc_url( admin_url( 'post-new.php?in_reply_to=' . rawurlencode( $quote_url ) ) ); ?>">
 			<?php esc_html_e( 'Reply to the post', 'activitypub' ); ?>
 		</a>
-	</p>
 	<?php endif; ?>
-<?php elseif ( ! empty( $args['quoted_url'] ) ) : ?>
-	<p>
-		<strong><?php esc_html_e( 'Your post:', 'activitypub' ); ?></strong>
-		<a href="<?php echo esc_url( $args['quoted_url'] ); ?>"><?php echo esc_html( $args['quoted_url'] ); ?></a>
-	</p>
-<?php endif; ?>
+
+	<a href="<?php echo esc_url( $quote_url ); ?>"><?php esc_html_e( 'View post', 'activitypub' ); ?></a>
+</p>
 
 <?php
 /**

--- a/templates/emails/new-quote.php
+++ b/templates/emails/new-quote.php
@@ -7,26 +7,21 @@
 
 use Activitypub\Embed;
 
-use function Activitypub\object_to_uri;
 use function Activitypub\site_supports_blocks;
 
 /* @var array $args Template arguments. */
 $args = wp_parse_args( $args ?? array() );
-
-$quote_object = $args['quote_object'];
-$quote_url    = object_to_uri( $quote_object );
 
 $comment_author = esc_html( $args['actor']['webfinger'] );
 if ( ! empty( $args['actor']['url'] ) ) {
 	$comment_author = sprintf( '<a href="%s">%s</a>', esc_url( $args['actor']['url'] ), esc_html( $args['actor']['webfinger'] ) );
 }
 
+/* translators: 1: actor name/link, 2: quoted post URL */
+$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">your post</a>. Here&#8217;s what they said:', 'activitypub' );
 if ( ! empty( $args['quoted_title'] ) ) {
 	/* translators: 1: actor name/link, 2: quoted post URL, 3: quoted post title */
-	$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">%3$s</a>.', 'activitypub' );
-} else {
-	/* translators: 1: actor name/link, 2: quoted post URL */
-	$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">your post</a>.', 'activitypub' );
+	$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">%3$s</a>. Here&#8217;s what they said:', 'activitypub' );
 }
 
 // Load header.
@@ -46,31 +41,20 @@ require __DIR__ . '/parts/header.php';
 	?>
 </p>
 
-<?php
-
-// Only show embed if we have a valid object (not just a URL string).
-if ( is_array( $quote_object ) ) :
+<div class="embed">
+	<?php
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo Embed::get_html_for_object( $args['quote_object'] );
 	?>
-	<p>
-		<strong><?php esc_html_e( 'Here&#8217;s what they said:', 'activitypub' ); ?></strong>
-	</p>
-	<div class="embed">
-		<?php
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo Embed::get_html_for_object( $quote_object );
-		?>
-	</div>
-<?php endif; ?>
+</div>
 
-<p>
-	<?php if ( site_supports_blocks() && ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) : ?>
-		<a class="button" href="<?php echo esc_url( admin_url( 'post-new.php?in_reply_to=' . rawurlencode( $quote_url ) ) ); ?>">
+<?php if ( site_supports_blocks() && ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) : ?>
+	<p>
+		<a class="button" href="<?php echo esc_url( admin_url( 'post-new.php?in_reply_to=' . rawurlencode( $args['quote_object']['id'] ) ) ); ?>">
 			<?php esc_html_e( 'Reply to the post', 'activitypub' ); ?>
 		</a>
-	<?php endif; ?>
-
-	<a href="<?php echo esc_url( $quote_url ); ?>"><?php esc_html_e( 'View post', 'activitypub' ); ?></a>
-</p>
+	</p>
+<?php endif; ?>
 
 <?php
 /**

--- a/templates/emails/new-quote.php
+++ b/templates/emails/new-quote.php
@@ -12,6 +12,28 @@ use function Activitypub\site_supports_blocks;
 /* @var array $args Template arguments. */
 $args = wp_parse_args( $args ?? array() );
 
+// For QuoteRequest activities, the instrument contains the quote post URL.
+$quote_object = $args['activity']['instrument'] ?? $args['activity']['object'];
+
+$comment_author = esc_html( $args['actor']['webfinger'] );
+if ( ! empty( $args['actor']['url'] ) ) {
+	$comment_author = sprintf( '<a href="%s">%s</a>', esc_url( $args['actor']['url'] ), esc_html( $args['actor']['webfinger'] ) );
+}
+
+/* translators: %s: The name of the person who quoted the post. */
+$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %s just shared one of your posts.', 'activitypub' );
+
+// Determine the message based on available data.
+if ( ! empty( $args['quoted_url'] ) ) {
+	if ( ! empty( $args['quoted_title'] ) ) {
+		/* translators: 1: actor name/link, 2: quoted post URL, 3: quoted post title */
+		$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">%3$s</a>.', 'activitypub' );
+	} else {
+		/* translators: 1: actor name/link, 2: quoted post URL */
+		$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">your post</a>.', 'activitypub' );
+	}
+}
+
 // Load header.
 require __DIR__ . '/parts/header.php';
 ?>
@@ -20,20 +42,23 @@ require __DIR__ . '/parts/header.php';
 
 <p>
 	<?php
-	/* translators: %s: The name of the person who quoted the post. */
-	$message = __( 'Your post was shared by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
-
-	printf( esc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
+	printf(
+		wp_kses( $message, array( 'a' => array( 'href' => array() ) ) ),
+		wp_kses( $comment_author, array( 'a' => array( 'href' => array() ) ) ),
+		esc_url( $args['quoted_url'] ),
+		esc_html( $args['quoted_title'] )
+	);
 	?>
 </p>
 
 <?php
-// For QuoteRequest activities, the instrument contains the quote post URL.
-$quote_object = $args['activity']['instrument'] ?? $args['activity']['object'];
 
 // Only show embed if we have a valid object (not just a URL string).
 if ( is_array( $quote_object ) ) :
 	?>
+	<p>
+		<strong><?php esc_html_e( 'Here&#8217;s what they said:', 'activitypub' ); ?></strong>
+	</p>
 	<div class="embed">
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/templates/emails/new-quote.php
+++ b/templates/emails/new-quote.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * ActivityPub New Quote E-Mail template with styles.
+ *
+ * @package Activitypub
+ */
+
+use Activitypub\Collection\Actors;
+use Activitypub\Embed;
+
+use function Activitypub\site_supports_blocks;
+
+/* @var array $args Template arguments. */
+$args = wp_parse_args( $args ?? array() );
+
+// Load header.
+require __DIR__ . '/parts/header.php';
+?>
+
+<h1><?php esc_html_e( 'Your post was quoted!', 'activitypub' ); ?></h1>
+
+<p>
+	<?php
+	if ( Actors::BLOG_USER_ID === $args['user_id'] ) :
+		/* translators: %s: The name of the person who quoted the blog. */
+		$message = __( 'Looks like someone&#8217;s sharing one of your posts! Your post was just quoted by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
+	else :
+		/* translators: %s: The name of the person who quoted the user. */
+		$message = __( 'Looks like someone&#8217;s sharing one of your posts! Your post was just quoted by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
+	endif;
+
+	printf( esc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
+	?>
+</p>
+
+<?php
+// For QuoteRequest activities, the instrument contains the quote post URL.
+$quote_object = $args['activity']['instrument'] ?? $args['activity']['object'];
+
+// Only show embed if we have a valid object (not just a URL string).
+if ( is_array( $quote_object ) ) :
+	?>
+	<div class="embed">
+		<?php
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo Embed::get_html_for_object( $quote_object );
+		?>
+	</div>
+
+	<?php if ( site_supports_blocks() && ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) : ?>
+	<p>
+		<a class="button" href="<?php echo esc_url( admin_url( 'post-new.php?in_reply_to=' . $quote_object['id'] ) ); ?>">
+			<?php esc_html_e( 'Reply to the post', 'activitypub' ); ?>
+		</a>
+	</p>
+	<?php endif; ?>
+<?php elseif ( ! empty( $args['quoted_url'] ) ) : ?>
+	<p>
+		<strong><?php esc_html_e( 'Your post:', 'activitypub' ); ?></strong>
+		<a href="<?php echo esc_url( $args['quoted_url'] ); ?>"><?php echo esc_html( $args['quoted_url'] ); ?></a>
+	</p>
+<?php endif; ?>
+
+<?php
+/**
+ * Fires at the bottom of the new quote emails.
+ *
+ * @param array $args The template arguments.
+ */
+do_action( 'activitypub_new_quote_email', $args );
+
+// Load footer.
+require __DIR__ . '/parts/footer.php';

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -774,13 +774,25 @@ class Test_Mailer extends WP_UnitTestCase {
 			}
 		);
 
+		// Mock HTTP request to fetch quote object.
+		add_filter(
+			'activitypub_pre_http_get_remote_object',
+			function ( $preempt, $url ) use ( $activity ) {
+				if ( 'https://example.com/post/1' === $url || $url === $activity['object'] ) {
+					return $activity['object'];
+				}
+				return $preempt;
+			},
+			10,
+			2
+		);
+
 		// Capture email.
 		add_filter(
 			'wp_mail',
 			function ( $args ) {
 				$this->assertStringContainsString( 'Test Quoter', $args['subject'] );
 				$this->assertStringContainsString( 'Quote from', $args['subject'] );
-				$this->assertStringContainsString( 'https://example.com/post/1', $args['message'] );
 				$this->assertStringContainsString( 'Great article', $args['message'] );
 				$this->assertEquals( get_user_by( 'id', self::$user_id )->user_email, $args['to'] );
 				return $args;
@@ -791,6 +803,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'activitypub_pre_http_get_remote_object' );
 		remove_all_filters( 'wp_mail' );
 	}
 
@@ -891,12 +904,25 @@ class Test_Mailer extends WP_UnitTestCase {
 			}
 		);
 
+		// Mock HTTP request to fetch quote object.
+		add_filter(
+			'activitypub_pre_http_get_remote_object',
+			function ( $preempt, $url ) use ( $activity ) {
+				if ( 'https://example.com/post/1' === $url || $url === $activity['object'] ) {
+					return $activity['object'];
+				}
+				return $preempt;
+			},
+			10,
+			2
+		);
+
 		// Capture email.
 		add_filter(
 			'wp_mail',
 			function ( $args ) {
 				$this->assertStringContainsString( 'Test Quoter', $args['subject'] );
-				$this->assertStringContainsString( 'https://example.com/post/1', $args['message'] );
+				$this->assertStringContainsString( 'Great blog post!', $args['message'] );
 				$this->assertEquals( get_option( 'admin_email' ), $args['to'] );
 				return $args;
 			}
@@ -906,6 +932,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'activitypub_pre_http_get_remote_object' );
 		remove_all_filters( 'wp_mail' );
 		delete_option( 'activitypub_blog_user_mailer_new_quote' );
 		delete_option( 'activitypub_actor_mode' );

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -748,7 +748,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test quote notification.
 	 *
-	 * @covers ::quoted
+	 * @covers ::quote
 	 */
 	public function test_quoted() {
 		$activity = array(
@@ -797,7 +797,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test quote notification when state is false.
 	 *
-	 * @covers ::quoted
+	 * @covers ::quote
 	 */
 	public function test_quoted_with_false_state() {
 		$activity = array(
@@ -828,7 +828,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test quote notification when user option is disabled.
 	 *
-	 * @covers ::quoted
+	 * @covers ::quote
 	 */
 	public function test_quoted_with_disabled_option() {
 		// Disable the user option.
@@ -862,7 +862,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test quote notification for blog user.
 	 *
-	 * @covers ::quoted
+	 * @covers ::quote
 	 */
 	public function test_blog_quoted() {
 		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
@@ -914,7 +914,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test quote notification for blog user when option is disabled.
 	 *
-	 * @covers ::quoted
+	 * @covers ::quote
 	 */
 	public function test_blog_quoted_with_disabled_option() {
 		// Set blog option to false (0).
@@ -951,7 +951,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test quote notification does not send to Application user.
 	 *
-	 * @covers ::quoted
+	 * @covers ::quote
 	 */
 	public function test_quoted_application_user() {
 		$activity = array(

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -46,6 +46,7 @@ class Test_Mailer extends WP_UnitTestCase {
 					$blog_prefix . 'activitypub_mailer_new_dm'       => 1,
 					$blog_prefix . 'activitypub_mailer_new_follower' => 1,
 					$blog_prefix . 'activitypub_mailer_new_mention'  => 1,
+					$blog_prefix . 'activitypub_mailer_new_quote'    => 1,
 				),
 			)
 		);
@@ -742,5 +743,239 @@ class Test_Mailer extends WP_UnitTestCase {
 		remove_all_filters( 'wp_before_load_template' );
 		delete_option( 'activitypub_blog_user_mailer_new_mention' );
 		delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * Test quote notification.
+	 *
+	 * @covers ::quoted
+	 */
+	public function test_quoted() {
+		$activity = array(
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'       => 'https://example.com/post/1',
+				'type'     => 'Note',
+				'content'  => '<p>Great article! I have some thoughts on this.</p>',
+				'quoteUrl' => get_permalink( self::$post_id ),
+			),
+		);
+
+		// Mock remote metadata.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function () {
+				return array(
+					'name'              => 'Test Quoter',
+					'url'               => 'https://example.com/author',
+					'preferredUsername' => 'quoter',
+				);
+			}
+		);
+
+		// Capture email.
+		add_filter(
+			'wp_mail',
+			function ( $args ) {
+				$this->assertStringContainsString( 'Test Quoter', $args['subject'] );
+				$this->assertStringContainsString( 'Quote from', $args['subject'] );
+				$this->assertStringContainsString( 'https://example.com/post/1', $args['message'] );
+				$this->assertStringContainsString( 'Great article', $args['message'] );
+				$this->assertEquals( get_user_by( 'id', self::$user_id )->user_email, $args['to'] );
+				return $args;
+			}
+		);
+
+		Mailer::quote( $activity, self::$user_id, true );
+
+		// Clean up.
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'wp_mail' );
+	}
+
+	/**
+	 * Test quote notification when state is false.
+	 *
+	 * @covers ::quoted
+	 */
+	public function test_quoted_with_false_state() {
+		$activity = array(
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'       => 'https://example.com/post/1',
+				'type'     => 'Note',
+				'content'  => '<p>Great article!</p>',
+				'quoteUrl' => get_permalink( self::$post_id ),
+			),
+		);
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call with false state - should not send email.
+		Mailer::quote( $activity, self::$user_id, false );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
+	}
+
+	/**
+	 * Test quote notification when user option is disabled.
+	 *
+	 * @covers ::quoted
+	 */
+	public function test_quoted_with_disabled_option() {
+		// Disable the user option.
+		update_user_option( self::$user_id, 'activitypub_mailer_new_quote', false );
+
+		$activity = array(
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'       => 'https://example.com/post/1',
+				'type'     => 'Note',
+				'content'  => '<p>Great article!</p>',
+				'quoteUrl' => get_permalink( self::$post_id ),
+			),
+		);
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		Mailer::quote( $activity, self::$user_id, true );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
+		delete_user_option( self::$user_id, 'activitypub_mailer_new_quote' );
+	}
+
+	/**
+	 * Test quote notification for blog user.
+	 *
+	 * @covers ::quoted
+	 */
+	public function test_blog_quoted() {
+		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		update_option( 'activitypub_blog_user_mailer_new_quote', '1' );
+
+		$activity = array(
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'       => 'https://example.com/post/1',
+				'type'     => 'Note',
+				'content'  => '<p>Great blog post!</p>',
+				'quoteUrl' => get_permalink( self::$post_id ),
+			),
+		);
+
+		// Mock remote metadata.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function () {
+				return array(
+					'name'              => 'Test Quoter',
+					'url'               => 'https://example.com/author',
+					'preferredUsername' => 'quoter',
+				);
+			}
+		);
+
+		// Capture email.
+		add_filter(
+			'wp_mail',
+			function ( $args ) {
+				$this->assertStringContainsString( 'Test Quoter', $args['subject'] );
+				$this->assertStringContainsString( 'https://example.com/post/1', $args['message'] );
+				$this->assertEquals( get_option( 'admin_email' ), $args['to'] );
+				return $args;
+			}
+		);
+
+		Mailer::quote( $activity, Actors::BLOG_USER_ID, true );
+
+		// Clean up.
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'wp_mail' );
+		delete_option( 'activitypub_blog_user_mailer_new_quote' );
+		delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * Test quote notification for blog user when option is disabled.
+	 *
+	 * @covers ::quoted
+	 */
+	public function test_blog_quoted_with_disabled_option() {
+		// Set blog option to false (0).
+		update_option( 'activitypub_blog_user_mailer_new_quote', '0' );
+		update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$activity = array(
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'       => 'https://example.com/post/1',
+				'type'     => 'Note',
+				'content'  => '<p>Great blog!</p>',
+				'quoteUrl' => get_permalink( self::$post_id ),
+			),
+		);
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call the method with blog user ID.
+		Mailer::quote( $activity, Actors::BLOG_USER_ID, true );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
+		delete_option( 'activitypub_blog_user_mailer_new_quote' );
+		delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * Test quote notification does not send to Application user.
+	 *
+	 * @covers ::quoted
+	 */
+	public function test_quoted_application_user() {
+		$activity = array(
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'object' => array(
+				'id'       => 'https://example.com/post/1',
+				'type'     => 'Note',
+				'content'  => '<p>Great article!</p>',
+				'quoteUrl' => get_permalink( self::$post_id ),
+			),
+		);
+
+		// Add a filter to fail the test if an email is sent.
+		$mock = new \MockAction();
+		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
+
+		// Call with Application user - should not send email.
+		Mailer::quote( $activity, Actors::APPLICATION_USER_ID, true );
+
+		// Assert no email was sent.
+		$this->assertEquals( 0, $mock->get_call_count() );
+
+		// Clean up.
+		remove_all_filters( 'wp_before_load_template' );
 	}
 }

--- a/tests/phpunit/tests/includes/handler/class-test-quote-request.php
+++ b/tests/phpunit/tests/includes/handler/class-test-quote-request.php
@@ -151,10 +151,11 @@ class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase 
 			'pre_get_remote_metadata_by_actor',
 			function () use ( $actor_url ) {
 				return array(
-					'id'    => $actor_url,
-					'actor' => $actor_url,
-					'type'  => 'Person',
-					'inbox' => str_replace( '/users/', '/inbox/', $actor_url ),
+					'id'                => $actor_url,
+					'actor'             => $actor_url,
+					'type'              => 'Person',
+					'preferredUsername' => 'remote_user',
+					'inbox'             => str_replace( '/users/', '/inbox/', $actor_url ),
 				);
 			}
 		);

--- a/tests/phpunit/tests/includes/handler/class-test-quote-request.php
+++ b/tests/phpunit/tests/includes/handler/class-test-quote-request.php
@@ -160,6 +160,23 @@ class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase 
 			}
 		);
 
+		// Mock HTTP request to fetch quote object (instrument).
+		add_filter(
+			'activitypub_pre_http_get_remote_object',
+			function ( $preempt, $url ) use ( $activity ) {
+				if ( $activity['instrument'] === $url ) {
+					return array(
+						'id'      => $activity['instrument'],
+						'type'    => 'Note',
+						'content' => '<p>Great post! I have some thoughts.</p>',
+					);
+				}
+				return $preempt;
+			},
+			10,
+			2
+		);
+
 		$remote_actor_id = false;
 
 		// Run setup callback if provided.
@@ -473,6 +490,7 @@ class Test_Quote_Request extends \Activitypub\Tests\ActivityPub_Outbox_TestCase 
 	public function tear_down() {
 		// Remove all the filters we added during tests.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		remove_all_filters( 'activitypub_pre_http_get_remote_object' );
 
 		parent::tear_down();
 	}


### PR DESCRIPTION
Implements email notifications when a user's post is quoted, including user and blog-level settings, email template, and tests. Updates admin and settings UI to allow enabling/disabling quote notifications. Adds comprehensive PHPUnit tests for the new notification logic.

<img width="696" height="611" alt="Screenshot 2025-10-09 at 12 32 44" src="https://github.com/user-attachments/assets/0bf54070-c6c5-4e5f-a438-bc520930f9e0" />

## Proposed changes:
- Adds email notification functionality for quote events with user and blog-level settings
- Creates a new email template specifically for quote notifications
- Implements comprehensive PHPUnit test coverage for the notification logic

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout on a test site
* Quote a blog-post with a mastodon user
* Check Mail

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added email notifications for quoted posts, with user and blog-level settings and a new customizable email template.

</details>
