### PR TITLE
Fix infinite recursion when storing remote actors with mentions

### DIFF
--- a/.github/changelog/2369-from-description
+++ b/.github/changelog/2369-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix infinite recursion when storing remote actors with mentions in their bios

--- a/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
+++ b/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Tests\Collection;
 
 use Activitypub\Collection\Remote_Actors;
+use Activitypub\Mention;
 
 /**
  * Class Test_Remote_Actors
@@ -881,7 +882,7 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 	 */
 	public function test_create_actor_with_self_mention_no_recursion() {
 		// Ensure the Mention filter is active to test for recursion.
-		\Activitypub\Mention::init();
+		Mention::init();
 
 		// Create an actor with a self-mention in their summary.
 		$actor = array(
@@ -898,44 +899,38 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 		);
 
 		// Mock webfinger to resolve the mention.
-		\add_filter(
-			'pre_http_request',
-			function ( $preempt, $parsed_args, $url ) use ( $actor ) {
-				if ( strpos( $url, '.well-known/webfinger' ) !== false ) {
-					return array(
-						'response' => array( 'code' => 200 ),
-						'body'     => wp_json_encode(
-							array(
-								'subject' => 'acct:selfmention@remote.example.com',
-								'links'   => array(
-									array(
-										'rel'  => 'self',
-										'type' => 'application/activity+json',
-										'href' => 'https://remote.example.com/actor/self-mention',
-									),
+		$webfinger_callback = function ( $preempt, $parsed_args, $url ) {
+			if ( strpos( $url, '.well-known/webfinger' ) !== false ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode(
+						array(
+							'subject' => 'acct:selfmention@remote.example.com',
+							'links'   => array(
+								array(
+									'rel'  => 'self',
+									'type' => 'application/activity+json',
+									'href' => 'https://remote.example.com/actor/self-mention',
 								),
-							)
-						),
-					);
-				}
-				return $preempt;
-			},
-			10,
-			3
-		);
+							),
+						)
+					),
+				);
+			}
+
+			return $preempt;
+		};
+		\add_filter( 'pre_http_request', $webfinger_callback, 10, 3 );
 
 		// Mock remote actor fetch to return the same actor (creating potential recursion).
-		\add_filter(
-			'activitypub_pre_http_get_remote_object',
-			function ( $pre, $url_or_object ) use ( $actor ) {
-				if ( $url_or_object === $actor['id'] ) {
-					return $actor;
-				}
-				return $pre;
-			},
-			10,
-			2
-		);
+		$actor_fetch_callback = function ( $pre, $url_or_object ) use ( $actor ) {
+			if ( $url_or_object === $actor['id'] ) {
+				return $actor;
+			}
+
+			return $pre;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $actor_fetch_callback, 10, 2 );
 
 		// This should not cause infinite recursion.
 		$post_id = Remote_Actors::create( $actor );
@@ -950,10 +945,12 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 		// Verify the summary was stored correctly (without being processed for mentions).
 		$this->assertStringContainsString( '@selfmention@remote.example.com', $post->post_excerpt );
 
-		// Clean up.
-		\remove_all_filters( 'pre_http_request' );
-		\remove_all_filters( 'activitypub_pre_http_get_remote_object' );
-		\remove_all_filters( 'activitypub_activity_object_array' );
+		// Clean up - remove only the specific filters we added.
+		\remove_filter( 'pre_http_request', $webfinger_callback );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $actor_fetch_callback );
+		\remove_filter( 'activitypub_activity_object_array', array( 'Activitypub\Mention', 'filter_activity_object' ), 99 );
+		\remove_filter( 'activitypub_activity_object_array', array( 'Activitypub\Hashtag', 'filter_activity_object' ), 99 );
+		\remove_filter( 'activitypub_activity_object_array', array( 'Activitypub\Link', 'filter_activity_object' ), 99 );
 		\wp_delete_post( $post_id, true );
 	}
 
