### PR TITLE
Add scheduled inbox purge and retention setting

### DIFF
--- a/.github/changelog/2305-from-description
+++ b/.github/changelog/2305-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a scheduled task and setting to automatically purge old inbox items, helping maintain site performance and storage control.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -123,11 +123,11 @@ class Scheduler {
 	 * @return void
 	 */
 	public static function deregister_schedules() {
-		wp_unschedule_hook( 'activitypub_update_remote_actors' );
-		wp_unschedule_hook( 'activitypub_cleanup_remote_actors' );
-		wp_unschedule_hook( 'activitypub_reprocess_outbox' );
-		wp_unschedule_hook( 'activitypub_outbox_purge' );
-		wp_unschedule_hook( 'activitypub_inbox_purge' );
+		\wp_unschedule_hook( 'activitypub_update_remote_actors' );
+		\wp_unschedule_hook( 'activitypub_cleanup_remote_actors' );
+		\wp_unschedule_hook( 'activitypub_reprocess_outbox' );
+		\wp_unschedule_hook( 'activitypub_outbox_purge' );
+		\wp_unschedule_hook( 'activitypub_inbox_purge' );
 	}
 
 	/**
@@ -371,9 +371,9 @@ class Scheduler {
 	 */
 	public static function handle_outbox_purge_days_update( $old_value, $value ) {
 		if ( 0 === (int) $value ) {
-			wp_clear_scheduled_hook( 'activitypub_outbox_purge' );
-		} elseif ( ! wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
-			wp_schedule_event( time(), 'daily', 'activitypub_outbox_purge' );
+			\wp_clear_scheduled_hook( 'activitypub_outbox_purge' );
+		} elseif ( ! \wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
+			\wp_schedule_event( \time(), 'daily', 'activitypub_outbox_purge' );
 		}
 	}
 
@@ -385,9 +385,9 @@ class Scheduler {
 	 */
 	public static function handle_inbox_purge_days_update( $old_value, $value ) {
 		if ( 0 === (int) $value ) {
-			wp_clear_scheduled_hook( 'activitypub_inbox_purge' );
-		} elseif ( ! wp_next_scheduled( 'activitypub_inbox_purge' ) ) {
-			wp_schedule_event( time(), 'daily', 'activitypub_inbox_purge' );
+			\wp_clear_scheduled_hook( 'activitypub_inbox_purge' );
+		} elseif ( ! \wp_next_scheduled( 'activitypub_inbox_purge' ) ) {
+			\wp_schedule_event( \time(), 'daily', 'activitypub_inbox_purge' );
 		}
 	}
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -10,6 +10,7 @@ namespace Activitypub;
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
+use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Scheduler\Actor;
@@ -44,11 +45,13 @@ class Scheduler {
 		\add_action( 'activitypub_async_batch', array( self::class, 'async_batch' ), 10, 99 );
 		\add_action( 'activitypub_reprocess_outbox', array( self::class, 'reprocess_outbox' ) );
 		\add_action( 'activitypub_outbox_purge', array( self::class, 'purge_outbox' ) );
+		\add_action( 'activitypub_inbox_purge', array( self::class, 'purge_inbox' ) );
 
 		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'schedule_outbox_activity_for_federation' ) );
 		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'schedule_announce_activity' ), 10, 4 );
 
 		\add_action( 'update_option_activitypub_outbox_purge_days', array( self::class, 'handle_outbox_purge_days_update' ), 10, 2 );
+		\add_action( 'update_option_activitypub_inbox_purge_days', array( self::class, 'handle_inbox_purge_days_update' ), 10, 2 );
 	}
 
 	/**
@@ -64,7 +67,7 @@ class Scheduler {
 		 *
 		 * @since 5.0.0
 		 */
