### PR TITLE
Add REST API preload routes for Social Web site-hub component

### DIFF
--- a/includes/wp-admin/class-social-web.php
+++ b/includes/wp-admin/class-social-web.php
@@ -32,6 +32,25 @@ class Social_Web {
 	 * Enqueue scripts and styles for the Social Web page.
 	 */
 	public static function enqueue_scripts() {
+		// Define paths to preload - must match exact fields from entities.js.
+		$preload_paths = array(
+			'/?_fields=description,gmt_offset,home,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
+			array( '/wp/v2/settings', 'OPTIONS' ),
+		);
+
+		// Use rest_preload_api_request to gather the preloaded data.
+		$preload_data = \array_reduce(
+			$preload_paths,
+			'rest_preload_api_request',
+			array()
+		);
+
+		// Register the preloading middleware with wp-api-fetch.
+		\wp_add_inline_script(
+			'wp-api-fetch',
+			\sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', \wp_json_encode( $preload_data ) )
+		);
+
 		$vendors_asset = include \plugin_dir_path( ACTIVITYPUB_PLUGIN_FILE ) . 'build/social-web/vendors.asset.php';
 
 		\wp_enqueue_script(


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Adds preloading of REST API data needed by the site-hub component
* Preloads root endpoint with specific fields (name, URL, site icon, etc.)
* Preloads settings OPTIONS to avoid additional requests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Navigate to the Social Web admin page
* Verify site icon and title display correctly in the site-hub component
* Check browser network tab to confirm no additional REST API requests for root endpoint on page load