### PR TITLE
Fix add_follower CLI command to properly handle --user global flag

### DIFF
--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -25,11 +25,11 @@ class Cli extends \WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <actor_url>
-	 *     The URL of the actor to add as a follower.
+	 * <actor>
+	 *     The URL or Webfinger of the actor to add as a follower.
 	 *
-	 * [--user=<user>]
-	 *     The user to add the follower to. Defaults to the blog actor.
+	 * [--user=<id|login|email>]
+	 *     The WordPress user to add the follower to. Omit to add to blog actor.
 	 *     ---
 	 *     default: 0
 	 *     ---
@@ -37,10 +37,10 @@ class Cli extends \WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *    $ wp activitypub add_follower https://example.com/@user
-	 *    $ wp activitypub add_follower https://example.com/@user --user=1
+	 *    $ wp activitypub add_follower user@example.com --user=1
 	 *    $ wp --user=pfefferle activitypub add_follower https://example.com/@user
 	 *
-	 * @synopsis <actor_url> [--user=<user>]
+	 * @synopsis <actor> [--user=<id|login|email>]
 	 *
 	 * @param array $args The arguments.
 	 */

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -7,7 +7,6 @@
 
 namespace Activitypub\Development;
 
-use Activitypub\Collection\Actors;
 use Activitypub\Collection\Followers;
 use Activitypub\Comment;
 
@@ -43,12 +42,11 @@ class Cli extends \WP_CLI_Command {
 	 *
 	 * @synopsis <actor_url> [--user=<user>]
 	 *
-	 * @param array $args       The arguments.
-	 * @param array $assoc_args The associative arguments.
+	 * @param array $args The arguments.
 	 */
-	public function add_follower( $args, $assoc_args ) {
+	public function add_follower( $args ) {
 		$actor_url = $args[0];
-		$user_id   = get_flag_value( $assoc_args, 'user', Actors::BLOG_USER_ID );
+		$user_id   = get_current_user_id();
 		\WP_CLI::log( sprintf( 'Adding follower %s to user %d...', $actor_url, $user_id ) );
 
 		$result = Followers::add( $user_id, $actor_url );


### PR DESCRIPTION
## Proposed changes:
* Fixed the `add_follower` CLI command to properly handle the `--user` global flag by using `get_current_user_id()` instead of manually parsing the flag
* Removed unused `Actors` import

The command was incorrectly trying to manually handle the `--user` flag through `$assoc_args`. Since `--user` is a WP-CLI global flag, it's automatically handled by WP-CLI which sets the current user context before command execution.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Run `wp activitypub add_follower https://example.com/@user --user=1`
2. Verify the follower is added to user ID 1
3. Run `wp --user=2 activitypub add_follower https://example.com/@another`
4. Verify the follower is added to user ID 2 (using the alternative global flag syntax)