### PR TITLE
Require Shared-Inbox

### DIFF
--- a/.github/changelog/2359-from-description
+++ b/.github/changelog/2359-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Simplified configuration by always enabling the shared inbox and removing its separate setting, UI field, and related logic.

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -18,7 +18,6 @@ class Options {
 	public static function init() {
 		\add_filter( 'pre_option_activitypub_actor_mode', array( self::class, 'pre_option_activitypub_actor_mode' ) );
 		\add_filter( 'pre_option_activitypub_authorized_fetch', array( self::class, 'pre_option_activitypub_authorized_fetch' ) );
-		\add_filter( 'pre_option_activitypub_shared_inbox', array( self::class, 'pre_option_activitypub_shared_inbox' ) );
 		\add_filter( 'pre_option_activitypub_vary_header', array( self::class, 'pre_option_activitypub_vary_header' ) );
 
 		\add_filter( 'pre_option_activitypub_allow_likes', array( self::class, 'maybe_disable_interactions' ) );
@@ -76,25 +75,6 @@ class Options {
 		}
 
 		if ( ACTIVITYPUB_AUTHORIZED_FETCH ) {
-			return '1';
-		}
-
-		return '0';
-	}
-
-	/**
-	 * Pre-get option filter for the Shared Inbox.
-	 *
-	 * @param string $pre The pre-get option value.
-	 *
-	 * @return string If the constant is defined, return the value, otherwise return the pre-get option value.
-	 */
-	public static function pre_option_activitypub_shared_inbox( $pre ) {
-		if ( ! \defined( 'ACTIVITYPUB_SHARED_INBOX_FEATURE' ) ) {
-			return $pre;
-		}
-
-		if ( ACTIVITYPUB_SHARED_INBOX_FEATURE ) {
 			return '1';
 		}
 

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -391,15 +391,9 @@ class Blog extends Actor {
 	 * @return string[]|null The endpoints.
 	 */
 	public function get_endpoints() {
-		$endpoints = null;
-
-		if ( \get_option( 'activitypub_shared_inbox' ) ) {
-			$endpoints = array(
-				'sharedInbox' => get_rest_url_by_path( 'inbox' ),
-			);
-		}
-
-		return $endpoints;
+		return array(
+			'sharedInbox' => get_rest_url_by_path( 'inbox' ),
+		);
 	}
 
 	/**

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -317,15 +317,9 @@ class User extends Actor {
 	 * @return string[]|null The endpoints.
 	 */
 	public function get_endpoints() {
-		$endpoints = null;
-
-		if ( \get_option( 'activitypub_shared_inbox' ) ) {
-			$endpoints = array(
-				'sharedInbox' => get_rest_url_by_path( 'inbox' ),
-			);
-		}
-
-		return $endpoints;
+		return array(
+			'sharedInbox' => get_rest_url_by_path( 'inbox' ),
+		);
 	}
 
 	/**

--- a/includes/wp-admin/class-advanced-settings-fields.php
+++ b/includes/wp-admin/class-advanced-settings-fields.php
@@ -79,17 +79,6 @@ class Advanced_Settings_Fields {
 			array( 'label_for' => 'activitypub_following_ui' )
 		);
 
-		if ( ! defined( 'ACTIVITYPUB_SHARED_INBOX_FEATURE' ) ) {
-			\add_settings_field(
-				'activitypub_shared_inbox',
-				\__( 'Shared Inbox (beta)', 'activitypub' ),
-				array( self::class, 'render_shared_inbox_field' ),
-				'activitypub_advanced_settings',
-				'activitypub_advanced_settings',
-				array( 'label_for' => 'activitypub_shared_inbox' )
-			);
-		}
-
 		\add_settings_field(
 			'activitypub_persist_inbox',
 			\__( 'Inbox', 'activitypub' ),
@@ -220,24 +209,6 @@ class Advanced_Settings_Fields {
 		</p>
 		<p class="description">
 			⚠ A reader interface is not available yet. Please follow accounts sparingly—you won't be able to see their posts or shares. This feature is intended for testing the follow functionality. Once fully implemented, it will be enabled by default.
-		</p>
-		<?php
-	}
-
-	/**
-	 * Render shared inbox field.
-	 */
-	public static function render_shared_inbox_field() {
-		$value = \get_option( 'activitypub_shared_inbox', '0' );
-		?>
-		<p>
-			<label>
-				<input type="checkbox" id="activitypub_shared_inbox" name="activitypub_shared_inbox" value="1" <?php checked( '1', $value ); ?> />
-				<?php \esc_html_e( 'Use a shared inbox for incoming messages.', 'activitypub' ); ?>
-			</label>
-		</p>
-		<p class="description">
-			<?php \esc_html_e( 'Allows your site to handle incoming ActivityPub messages more efficiently, especially helpful for busy or multi-user sites. This feature is still in beta and may encounter issues.', 'activitypub' ); ?>
 		</p>
 		<?php
 	}

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -355,12 +355,6 @@ class Health_Check {
 			'private' => false,
 		);
 
-		$info['activitypub']['fields']['shared_inbox'] = array(
-			'label'   => \__( 'Shared Inbox', 'activitypub' ),
-			'value'   => \esc_attr( (int) \get_option( 'activitypub_shared_inbox', '0' ) ),
-			'private' => false,
-		);
-
 		$constants = get_defined_constants( true );
 
 		if ( ! isset( $constants['user'] ) ) {

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -248,16 +248,6 @@ class Settings {
 
 		\register_setting(
 			'activitypub_advanced',
-			'activitypub_shared_inbox',
-			array(
-				'type'        => 'boolean',
-				'description' => \__( 'Enable the shared inbox.', 'activitypub' ),
-				'default'     => false,
-			)
-		);
-
-		\register_setting(
-			'activitypub_advanced',
 			'activitypub_persist_inbox',
 			array(
 				'type'        => 'boolean',


### PR DESCRIPTION
The Shared-Inbox is essential for the work on the Reader and helps deduplicating Activities.

Eliminates the shared inbox option, its settings field, health check display, and associated logic. The shared inbox endpoint is now always provided, simplifying configuration and code maintenance.

## Proposed changes:
- Removed the `activitypub_shared_inbox` setting registration and its associated UI field
- Simplified `get_endpoints()` methods to always return the shared inbox endpoint
- Removed constant-based feature flag handling for `ACTIVITYPUB_SHARED_INBOX_FEATURE`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Simplified configuration by always enabling the shared inbox and removing its separate setting, UI field, and related logic.

</details>
