### PR TITLE
Fix logic errors in Move handler

### DIFF
--- a/.github/changelog/2362-from-description
+++ b/.github/changelog/2362-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix logic errors in Move handler: remove redundant assignment and fix variable name collision.

--- a/includes/handler/class-move.php
+++ b/includes/handler/class-move.php
@@ -57,10 +57,7 @@ class Move {
 		$result        = null;
 		$success       = false;
 
-		/*
-		 * If the new target is followed, but the origin is not,
-		 * everything is fine, so we can return.
-		 */
+		// If the origin is followed but the target is not, update the origin to point to the target.
 		if ( \is_wp_error( $target_object ) && ! \is_wp_error( $origin_object ) ) {
 			global $wpdb;
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
@@ -77,6 +74,7 @@ class Move {
 			$result  = Remote_Actors::upsert( $target_json );
 		}
 
+		// If both the target and origin are followed, merge them.
 		if ( ! \is_wp_error( $target_object ) && ! \is_wp_error( $origin_object ) ) {
 			$origin_users = \get_post_meta( $origin_object->ID, Followers::FOLLOWER_META_KEY, false );
 			$target_users = \get_post_meta( $target_object->ID, Followers::FOLLOWER_META_KEY, false );

--- a/includes/handler/class-move.php
+++ b/includes/handler/class-move.php
@@ -61,9 +61,7 @@ class Move {
 		 * If the new target is followed, but the origin is not,
 		 * everything is fine, so we can return.
 		 */
-		if ( ! \is_wp_error( $target_object ) && \is_wp_error( $origin_object ) ) {
-			$success = false;
-		} elseif ( \is_wp_error( $target_object ) && ! \is_wp_error( $origin_object ) ) {
+		if ( \is_wp_error( $target_object ) && ! \is_wp_error( $origin_object ) ) {
 			global $wpdb;
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$wpdb->update(
@@ -77,15 +75,17 @@ class Move {
 
 			$success = true;
 			$result  = Remote_Actors::upsert( $target_json );
-		} elseif ( ! \is_wp_error( $target_object ) && ! \is_wp_error( $origin_object ) ) {
+		}
+
+		if ( ! \is_wp_error( $target_object ) && ! \is_wp_error( $origin_object ) ) {
 			$origin_users = \get_post_meta( $origin_object->ID, Followers::FOLLOWER_META_KEY, false );
 			$target_users = \get_post_meta( $target_object->ID, Followers::FOLLOWER_META_KEY, false );
 
 			// Get all user ids from $origin_users that are not in $target_users.
 			$users = \array_diff( $origin_users, $target_users );
 
-			foreach ( $users as $user_id ) {
-				\add_post_meta( $target_object->ID, Followers::FOLLOWER_META_KEY, $user_id );
+			foreach ( $users as $follower_user_id ) {
+				\add_post_meta( $target_object->ID, Followers::FOLLOWER_META_KEY, $follower_user_id );
 			}
 
 			$success = true;


### PR DESCRIPTION
Fixes #

## Proposed changes:

This PR fixes two logic errors in the `Move::handle_move` method that were identified by IDE analysis:

1. **Removed redundant variable assignment and empty if statement**
   - The empty if block was setting `$success = false`, which was already its initial value
   - This also caused a phpcs error: `Generic.CodeAnalysis.EmptyStatement.DetectedIf`
   - Restructured the if-elseif chain into two separate if blocks

2. **Fixed variable name collision in foreach loop**
   - Changed loop variable from `$user_id` to `$follower_user_id` to avoid overwriting the function parameter

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Run the test suite: `npm run env-test`
2. All tests should pass, including the new test case `test_handle_move_with_existing_target_but_missing_origin`
3. Run linting: `composer lint`
4. No phpcs errors should be reported

The new test specifically covers the scenario where the target profile is already followed but the origin profile is not, ensuring the refactored code maintains correct behavior.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed - for any bug fixes

#### Message

Fix logic errors in Move handler: remove redundant assignment and fix variable name collision.

</details>