### PR TITLE
Ignore announces from blog actor in Announce handler

### DIFF
--- a/.github/changelog/2437-from-description
+++ b/.github/changelog/2437-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Prevented self-announcing by ignoring announces from the blog actor, while still processing announces from user and external actors.

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -42,10 +42,10 @@ class Announce {
 			return;
 		}
 
-		$actor_id = object_to_uri( $announcement['actor'] );
 		// Ignore announces from the blog actor.
-		$actor_resource_id = Actors::get_id_by_resource( $actor_id );
-		if ( is_same_domain( $actor_id ) && ! is_wp_error( $actor_resource_id ) && Actors::BLOG_USER_ID === $actor_resource_id ) {
+		$actor_id = object_to_uri( $announcement['actor'] );
+		$user_id  = Actors::get_id_by_resource( $actor_id );
+		if ( is_same_domain( $actor_id ) && ! \is_wp_error( $user_id ) && Actors::BLOG_USER_ID === $user_id ) {
 			return;
 		}
 

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -14,7 +14,6 @@ use Activitypub\Http;
 
 use function Activitypub\is_activity;
 use function Activitypub\is_activity_public;
-use function Activitypub\is_same_domain;
 use function Activitypub\object_to_uri;
 
 /**

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -43,9 +43,7 @@ class Announce {
 		}
 
 		// Ignore announces from the blog actor.
-		$actor_id = object_to_uri( $announcement['actor'] );
-		$user_id  = Actors::get_id_by_resource( $actor_id );
-		if ( is_same_domain( $actor_id ) && ! \is_wp_error( $user_id ) && Actors::BLOG_USER_ID === $user_id ) {
+		if ( Actors::BLOG_USER_ID === Actors::get_id_by_resource( $announcement['actor'] ) ) {
 			return;
 		}
 

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -7,12 +7,14 @@
 
 namespace Activitypub\Handler;
 
+use Activitypub\Collection\Actors;
 use Activitypub\Collection\Interactions;
 use Activitypub\Comment;
 use Activitypub\Http;
 
 use function Activitypub\is_activity;
 use function Activitypub\is_activity_public;
+use function Activitypub\is_same_domain;
 use function Activitypub\object_to_uri;
 
 /**
@@ -37,6 +39,12 @@ class Announce {
 		// Check if Activity is public or not.
 		if ( ! is_activity_public( $announcement ) ) {
 			// @todo maybe send email
+			return;
+		}
+
+		$actor_id = object_to_uri( $announcement['actor'] );
+		// Ignore announces from the blog actor.
+		if ( is_same_domain( $actor_id ) && Actors::BLOG_USER_ID === Actors::get_id_by_resource( $actor_id ) ) {
 			return;
 		}
 

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -44,7 +44,8 @@ class Announce {
 
 		$actor_id = object_to_uri( $announcement['actor'] );
 		// Ignore announces from the blog actor.
-		if ( is_same_domain( $actor_id ) && Actors::BLOG_USER_ID === Actors::get_id_by_resource( $actor_id ) ) {
+		$actor_resource_id = Actors::get_id_by_resource( $actor_id );
+		if ( is_same_domain( $actor_id ) && ! is_wp_error( $actor_resource_id ) && Actors::BLOG_USER_ID === $actor_resource_id ) {
 			return;
 		}
 

--- a/tests/phpunit/tests/includes/handler/class-test-announce.php
+++ b/tests/phpunit/tests/includes/handler/class-test-announce.php
@@ -9,6 +9,7 @@ namespace Activitypub\Tests\Handler;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Handler\Announce;
+use Activitypub\Model\Blog;
 
 /**
  * Test class for Activitypub Announce Handler.
@@ -104,13 +105,13 @@ class Test_Announce extends \WP_UnitTestCase {
 	 * @covers ::handle_announce
 	 */
 	public function test_handle_announce() {
-		$user_url = \get_userdata( $this->user_id )->user_url;
+		$external_actor = 'https://example.com/users/testuser';
 
 		$object = array(
-			'actor'  => $user_url,
+			'actor'  => $external_actor,
 			'type'   => 'Announce',
 			'id'     => 'https://example.com/id/' . microtime( true ),
-			'to'     => array( $user_url ),
+			'to'     => array( $external_actor ),
 			'cc'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
 			'object' => $this->post_permalink,
 		);
@@ -156,13 +157,13 @@ class Test_Announce extends \WP_UnitTestCase {
 	 * @covers ::maybe_save_announce
 	 */
 	public function test_maybe_save_announce() {
-		$user_url = \get_userdata( $this->user_id )->user_url;
+		$external_actor = 'https://example.com/users/testuser';
 
 		$activity = array(
-			'actor'  => $user_url,
+			'actor'  => $external_actor,
 			'type'   => 'Announce',
 			'id'     => 'https://example.com/id/' . microtime( true ),
-			'to'     => array( $user_url ),
+			'to'     => array( $external_actor ),
 			'object' => $this->post_permalink,
 		);
 
@@ -220,5 +221,132 @@ class Test_Announce extends \WP_UnitTestCase {
 				'message'   => 'Announce of an Announce-Object.',
 			),
 		);
+	}
+
+	/**
+	 * Test that announces from the blog actor are ignored.
+	 *
+	 * @covers ::handle_announce
+	 */
+	public function test_ignore_blog_actor_announce() {
+		$blog     = new Blog();
+		$blog_url = $blog->get_id();
+
+		$object = array(
+			'actor'  => $blog_url,
+			'type'   => 'Announce',
+			'id'     => 'https://example.com/id/' . microtime( true ),
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'object' => $this->post_permalink,
+		);
+
+		// Set up mock action to verify the announce is handled.
+		$handled_action = new \MockAction();
+		\add_action( 'activitypub_handled_announce', array( $handled_action, 'action' ) );
+
+		// Call with blog actor as sender - should be ignored.
+		Announce::handle_announce( $object, $this->user_id );
+
+		// Verify the announce was NOT handled.
+		$this->assertEquals( 0, $handled_action->get_call_count() );
+
+		// Verify no comment was created.
+		$args = array(
+			'type'    => 'repost',
+			'post_id' => $this->post_id,
+		);
+
+		$query  = new \WP_Comment_Query( $args );
+		$result = $query->comments;
+
+		$this->assertEmpty( $result );
+
+		\remove_action( 'activitypub_handled_announce', array( $handled_action, 'action' ) );
+	}
+
+	/**
+	 * Test that announces from external actors are not ignored.
+	 *
+	 * @covers ::handle_announce
+	 */
+	public function test_external_actor_announce_not_ignored() {
+		$external_actor = 'https://external.example.com/users/someone';
+
+		$object = array(
+			'actor'  => $external_actor,
+			'type'   => 'Announce',
+			'id'     => 'https://external.example.com/id/' . microtime( true ),
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'object' => $this->post_permalink,
+		);
+
+		// Set up mock action to verify the announce is handled.
+		$handled_action = new \MockAction();
+		\add_action( 'activitypub_handled_announce', array( $handled_action, 'action' ) );
+
+		// Call with external actor - should be processed.
+		Announce::handle_announce( $object, $this->user_id );
+
+		// Verify the announce WAS handled.
+		$this->assertEquals( 1, $handled_action->get_call_count() );
+
+		// Verify comment was created.
+		$args = array(
+			'type'    => 'repost',
+			'post_id' => $this->post_id,
+		);
+
+		$query  = new \WP_Comment_Query( $args );
+		$result = $query->comments;
+
+		$this->assertNotEmpty( $result );
+		$this->assertInstanceOf( 'WP_Comment', $result[0] );
+
+		\remove_action( 'activitypub_handled_announce', array( $handled_action, 'action' ) );
+	}
+
+	/**
+	 * Test that announces from same domain but different actor are not ignored.
+	 *
+	 * @covers ::handle_announce
+	 */
+	public function test_same_domain_different_actor_not_ignored() {
+		// Get a regular user actor URL (not the blog actor).
+		$user_url = \get_author_posts_url( $this->user_id );
+
+		$object = array(
+			'actor'  => $user_url,
+			'type'   => 'Announce',
+			'id'     => \home_url( '/activity/' . microtime( true ) ),
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'object' => $this->post_permalink,
+		);
+
+		// Set up mock action to verify the announce is handled.
+		$handled_action = new \MockAction();
+		\add_action( 'activitypub_handled_announce', array( $handled_action, 'action' ) );
+
+		// Call with same domain but user actor - should be processed.
+		Announce::handle_announce( $object, $this->user_id );
+
+		// Verify the announce WAS handled.
+		$this->assertEquals( 1, $handled_action->get_call_count() );
+
+		// Verify comment was created.
+		$args = array(
+			'type'    => 'repost',
+			'post_id' => $this->post_id,
+		);
+
+		$query  = new \WP_Comment_Query( $args );
+		$result = $query->comments;
+
+		$this->assertNotEmpty( $result );
+		$this->assertInstanceOf( 'WP_Comment', $result[0] );
+
+		\remove_action( 'activitypub_handled_announce', array( $handled_action, 'action' ) );
 	}
 }

--- a/tests/phpunit/tests/includes/handler/class-test-announce.php
+++ b/tests/phpunit/tests/includes/handler/class-test-announce.php
@@ -241,7 +241,7 @@ class Test_Announce extends \WP_UnitTestCase {
 			'object' => $this->post_permalink,
 		);
 
-		// Set up mock action to verify the announce is handled.
+		// Set up mock action to track whether the announce is handled (should be ignored).
 		$handled_action = new \MockAction();
 		\add_action( 'activitypub_handled_announce', array( $handled_action, 'action' ) );
 


### PR DESCRIPTION
Announces originating from the blog actor are now ignored in the Announce handler to prevent self-announcing behavior. Added corresponding unit tests to verify that announces from the blog actor are not processed, while those from external and same-domain non-blog actors are handled as expected.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added logic to ignore announces from the blog actor while allowing announces from regular user actors and external actors
* Added comprehensive test coverage for the new filtering behavior
* Updated existing tests to use external actor URLs instead of local user URLs

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [X] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Prevented self-announcing by ignoring announces from the blog actor, while still processing announces from user and external actors.

</details>
