### PR TITLE
Notes: do not prepend post titles to reply posts

### DIFF
--- a/.github/changelog/fix-note-title-detection
+++ b/.github/changelog/fix-note-title-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reply posts: do not display post title before @mentions in posts that are replies to somebody else

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -900,9 +900,7 @@ class Post extends Base {
 			$template = '';
 
 			// If the post is a note and not a reply, force the inclusion of the post title.
-			$is_reply = null !== $this->get_in_reply_to();
-
-			if ( 'Note' === $type && ! $is_reply ) {
+			if ( 'Note' === $type && empty( $this->get_in_reply_to() ) ) {
 				$template .= "[ap_title type=\"html\"]\n\n";
 			}
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -899,7 +899,10 @@ class Post extends Base {
 		if ( 'wordpress-post-format' === $post_format_setting ) {
 			$template = '';
 
-			if ( 'Note' === $type ) {
+			// If the post is a note and not a reply, force the inclusion of the post title.
+			$is_reply = null !== $this->get_in_reply_to();
+
+			if ( 'Note' === $type && ! $is_reply ) {
 				$template .= "[ap_title type=\"html\"]\n\n";
 			}
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -899,8 +899,15 @@ class Post extends Base {
 		if ( 'wordpress-post-format' === $post_format_setting ) {
 			$template = '';
 
-			// If the post is a note and not a reply, force the inclusion of the post title.
-			if ( 'Note' === $type && empty( $this->get_in_reply_to() ) ) {
+			/*
+			 *If the post is a note, not a reply, and does not have mentions
+			 * force the inclusion of the post title.
+			 */
+			if (
+				'Note' === $type
+				&& empty( $this->get_in_reply_to() )
+				&& empty( $this->get_mentions() )
+			) {
 				$template .= "[ap_title type=\"html\"]\n\n";
 			}
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -894,11 +894,12 @@ class Post extends Base {
 		$template = $content ?: ACTIVITYPUB_CUSTOM_POST_CONTENT; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 
 		$post_format_setting = \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
+		$type                = $this->get_type();
 
 		if ( 'wordpress-post-format' === $post_format_setting ) {
 			$template = '';
 
-			if ( 'Note' === $this->get_type() ) {
+			if ( 'Note' === $type ) {
 				$template .= "[ap_title type=\"html\"]\n\n";
 			}
 
@@ -915,8 +916,9 @@ class Post extends Base {
 		 *
 		 * @param string   $template  The template string containing shortcodes.
 		 * @param \WP_Post $item The WordPress post object being transformed.
+		 * @param string   $type ActivityStreams 2.0 Object-Type for the post.
 		 */
-		return apply_filters( 'activitypub_object_content_template', $template, $this->item );
+		return apply_filters( 'activitypub_object_content_template', $template, $this->item, $type );
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -917,6 +917,8 @@ class Post extends Base {
 		 * shortcodes like [ap_title] and [ap_content] that are processed during content
 		 * generation.
 		 *
+		 * @since 7.6.0 Added the $type parameter.
+		 *
 		 * @param string   $template  The template string containing shortcodes.
 		 * @param \WP_Post $item The WordPress post object being transformed.
 		 * @param string   $type ActivityStreams 2.0 Object-Type for the post.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -900,7 +900,7 @@ class Post extends Base {
 			$template = '';
 
 			/*
-			 *If the post is a note, not a reply, and does not have mentions
+			 * If the post is a note, not a reply, and does not have mentions
 			 * force the inclusion of the post title.
 			 */
 			if (

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -1034,18 +1034,32 @@ class Test_Post extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_post_content_template falls back to constant when option is empty.
+	 * Test get_post_content_template with various post types and reply scenarios.
 	 *
+	 * Tests how the template is generated for different post types (Article, Note)
+	 * and reply configurations, as well as option fallback scenarios.
+	 *
+	 * @dataProvider wordpress_post_format_template_provider
 	 * @covers ::get_post_content_template
+	 *
+	 * @param array       $post_data           The post data to create.
+	 * @param string      $expected_template   The expected template string.
+	 * @param string      $object_type         The activitypub_object_type option value.
+	 * @param string|null $custom_post_content The activitypub_custom_post_content option value (null to delete).
+	 * @param string      $description         Description of the test case.
 	 */
-	public function test_get_post_content_template_fallback_with_empty_option() {
-		$post = $this->create_test_post();
+	public function test_get_post_content_template_with_scenarios( $post_data, $expected_template, $object_type, $custom_post_content, $description ) {
+		// Set object type.
+		\update_option( 'activitypub_object_type', $object_type );
 
-		// Set object type to something other than wordpress-post-format.
-		\update_option( 'activitypub_object_type', 'Article' );
+		// Set or delete custom post content option.
+		if ( null === $custom_post_content ) {
+			\delete_option( 'activitypub_custom_post_content' );
+		} else {
+			\update_option( 'activitypub_custom_post_content', $custom_post_content );
+		}
 
-		// Test with empty string option - should fall back to constant.
-		\update_option( 'activitypub_custom_post_content', '' );
+		$post = self::factory()->post->create_and_get( $post_data );
 
 		$transformer = new Post( $post );
 		$reflection  = new \ReflectionClass( Post::class );
@@ -1054,104 +1068,93 @@ class Test_Post extends \WP_UnitTestCase {
 
 		$template = $method->invoke( $transformer );
 
-		$this->assertSame( ACTIVITYPUB_CUSTOM_POST_CONTENT, $template, 'Empty option should fall back to ACTIVITYPUB_CUSTOM_POST_CONTENT constant.' );
+		// All wordpress-post-format templates should contain [ap_content].
+		if ( 'wordpress-post-format' === $object_type ) {
+			$this->assertStringContainsString( '[ap_content]', $template, $description . ' - should contain [ap_content]' );
+		}
+
+		$this->assertSame( $expected_template, $template, $description );
 	}
 
 	/**
-	 * Test that get_post_content_template uses option value when set.
+	 * Data provider for get_post_content_template tests with various scenarios.
 	 *
-	 * @covers ::get_post_content_template
+	 * @return array Each test case contains:
+	 *               - post_data: The post data to create
+	 *               - expected_template: The expected template string
+	 *               - object_type: The activitypub_object_type option value
+	 *               - custom_post_content: The activitypub_custom_post_content option value (null to delete)
+	 *               - description: Description of the test case
 	 */
-	public function test_get_post_content_template_uses_option_when_set() {
-		$post = $this->create_test_post();
-
-		// Set object type to something other than wordpress-post-format.
-		\update_option( 'activitypub_object_type', 'Article' );
-
-		// Test with custom template option.
-		$custom_template = '[ap_title]\n\n[ap_content]\n\n[ap_hashtags]';
-		\update_option( 'activitypub_custom_post_content', $custom_template );
-
-		$transformer = new Post( $post );
-		$reflection  = new \ReflectionClass( Post::class );
-		$method      = $reflection->getMethod( 'get_post_content_template' );
-		$method->setAccessible( true );
-
-		$template = $method->invoke( $transformer );
-
-		$this->assertSame( $custom_template, $template, 'Should use custom template option when set.' );
-	}
-
-	/**
-	 * Test that get_post_content_template falls back with null option.
-	 *
-	 * @covers ::get_post_content_template
-	 */
-	public function test_get_post_content_template_fallback_with_false_option() {
-		$post = $this->create_test_post();
-
-		// Set object type to something other than wordpress-post-format.
-		\update_option( 'activitypub_object_type', 'Article' );
-
-		// Test with false option (not set) - should fall back to constant.
-		\delete_option( 'activitypub_custom_post_content' );
-
-		$transformer = new Post( $post );
-		$reflection  = new \ReflectionClass( Post::class );
-		$method      = $reflection->getMethod( 'get_post_content_template' );
-		$method->setAccessible( true );
-
-		$template = $method->invoke( $transformer );
-
-		$this->assertSame( ACTIVITYPUB_CUSTOM_POST_CONTENT, $template, 'False option should fall back to ACTIVITYPUB_CUSTOM_POST_CONTENT constant.' );
-	}
-
-	/**
-	 * Test that get_post_content_template respects wordpress-post-format setting.
-	 *
-	 * @covers ::get_post_content_template
-	 */
-	public function test_get_post_content_template_wordpress_post_format() {
-		// Create a post with long content and title (will be Article type).
-		$article_post = self::factory()->post->create_and_get(
-			array(
-				'post_title'   => 'Test Article',
-				'post_content' => str_repeat( 'Long content. ', 100 ),
-				'post_status'  => 'publish',
-			)
+	public function wordpress_post_format_template_provider() {
+		return array(
+			'Article type'                => array(
+				array(
+					'post_title'   => 'Test Article',
+					'post_content' => str_repeat( 'Long content. ', 100 ),
+					'post_status'  => 'publish',
+				),
+				'[ap_content]',
+				'wordpress-post-format',
+				'[ap_title]\n\n[ap_content]',
+				'wordpress-post-format should override custom template for Article type.',
+			),
+			'Note type without reply'     => array(
+				array(
+					'post_title'   => '',
+					'post_content' => 'Short note',
+					'post_status'  => 'publish',
+				),
+				"[ap_title type=\"html\"]\n\n[ap_content]",
+				'wordpress-post-format',
+				'[ap_title]\n\n[ap_content]',
+				'wordpress-post-format should add title for Note type without reply.',
+			),
+			'Note type with reply block'  => array(
+				array(
+					'post_title'   => '',
+					'post_content' => '<!-- wp:activitypub/reply {"url":"https://example.com/posts/123"} /-->' . PHP_EOL .
+										'<!-- wp:paragraph --><p>This is a reply note.</p><!-- /wp:paragraph -->',
+					'post_status'  => 'publish',
+				),
+				'[ap_content]',
+				'wordpress-post-format',
+				'[ap_title]\n\n[ap_content]',
+				'wordpress-post-format should not add title for Note type when it is a reply.',
+			),
+			'fallback_with_false_option'  => array(
+				array(
+					'post_title'   => 'Interaction Policy Test',
+					'post_content' => 'Content',
+					'post_status'  => 'publish',
+				),
+				ACTIVITYPUB_CUSTOM_POST_CONTENT,
+				'Article',
+				null,
+				'False option should fall back to ACTIVITYPUB_CUSTOM_POST_CONTENT constant.',
+			),
+			'uses_custom_option_when_set' => array(
+				array(
+					'post_title'   => 'Interaction Policy Test',
+					'post_content' => 'Content',
+					'post_status'  => 'publish',
+				),
+				'[ap_title]\n\n[ap_content]\n\n[ap_hashtags]',
+				'Article',
+				'[ap_title]\n\n[ap_content]\n\n[ap_hashtags]',
+				'Should use custom template option when set.',
+			),
+			'fallback_with_empty_option'  => array(
+				array(
+					'post_title'   => 'Interaction Policy Test',
+					'post_content' => 'Content',
+					'post_status'  => 'publish',
+				),
+				ACTIVITYPUB_CUSTOM_POST_CONTENT,
+				'Article',
+				'',
+				'Empty activitypub_custom_post_content option should fall back to ACTIVITYPUB_CUSTOM_POST_CONTENT constant.',
+			),
 		);
-
-		// Set custom content template.
-		\update_option( 'activitypub_custom_post_content', '[ap_title]\n\n[ap_content]' );
-
-		// Set post format setting to wordpress-post-format.
-		\update_option( 'activitypub_object_type', 'wordpress-post-format' );
-
-		$transformer = new Post( $article_post );
-		$reflection  = new \ReflectionClass( Post::class );
-		$method      = $reflection->getMethod( 'get_post_content_template' );
-		$method->setAccessible( true );
-
-		$template = $method->invoke( $transformer );
-
-		// When wordpress-post-format is set, template should be generated based on post type.
-		// For an Article (long content with title), it should just be [ap_content].
-		$this->assertSame( '[ap_content]', $template, 'wordpress-post-format should override custom template for Article type.' );
-
-		// Test with a Note type (no title or short content).
-		$note_post = self::factory()->post->create_and_get(
-			array(
-				'post_title'   => '',
-				'post_content' => 'Short note',
-				'post_status'  => 'publish',
-			)
-		);
-
-		$note_transformer = new Post( $note_post );
-		$note_template    = $method->invoke( $note_transformer );
-
-		// For a Note, the template should include the title.
-		$this->assertStringContainsString( '[ap_title type="html"]', $note_template, 'wordpress-post-format should add title for Note type.' );
-		$this->assertStringContainsString( '[ap_content]', $note_template, 'wordpress-post-format should include content for Note type.' );
 	}
 }

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -1059,6 +1059,21 @@ class Test_Post extends \WP_UnitTestCase {
 			\update_option( 'activitypub_custom_post_content', $custom_post_content );
 		}
 
+		// Mock mentions extraction if the post content contains mention patterns.
+		$content         = $post_data['post_content'] ?? '';
+		$mentions_filter = null;
+		if ( \preg_match( '/@' . ACTIVITYPUB_USERNAME_REGEXP . '/i', $content ) ) {
+			$mentions_filter = function ( $mentions, $post_content ) {
+				// Extract all mention patterns from content.
+				\preg_match_all( '/@' . ACTIVITYPUB_USERNAME_REGEXP . '/i', $post_content, $all_matches );
+				foreach ( $all_matches[0] as $match ) {
+					$mentions[ $match ] = 'https://example.com/' . \ltrim( $match, '@' );
+				}
+				return $mentions;
+			};
+			\add_filter( 'activitypub_extract_mentions', $mentions_filter, 10, 2 );
+		}
+
 		$post = self::factory()->post->create_and_get( $post_data );
 
 		$transformer = new Post( $post );
@@ -1067,6 +1082,11 @@ class Test_Post extends \WP_UnitTestCase {
 		$method->setAccessible( true );
 
 		$template = $method->invoke( $transformer );
+
+		// Clean up mentions filter if it was added.
+		if ( $mentions_filter ) {
+			\remove_filter( 'activitypub_extract_mentions', $mentions_filter, 10 );
+		}
 
 		// All wordpress-post-format templates should contain [ap_content].
 		if ( 'wordpress-post-format' === $object_type ) {
@@ -1121,6 +1141,17 @@ class Test_Post extends \WP_UnitTestCase {
 				'wordpress-post-format',
 				'[ap_title]\n\n[ap_content]',
 				'wordpress-post-format should not add title for Note type when it is a reply.',
+			),
+			'Note type with mentions'     => array(
+				array(
+					'post_title'   => '',
+					'post_content' => 'Short note mentioning @activitypub.blog@activitypub.blog',
+					'post_status'  => 'publish',
+				),
+				'[ap_content]',
+				'wordpress-post-format',
+				null,
+				'wordpress-post-format should not add title for Note type when it has mentions.',
 			),
 			'fallback_with_false_option'  => array(
 				array(


### PR DESCRIPTION
## Proposed changes:

We currently force the addition of the post title to notes, so that title is included before the post content if it exists.

This does not make sense when the note includes a Federated Reply block. In those situations, you would expect the beginning of the note to be a @mention of the person you are replying to, not the post title.

> [!NOTE]
> This PR is also an opportunity to add an extra parameter to the existing `activitypub_object_content_template`, so it's easier for folks to customize their content template based off the type of the post.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Write and publish 2 posts:
    * One that includes a Federated reply block in reply to a random post on the Fediverse.
    * One that does not.
* Both posts should have a post title, but should have very content in the post so they're automatically classified as "Notes".
* View the posts on the frontend, and add `/activitypub` to the end of the post URL
    * The post title should only be prepended to the post that does not include the reply block.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
