### PR TITLE
Fix: Handle WP_Error in transformer Factory gracefully

### DIFF
--- a/.github/changelog/2429-from-description
+++ b/.github/changelog/2429-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed fatal error when transformer Factory receives WP_Error objects.

--- a/includes/transformer/class-factory.php
+++ b/includes/transformer/class-factory.php
@@ -27,6 +27,11 @@ class Factory {
 	 * @return Base|\WP_Error The transformer to use, or an error.
 	 */
 	public static function get_transformer( $data ) {
+		// Early return for WP_Error objects.
+		if ( \is_wp_error( $data ) ) {
+			return $data;
+		}
+
 		if ( \is_string( $data ) && \filter_var( $data, FILTER_VALIDATE_URL ) ) {
 			$response = Http::get_remote_object( $data );
 

--- a/tests/phpunit/tests/includes/transformer/class-test-factory.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-factory.php
@@ -267,4 +267,19 @@ class Test_Factory extends \WP_UnitTestCase {
 
 		\remove_filter( 'pre_http_request', $fake_request );
 	}
+
+	/**
+	 * Test get_transformer with WP_Error input.
+	 *
+	 * @covers ::get_transformer
+	 */
+	public function test_get_transformer_with_wp_error() {
+		$wp_error = new \WP_Error( 'test_error', 'Test error message' );
+		$result   = Factory::get_transformer( $wp_error );
+
+		// Should return the same WP_Error object
+		$this->assertWPError( $result );
+		$this->assertEquals( 'test_error', $result->get_error_code() );
+		$this->assertEquals( 'Test error message', $result->get_error_message() );
+	}
 }

--- a/tests/phpunit/tests/includes/transformer/class-test-factory.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-factory.php
@@ -277,7 +277,7 @@ class Test_Factory extends \WP_UnitTestCase {
 		$wp_error = new \WP_Error( 'test_error', 'Test error message' );
 		$result   = Factory::get_transformer( $wp_error );
 
-		// Should return the same WP_Error object
+		// Should return the same WP_Error object.
 		$this->assertWPError( $result );
 		$this->assertEquals( 'test_error', $result->get_error_code() );
 		$this->assertEquals( 'Test error message', $result->get_error_message() );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add early return when `Factory::get_transformer()` receives WP_Error input
* Prevents unnecessary processing and preserves original error details  
* Handles cases where `activitypub_queried_object` filter might return WP_Error

### Other information:

This fixes a fatal error that was occurring in production:

```
Fatal error: Uncaught Error: Call to undefined method WP_Error::get_id() in /wp-content/plugins/activitypub/includes/transformer/class-activity-object.php:42
Stack trace:
#0 /wp-content/plugins/activitypub/includes/transformer/class-base.php(221): Activitypub\Transformer\Activity_Object->get_id()
#1 /wp-content/plugins/activitypub/includes/class-query.php(128): Activitypub\Transformer\Base->to_id()
#2 /wp-content/plugins/activitypub/includes/class-router.php(142): Activitypub\Query->get_activitypub_object_id()
#3 /wp-content/plugins/activitypub/includes/class-router.php(74): Activitypub\Router::add_headers()
#4 /wp-includes/class-wp-hook.php(324): Activitypub\Router::render_activitypub_template('...')
```

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `npm run env-test -- --filter=Test_Query` to verify all Query tests pass
* Run `npm run env-test -- --filter=Test_Factory` to verify all Factory tests pass
* Specifically test the new test case: `npm run env-test -- --filter=test_get_activitypub_object_id_with_wp_error_from_queried_object_filter`

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed fatal error when transformer Factory receives WP_Error objects.

</details>