-		do_action( 'activitypub_register_schedulers' );
+		\do_action( 'activitypub_register_schedulers' );
 	}
 
 	/**
@@ -108,6 +111,10 @@ class Scheduler {
 		if ( ! wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
 			wp_schedule_event( time(), 'daily', 'activitypub_outbox_purge' );
 		}
+
+		if ( ! wp_next_scheduled( 'activitypub_inbox_purge' ) ) {
+			wp_schedule_event( time(), 'daily', 'activitypub_inbox_purge' );
+		}
 	}
 
 	/**
@@ -120,6 +127,7 @@ class Scheduler {
 		wp_unschedule_hook( 'activitypub_cleanup_remote_actors' );
 		wp_unschedule_hook( 'activitypub_reprocess_outbox' );
 		wp_unschedule_hook( 'activitypub_outbox_purge' );
+		wp_unschedule_hook( 'activitypub_inbox_purge' );
 	}
 
 	/**
@@ -322,6 +330,40 @@ class Scheduler {
 	}
 
 	/**
+	 * Purge inbox items based on a schedule.
+	 */
+	public static function purge_inbox() {
+		$total_posts = (int) wp_count_posts( Inbox::POST_TYPE )->publish;
+		if ( $total_posts <= 200 ) {
+			return;
+		}
+
+		$days     = (int) get_option( 'activitypub_inbox_purge_days', 360 );
+		$timezone = new \DateTimeZone( 'UTC' );
+		$date     = new \DateTime( 'now', $timezone );
+
+		$date->sub( \DateInterval::createFromDateString( "$days days" ) );
+
+		$post_ids = \get_posts(
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'any',
+				'fields'      => 'ids',
+				'numberposts' => -1,
+				'date_query'  => array(
+					array(
+						'before' => $date->format( 'Y-m-d' ),
+					),
+				),
+			)
+		);
+
+		foreach ( $post_ids as $post_id ) {
+			\wp_delete_post( $post_id, true );
+		}
+	}
+
+	/**
 	 * Update schedules when outbox purge days settings change.
 	 *
 	 * @param int $old_value The old value.
@@ -332,6 +374,20 @@ class Scheduler {
 			wp_clear_scheduled_hook( 'activitypub_outbox_purge' );
 		} elseif ( ! wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
 			wp_schedule_event( time(), 'daily', 'activitypub_outbox_purge' );
+		}
+	}
+
+	/**
+	 * Update schedules when inbox purge days settings change.
+	 *
+	 * @param int $old_value The old value.
+	 * @param int $value     The new value.
+	 */
+	public static function handle_inbox_purge_days_update( $old_value, $value ) {
+		if ( 0 === (int) $value ) {
+			wp_clear_scheduled_hook( 'activitypub_inbox_purge' );
+		} elseif ( ! wp_next_scheduled( 'activitypub_inbox_purge' ) ) {
+			wp_schedule_event( time(), 'daily', 'activitypub_inbox_purge' );
 		}
 	}
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -338,7 +338,7 @@ class Scheduler {
 			return;
 		}
 
-		$days     = (int) get_option( 'activitypub_inbox_purge_days', 360 );
+		$days     = (int) get_option( 'activitypub_inbox_purge_days', 180 );
 		$timezone = new \DateTimeZone( 'UTC' );
 		$date     = new \DateTime( 'now', $timezone );
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -339,11 +339,6 @@ class Scheduler {
 		}
 
 		$days     = (int) get_option( 'activitypub_inbox_purge_days', 180 );
