### PR TITLE
Update hashtag escaping to use slugs and improve tests

### DIFF
--- a/.github/changelog/2352-from-description
+++ b/.github/changelog/2352-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved hashtag encoding for consistent formatting.

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -62,7 +62,7 @@ class Shortcodes {
 			$hash_tags[] = \sprintf(
 				'<a rel="tag" class="hashtag u-tag u-category" href="%s">%s</a>',
 				\esc_url( \get_tag_link( $tag ) ),
-				esc_hashtag( $tag->name )
+				esc_hashtag( $tag->slug )
 			);
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -266,12 +266,12 @@ function snake_to_camel_case( $input ) {
 function esc_hashtag( $input ) {
 
 	$hashtag = \wp_specialchars_decode( $input, ENT_QUOTES );
-	// Remove all characters that are not letters, numbers, or underscores.
-	$hashtag = \preg_replace( '/emoji-regex(*SKIP)(?!)|[^\p{L}\p{Nd}_]+/u', '_', $hashtag );
+	// Remove all characters that are not letters, numbers, or hyphens.
+	$hashtag = \preg_replace( '/emoji-regex(*SKIP)(?!)|[^\p{L}\p{Nd}-]+/u', '-', $hashtag );
 
-	// Capitalize every letter that is preceded by an underscore.
+	// Capitalize every letter that is preceded by a hyphen.
 	$hashtag = preg_replace_callback(
-		'/_(.)/',
+		'/-+(.)/',
 		function ( $matches ) {
 			return strtoupper( $matches[1] );
 		},
@@ -280,6 +280,7 @@ function esc_hashtag( $input ) {
 
 	// Add a hashtag to the beginning of the string.
 	$hashtag = ltrim( $hashtag, '#' );
+	$hashtag = trim( $hashtag, '-' );
 	$hashtag = '#' . $hashtag;
 
 	/**

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -510,7 +510,7 @@ class Blog extends Actor {
 			$hashtags[] = array(
 				'type' => 'Hashtag',
 				'href' => \get_tag_link( $tag->term_id ),
-				'name' => esc_hashtag( $tag->name ),
+				'name' => esc_hashtag( $tag->slug ),
 			);
 		}
 

--- a/includes/rest/class-collections-controller.php
+++ b/includes/rest/class-collections-controller.php
@@ -140,7 +140,7 @@ class Collections_Controller extends Actors_Controller {
 			$response['items'][] = array(
 				'type' => 'Hashtag',
 				'href' => \esc_url( \get_tag_link( $tag ) ),
-				'name' => esc_hashtag( $tag->name ),
+				'name' => esc_hashtag( $tag->slug ),
 			);
 		}
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -443,7 +443,7 @@ class Post extends Base {
 				$tags[] = array(
 					'type' => 'Hashtag',
 					'href' => \esc_url( \get_tag_link( $post_tag->term_id ) ),
-					'name' => esc_hashtag( $post_tag->name ),
+					'name' => esc_hashtag( $post_tag->slug ),
 				);
 			}
 		}


### PR DESCRIPTION
Changed hashtag generation to use tag slugs instead of names for consistency across shortcodes, models, REST controllers, and transformers. Improved esc_hashtag to handle hyphens, capitalization, and trimming, and added comprehensive PHPUnit tests for hashtag escaping, including edge cases and filter hooks.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #https://wordpress.org/support/topic/wordpress-mastodon-display-name-not-valid/

## Proposed changes:
- Updated `esc_hashtag()` to use hyphens instead of underscores as word separators and trim leading/trailing hyphens
- Changed all hashtag generation points to use `$tag->slug` instead of `$tag->name`
- Added 118 lines of PHPUnit tests covering edge cases, Unicode support, and filter hooks

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use normalized and properly encoded `slug` instead of `name`
* Improve hashtag generation

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Improved hashtag encoding for consistent formatting.

</details>
