### PR TITLE
Use short ternary for post content template fallback

### DIFF
--- a/.github/changelog/2417-from-description
+++ b/.github/changelog/2417-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue with post content templates to ensure the correct fallback is always applied.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -891,7 +891,7 @@ class Post extends Base {
 	 */
 	protected function get_post_content_template() {
 		$content  = \get_option( 'activitypub_custom_post_content', ACTIVITYPUB_CUSTOM_POST_CONTENT );
-		$template = $content ?? ACTIVITYPUB_CUSTOM_POST_CONTENT;
+		$template = $content ?: ACTIVITYPUB_CUSTOM_POST_CONTENT; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 
 		$post_format_setting = \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
 


### PR DESCRIPTION
Replaces the null coalescing operator with the short ternary operator when assigning the post content template, ensuring compatibility and maintaining the intended fallback behavior.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #2403 

## Proposed changes:
- Replaced null coalescing operator with short ternary operator for the template fallback logic
- Added a phpcs ignore comment for the DisallowShortTernary rule

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed an issue with post content templates to ensure the correct fallback is always applied.

</details>
