### PR TITLE
Improve quote notification email with post references

### DIFF
--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -424,11 +424,19 @@ class Mailer {
 			return;
 		}
 
+		// Try to get the quoted post title.
+		$quoted_title = null;
+		$post_id      = \url_to_postid( $quoted_url );
+		if ( $post_id ) {
+			$quoted_title = \get_the_title( $post_id );
+		}
+
 		$template_args = array(
-			'activity'   => $activity,
-			'actor'      => $actor,
-			'user_id'    => $user_id,
-			'quoted_url' => $quoted_url,
+			'activity'     => $activity,
+			'actor'        => $actor,
+			'user_id'      => $user_id,
+			'quoted_url'   => $quoted_url,
+			'quoted_title' => $quoted_title,
 		);
 
 		/* translators: 1: Blog name, 2: Actor name */

--- a/templates/emails/new-quote.php
+++ b/templates/emails/new-quote.php
@@ -12,6 +12,28 @@ use function Activitypub\site_supports_blocks;
 /* @var array $args Template arguments. */
 $args = wp_parse_args( $args ?? array() );
 
+// For QuoteRequest activities, the instrument contains the quote post URL.
+$quote_object = $args['activity']['instrument'] ?? $args['activity']['object'];
+
+$comment_author = esc_html( $args['actor']['webfinger'] );
+if ( ! empty( $args['actor']['url'] ) ) {
+	$comment_author = sprintf( '<a href="%s">%s</a>', esc_url( $args['actor']['url'] ), esc_html( $args['actor']['webfinger'] ) );
+}
+
+/* translators: %s: The name of the person who quoted the post. */
+$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %s just shared one of your posts.', 'activitypub' );
+
+// Determine the message based on available data.
+if ( ! empty( $args['quoted_url'] ) ) {
+	if ( ! empty( $args['quoted_title'] ) ) {
+		/* translators: 1: actor name/link, 2: quoted post URL, 3: quoted post title */
+		$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">%3$s</a>.', 'activitypub' );
+	} else {
+		/* translators: 1: actor name/link, 2: quoted post URL */
+		$message = __( 'Looks like one of your posts caught someone&#8217;s attention! %1$s just shared <a href="%2$s">your post</a>.', 'activitypub' );
+	}
+}
+
 // Load header.
 require __DIR__ . '/parts/header.php';
 ?>
@@ -20,20 +42,23 @@ require __DIR__ . '/parts/header.php';
 
 <p>
 	<?php
-	/* translators: %s: The name of the person who quoted the post. */
-	$message = __( 'Your post was shared by %s on the Fediverse. Here&#8217;s what they said:', 'activitypub' );
-
-	printf( esc_html( $message ), '<a href="' . esc_url( $args['actor']['url'] ) . '">' . esc_html( $args['actor']['webfinger'] ) . '</a>' );
+	printf(
+		wp_kses( $message, array( 'a' => array( 'href' => array() ) ) ),
+		wp_kses( $comment_author, array( 'a' => array( 'href' => array() ) ) ),
+		esc_url( $args['quoted_url'] ),
+		esc_html( $args['quoted_title'] )
+	);
 	?>
 </p>
 
 <?php
-// For QuoteRequest activities, the instrument contains the quote post URL.
-$quote_object = $args['activity']['instrument'] ?? $args['activity']['object'];
 
 // Only show embed if we have a valid object (not just a URL string).
 if ( is_array( $quote_object ) ) :
 	?>
+	<p>
+		<strong><?php esc_html_e( 'Here&#8217;s what they said:', 'activitypub' ); ?></strong>
+	</p>
 	<div class="embed">
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
## Proposed changes:
* Adds reference to the quoted post in the intro paragraph
* Displays post title when available, with fallback to "your post"
* Moves "Here's what they said" to only show when there's an embed object
* Adds playful "Looks like your post caught someone's attention!" opening
* Retrieves and passes quoted post title from Mailer class

## Testing instructions:

* Test the email template with various scenarios:
  * Quote with post title available
  * Quote without post title (should show "your post")
  * Quote without any URL data