-		$timezone = new \DateTimeZone( 'UTC' );
-		$date     = new \DateTime( 'now', $timezone );
-
-		$date->sub( \DateInterval::createFromDateString( "$days days" ) );
-
 		$post_ids = \get_posts(
 			array(
 				'post_type'   => Inbox::POST_TYPE,
@@ -352,7 +347,7 @@ class Scheduler {
 				'numberposts' => -1,
 				'date_query'  => array(
 					array(
-						'before' => $date->format( 'Y-m-d' ),
+						'before' => gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
 					),
 				),
 			)

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -30,24 +30,6 @@ class Advanced_Settings_Fields {
 			'activitypub_advanced_settings'
 		);
 
-		\add_settings_field(
-			'activitypub_outbox_purge_days',
-			\__( 'Outbox Retention Period', 'activitypub' ),
-			array( self::class, 'render_outbox_purge_days_field' ),
-			'activitypub_advanced_settings',
-			'activitypub_advanced_settings',
-			array( 'label_for' => 'activitypub_outbox_purge_days' )
-		);
-
-		\add_settings_field(
-			'activitypub_inbox_purge_days',
-			\__( 'Inbox Retention Period', 'activitypub' ),
-			array( self::class, 'render_inbox_purge_days_field' ),
-			'activitypub_advanced_settings',
-			'activitypub_advanced_settings',
-			array( 'label_for' => 'activitypub_inbox_purge_days' )
-		);
-
 		if ( ! defined( 'ACTIVITYPUB_SEND_VARY_HEADER' ) ) {
 			\add_settings_field(
 				'activitypub_vary_header',
@@ -144,46 +126,6 @@ class Advanced_Settings_Fields {
 			?>
 		</p>
 		<?php
-	}
-
-	/**
-	 * Render outbox purge days field.
-	 */
-	public static function render_outbox_purge_days_field() {
-		$value = \get_option( 'activitypub_outbox_purge_days', 180 );
-		echo '<input type="number" id="activitypub_outbox_purge_days" name="activitypub_outbox_purge_days" value="' . esc_attr( $value ) . '" class="small-text" min="0" max="365" />';
-		echo '<p class="description">' . \wp_kses(
-			sprintf(
-				// translators: 1: Definition of Outbox; 2: Default value (180).
-				\__( 'Maximum number of days to keep items in the <abbr title="%1$s">Outbox</abbr>. A lower value might be better for sites with lots of activity to maintain site performance. Default: <code>%2$s</code>', 'activitypub' ),
-				\esc_attr__( 'A virtual location on a user&#8217;s profile where all the activities (posts, likes, replies) they publish are stored, acting as a feed that other users can access to see their publicly shared content', 'activitypub' ),
-				\esc_html( 180 )
-			),
-			array(
-				'abbr' => array( 'title' => array() ),
-				'code' => array(),
-			)
-		) . '</p>';
-	}
-
-	/**
-	 * Render inbox purge days field.
-	 */
-	public static function render_inbox_purge_days_field() {
-		$value = \get_option( 'activitypub_inbox_purge_days', 180 );
-		echo '<input type="number" id="activitypub_inbox_purge_days" name="activitypub_inbox_purge_days" value="' . esc_attr( $value ) . '" class="small-text" min="0" max="365" />';
-		echo '<p class="description">' . \wp_kses(
-			sprintf(
-				// translators: 1: Definition of Inbox; 2: Default value (180).
-				\__( 'Maximum number of days to keep items in the <abbr title="%1$s">Inbox</abbr>. A lower value might be better for sites with lots of activity to maintain site performance. Default: <code>%2$s</code>', 'activitypub' ),
-				\esc_attr__( 'A virtual mailbox where a user receives all incoming activities (posts, likes, follows, replies) from other users across the Fediverse, allowing them to see and interact with content directed at them', 'activitypub' ),
-				\esc_html( 180 )
-			),
-			array(
-				'abbr' => array( 'title' => array() ),
-				'code' => array(),
-			)
-		) . '</p>';
 	}
 
 	/**

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -170,14 +170,14 @@ class Advanced_Settings_Fields {
 	 * Render inbox purge days field.
 	 */
 	public static function render_inbox_purge_days_field() {
-		$value = \get_option( 'activitypub_inbox_purge_days', 360 );
+		$value = \get_option( 'activitypub_inbox_purge_days', 180 );
 		echo '<input type="number" id="activitypub_inbox_purge_days" name="activitypub_inbox_purge_days" value="' . esc_attr( $value ) . '" class="small-text" min="0" max="365" />';
 		echo '<p class="description">' . \wp_kses(
 			sprintf(
-				// translators: 1: Definition of Inbox; 2: Default value (360).
+				// translators: 1: Definition of Inbox; 2: Default value (180).
 				\__( 'Maximum number of days to keep items in the <abbr title="%1$s">Inbox</abbr>. A lower value might be better for sites with lots of activity to maintain site performance. Default: <code>%2$s</code>', 'activitypub' ),
 				\esc_attr__( 'A virtual mailbox where a user receives all incoming activities (posts, likes, follows, replies) from other users across the Fediverse, allowing them to see and interact with content directed at them', 'activitypub' ),
-				\esc_html( 360 )
+				\esc_html( 180 )
 			),
 			array(
 				'abbr' => array( 'title' => array() ),

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -39,6 +39,15 @@ class Advanced_Settings_Fields {
 			array( 'label_for' => 'activitypub_outbox_purge_days' )
 		);
 
+		\add_settings_field(
+			'activitypub_inbox_purge_days',
+			\__( 'Inbox Retention Period', 'activitypub' ),
+			array( self::class, 'render_inbox_purge_days_field' ),
+			'activitypub_advanced_settings',
+			'activitypub_advanced_settings',
+			array( 'label_for' => 'activitypub_inbox_purge_days' )
+		);
+
 		if ( ! defined( 'ACTIVITYPUB_SEND_VARY_HEADER' ) ) {
 			\add_settings_field(
 				'activitypub_vary_header',
@@ -149,6 +158,26 @@ class Advanced_Settings_Fields {
 				\__( 'Maximum number of days to keep items in the <abbr title="%1$s">Outbox</abbr>. A lower value might be better for sites with lots of activity to maintain site performance. Default: <code>%2$s</code>', 'activitypub' ),
 				\esc_attr__( 'A virtual location on a user&#8217;s profile where all the activities (posts, likes, replies) they publish are stored, acting as a feed that other users can access to see their publicly shared content', 'activitypub' ),
 				\esc_html( 180 )
+			),
+			array(
+				'abbr' => array( 'title' => array() ),
+				'code' => array(),
+			)
+		) . '</p>';
+	}
+
+	/**
+	 * Render inbox purge days field.
+	 */
+	public static function render_inbox_purge_days_field() {
+		$value = \get_option( 'activitypub_inbox_purge_days', 360 );
+		echo '<input type="number" id="activitypub_inbox_purge_days" name="activitypub_inbox_purge_days" value="' . esc_attr( $value ) . '" class="small-text" min="0" max="365" />';
+		echo '<p class="description">' . \wp_kses(
+			sprintf(
+				// translators: 1: Definition of Inbox; 2: Default value (360).
+				\__( 'Maximum number of days to keep items in the <abbr title="%1$s">Inbox</abbr>. A lower value might be better for sites with lots of activity to maintain site performance. Default: <code>%2$s</code>', 'activitypub' ),
+				\esc_attr__( 'A virtual mailbox where a user receives all incoming activities (posts, likes, follows, replies) from other users across the Fediverse, allowing them to see and interact with content directed at them', 'activitypub' ),
+				\esc_html( 360 )
 			),
 			array(
 				'abbr' => array( 'title' => array() ),

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -178,6 +178,16 @@ class Settings {
 
 		\register_setting(
 			'activitypub_advanced',
+			'activitypub_inbox_purge_days',
+			array(
+				'type'        => 'integer',
+				'description' => \__( 'Number of days to keep items in the Inbox.', 'activitypub' ),
+				'default'     => 360,
+			)
+		);
+
+		\register_setting(
+			'activitypub_advanced',
 			'activitypub_vary_header',
 			array(
 				'type'        => 'boolean',

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -182,7 +182,7 @@ class Settings {
 			array(
 				'type'        => 'integer',
 				'description' => \__( 'Number of days to keep items in the Inbox.', 'activitypub' ),
-				'default'     => 360,
+				'default'     => 180,
 			)
 		);
 

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -631,14 +631,14 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			2
 		);
 
-		// Run purge_inbox with default days (360).
+		// Run purge_inbox with default days (180).
 		Scheduler::purge_inbox();
 		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
 		// Remove filter before checking actual count.
 		remove_all_filters( 'wp_count_posts' );
 
-		// Verify posts are not deleted (2 months < 360 days).
+		// Verify posts are not deleted (2 months < 180 days).
 		$this->assertEquals( 25, wp_count_posts( Inbox::POST_TYPE )->publish );
 
 		// Change the purge days option to 30 days.

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -10,6 +10,7 @@ namespace Activitypub\Tests;
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
+use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Comment;
@@ -512,6 +513,159 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		wp_delete_post( $outbox_activity_id, true );
 		wp_delete_post( $announce_outbox_id, true );
 		remove_all_filters( 'schedule_event' );
+	}
+
+	/**
+	 * Test purge_inbox method with more than 200 posts.
+	 *
+	 * @covers ::purge_inbox
+	 */
+	public function test_purge_inbox_more_than_200_posts() {
+		// Create 25 posts, 5 older than 1 year.
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'meta_input'  => array(
+					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Follow',
+				),
+			)
+		);
+		self::factory()->post->create_many(
+			5,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-13 months' ) ),
+				'meta_input'  => array(
+					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Follow',
+				),
+			)
+		);
+
+		// Mock the count to exceed the 200-post threshold.
+		add_filter(
+			'wp_count_posts',
+			function ( $counts, $type ) {
+				if ( Inbox::POST_TYPE === $type ) {
+					$counts->publish = 225;
+				}
+				return $counts;
+			},
+			10,
+			2
+		);
+
+		Scheduler::purge_inbox();
+		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+
+		// Assert that 5 posts were deleted, leaving 20.
+		$actual_count = get_posts(
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+		$this->assertEquals( 20, count( $actual_count ) );
+
+		// Clean up filter.
+		remove_all_filters( 'wp_count_posts' );
+	}
+
+	/**
+	 * Test purge_inbox method with 200 or fewer posts.
+	 *
+	 * @covers ::purge_inbox
+	 */
+	public function test_purge_inbox_200_or_fewer_posts() {
+		// Create 20 posts, all older than 1 year.
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-13 months' ) ),
+			)
+		);
+
+		Scheduler::purge_inbox();
+		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+
+		// Assert that no posts were deleted.
+		$this->assertEquals( 20, wp_count_posts( Inbox::POST_TYPE )->publish );
+	}
+
+	/**
+	 * Test purge_inbox method with changing activitypub_inbox_purge_days option.
+	 *
+	 * @covers ::purge_inbox
+	 */
+	public function test_purge_inbox_with_different_purge_days() {
+		// Create posts older than 2 months.
+		self::factory()->post->create_many(
+			25,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-2 months' ) ),
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Follow',
+				),
+			)
+		);
+
+		// Mock the count to exceed the 200-post threshold.
+		add_filter(
+			'wp_count_posts',
+			function ( $counts, $type ) {
+				if ( Inbox::POST_TYPE === $type ) {
+					$counts->publish = 225;
+				}
+				return $counts;
+			},
+			10,
+			2
+		);
+
+		// Run purge_inbox with default days (360).
+		Scheduler::purge_inbox();
+		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+
+		// Remove filter before checking actual count.
+		remove_all_filters( 'wp_count_posts' );
+
+		// Verify posts are not deleted (2 months < 360 days).
+		$this->assertEquals( 25, wp_count_posts( Inbox::POST_TYPE )->publish );
+
+		// Change the purge days option to 30 days.
+		update_option( 'activitypub_inbox_purge_days', 30 );
+
+		// Re-add the mock filter for the second purge run.
+		add_filter(
+			'wp_count_posts',
+			function ( $counts, $type ) {
+				if ( Inbox::POST_TYPE === $type ) {
+					$counts->publish = 225;
+				}
+				return $counts;
+			},
+			10,
+			2
+		);
+
+		// Run purge_inbox with changed days.
+		Scheduler::purge_inbox();
+		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+
+		// Remove filter before checking actual count.
+		remove_all_filters( 'wp_count_posts' );
+
+		// Verify posts are deleted (2 months > 30 days).
+		$this->assertEquals( 0, wp_count_posts( Inbox::POST_TYPE )->publish );
 	}
 
 	/**


### PR DESCRIPTION
Introduces a scheduled task to purge old inbox items, similar to the existing outbox purge. Adds an advanced setting for configuring the inbox retention period, including UI and option registration. Ensures site performance by allowing administrators to control how long inbox items are kept.

## Proposed changes:
- Adds a new advanced setting for configuring inbox retention period (default 360 days)
- Implements a daily scheduled task to automatically purge old inbox items
- Provides UI for administrators to control the inbox retention setting

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See unittests

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added a scheduled task and setting to automatically purge old inbox items, helping maintain site performance and storage control.

</details>
