### PR TITLE
Update mailer hooks and add success checks for notifications

### DIFF
--- a/.github/changelog/2304-from-description
+++ b/.github/changelog/2304-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated mailer hooks to send notifications only when activities are successfully handled, preventing emails for failed events.

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -20,9 +20,10 @@ class Mailer {
 		\add_filter( 'comment_notification_subject', array( self::class, 'comment_notification_subject' ), 10, 2 );
 		\add_filter( 'comment_notification_text', array( self::class, 'comment_notification_text' ), 10, 2 );
 
-		\add_action( 'activitypub_handled_follow', array( self::class, 'new_follower' ), 10, 4 );
-		\add_action( 'activitypub_handled_create', array( self::class, 'direct_message' ), 10, 4 );
-		\add_action( 'activitypub_handled_create', array( self::class, 'mention' ), 10, 4 );
+		\add_action( 'activitypub_handled_follow', array( self::class, 'new_follower' ), 10, 3 );
+
+		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
+		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );
 	}
 
 	/**
@@ -215,14 +216,8 @@ class Mailer {
 	 *
 	 * @param array $activity The activity object.
 	 * @param int   $user_id  The id of the local blog-user.
-	 * @param bool  $success  True on success, false otherwise.
 	 */
-	public static function direct_message( $activity, $user_id, $success ) {
-		// Only send notification if the activity was not successfully handled.
-		if ( $success ) {
-			return;
-		}
-
+	public static function direct_message( $activity, $user_id ) {
 		if (
 			is_activity_public( $activity ) ||
 			// Only accept messages that have the user in the "to" field.
@@ -296,14 +291,8 @@ class Mailer {
 	 *
 	 * @param array $activity The activity object.
 	 * @param int   $user_id  The id of the local blog-user.
-	 * @param bool  $success  True on success, false otherwise.
 	 */
-	public static function mention( $activity, $user_id, $success ) {
-		// Only send notification if the activity was successfully handled.
-		if ( ! $success ) {
-			return;
-		}
-
+	public static function mention( $activity, $user_id ) {
 		if (
 			// Only accept messages that have the user in the "cc" field.
 			empty( $activity['cc'] ) ||

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -126,7 +126,7 @@ class Mailer {
 	 * @param int   $user_id  The id of the local blog-user.
 	 * @param bool  $success  True on success, false otherwise.
 	 */
-	public static function new_follower( $activity, $user_id, $success = true ) {
+	public static function new_follower( $activity, $user_id, $success ) {
 		// Only send notification if the follow was successful.
 		if ( ! $success ) {
 			return;
@@ -217,7 +217,7 @@ class Mailer {
 	 * @param int   $user_id  The id of the local blog-user.
 	 * @param bool  $success  True on success, false otherwise.
 	 */
-	public static function direct_message( $activity, $user_id, $success = true ) {
+	public static function direct_message( $activity, $user_id, $success ) {
 		// Only send notification if the activity was successfully handled.
 		if ( ! $success ) {
 			return;
@@ -298,7 +298,7 @@ class Mailer {
 	 * @param int   $user_id  The id of the local blog-user.
 	 * @param bool  $success  True on success, false otherwise.
 	 */
-	public static function mention( $activity, $user_id, $success = true ) {
+	public static function mention( $activity, $user_id, $success ) {
 		// Only send notification if the activity was successfully handled.
 		if ( ! $success ) {
 			return;

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -20,9 +20,9 @@ class Mailer {
 		\add_filter( 'comment_notification_subject', array( self::class, 'comment_notification_subject' ), 10, 2 );
 		\add_filter( 'comment_notification_text', array( self::class, 'comment_notification_text' ), 10, 2 );
 
-		\add_action( 'activitypub_inbox_follow', array( self::class, 'new_follower' ), 10, 2 );
-		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );  /** After @see \Activitypub\Handler\Create::handle_create() */
+		\add_action( 'activitypub_handled_follow', array( self::class, 'new_follower' ), 10, 4 );
+		\add_action( 'activitypub_handled_create', array( self::class, 'direct_message' ), 10, 4 );
+		\add_action( 'activitypub_handled_create', array( self::class, 'mention' ), 20, 4 );
 	}
 
 	/**
@@ -124,8 +124,14 @@ class Mailer {
 	 *
 	 * @param array $activity The activity object.
 	 * @param int   $user_id  The id of the local blog-user.
+	 * @param bool  $success  True on success, false otherwise.
 	 */
-	public static function new_follower( $activity, $user_id ) {
+	public static function new_follower( $activity, $user_id, $success = true ) {
+		// Only send notification if the follow was successful.
+		if ( ! $success ) {
+			return;
+		}
+
 		// Do not send notifications to the Application user.
 		if ( Actors::APPLICATION_USER_ID === $user_id ) {
 			return;
@@ -209,8 +215,14 @@ class Mailer {
 	 *
 	 * @param array $activity The activity object.
 	 * @param int   $user_id  The id of the local blog-user.
+	 * @param bool  $success  True on success, false otherwise.
 	 */
-	public static function direct_message( $activity, $user_id ) {
+	public static function direct_message( $activity, $user_id, $success = true ) {
+		// Only send notification if the activity was successfully handled.
+		if ( ! $success ) {
+			return;
+		}
+
 		if (
 			is_activity_public( $activity ) ||
 			// Only accept messages that have the user in the "to" field.
@@ -284,8 +296,14 @@ class Mailer {
 	 *
 	 * @param array $activity The activity object.
 	 * @param int   $user_id  The id of the local blog-user.
+	 * @param bool  $success  True on success, false otherwise.
 	 */
-	public static function mention( $activity, $user_id ) {
+	public static function mention( $activity, $user_id, $success = true ) {
+		// Only send notification if the activity was successfully handled.
+		if ( ! $success ) {
+			return;
+		}
+
 		if (
 			// Only accept messages that have the user in the "cc" field.
 			empty( $activity['cc'] ) ||

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -22,7 +22,7 @@ class Mailer {
 
 		\add_action( 'activitypub_handled_follow', array( self::class, 'new_follower' ), 10, 4 );
 		\add_action( 'activitypub_handled_create', array( self::class, 'direct_message' ), 10, 4 );
-		\add_action( 'activitypub_handled_create', array( self::class, 'mention' ), 20, 4 );
+		\add_action( 'activitypub_handled_create', array( self::class, 'mention' ), 10, 4 );
 	}
 
 	/**
@@ -219,7 +219,7 @@ class Mailer {
 	 */
 	public static function direct_message( $activity, $user_id, $success ) {
 		// Only send notification if the activity was successfully handled.
-		if ( ! $success ) {
+		if ( $success ) {
 			return;
 		}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -23,7 +23,7 @@ class Mailer {
 		\add_action( 'activitypub_handled_follow', array( self::class, 'new_follower' ), 10, 3 );
 
 		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );
+		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 ); /** After @see \Activitypub\Handler\Create::handle_create() */
 	}
 
 	/**

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -218,7 +218,7 @@ class Mailer {
 	 * @param bool  $success  True on success, false otherwise.
 	 */
 	public static function direct_message( $activity, $user_id, $success ) {
-		// Only send notification if the activity was successfully handled.
+		// Only send notification if the activity was not successfully handled.
 		if ( $success ) {
 			return;
 		}

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -23,7 +23,7 @@ class Mailer {
 		\add_action( 'activitypub_handled_follow', array( self::class, 'new_follower' ), 10, 3 );
 
 		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 ); /** After @see \Activitypub\Handler\Create::handle_create() */
+		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );  /** After @see \Activitypub\Handler\Create::handle_create() */
 	}
 
 	/**

--- a/includes/handler/class-create.php
+++ b/includes/handler/class-create.php
@@ -34,14 +34,6 @@ class Create {
 	 * @param \Activitypub\Activity\Activity $activity_object Optional. The activity object. Default null.
 	 */
 	public static function handle_create( $activity, $user_id, $activity_object = null ) {
-		// Check if Activity is public or not.
-		if (
-			ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE === get_activity_visibility( $activity ) ||
-			! is_activity_reply( $activity )
-		) {
-			return;
-		}
-
 		$check_dupe = object_id_to_comment( $activity['object']['id'] );
 
 		// If comment exists, call update action.
@@ -62,7 +54,15 @@ class Create {
 		}
 
 		$success = false;
-		$result  = Interactions::add_comment( $activity );
+		$result  = false;
+
+		// Check if Activity is public or not.
+		if (
+			in_array( get_activity_visibility( $activity ), array( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC ), true ) ||
+			is_activity_reply( $activity )
+		) {
+			$result = Interactions::add_comment( $activity );
+		}
 
 		if ( $result && ! \is_wp_error( $result ) ) {
 			$success = true;

--- a/includes/handler/class-create.php
+++ b/includes/handler/class-create.php
@@ -34,6 +34,14 @@ class Create {
 	 * @param \Activitypub\Activity\Activity $activity_object Optional. The activity object. Default null.
 	 */
 	public static function handle_create( $activity, $user_id, $activity_object = null ) {
+		// Check if Activity is public or not.
+		if (
+			ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE === get_activity_visibility( $activity ) ||
+			! is_activity_reply( $activity )
+		) {
+			return;
+		}
+
 		$check_dupe = object_id_to_comment( $activity['object']['id'] );
 
 		// If comment exists, call update action.
@@ -54,15 +62,7 @@ class Create {
 		}
 
 		$success = false;
-		$result  = false;
-
-		// Check if Activity is public or not.
-		if (
-			in_array( get_activity_visibility( $activity ), array( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC ), true ) ||
-			is_activity_reply( $activity )
-		) {
-			$result = Interactions::add_comment( $activity );
-		}
+		$result  = Interactions::add_comment( $activity );
 
 		if ( $result && ! \is_wp_error( $result ) ) {
 			$success = true;

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -698,7 +698,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method with blog user ID.
-		Mailer::direct_message( $activity, Actors::BLOG_USER_ID, true );
+		Mailer::direct_message( $activity, Actors::BLOG_USER_ID );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -253,9 +253,9 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		$this->assertEquals( 10, \has_filter( 'comment_notification_subject', array( Mailer::class, 'comment_notification_subject' ) ) );
 		$this->assertEquals( 10, \has_filter( 'comment_notification_text', array( Mailer::class, 'comment_notification_text' ) ) );
-		$this->assertEquals( 10, \has_action( 'activitypub_inbox_follow', array( Mailer::class, 'new_follower' ) ) );
-		$this->assertEquals( 10, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'direct_message' ) ) );
-		$this->assertEquals( 20, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'mention' ) ) );
+		$this->assertEquals( 10, \has_action( 'activitypub_handled_follow', array( Mailer::class, 'new_follower' ) ) );
+		$this->assertEquals( 10, \has_action( 'activitypub_handled_create', array( Mailer::class, 'direct_message' ) ) );
+		$this->assertEquals( 20, \has_action( 'activitypub_handled_create', array( Mailer::class, 'mention' ) ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -195,7 +195,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			}
 		);
 
-		Mailer::new_follower( $activity, self::$user_id );
+		Mailer::new_follower( $activity, self::$user_id, true );
 
 		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
@@ -236,7 +236,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			}
 		);
 
-		Mailer::new_follower( $activity, self::$user_id );
+		Mailer::new_follower( $activity, self::$user_id, true );
 
 		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
@@ -416,7 +416,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		}
 
-		Mailer::direct_message( $activity, $user_id );
+		Mailer::direct_message( $activity, $user_id, true );
 
 		$this->assertEquals( $send_email ? 1 : 0, $mock->get_call_count() );
 
@@ -468,7 +468,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		);
 
 		// Call the method.
-		Mailer::direct_message( $activity, self::$user_id );
+		Mailer::direct_message( $activity, self::$user_id, true );
 
 		// Clean up.
 		remove_all_filters( 'wp_before_load_template' );
@@ -537,7 +537,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			}
 		);
 
-		Mailer::direct_message( $activity, $user_id );
+		Mailer::direct_message( $activity, $user_id, true );
 
 		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
@@ -565,7 +565,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method.
-		Mailer::new_follower( $activity, self::$user_id );
+		Mailer::new_follower( $activity, self::$user_id, true );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );
@@ -599,7 +599,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method.
-		Mailer::direct_message( $activity, self::$user_id );
+		Mailer::direct_message( $activity, self::$user_id, true );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );
@@ -632,7 +632,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method.
-		Mailer::mention( $activity, self::$user_id );
+		Mailer::mention( $activity, self::$user_id, true );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );
@@ -663,7 +663,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method with blog user ID.
-		Mailer::new_follower( $activity, Actors::BLOG_USER_ID );
+		Mailer::new_follower( $activity, Actors::BLOG_USER_ID, true );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );
@@ -698,7 +698,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method with blog user ID.
-		Mailer::direct_message( $activity, Actors::BLOG_USER_ID );
+		Mailer::direct_message( $activity, Actors::BLOG_USER_ID, true );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );
@@ -733,7 +733,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method with blog user ID.
-		Mailer::mention( $activity, Actors::BLOG_USER_ID );
+		Mailer::mention( $activity, Actors::BLOG_USER_ID, true );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -468,7 +468,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		);
 
 		// Call the method.
-		Mailer::direct_message( $activity, self::$user_id, true );
+		Mailer::direct_message( $activity, self::$user_id );
 
 		// Clean up.
 		remove_all_filters( 'wp_before_load_template' );
@@ -599,7 +599,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method.
-		Mailer::direct_message( $activity, self::$user_id, true );
+		Mailer::direct_message( $activity, self::$user_id );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );
@@ -733,7 +733,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method with blog user ID.
-		Mailer::mention( $activity, Actors::BLOG_USER_ID, true );
+		Mailer::mention( $activity, Actors::BLOG_USER_ID );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -254,8 +254,8 @@ class Test_Mailer extends WP_UnitTestCase {
 		$this->assertEquals( 10, \has_filter( 'comment_notification_subject', array( Mailer::class, 'comment_notification_subject' ) ) );
 		$this->assertEquals( 10, \has_filter( 'comment_notification_text', array( Mailer::class, 'comment_notification_text' ) ) );
 		$this->assertEquals( 10, \has_action( 'activitypub_handled_follow', array( Mailer::class, 'new_follower' ) ) );
-		$this->assertEquals( 10, \has_action( 'activitypub_handled_create', array( Mailer::class, 'direct_message' ) ) );
-		$this->assertEquals( 20, \has_action( 'activitypub_handled_create', array( Mailer::class, 'mention' ) ) );
+		$this->assertEquals( 10, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'direct_message' ) ) );
+		$this->assertEquals( 20, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'mention' ) ) );
 	}
 
 	/**
@@ -416,7 +416,7 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		}
 
-		Mailer::direct_message( $activity, $user_id, true );
+		Mailer::direct_message( $activity, $user_id );
 
 		$this->assertEquals( $send_email ? 1 : 0, $mock->get_call_count() );
 
@@ -537,7 +537,7 @@ class Test_Mailer extends WP_UnitTestCase {
 			}
 		);
 
-		Mailer::direct_message( $activity, $user_id, true );
+		Mailer::direct_message( $activity, $user_id );
 
 		// Clean up.
 		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
@@ -632,7 +632,7 @@ class Test_Mailer extends WP_UnitTestCase {
 		add_action( 'wp_before_load_template', array( $mock, 'action' ) );
 
 		// Call the method.
-		Mailer::mention( $activity, self::$user_id, true );
+		Mailer::mention( $activity, self::$user_id );
 
 		// Assert no email was sent.
 		$this->assertEquals( 0, $mock->get_call_count() );

--- a/tests/phpunit/tests/includes/handler/class-test-create.php
+++ b/tests/phpunit/tests/includes/handler/class-test-create.php
@@ -80,12 +80,13 @@ class Test_Create extends \WP_UnitTestCase {
 	 */
 	public static function get_remote_metadata_by_actor( $value, $actor ) {
 		return array(
-			'name' => 'Example User',
-			'icon' => array(
+			'name'              => 'Example User',
+			'preferredUsername' => 'exampleuser',
+			'icon'              => array(
 				'url' => 'https://example.com/icon',
 			),
-			'url'  => $actor,
-			'id'   => 'http://example.org/users/example',
+			'url'               => $actor,
+			'id'                => 'http://example.org/users/example',
 		);
 	}
 

--- a/tests/phpunit/tests/includes/handler/class-test-follow.php
+++ b/tests/phpunit/tests/includes/handler/class-test-follow.php
@@ -86,10 +86,11 @@ class Test_Follow extends \WP_UnitTestCase {
 				'pre_get_remote_metadata_by_actor',
 				function () use ( $actor_url ) {
 					return array(
-						'id'    => $actor_url,
-						'actor' => $actor_url,
-						'type'  => 'Person',
-						'inbox' => str_replace( '/actor', '/inbox', $actor_url ),
+						'id'                => $actor_url,
+						'actor'             => $actor_url,
+						'type'              => 'Person',
+						'preferredUsername' => 'testactor',
+						'inbox'             => str_replace( '/actor', '/inbox', $actor_url ),
 					);
 				}
 			);
@@ -213,10 +214,11 @@ class Test_Follow extends \WP_UnitTestCase {
 			'pre_get_remote_metadata_by_actor',
 			function () use ( $actor ) {
 				return array(
-					'id'    => $actor,
-					'actor' => $actor,
-					'type'  => 'Person',
-					'inbox' => 'https://example.com/inbox',
+					'id'                => $actor,
+					'actor'             => $actor,
+					'type'              => 'Person',
+					'preferredUsername' => 'testactor',
+					'inbox'             => 'https://example.com/inbox',
 				);
 			}
 		);
@@ -352,10 +354,11 @@ class Test_Follow extends \WP_UnitTestCase {
 			'pre_get_remote_metadata_by_actor',
 			function () use ( $actor_url ) {
 				return array(
-					'id'    => $actor_url,
-					'actor' => $actor_url,
-					'type'  => 'Person',
-					'inbox' => str_replace( '/deprecated-test-actor', '/inbox', $actor_url ),
+					'id'                => $actor_url,
+					'actor'             => $actor_url,
+					'type'              => 'Person',
+					'preferredUsername' => 'testactor',
+					'inbox'             => str_replace( '/deprecated-test-actor', '/inbox', $actor_url ),
 				);
 			}
 		);
@@ -429,10 +432,11 @@ class Test_Follow extends \WP_UnitTestCase {
 			'pre_get_remote_metadata_by_actor',
 			function () use ( $actor_url ) {
 				return array(
-					'id'    => $actor_url,
-					'actor' => $actor_url,
-					'type'  => 'Person',
-					'inbox' => str_replace( '/new-hook-test-actor', '/inbox', $actor_url ),
+					'id'                => $actor_url,
+					'actor'             => $actor_url,
+					'type'              => 'Person',
+					'preferredUsername' => 'testactor',
+					'inbox'             => str_replace( '/new-hook-test-actor', '/inbox', $actor_url ),
 				);
 			}
 		);


### PR DESCRIPTION
Switched mailer action hooks from 'activitypub_inbox_*' to 'activitypub_handled_*' and updated callback signatures to accept a success parameter. Notifications for new followers, direct messages, and mentions are now only sent if the activity was successfully handled. Updated related tests to match new hook names and signatures, and added 'preferredUsername' to test actor metadata.

With this PR, mails will only be sent, if the Activity was really handled!

## Proposed changes:
- Updated mailer hook registration to use 'activitypub_handled_*' instead of 'activitypub_inbox_*'
- Added success parameter checks to prevent notifications for failed activity handling
- Updated method signatures to accept a success parameter with default value

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Deploy changes
* Test Follow, Comment and Mention
* Check mails

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Updated mailer hooks to send notifications only when activities are successfully handled, preventing emails for failed events.

</details>
