### PR TITLE
Add quote visibility setting for Classic Editor

### DIFF
--- a/.github/changelog/2374-from-description
+++ b/.github/changelog/2374-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add quote visibility setting for Classic Editor users.

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -79,7 +79,7 @@ class Classic_Editor {
 		}
 
 		// Save quote interaction policy based on checkbox.
-		if ( isset( $_POST['activitypub_allow_quotes'] ) && '1' === $_POST['activitypub_allow_quotes'] ) {
+		if ( '1' === \sanitize_text_field( \wp_unslash( $_POST['activitypub_allow_quotes'] ?? '0' ) ) ) {
 			// Checked: allow anyone to quote (default value).
 			\update_post_meta( $post_id, 'activitypub_interaction_policy_quote', ACTIVITYPUB_INTERACTION_POLICY_ANYONE );
 		} else {

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Classic Editor integration file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Integration;
+
+/**
+ * Classic Editor integration class.
+ *
+ * Handles compatibility with the Classic Editor plugin and sites without block editor support.
+ */
+class Classic_Editor {
+
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_action( 'post_comment_status_meta_box-options', array( self::class, 'add_quote_policy_field' ) );
+		\add_action( 'save_post', array( self::class, 'save_quote_policy' ) );
+	}
+
+	/**
+	 * Add quote policy field to the Discussion meta box.
+	 *
+	 * @param \WP_Post $post The post object.
+	 */
+	public static function add_quote_policy_field( $post ) {
+		// Only add field for post types that support ActivityPub.
+		if ( ! \post_type_supports( $post->post_type, 'activitypub' ) ) {
+			return;
+		}
+
+		// Add nonce for security.
+		\wp_nonce_field( 'activitypub_quote_policy', 'activitypub_quote_policy_nonce' );
+
+		// Get current value.
+		$quote_interaction_policy = \get_post_meta( $post->ID, 'activitypub_interaction_policy_quote', true );
+
+		// Set default if empty.
+		if ( '' === $quote_interaction_policy ) {
+			$quote_interaction_policy = ACTIVITYPUB_INTERACTION_POLICY_ANYONE;
+		}
+		?>
+		<br class="clear" />
+		<label for="activitypub_allow_quotes" class="selectit">
+			<input name="activitypub_allow_quotes" type="checkbox" id="activitypub_allow_quotes" value="1" <?php \checked( ACTIVITYPUB_INTERACTION_POLICY_ANYONE === $quote_interaction_policy ); ?> />
+			<?php \esc_html_e( 'Allow quotes from the Fediverse', 'activitypub' ); ?>
+		</label>
+		<?php
+	}
+
+	/**
+	 * Save quote policy data.
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	public static function save_quote_policy( $post_id ) {
+		// Check if this is an autosave.
+		if ( \defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		// Only process if nonce is set (meaning we're saving from the post editor).
+		if ( ! isset( $_POST['activitypub_quote_policy_nonce'] ) ) {
+			return;
+		}
+
+		// Verify nonce.
+		if ( ! \wp_verify_nonce( \sanitize_text_field( \wp_unslash( $_POST['activitypub_quote_policy_nonce'] ) ), 'activitypub_quote_policy' ) ) {
+			return;
+		}
+
+		// Only process for post types that support ActivityPub.
+		if ( ! \post_type_supports( \get_post_type( $post_id ), 'activitypub' ) ) {
+			return;
+		}
+
+		// Check user permissions.
+		if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		// Save quote interaction policy based on checkbox.
+		if ( isset( $_POST['activitypub_allow_quotes'] ) && '1' === $_POST['activitypub_allow_quotes'] ) {
+			// Checked: allow anyone to quote (default value).
+			\update_post_meta( $post_id, 'activitypub_interaction_policy_quote', ACTIVITYPUB_INTERACTION_POLICY_ANYONE );
+		} else {
+			// Unchecked: only allow "just me" to quote.
+			\update_post_meta( $post_id, 'activitypub_interaction_policy_quote', ACTIVITYPUB_INTERACTION_POLICY_ME );
+		}
+	}
+}

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -37,16 +37,11 @@ class Classic_Editor {
 		\wp_nonce_field( 'activitypub_quote_policy', 'activitypub_quote_policy_nonce' );
 
 		// Get current value.
-		$quote_interaction_policy = \get_post_meta( $post->ID, 'activitypub_interaction_policy_quote', true );
-
-		// Set default if empty.
-		if ( '' === $quote_interaction_policy ) {
-			$quote_interaction_policy = ACTIVITYPUB_INTERACTION_POLICY_ANYONE;
-		}
+		$quote_interaction_policy = \get_post_meta( $post->ID, 'activitypub_interaction_policy_quote', true ) ?: ACTIVITYPUB_INTERACTION_POLICY_ANYONE; // phpcs:ignore Universal.Operators.DisallowShortTernary
 		?>
 		<br class="clear" />
 		<label for="activitypub_allow_quotes" class="selectit">
-			<input name="activitypub_allow_quotes" type="checkbox" id="activitypub_allow_quotes" value="1" <?php \checked( ACTIVITYPUB_INTERACTION_POLICY_ANYONE === $quote_interaction_policy ); ?> />
+			<input name="activitypub_allow_quotes" type="checkbox" id="activitypub_allow_quotes" value="1" <?php \checked( $quote_interaction_policy, ACTIVITYPUB_INTERACTION_POLICY_ANYONE ); ?> />
 			<?php \esc_html_e( 'Allow quotes from the Fediverse', 'activitypub' ); ?>
 		</label>
 		<?php

--- a/integration/load.php
+++ b/integration/load.php
@@ -23,7 +23,7 @@ function plugin_init() {
 	 *
 	 * @see https://wordpress.org/plugins/classic-editor/
 	 */
-	if ( class_exists( 'Classic_Editor' ) || ! site_supports_blocks() ) {
+	if ( class_exists( '\Classic_Editor' ) || ! site_supports_blocks() ) {
 		Classic_Editor::init();
 	}
 

--- a/integration/load.php
+++ b/integration/load.php
@@ -7,12 +7,26 @@
 
 namespace Activitypub\Integration;
 
+use function Activitypub\site_supports_blocks;
+
 \Activitypub\Autoloader::register_path( __NAMESPACE__, __DIR__ );
 
 /**
  * Initialize the ActivityPub integrations.
  */
 function plugin_init() {
+	/**
+	 * Adds Classic Editor support.
+	 *
+	 * This class handles the compatibility with the Classic Editor plugin
+	 * and sites without block editor support.
+	 *
+	 * @see https://wordpress.org/plugins/classic-editor/
+	 */
+	if ( class_exists( 'Classic_Editor' ) || ! site_supports_blocks() ) {
+		Classic_Editor::init();
+	}
+
 	/**
 	 * Adds WebFinger (plugin) support.
 	 *


### PR DESCRIPTION
Fixes #2268

## Proposed changes:

Adds a checkbox to the Discussion meta box that allows Classic Editor users and sites without block editor support to control who can quote their posts on the Fediverse.

- Created new `Classic_Editor` integration class
- Adds "Allow quotes from the Fediverse" checkbox to the Discussion meta box
- Checkbox appears alongside "Allow comments" and "Allow pingbacks and trackbacks"
- Uses the `post_comment_status_meta_box-options` hook to integrate seamlessly
- Checked (default): Anyone can quote the post
- Unchecked: Only the author can quote the post

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Ensure you're using the Classic Editor (install the Classic Editor plugin or disable the block editor)
2. Go to 'Posts' → 'Add New'
3. Scroll down to the 'Discussion' meta box on the right side
4. Verify that the "Allow quotes from the Fediverse" checkbox appears below the "Allow comments" and "Allow pingbacks and trackbacks" checkboxes
5. Uncheck the "Allow quotes from the Fediverse" checkbox
6. Publish or update the post
7. Reload the post editor
8. Verify the checkbox remains unchecked
9. Check the checkbox again and save
10. Verify it remains checked after reload

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Minor

#### Type

- [x] Added - for new features

#### Message

Add quote visibility setting for Classic Editor users.

</details>