### PR TITLE
Update Jetpack initialization and enable dev debug

### DIFF
--- a/.github/changelog/2434-from-description
+++ b/.github/changelog/2434-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved Jetpack integration by initializing it during the WordPress startup process.

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -39,8 +39,6 @@ class Jetpack {
 			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
 			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
 		}
-
-		\add_action( 'load-post-new.php', array( self::class, 'adapt_post_share' ) );
 	}
 
 	/**

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -9,7 +9,6 @@ namespace Activitypub\Integration;
 
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
-use Activitypub\Comment;
 use Activitypub\Http;
 use Automattic\Jetpack\Connection\Manager;
 
@@ -39,6 +38,8 @@ class Jetpack {
 			\add_filter( 'activitypub_following_row_actions', array( self::class, 'add_reader_link' ), 10, 2 );
 			\add_filter( 'pre_option_activitypub_following_ui', array( self::class, 'pre_option_activitypub_following_ui' ) );
 		}
+
+		\add_action( 'load-post-new.php', array( self::class, 'adapt_post_share' ) );
 	}
 
 	/**
@@ -72,15 +73,14 @@ class Jetpack {
 	 * Add custom comment types to the list of comment types.
 	 *
 	 * @param array $comment_types Default comment types.
-	 * @return array
+	 *
+	 * @return array The comment types with ActivityPub types added.
 	 */
 	public static function add_comment_types( $comment_types ) {
-		// jetpack_sync_whitelisted_comment_types runs on plugins_loaded, before comment types are registered.
-		if ( 'jetpack_sync_whitelisted_comment_types' === current_filter() ) {
-			Comment::register_comment_types();
-		}
+		$comment_types[] = 'repost';
+		$comment_types[] = 'like';
 
-		return array_unique( \array_merge( $comment_types, Comment::get_comment_type_slugs() ) );
+		return array_unique( $comment_types );
 	}
 
 	/**

--- a/integration/load.php
+++ b/integration/load.php
@@ -57,8 +57,7 @@ function plugin_init() {
 	 * @see https://jetpack.com/
 	 */
 	if ( \defined( 'JETPACK__VERSION' ) ) {
-		\add_action( 'init', array( Jetpack::class, 'init' ) );
-		\add_action( 'load-post-new.php', array( Jetpack::class, 'adapt_post_share' ) );
+		Jetpack::init();
 	}
 
 	/**

--- a/integration/load.php
+++ b/integration/load.php
@@ -58,6 +58,7 @@ function plugin_init() {
 	 */
 	if ( \defined( 'JETPACK__VERSION' ) ) {
 		\add_action( 'init', array( Jetpack::class, 'init' ) );
+		\add_action( 'load-post-new.php', array( Jetpack::class, 'adapt_post_share' ) );
 	}
 
 	/**

--- a/integration/load.php
+++ b/integration/load.php
@@ -57,7 +57,7 @@ function plugin_init() {
 	 * @see https://jetpack.com/
 	 */
 	if ( \defined( 'JETPACK__VERSION' ) ) {
-		Jetpack::init();
+		\add_action( 'init', array( Jetpack::class, 'init' ) );
 	}
 
 	/**

--- a/local/load.php
+++ b/local/load.php
@@ -17,7 +17,9 @@ namespace Activitypub\Development;
  * Setting JETPACK_DEV_DEBUG to true allows Jetpack features to run in a local development environment,
  * bypassing certain production checks and enabling debugging tools. This should only be enabled for local development.
  */
-define( 'JETPACK_DEV_DEBUG', true );
+if ( ! defined( 'JETPACK_DEV_DEBUG' ) ) {
+    define( 'JETPACK_DEV_DEBUG', true );
+}
 
 // Load development WP-CLI commands.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/local/load.php
+++ b/local/load.php
@@ -10,8 +10,10 @@ namespace Activitypub\Development;
 \Activitypub\Autoloader::register_path( __NAMESPACE__, __DIR__ );
 
 // Initialize local development tools below.
-/**
+
+/*
  * Enables Jetpack development/debug mode.
+ *
  * Setting JETPACK_DEV_DEBUG to true allows Jetpack features to run in a local development environment,
  * bypassing certain production checks and enabling debugging tools. This should only be enabled for local development.
  */

--- a/local/load.php
+++ b/local/load.php
@@ -10,6 +10,7 @@ namespace Activitypub\Development;
 \Activitypub\Autoloader::register_path( __NAMESPACE__, __DIR__ );
 
 // Initialize local development tools below.
+define( 'JETPACK_DEV_DEBUG', true );
 
 // Load development WP-CLI commands.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/local/load.php
+++ b/local/load.php
@@ -10,6 +10,11 @@ namespace Activitypub\Development;
 \Activitypub\Autoloader::register_path( __NAMESPACE__, __DIR__ );
 
 // Initialize local development tools below.
+/**
+ * Enables Jetpack development/debug mode.
+ * Setting JETPACK_DEV_DEBUG to true allows Jetpack features to run in a local development environment,
+ * bypassing certain production checks and enabling debugging tools. This should only be enabled for local development.
+ */
 define( 'JETPACK_DEV_DEBUG', true );
 
 // Load development WP-CLI commands.

--- a/local/load.php
+++ b/local/load.php
@@ -18,7 +18,7 @@ namespace Activitypub\Development;
  * bypassing certain production checks and enabling debugging tools. This should only be enabled for local development.
  */
 if ( ! defined( 'JETPACK_DEV_DEBUG' ) ) {
-    define( 'JETPACK_DEV_DEBUG', true );
+	define( 'JETPACK_DEV_DEBUG', true );
 }
 
 // Load development WP-CLI commands.


### PR DESCRIPTION
Jetpack is now initialized via an 'init' action hook for better compatibility. Additionally, JETPACK_DEV_DEBUG is defined as true in local development to enable Jetpack debug mode.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #2431, #2432

## Proposed changes:
- Changed Jetpack integration to use deferred initialization via WordPress 'init' action hook
- Added JETPACK_DEV_DEBUG constant definition in local development loader


### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Improved Jetpack integration by initializing it during the WordPress startup process.

</details>
