### PR TITLE
Fix PHPUnit tests for offline execution

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,6 +23,33 @@ if [ -n "$PHP_FILES" ]; then
     exit 1
   fi
 
+  # Check for forbidden remove_all_filters patterns in test files.
+  FORBIDDEN_PATTERN=0
+  for file in $PHP_FILES; do
+    if echo "$file" | grep -q "^tests/"; then
+      if grep -n "remove_all_filters.*['\"]pre_http_request['\"]" "$file" > /dev/null 2>&1; then
+        if [ $FORBIDDEN_PATTERN -eq 0 ]; then
+          echo "❌ Found forbidden pattern in test files:"
+          echo ""
+          FORBIDDEN_PATTERN=1
+        fi
+        echo "  $file:"
+        grep -n "remove_all_filters.*['\"]pre_http_request['\"]" "$file" | sed 's/^/    Line /'
+        echo ""
+      fi
+    fi
+  done
+
+  if [ $FORBIDDEN_PATTERN -eq 1 ]; then
+    echo "⚠️  Please use remove_filter() with specific callback variables instead of remove_all_filters()."
+    echo ""
+    echo "Example:"
+    echo "  ❌ Bad:  remove_all_filters( 'pre_http_request' );"
+    echo "  ✅ Good: remove_filter( 'pre_http_request', \$callback_variable );"
+    echo ""
+    exit 1
+  fi
+
   # Run PHP Code Sniffer on all changed PHP files at once.
   echo "$PHP_FILES" | xargs composer lint:fix > /dev/null 2>&1 || { echo "PHP formatting failed"; exit 1; }
 fi

--- a/tests/phpunit/includes/class-test-rest-controller-testcase.php
+++ b/tests/phpunit/includes/class-test-rest-controller-testcase.php
@@ -7,35 +7,33 @@
 
 namespace Activitypub\Tests;
 
