### PR TITLE
Improve WP Stream Connector mock log method signature

### DIFF
--- a/tests/phpunit/tests/integration/class-test-stream-connector.php
+++ b/tests/phpunit/tests/integration/class-test-stream-connector.php
@@ -761,12 +761,21 @@ if ( ! class_exists( 'WP_Stream\Connector' ) ) {
 		}
 
 		/**
-		 * Log activity.
+		 * Log handler.
 		 *
-		 * @param array $args Log arguments.
+		 * @param string   $message   sprintf-ready error message string.
+		 * @param array    $args      sprintf (and extra) arguments to use.
+		 * @param int|null $object_id Target object id (if any).
+		 * @param string   $context   Context of the event.
+		 * @param string   $action    Action of the event.
+		 * @param int      $user_id   User responsible for the event.
+		 *
+		 * @return bool
 		 */
-		public function log( $args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		public function log( $message, $args, $object_id, $context, $action, $user_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable, Generic.CodeAnalysis.UnusedFunctionParameter
 			// Mock implementation - parameter intentionally unused.
+
+			return true;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:
Updates the mock `log()` method in the Stream Connector test to match the actual WP Stream Connector API signature. This improves test accuracy and code maintainability by using the correct parameter names and adding proper documentation.

Changes:
- Update method signature to use actual parameters (`$message`, `$args`, `$object_id`, `$context`, `$action`, `$user_id`)
- Add detailed PHPDoc with parameter descriptions and return type
- Add `return true` statement for proper mock behavior
- Update phpcs ignore annotations

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

This is a code cleanup/refactoring change to the test mock. To verify:

1. Run `npm run env-test` to ensure all tests still pass
2. Review the code to confirm the mock signature now matches the actual WP Stream Connector API