### PR TITLE
Handle local inbox delivery via internal REST API

### DIFF
--- a/.github/changelog/2379-from-description
+++ b/.github/changelog/2379-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix local inbox delivery to use internal REST API instead of HTTP, enabling local follows and proper boost counting.

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -232,6 +232,41 @@ class Dispatcher {
 	}
 
 	/**
+	 * Send an activity to a local inbox via internal REST API request.
+	 *
+	 * @param string $inbox_url The local inbox URL.
+	 * @param string $json      The ActivityPub Activity JSON.
+	 * @return array|\WP_Error The result in the format of a remote post response, or WP_Error on failure.
+	 */
+	private static function send_to_local_inbox( $inbox_url, $json ) {
+		// Parse the inbox URL to extract the REST route.
+		$path       = \wp_parse_url( $inbox_url, PHP_URL_PATH ) ?? '';
+		$rest_route = \preg_replace( '#^/wp-json#', '', $path );
+
+		// Create a REST request.
+		$request = new \WP_REST_Request( 'POST', $rest_route );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( $json );
+		$request->get_json_params();
+
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		$response = \rest_do_request( $request );
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		// Return result in format similar to remote post response.
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		return array(
+			'response' => array(
+				'code' => $response->get_status(),
+			),
+			'body'     => \wp_json_encode( $response->get_data() ),
+		);
+	}
+
+	/**
 	 * Send to inboxes.
 	 *
 	 * @param array $inboxes        The inboxes to notify.
@@ -253,16 +288,21 @@ class Dispatcher {
 		\do_action( 'activitypub_pre_send_to_inboxes', $json, $inboxes, $outbox_item_id );
 
 		foreach ( $inboxes as $inbox ) {
-			$result = safe_remote_post( $inbox, $json, $outbox_item->post_author );
+			// Handle local inboxes via internal REST API, remote via HTTP.
+			if ( is_same_domain( $inbox ) ) {
+				$result = self::send_to_local_inbox( $inbox, $json );
+			} else {
+				$result = safe_remote_post( $inbox, $json, $outbox_item->post_author );
 
-			if ( is_wp_error( $result ) && in_array( $result->get_error_code(), self::get_retry_error_codes(), true ) ) {
-				$retries[] = $inbox;
+				if ( is_wp_error( $result ) && in_array( $result->get_error_code(), self::get_retry_error_codes(), true ) ) {
+					$retries[] = $inbox;
+				}
 			}
 
 			/**
 			 * Fires after an Activity has been sent to an inbox.
 			 *
-			 * @param array  $result         The result of the remote post request.
+			 * @param array  $result         The result of the internal or remote post request.
 			 * @param string $inbox          The inbox URL.
 			 * @param string $json           The ActivityPub Activity JSON.
 			 * @param int    $actor_id       The actor ID.
@@ -335,13 +375,8 @@ class Dispatcher {
 
 		$audience = array_merge( $cc, $to );
 
-		// Remove "public placeholder" and "same domain" from the audience.
-		$audience = array_filter(
-			$audience,
-			function ( $actor ) {
-				return 'https://www.w3.org/ns/activitystreams#Public' !== $actor && ! is_same_domain( $actor );
-			}
-		);
+		// Remove "public placeholder" from the audience.
+		$audience = array_diff( $audience, array( 'https://www.w3.org/ns/activitystreams#Public' ) );
 
 		if ( $audience ) {
 			$mentioned_inboxes = Mention::get_inboxes( $audience );

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -22,11 +22,28 @@ class Dispatcher {
 	/**
 	 * Batch size.
 	 *
-	 * @deprecated unreleased {@see Activitypub\Dispatcher::get_batch_size()}
+	 * @deprecated unreleased Use {@see Dispatcher::get_batch_size()}.
 	 *
 	 * @var int
 	 */
 	public static $batch_size = ACTIVITYPUB_OUTBOX_PROCESSING_BATCH_SIZE;
