### PR TITLE
Add fallback to trigger create on update failure

### DIFF
--- a/.github/changelog/2328-from-description
+++ b/.github/changelog/2328-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added fallback to trigger create handling when updates fail for missing posts or comments, ensuring objects are properly created.

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -84,8 +84,8 @@ class Posts {
 
 		if ( ! $post_id ) {
 			return new \WP_Error(
-				'activitypub_object_not_found',
-				\__( 'Object not found', 'activitypub' ),
+				'activitypub_post_not_found',
+				\__( 'Post not found', 'activitypub' ),
 				array( 'status' => 404 )
 			);
 		}


### PR DESCRIPTION
Update handling now triggers the 'activitypub_inbox_create' action if an update fails due to a missing post or comment. This ensures that create logic is invoked for objects not found during update requests. Includes a new test to verify the fallback behavior.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The ActivityPub update handler was modified to add a fallback mechanism.
* If an "Update" activity fails (e.g., the actor cannot be found or updated), the handler now triggers the activitypub_inbox_create action as a fallback.
* This ensures that "Create" logic is executed when "Update" cannot be processed, improving robustness and compatibility.
* New tests were added to verify that the fallback (activitypub_inbox_create) is triggered correctly when an update fails.
* The tests simulate update failures and check that the fallback action is called.
* Indentation and formatting were improved in the test file to comply with coding standards.

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Added fallback to trigger create handling when updates fail for missing posts or comments, ensuring objects are properly created.

</details>