@@ -965,7 +962,7 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 	 */
 	public function test_create_actor_with_cross_mentions_no_recursion() {
 		// Ensure the Mention filter is active to test for recursion.
-		\Activitypub\Mention::init();
+		Mention::init();
 
 		// Create two actors that mention each other in their bios.
 		$actor_a = array(
@@ -995,65 +992,59 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 		);
 
 		// Mock webfinger to resolve the mentions.
-		\add_filter(
-			'pre_http_request',
-			function ( $preempt, $parsed_args, $url ) {
-				if ( strpos( $url, '.well-known/webfinger' ) !== false ) {
-					if ( strpos( $url, 'bob@remote.example.com' ) !== false ) {
-						return array(
-							'response' => array( 'code' => 200 ),
-							'body'     => wp_json_encode(
-								array(
-									'subject' => 'acct:bob@remote.example.com',
-									'links'   => array(
-										array(
-											'rel'  => 'self',
-											'type' => 'application/activity+json',
-											'href' => 'https://remote.example.com/actor/bob-cross',
-										),
+		$webfinger_callback = function ( $preempt, $parsed_args, $url ) {
+			if ( strpos( $url, '.well-known/webfinger' ) !== false ) {
+				if ( strpos( $url, 'bob@remote.example.com' ) !== false ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => wp_json_encode(
+							array(
+								'subject' => 'acct:bob@remote.example.com',
+								'links'   => array(
+									array(
+										'rel'  => 'self',
+										'type' => 'application/activity+json',
+										'href' => 'https://remote.example.com/actor/bob-cross',
 									),
-								)
-							),
-						);
-					} elseif ( strpos( $url, 'alice@remote.example.com' ) !== false ) {
-						return array(
-							'response' => array( 'code' => 200 ),
-							'body'     => wp_json_encode(
-								array(
-									'subject' => 'acct:alice@remote.example.com',
-									'links'   => array(
-										array(
-											'rel'  => 'self',
-											'type' => 'application/activity+json',
-											'href' => 'https://remote.example.com/actor/alice-cross',
-										),
+								),
+							)
+						),
+					);
+				} elseif ( strpos( $url, 'alice@remote.example.com' ) !== false ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => wp_json_encode(
+							array(
+								'subject' => 'acct:alice@remote.example.com',
+								'links'   => array(
+									array(
+										'rel'  => 'self',
+										'type' => 'application/activity+json',
+										'href' => 'https://remote.example.com/actor/alice-cross',
 									),
-								)
-							),
-						);
-					}
+								),
+							)
+						),
+					);
 				}
-				return $preempt;
-			},
-			10,
-			3
-		);
+			}
+
+			return $preempt;
+		};
+		\add_filter( 'pre_http_request', $webfinger_callback, 10, 3 );
 
 		// Mock the remote fetch to return the cross-mentioned actors.
-		\add_filter(
-			'activitypub_pre_http_get_remote_object',
-			function ( $pre, $url_or_object ) use ( $actor_a, $actor_b ) {
-				if ( $url_or_object === $actor_a['id'] ) {
-					return $actor_a;
-				}
-				if ( $url_or_object === $actor_b['id'] ) {
-					return $actor_b;
-				}
-				return $pre;
-			},
-			10,
-			2
-		);
+		$actor_fetch_callback = function ( $pre, $url_or_object ) use ( $actor_a, $actor_b ) {
+			if ( $url_or_object === $actor_a['id'] ) {
+				return $actor_a;
+			}
+			if ( $url_or_object === $actor_b['id'] ) {
+				return $actor_b;
+			}
+
+			return $pre;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $actor_fetch_callback, 10, 2 );
 
 		// This should not cause infinite recursion when creating both actors.
 		$post_id_a = Remote_Actors::create( $actor_a );
@@ -1066,10 +1057,12 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 		$this->assertGreaterThan( 0, $post_id_a );
 		$this->assertGreaterThan( 0, $post_id_b );
 
-		// Clean up.
-		\remove_all_filters( 'pre_http_request' );
-		\remove_all_filters( 'activitypub_pre_http_get_remote_object' );
-		\remove_all_filters( 'activitypub_activity_object_array' );
+		// Clean up - remove only the specific filters we added.
+		\remove_filter( 'pre_http_request', $webfinger_callback );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $actor_fetch_callback );
+		\remove_filter( 'activitypub_activity_object_array', array( 'Activitypub\Mention', 'filter_activity_object' ), 99 );
+		\remove_filter( 'activitypub_activity_object_array', array( 'Activitypub\Hashtag', 'filter_activity_object' ), 99 );
+		\remove_filter( 'activitypub_activity_object_array', array( 'Activitypub\Link', 'filter_activity_object' ), 99 );
 		\wp_delete_post( $post_id_a, true );
 		\wp_delete_post( $post_id_b, true );
 	}