+
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_action( 'activitypub_process_outbox', array( self::class, 'process_outbox' ) );
+
+		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'send_immediate_accept' ), 10, 2 );
+
+		// Default filters to add Inboxes to sent to.
+		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_by_mentioned_actors' ), 10, 3 );
+		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_of_replied_urls' ), 10, 3 );
+		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_of_relays' ), 10, 3 );
+
+		Scheduler::register_async_batch_callback( 'activitypub_send_activity', array( self::class, 'send_to_followers' ) );
+		Scheduler::register_async_batch_callback( 'activitypub_retry_activity', array( self::class, 'retry_send_to_followers' ) );
+	}
 
 	/**
 	 * Get the batch size for processing outbox items.
@@ -88,23 +105,6 @@ class Dispatcher {
 		 * @param int[] $retry_error_codes The error codes. Default array( 408, 429, 500, 502, 503, 504 ).
 		 */
 		return apply_filters( 'activitypub_dispatcher_retry_error_codes', array( 408, 429, 500, 502, 503, 504 ) );
-	}
-
-	/**
-	 * Initialize the class, registering WordPress hooks.
-	 */
-	public static function init() {
-		\add_action( 'activitypub_process_outbox', array( self::class, 'process_outbox' ) );
-
-		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'send_immediate_accept' ), 10, 2 );
-
-		// Default filters to add Inboxes to sent to.
-		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_by_mentioned_actors' ), 10, 3 );
-		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_of_replied_urls' ), 10, 3 );
-		\add_filter( 'activitypub_additional_inboxes', array( self::class, 'add_inboxes_of_relays' ), 10, 3 );
-
-		Scheduler::register_async_batch_callback( 'activitypub_send_activity', array( self::class, 'send_to_followers' ) );
-		Scheduler::register_async_batch_callback( 'activitypub_retry_activity', array( self::class, 'retry_send_to_followers' ) );
 	}
 
 	/**

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -232,44 +232,6 @@ class Dispatcher {
 	}
 
 	/**
-	 * Send an activity to a local inbox via internal REST API request.
-	 *
-	 * @param string $inbox_url The local inbox URL.
-	 * @param string $json      The ActivityPub Activity JSON.
-	 * @return array|\WP_Error The result in the format of a remote post response, or WP_Error on failure.
-	 */
-	private static function send_to_local_inbox( $inbox_url, $json ) {
-		// Parse the inbox URL to extract the REST route.
-		$path       = \wp_parse_url( $inbox_url, PHP_URL_PATH ) ?? '';
-		$rest_route = \preg_replace( '#^/wp-json#', '', $path );
-
-		// Create a REST request.
-		$request = new \WP_REST_Request( 'POST', $rest_route );
-		$request->set_header( 'Content-Type', 'application/activity+json' );
-		$request->set_body( $json );
-		$json_params = $request->get_json_params();
-		if ( null === $json_params ) {
-			return new \WP_Error( 'invalid_json', 'The provided JSON body could not be parsed.', array( 'status' => 400 ) );
-		}
-
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
-		$response = \rest_do_request( $request );
-		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
-
-		// Return result in format similar to remote post response.
-		if ( $response->is_error() ) {
-			return $response->as_error();
-		}
-
-		return array(
-			'response' => array(
-				'code' => $response->get_status(),
-			),
-			'body'     => \wp_json_encode( $response->get_data() ),
-		);
-	}
-
-	/**
 	 * Send to inboxes.
 	 *
 	 * @param array $inboxes        The inboxes to notify.
@@ -296,10 +258,10 @@ class Dispatcher {
 				$result = self::send_to_local_inbox( $inbox, $json );
 			} else {
 				$result = safe_remote_post( $inbox, $json, $outbox_item->post_author );
+			}
 
-				if ( is_wp_error( $result ) && in_array( $result->get_error_code(), self::get_retry_error_codes(), true ) ) {
-					$retries[] = $inbox;
-				}
+			if ( \is_wp_error( $result ) && in_array( $result->get_error_code(), self::get_retry_error_codes(), true ) ) {
+				$retries[] = $inbox;
 			}
 
 			/**
@@ -315,6 +277,41 @@ class Dispatcher {
 		}
 
 		return $retries;
+	}
+
+	/**
+	 * Send an activity to a local inbox via internal REST API request.
+	 *
+	 * @param string $inbox_url The local inbox URL.
+	 * @param string $json      The ActivityPub Activity JSON.
+	 * @return array|\WP_Error The result in the format of a remote post response, or WP_Error on failure.
+	 */
+	private static function send_to_local_inbox( $inbox_url, $json ) {
+		// Parse the inbox URL to extract the REST route.
+		$path       = \wp_parse_url( $inbox_url, PHP_URL_PATH ) ?? '';
+		$rest_route = \preg_replace( '#^/' . preg_quote( \rest_get_url_prefix(), '#' ) . '#', '', $path );
+
+		// Create a REST request.
+		$request = new \WP_REST_Request( 'POST', $rest_route );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( $json );
+		$request->get_json_params();
+
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		$response = \rest_do_request( $request );
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		// Return result in format similar to remote post response.
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		return array(
+			'response' => array(
+				'code' => $response->get_status(),
+			),
+			'body'     => \wp_json_encode( $response->get_data() ),
+		);
 	}
 
 	/**

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -247,7 +247,10 @@ class Dispatcher {
 		$request = new \WP_REST_Request( 'POST', $rest_route );
 		$request->set_header( 'Content-Type', 'application/activity+json' );
 		$request->set_body( $json );
-		$request->get_json_params();
+		$json_params = $request->get_json_params();
+		if ( null === $json_params ) {
+			return new \WP_Error( 'invalid_json', 'The provided JSON body could not be parsed.', array( 'status' => 400 ) );
+		}
 
 		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 		$response = \rest_do_request( $request );

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -535,6 +535,7 @@ class Scheduler {
 		$announce->set_type( 'Announce' );
 		$announce->set_actor( Actors::get_by_id( Actors::BLOG_USER_ID )->get_id() );
 		$announce->set_object( $activity );
+		$announce->add_cc( object_to_uri( $activity->get_actor() ) );
 
 		$outbox_activity_id = Outbox::add( $announce, Actors::BLOG_USER_ID );
 

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -101,6 +101,11 @@ class Announce {
 			return;
 		}
 
+		// If the object is a Create activity, extract the actual object from it.
+		if ( isset( $activity['object']['type'] ) && 'Create' === $activity['object']['type'] ) {
+			$activity['object'] = object_to_uri( $activity['object']['object'] );
+		}
+
 		$success = false;
 		$result  = Interactions::add_reaction( $activity );
 

--- a/tests/phpunit/tests/includes/class-test-dispatcher.php
+++ b/tests/phpunit/tests/includes/class-test-dispatcher.php
@@ -470,6 +470,145 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test send_to_inboxes separates local and remote inboxes.
+	 *
+	 * @covers ::send_to_inboxes
+	 */
+	public function test_send_to_inboxes_separates_local_and_remote() {
+		$post_id     = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$outbox_item = $this->get_latest_outbox_item( \add_query_arg( 'p', $post_id, \home_url( '/' ) ) );
+
+		// Track which inboxes were sent to and via which method.
+		$sent_inboxes = array();
+		$http_called  = false;
+
+		// Mock HTTP requests to track remote inbox delivery.
+		$http_callback = function ( $preempt, $args, $url ) use ( &$sent_inboxes, &$http_called ) {
+			$http_called    = true;
+			$sent_inboxes[] = $url;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '',
+			);
+		};
+		\add_filter( 'pre_http_request', $http_callback, 10, 3 );
+
+		// Track local inbox deliveries.
+		$inbox_callback = function ( $result, $inbox ) use ( &$sent_inboxes ) {
+			if ( \Activitypub\is_same_domain( $inbox ) ) {
+				$sent_inboxes[] = $inbox;
+			}
+		};
+		\add_action( 'activitypub_sent_to_inbox', $inbox_callback, 10, 2 );
+
+		// Create mixed list of local and remote inboxes.
+		$local_inbox  = \rest_url( sprintf( '/%s/users/%d/inbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
+		$remote_inbox = 'https://remote.example/inbox';
+		$inboxes      = array( $local_inbox, $remote_inbox );
+
+		// Make the method accessible.
+		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
+		$send_to_inboxes->setAccessible( true );
+
+		// Invoke the method.
+		$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+
+		// Verify both inboxes were processed.
+		$this->assertCount( 2, $sent_inboxes, 'Both inboxes should be processed' );
+		$this->assertContains( $local_inbox, $sent_inboxes, 'Local inbox should be processed' );
+		$this->assertContains( $remote_inbox, $sent_inboxes, 'Remote inbox should be processed' );
+		$this->assertTrue( $http_called, 'HTTP should be called for remote inbox' );
+
+		// Clean up.
+		\remove_filter( 'pre_http_request', $http_callback, 10 );
+		\remove_action( 'activitypub_sent_to_inbox', $inbox_callback, 10 );
+		\wp_delete_post( $post_id );
+		\wp_delete_post( $outbox_item->ID );
+	}
+
+	/**
+	 * Test that local inboxes do not trigger HTTP requests.
+	 *
+	 * @covers ::send_to_inboxes
+	 */
+	public function test_local_inboxes_skip_http() {
+		$post_id     = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$outbox_item = $this->get_latest_outbox_item( \add_query_arg( 'p', $post_id, \home_url( '/' ) ) );
+
+		$http_called = false;
+
+		// Mock HTTP requests to verify they're not called for local inboxes.
+		$http_callback = function () use ( &$http_called ) {
+			$http_called = true;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '',
+			);
+		};
+		\add_filter( 'pre_http_request', $http_callback );
+
+		// Only local inboxes.
+		$local_inbox = \rest_url( sprintf( '/%s/users/%d/inbox', ACTIVITYPUB_REST_NAMESPACE, self::$user_id ) );
+		$inboxes     = array( $local_inbox );
+
+		// Make the method accessible.
+		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
+		$send_to_inboxes->setAccessible( true );
+
+		// Invoke the method.
+		$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+
+		// Verify HTTP was not called.
+		$this->assertFalse( $http_called, 'HTTP should not be called for local inboxes' );
+
+		// Clean up.
+		\remove_filter( 'pre_http_request', $http_callback );
+		\wp_delete_post( $post_id );
+		\wp_delete_post( $outbox_item->ID );
+	}
+
+	/**
+	 * Test that remote inboxes still use HTTP.
+	 *
+	 * @covers ::send_to_inboxes
+	 */
+	public function test_remote_inboxes_use_http() {
+		$post_id     = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$outbox_item = $this->get_latest_outbox_item( \add_query_arg( 'p', $post_id, \home_url( '/' ) ) );
+
+		$http_called = false;
+
+		// Mock HTTP requests to verify they're called for remote inboxes.
+		$http_callback = function () use ( &$http_called ) {
+			$http_called = true;
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '',
+			);
+		};
+		\add_filter( 'pre_http_request', $http_callback );
+
+		// Only remote inboxes.
+		$remote_inbox = 'https://remote.example/inbox';
+		$inboxes      = array( $remote_inbox );
+
+		// Make the method accessible.
+		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
+		$send_to_inboxes->setAccessible( true );
+
+		// Invoke the method.
+		$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+
+		// Verify HTTP was called.
+		$this->assertTrue( $http_called, 'HTTP should be called for remote inboxes' );
+
+		// Clean up.
+		\remove_filter( 'pre_http_request', $http_callback );
+		\wp_delete_post( $post_id );
+		\wp_delete_post( $outbox_item->ID );
+	}
+
+	/**
 	 * Test that post_activitypub_add_to_outbox hook triggers send_immediate_accept.
 	 *
 	 * @covers ::send_immediate_accept

--- a/tests/phpunit/tests/includes/class-test-dispatcher.php
+++ b/tests/phpunit/tests/includes/class-test-dispatcher.php
@@ -13,6 +13,8 @@ use Activitypub\Collection\Followers;
 use Activitypub\Collection\Outbox;
 use Activitypub\Dispatcher;
 
+use function Activitypub\is_same_domain;
+
 /**
  * Test class for Activitypub Dispatcher.
  *
@@ -124,7 +126,11 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$send_to_inboxes->setAccessible( true );
 
 		// Invoke the method.
-		$retries = $send_to_inboxes->invoke( null, $inboxes, $outbox_item ); // null for static methods.
+		try {
+			$retries = $send_to_inboxes->invoke( null, $inboxes, $outbox_item ); // null for static methods.
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
 
 		$this->assertSame( $expected, $retries, 'Expected all inboxes to be scheduled for retry' );
 
@@ -151,7 +157,11 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$send_to_additional_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_additional_inboxes' );
 		$send_to_additional_inboxes->setAccessible( true );
 
-		$send_to_additional_inboxes->invoke( null, $this->get_activity_mock(), Actors::get_by_id( self::$user_id ), $outbox_item );
+		try {
+			$send_to_additional_inboxes->invoke( null, $this->get_activity_mock(), Actors::get_by_id( self::$user_id ), $outbox_item );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
 
 		// Test how often the request was sent.
 		$this->assertEquals( 0, did_action( 'activitypub_sent_to_inbox' ) );
@@ -163,7 +173,11 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$relays = array( 'https://relay1.example.com/inbox' );
 		update_option( 'activitypub_relays', $relays );
 
-		$send_to_additional_inboxes->invoke( null, $this->get_activity_mock(), Actors::get_by_id( self::$user_id ), $outbox_item );
+		try {
+			$send_to_additional_inboxes->invoke( null, $this->get_activity_mock(), Actors::get_by_id( self::$user_id ), $outbox_item );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
 
 		// Test how often the request was sent.
 		$this->assertEquals( 1, did_action( 'activitypub_sent_to_inbox' ) );
@@ -175,7 +189,11 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$relays = array( 'https://relay1.example.com/inbox', 'https://relay2.example.com/inbox' );
 		update_option( 'activitypub_relays', $relays );
 
-		$send_to_additional_inboxes->invoke( null, $this->get_activity_mock(), Actors::get_by_id( self::$user_id ), $outbox_item );
+		try {
+			$send_to_additional_inboxes->invoke( null, $this->get_activity_mock(), Actors::get_by_id( self::$user_id ), $outbox_item );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
 
 		// Test how often the request was sent.
 		$this->assertEquals( 2, did_action( 'activitypub_sent_to_inbox' ) );
@@ -190,12 +208,16 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		// Clone object.
 		$private_activity = clone $private_activity;
 
-		$send_to_additional_inboxes->invoke( null, $private_activity, Actors::get_by_id( self::$user_id ), $outbox_item );
+		try {
+			$send_to_additional_inboxes->invoke( null, $private_activity, Actors::get_by_id( self::$user_id ), $outbox_item );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
 
 		// Test how often the request was sent.
 		$this->assertEquals( 0, did_action( 'activitypub_sent_to_inbox' ) );
 
-		\remove_filter( 'pre_http_request', $fake_request, 10 );
+		\remove_filter( 'pre_http_request', $fake_request );
 
 		\delete_option( 'activitypub_relays' );
 		\wp_delete_post( $post_id );
@@ -210,27 +232,37 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 	public function test_should_send_to_followers() {
 		$post_id     = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
 		$outbox_item = $this->get_latest_outbox_item( \add_query_arg( 'p', $post_id, \home_url( '/' ) ) );
-		$activity    = \Activitypub\Collection\Outbox::get_activity( $outbox_item );
+		$activity    = Outbox::get_activity( $outbox_item );
 
 		$should_send = new \ReflectionMethod( Dispatcher::class, 'should_send_to_followers' );
 		$should_send->setAccessible( true );
 
 		// No followers, so should not send.
-		$this->assertFalse( $should_send->invoke( null, $activity, Actors::get_by_id( self::$user_id ), $outbox_item ) );
+		try {
+			$result = $should_send->invoke( null, $activity, Actors::get_by_id( self::$user_id ), $outbox_item );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
+		$this->assertFalse( $result );
 
 		// Add a follower.
 		Followers::add( self::$user_id, 'https://example.org/users/username' );
 
-		$this->assertTrue( $should_send->invoke( null, $activity, Actors::get_by_id( self::$user_id ), $outbox_item ) );
+		try {
+			$result = $should_send->invoke( null, $activity, Actors::get_by_id( self::$user_id ), $outbox_item );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
+		$this->assertTrue( $result );
 	}
 
 	/**
-	 * Returns a mock of an Activity object.
+	 * Returns a mocked Activity object.
 	 *
 	 * @return Activity
 	 */
 	private function get_activity_mock() {
-		$activity = $this->createMock( Activity::class, array( '__call' ) );
+		$activity = $this->createMock( Activity::class );
 
 		// Mock the static method using reflection.
 		$activity->expects( $this->any() )
@@ -495,7 +527,7 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 
 		// Track local inbox deliveries.
 		$inbox_callback = function ( $result, $inbox ) use ( &$sent_inboxes ) {
-			if ( \Activitypub\is_same_domain( $inbox ) ) {
+			if ( is_same_domain( $inbox ) ) {
 				$sent_inboxes[] = $inbox;
 			}
 		};
@@ -511,7 +543,11 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$send_to_inboxes->setAccessible( true );
 
 		// Invoke the method.
-		$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+		try {
+			$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
 
 		// Verify both inboxes were processed.
 		$this->assertCount( 2, $sent_inboxes, 'Both inboxes should be processed' );
@@ -556,7 +592,11 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$send_to_inboxes->setAccessible( true );
 
 		// Invoke the method.
-		$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+		try {
+			$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
 
 		// Verify HTTP was not called.
 		$this->assertFalse( $http_called, 'HTTP should not be called for local inboxes' );
@@ -597,7 +637,11 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$send_to_inboxes->setAccessible( true );
 
 		// Invoke the method.
-		$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+		try {
+			$send_to_inboxes->invoke( null, $inboxes, $outbox_item->ID );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
 
 		// Verify HTTP was called.
 		$this->assertTrue( $http_called, 'HTTP should be called for remote inboxes' );

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -509,6 +509,11 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		$announce_activity = json_decode( $announce_post->post_content, true );
 		$this->assertEquals( 'Announce', $announce_activity['type'] );
 
+		// Verify the original author is in the CC field.
+		$this->assertArrayHasKey( 'cc', $announce_activity, 'Announce should have a cc field' );
+		$original_author_url = Actors::get_by_id( self::$user_id )->get_id();
+		$this->assertContains( $original_author_url, $announce_activity['cc'], 'Original author should be in cc field' );
+
 		// Clean up.
 		wp_delete_post( $outbox_activity_id, true );
 		wp_delete_post( $announce_outbox_id, true );


### PR DESCRIPTION
Fixes #2054.
Fixes #1965.
See https://github.com/Automattic/wordpress-activitypub/pull/2359#issuecomment-3432788454.

## Proposed changes:
This PR fixes issues with local user interactions by routing same-domain inbox deliveries through internal REST API requests instead of external HTTP requests.

**Key changes:**
- Add `send_to_local_inbox()` method to handle same-domain deliveries using `rest_do_request()`
- Update `send_to_inboxes()` to check each inbox URL and route appropriately (local via REST, remote via HTTP)
- Remove `is_same_domain()` filter from `add_inboxes_by_mentioned_actors()` so local actors are properly included
- Improve performance by using `array_diff()` instead of `array_filter()` for removing public streams

**What this fixes:**
- Local users can now follow each other (#2054)
- Boosts/reposts from local users are properly counted (#1965)
- No more duplicate notifications - proper routing handles local vs remote delivery

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

### Test local follows:
1. Set up a WordPress site with ActivityPub plugin
2. Create two users (User A and User B)
3. Have User A follow User B from their profile
4. Verify the follow relationship is established correctly
5. Post as User B and verify User A sees it in their timeline

### Test local boosts:
1. Create a post as User A
2. Have User B boost/repost that post
3. Verify the boost is counted and displayed on User A's post
4. Verify User B's followers see the boosted post

### Verify remote functionality still works:
1. Follow a remote ActivityPub user
2. Verify remote follows still work via HTTP
3. Post content and verify it's delivered to remote followers

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Minor

#### Type

- [x] Fixed - for any bug fixes

#### Message

Fix local inbox delivery to use internal REST API instead of HTTP, enabling local follows and proper boost counting.

</details>