+use function Activitypub\object_to_uri;
+
 /**
  * REST Controller Testcase.
  */
 abstract class Test_REST_Controller_Testcase extends \WP_Test_REST_TestCase {
 
 	/**
-	 * The REST server.
-	 *
-	 * @var \WP_REST_Server
-	 */
-	protected $server;
-
-	/**
 	 * Set up the test.
 	 */
 	public function set_up() {
 		parent::set_up();
-		add_filter( 'rest_url', array( $this, 'filter_rest_url_for_leading_slash' ), 10, 2 );
+
+		\add_filter( 'rest_url', array( $this, 'filter_rest_url_for_leading_slash' ), 10, 2 );
+		\add_filter( 'activitypub_pre_http_get_remote_object', array( get_called_class(), 'bypass_url_validation' ), 10, 2 );
 
 		global $wp_rest_server;
 		$wp_rest_server = new \Spy_REST_Server();
-		do_action( 'rest_api_init', $wp_rest_server );
+		\do_action( 'rest_api_init', $wp_rest_server );
 	}
 
 	/**
 	 * Tear down the test.
 	 */
 	public function tear_down() {
-		remove_filter( 'rest_url', array( $this, 'test_rest_url_for_leading_slash' ) );
+		\remove_filter( 'rest_url', array( $this, 'test_rest_url_for_leading_slash' ) );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', array( get_called_class(), 'bypass_url_validation' ) );
 
 		global $wp_rest_server;
 		$wp_rest_server = null;
@@ -67,14 +65,43 @@ abstract class Test_REST_Controller_Testcase extends \WP_Test_REST_TestCase {
 
 		// Make sure path for rest_url has a leading slash for proper resolution.
 		if ( 0 !== strpos( $path, '/' ) ) {
-			$this->fail(
-				sprintf(
-					'REST API URL "%s" should have a leading slash.',
-					$path
-				)
-			);
+			$this->fail( \sprintf( 'REST API URL "%s" should have a leading slash.', $path ) );
 		}
 
 		return $url;
+	}
+
+	/**
+	 * Bypass URL validation by returning fixture data.
+	 *
+	 * This method is used to bypass wp_http_validate_url() which calls gethostbyname()
+	 * and fails when running tests offline. By returning fixture data early, we can
+	 * avoid the DNS lookup entirely.
+	 *
+	 * @param mixed        $pre           The preempted value.
+	 * @param array|string $url_or_object The URL or object.
+	 * @return mixed
+	 */
+	public static function bypass_url_validation( $pre, $url_or_object ) {
+		$url = object_to_uri( $url_or_object );
+		if ( ! $url ) {
+			return $pre;
+		}
+
+		// Check if fixture exists and return it to bypass wp_http_validate_url().
+		$p = \wp_parse_url( $url );
+		if ( ! $p || ! isset( $p['host'] ) || ! isset( $p['path'] ) ) {
+			return $pre;  // Invalid URL, let normal flow handle it.
+		}
+
+		$cache = AP_TESTS_DIR . '/data/fixtures/' . \sanitize_title( $p['host'] . '-' . $p['path'] ) . '.json';
+		if ( \file_exists( $cache ) ) {
+			$data = \json_decode( \file_get_contents( $cache ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+			if ( isset( $data['body'] ) ) {
+				return \json_decode( $data['body'], true );
+			}
+		}
+
+		return $pre;
 	}
 }

--- a/tests/phpunit/includes/class-test-rest-controller-testcase.php
+++ b/tests/phpunit/includes/class-test-rest-controller-testcase.php
@@ -32,7 +32,7 @@ abstract class Test_REST_Controller_Testcase extends \WP_Test_REST_TestCase {
 	 * Tear down the test.
 	 */
 	public function tear_down() {
-		\remove_filter( 'rest_url', array( $this, 'test_rest_url_for_leading_slash' ) );
+		\remove_filter( 'rest_url', array( $this, 'filter_rest_url_for_leading_slash' ) );
 		\remove_filter( 'activitypub_pre_http_get_remote_object', array( get_called_class(), 'bypass_url_validation' ) );
 
 		global $wp_rest_server;

--- a/tests/phpunit/tests/includes/class-test-move.php
+++ b/tests/phpunit/tests/includes/class-test-move.php
@@ -74,14 +74,14 @@ class Test_Move extends \WP_UnitTestCase {
 		$filter = function () {
 			return new \WP_Error( 'http_request_failed', 'Invalid URL' );
 		};
-		\add_filter( 'pre_http_request', $filter );
+		\add_filter( 'activitypub_pre_http_get_remote_object', $filter, 10, 2 );
 
 		$result = Move::externally( $from, $to );
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'http_request_failed', $result->get_error_code() );
 
-		\remove_filter( 'pre_http_request', $filter );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/handler/class-test-update.php
+++ b/tests/phpunit/tests/includes/handler/class-test-update.php
@@ -98,14 +98,11 @@ class Test_Update extends \WP_UnitTestCase {
 			if ( is_wp_error( $http_response ) ) {
 				return $http_response;
 			}
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => wp_json_encode( $http_response ),
-			);
+			return $http_response;
 		};
 
 		// Mock HTTP request.
-		\add_filter( 'pre_http_request', $fake_request, 10 );
+		\add_filter( 'activitypub_pre_http_get_remote_object', $fake_request, 10, 2 );
 
 		// Execute the update_actor method.
 		Update::update_actor( $activity_data, 1 );
@@ -129,7 +126,7 @@ class Test_Update extends \WP_UnitTestCase {
 			}
 		}
 
-		\remove_filter( 'pre_http_request', $fake_request, 10 );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $fake_request );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-interaction-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-interaction-controller.php
@@ -59,18 +59,15 @@ class Test_Interaction_Controller extends \Activitypub\Tests\Test_REST_Controlle
 	 */
 	public function test_get_item() {
 		\add_filter(
-			'pre_http_request',
+			'activitypub_pre_http_get_remote_object',
 			function () {
 				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => wp_json_encode(
-						array(
-							'type' => 'Note',
-							'url'  => 'https://example.org/note',
-						)
-					),
+					'type' => 'Note',
+					'url'  => 'https://example.org/note',
 				);
-			}
+			},
+			10,
+			2
 		);
 
 		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/interactions' );
@@ -89,25 +86,22 @@ class Test_Interaction_Controller extends \Activitypub\Tests\Test_REST_Controlle
 	 */
 	public function test_get_item_custom_follow_url() {
 		\add_filter(
-			'pre_http_request',
+			'activitypub_pre_http_get_remote_object',
 			function () {
 				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => wp_json_encode(
+					'type'  => 'Person',
+					'url'   => 'https://example.org/person',
+					'links' => array(
 						array(
-							'type'  => 'Person',
-							'url'   => 'https://example.org/person',
-							'links' => array(
-								array(
-									'rel'  => 'self',
-									'type' => 'application/activity+json',
-									'href' => 'https://example.org/user/person',
-								),
-							),
-						)
+							'rel'  => 'self',
+							'type' => 'application/activity+json',
+							'href' => 'https://example.org/user/person',
+						),
 					),
 				);
-			}
+			},
+			10,
+			2
 		);
 
 		\add_filter( 'activitypub_interactions_follow_url', array( $this, 'follow_or_reply_url' ) );