--- a/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
+++ b/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
@@ -874,6 +874,207 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 	}
 
 	/**
+	 * Test that saving a remote actor with a self-mention doesn't cause infinite recursion.
+	 *
+	 * @covers ::create
+	 * @covers ::prepare_custom_post_type
+	 */
+	public function test_create_actor_with_self_mention_no_recursion() {
+		// Ensure the Mention filter is active to test for recursion.
+		\Activitypub\Mention::init();
+
+		// Create an actor with a self-mention in their summary.
+		$actor = array(
+			'id'                => 'https://remote.example.com/actor/self-mention',
+			'type'              => 'Person',
+			'url'               => 'https://remote.example.com/actor/self-mention',
+			'inbox'             => 'https://remote.example.com/actor/self-mention/inbox',
+			'name'              => 'Self Mention User',
+			'preferredUsername' => 'selfmention',
+			'summary'           => 'Hello, I am @selfmention@remote.example.com and I like to mention myself!',
+			'endpoints'         => array(
+				'sharedInbox' => 'https://remote.example.com/inbox',
+			),
+		);
+
+		// Mock webfinger to resolve the mention.
+		\add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) use ( $actor ) {
+				if ( strpos( $url, '.well-known/webfinger' ) !== false ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => wp_json_encode(
+							array(
+								'subject' => 'acct:selfmention@remote.example.com',
+								'links'   => array(
+									array(
+										'rel'  => 'self',
+										'type' => 'application/activity+json',
+										'href' => 'https://remote.example.com/actor/self-mention',
+									),
+								),
+							)
+						),
+					);
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		// Mock remote actor fetch to return the same actor (creating potential recursion).
+		\add_filter(
+			'activitypub_pre_http_get_remote_object',
+			function ( $pre, $url_or_object ) use ( $actor ) {
+				if ( $url_or_object === $actor['id'] ) {
+					return $actor;
+				}
+				return $pre;
+			},
+			10,
+			2
+		);
+
+		// This should not cause infinite recursion.
+		$post_id = Remote_Actors::create( $actor );
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		$post = \get_post( $post_id );
+		$this->assertInstanceOf( '\WP_Post', $post );
+		$this->assertEquals( 'https://remote.example.com/actor/self-mention', $post->guid );
+
+		// Verify the summary was stored correctly (without being processed for mentions).
+		$this->assertStringContainsString( '@selfmention@remote.example.com', $post->post_excerpt );
+
+		// Clean up.
+		\remove_all_filters( 'pre_http_request' );
+		\remove_all_filters( 'activitypub_pre_http_get_remote_object' );
+		\remove_all_filters( 'activitypub_activity_object_array' );
+		\wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test that saving a remote actor with mentions of other actors doesn't cause recursion.
+	 *
+	 * @covers ::create
+	 * @covers ::prepare_custom_post_type
+	 */
+	public function test_create_actor_with_cross_mentions_no_recursion() {
+		// Ensure the Mention filter is active to test for recursion.
+		\Activitypub\Mention::init();
+
+		// Create two actors that mention each other in their bios.
+		$actor_a = array(
+			'id'                => 'https://remote.example.com/actor/alice-cross',
+			'type'              => 'Person',
+			'url'               => 'https://remote.example.com/actor/alice-cross',
+			'inbox'             => 'https://remote.example.com/actor/alice-cross/inbox',
+			'name'              => 'Alice',
+			'preferredUsername' => 'alice',
+			'summary'           => 'Best friends with @bob@remote.example.com',
+			'endpoints'         => array(
+				'sharedInbox' => 'https://remote.example.com/inbox',
+			),
+		);
+
+		$actor_b = array(
+			'id'                => 'https://remote.example.com/actor/bob-cross',
+			'type'              => 'Person',
+			'url'               => 'https://remote.example.com/actor/bob-cross',
+			'inbox'             => 'https://remote.example.com/actor/bob-cross/inbox',
+			'name'              => 'Bob',
+			'preferredUsername' => 'bob',
+			'summary'           => 'Best friends with @alice@remote.example.com',
+			'endpoints'         => array(
+				'sharedInbox' => 'https://remote.example.com/inbox',
+			),
+		);
+
+		// Mock webfinger to resolve the mentions.
+		\add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) {
+				if ( strpos( $url, '.well-known/webfinger' ) !== false ) {
+					if ( strpos( $url, 'bob@remote.example.com' ) !== false ) {
+						return array(
+							'response' => array( 'code' => 200 ),
+							'body'     => wp_json_encode(
+								array(
+									'subject' => 'acct:bob@remote.example.com',
+									'links'   => array(
+										array(
+											'rel'  => 'self',
+											'type' => 'application/activity+json',
+											'href' => 'https://remote.example.com/actor/bob-cross',
+										),
+									),
+								)
+							),
+						);
+					} elseif ( strpos( $url, 'alice@remote.example.com' ) !== false ) {
+						return array(
+							'response' => array( 'code' => 200 ),
+							'body'     => wp_json_encode(
+								array(
+									'subject' => 'acct:alice@remote.example.com',
+									'links'   => array(
+										array(
+											'rel'  => 'self',
+											'type' => 'application/activity+json',
+											'href' => 'https://remote.example.com/actor/alice-cross',
+										),
+									),
+								)
+							),
+						);
+					}
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		// Mock the remote fetch to return the cross-mentioned actors.
+		\add_filter(
+			'activitypub_pre_http_get_remote_object',
+			function ( $pre, $url_or_object ) use ( $actor_a, $actor_b ) {
+				if ( $url_or_object === $actor_a['id'] ) {
+					return $actor_a;
+				}
+				if ( $url_or_object === $actor_b['id'] ) {
+					return $actor_b;
+				}
+				return $pre;
+			},
+			10,
+			2
+		);
+
+		// This should not cause infinite recursion when creating both actors.
+		$post_id_a = Remote_Actors::create( $actor_a );
+		$this->assertIsInt( $post_id_a );
+
+		$post_id_b = Remote_Actors::create( $actor_b );
+		$this->assertIsInt( $post_id_b );
+
+		// Verify both were created successfully.
+		$this->assertGreaterThan( 0, $post_id_a );
+		$this->assertGreaterThan( 0, $post_id_b );
+
+		// Clean up.
+		\remove_all_filters( 'pre_http_request' );
+		\remove_all_filters( 'activitypub_pre_http_get_remote_object' );
+		\remove_all_filters( 'activitypub_activity_object_array' );
+		\wp_delete_post( $post_id_a, true );
+		\wp_delete_post( $post_id_b, true );
+	}
+
+	/**
 	 * Pre get remote metadata by actor.
 	 *
 	 * @param mixed  $value The value.


### PR DESCRIPTION
Fixes #2366, the infinite recursion bug that fills error logs when storing remote actors with @mentions in their bios.

## Proposed changes:
* Temporarily remove mention/hashtag/link filters when storing remote actors to prevent infinite recursion
* Add comprehensive tests for self-mention and cross-mention scenarios
* Document the problem, current approach, shortcomings, and long-term architectural solutions in code comments

### The Problem
When a remote actor's bio contains mentions (e.g., `@user@example.com`), the mention processing filter fetches that mentioned actor, which then processes mentions in *their* bio, creating an infinite loop that results in stack overflow errors.

### The Solution
In `Remote_Actors::prepare_custom_post_type()`, temporarily remove the `activitypub_activity_object_array` filters (Mention, Hashtag, Link) around `to_json()`, then re-add them. This prevents filters from triggering during storage while preserving functionality for outgoing federation.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
  - Added `test_create_actor_with_self_mention_no_recursion`
  - Added `test_create_actor_with_cross_mentions_no_recursion`

## Testing instructions:

* Run the new recursion tests: `npm run env-test -- --filter=test_create_actor_with`
* Verify both tests pass
* Run the full test suite: `npm run env-test`
* Verify all 1217 tests pass

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix infinite recursion when storing remote actors with mentions in their bios

</details>