@@ -138,18 +132,15 @@ class Test_Interaction_Controller extends \Activitypub\Tests\Test_REST_Controlle
 	 */
 	public function test_get_item_custom_reply_url() {
 		\add_filter(
-			'pre_http_request',
+			'activitypub_pre_http_get_remote_object',
 			function () {
 				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => wp_json_encode(
-						array(
-							'type' => 'Note',
-							'url'  => 'https://example.org/note',
-						)
-					),
+					'type' => 'Note',
+					'url'  => 'https://example.org/note',
 				);
-			}
+			},
+			10,
+			2
 		);
 
 		\add_filter( 'activitypub_interactions_reply_url', array( $this, 'follow_or_reply_url' ) );

--- a/tests/phpunit/tests/includes/wp-admin/table/class-test-blocked-actors.php
+++ b/tests/phpunit/tests/includes/wp-admin/table/class-test-blocked-actors.php
@@ -31,16 +31,6 @@ class Test_Blocked_Actors extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Clean up after each test.
-	 */
-	public function tear_down() {
-		parent::tear_down();
-
-		remove_all_filters( 'pre_http_request' );
-		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
-	}
-
-	/**
 	 * Data provider for actor identifier normalization test cases.
 	 *
 	 * @return array Test cases with input, expected output, and label.
@@ -129,19 +119,16 @@ class Test_Blocked_Actors extends \WP_UnitTestCase {
 
 		// Mock HTTP request to fetch actor data.
 		add_filter(
-			'pre_http_request',
-			function ( $response, $parsed_args, $url ) use ( $actor_data ) {
+			'activitypub_pre_http_get_remote_object',
+			function ( $pre, $url_or_object ) use ( $actor_data ) {
+				$url = \Activitypub\object_to_uri( $url_or_object );
 				if ( $url === $actor_data['id'] ) {
-					return array(
-						'headers'  => array( 'content-type' => 'application/activity+json' ),
-						'body'     => wp_json_encode( $actor_data ),
-						'response' => array( 'code' => 200 ),
-					);
+					return $actor_data;
 				}
-				return $response;
+				return $pre;
 			},
 			10,
-			3
+			2
 		);
 
 		// Mock remote metadata for the actor.

--- a/tests/phpunit/tests/includes/wp-admin/table/class-test-followers.php
+++ b/tests/phpunit/tests/includes/wp-admin/table/class-test-followers.php
@@ -42,16 +42,6 @@ class Test_Followers extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Clean up after each test.
-	 */
-	public function tear_down() {
-		parent::tear_down();
-
-		remove_all_filters( 'pre_http_request' );
-		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
-	}
-
-	/**
 	 * Test column_username with actor having icon object.
 	 *
 	 * @covers ::column_username

--- a/tests/phpunit/tests/includes/wp-admin/table/class-test-following.php
+++ b/tests/phpunit/tests/includes/wp-admin/table/class-test-following.php
@@ -42,16 +42,6 @@ class Test_Following extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Clean up after each test.
-	 */
-	public function tear_down() {
-		parent::tear_down();
-
-		remove_all_filters( 'pre_http_request' );
-		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
-	}
-
-	/**
 	 * Test column_username with actor having icon object using real prepare_items().
 	 *
 	 * This test uses Following::follow() to create a real following and uses


### PR DESCRIPTION
## Proposed changes:
* Converts HTTP request mocks from `pre_http_request` to `activitypub_pre_http_get_remote_object` filter in 9 test files
* Ensures tests work offline by bypassing `wp_http_validate_url()` which fails due to DNS lookups
* Modified filters now return ActivityPub object data directly instead of HTTP response structures
* Removes all instances of `remove_all_filters('pre_http_request')` from tests
* Adds pre-commit hook check to prevent future use of `remove_all_filters('pre_http_request')`

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Modified existing tests to work offline.

## Testing instructions:

1. Disconnect from the internet
2. Run the full PHPUnit test suite:
   ```bash
   npm run env-test
   ```
3. Verify all tests pass without internet connectivity
4. Test the pre-commit hook by attempting to add `remove_all_filters('pre_http_request')` to a test file and committing

### Changelog entry

No changelog entry required - this is a test-only change.