### PR TITLE
Improve Deduplication and date handling for Inbox-Purge

### DIFF
--- a/.github/changelog/2447-from-description
+++ b/.github/changelog/2447-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Improved date handling in the scheduler for greater consistency and reliability, aligning inbox purge logic with the existing outbox purge implementation.
+Made inbox cleanup more reliable and ensuring deduplication only affects the specific activity being removed.

--- a/.github/changelog/2447-from-description
+++ b/.github/changelog/2447-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved date handling in the scheduler for greater consistency and reliability, aligning inbox purge logic with the existing outbox purge implementation.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -315,11 +315,6 @@ class Scheduler {
 		}
 
 		$days     = (int) get_option( 'activitypub_outbox_purge_days', 180 );
-		$timezone = new \DateTimeZone( 'UTC' );
-		$date     = new \DateTime( 'now', $timezone );
-
-		$date->sub( \DateInterval::createFromDateString( "$days days" ) );
-
 		$post_ids = \get_posts(
 			array(
 				'post_type'   => Outbox::POST_TYPE,
@@ -328,7 +323,7 @@ class Scheduler {
 				'numberposts' => -1,
 				'date_query'  => array(
 					array(
-						'before' => $date->format( 'Y-m-d' ),
+						'before' => \gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
 					),
 				),
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -357,11 +352,6 @@ class Scheduler {
 		}
 
 		$days     = (int) get_option( 'activitypub_inbox_purge_days', 180 );
-		$timezone = new \DateTimeZone( 'UTC' );
-		$date     = new \DateTime( 'now', $timezone );
-
-		$date->sub( \DateInterval::createFromDateString( "$days days" ) );
-
 		$post_ids = \get_posts(
 			array(
 				'post_type'   => Inbox::POST_TYPE,
@@ -370,7 +360,7 @@ class Scheduler {
 				'numberposts' => -1,
 				'date_query'  => array(
 					array(
-						'before' => $date->format( 'Y-m-d' ),
+						'before' => \gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
 					),
 				),
 			)

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -323,7 +323,7 @@ class Scheduler {
 				'numberposts' => -1,
 				'date_query'  => array(
 					array(
-						'before' => \gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
+						'before' => gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
 					),
 				),
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -360,7 +360,7 @@ class Scheduler {
 				'numberposts' => -1,
 				'date_query'  => array(
 					array(
-						'before' => \gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
+						'before' => gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
 					),
 				),
 			)

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -125,12 +125,12 @@ class Scheduler {
 			\wp_schedule_event( time(), 'hourly', 'activitypub_reprocess_outbox' );
 		}
 
-		if ( ! wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
-			wp_schedule_event( time(), 'daily', 'activitypub_outbox_purge' );
+		if ( ! \wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
+			\wp_schedule_event( time(), 'daily', 'activitypub_outbox_purge' );
 		}
 
-		if ( ! wp_next_scheduled( 'activitypub_inbox_purge' ) ) {
-			wp_schedule_event( time(), 'daily', 'activitypub_inbox_purge' );
+		if ( ! \wp_next_scheduled( 'activitypub_inbox_purge' ) ) {
+			\wp_schedule_event( time(), 'daily', 'activitypub_inbox_purge' );
 		}
 	}
 
@@ -357,6 +357,11 @@ class Scheduler {
 		}
 
 		$days     = (int) get_option( 'activitypub_inbox_purge_days', 180 );
+		$timezone = new \DateTimeZone( 'UTC' );
+		$date     = new \DateTime( 'now', $timezone );
+
+		$date->sub( \DateInterval::createFromDateString( "$days days" ) );
+
 		$post_ids = \get_posts(
 			array(
 				'post_type'   => Inbox::POST_TYPE,
@@ -365,7 +370,7 @@ class Scheduler {
 				'numberposts' => -1,
 				'date_query'  => array(
 					array(
-						'before' => gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
+						'before' => $date->format( 'Y-m-d' ),
 					),
 				),
 			)

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -384,7 +384,7 @@ class Inbox {
 	public static function deduplicate( $guid ) {
 		global $wpdb;
 
-		// Query for all posts with this GUID directly (get_posts doesn't support guid parameter).
+		// Query for all posts with this GUID directly (get_posts doesn't supports guid parameter).
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$post_ids = $wpdb->get_col(
 			$wpdb->prepare(

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -382,26 +382,31 @@ class Inbox {
 	 * @return \WP_Post|false The primary inbox post, or false if no posts found.
 	 */
 	public static function deduplicate( $guid ) {
-		$duplicates = \get_posts(
-			array(
-				'post_type'      => self::POST_TYPE,
-				'guid'           => $guid,
-				'posts_per_page' => -1,
-				'post_status'    => 'any',
+		global $wpdb;
+
+		// Query for all posts with this GUID directly (get_posts doesn't support guid parameter).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$post_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM $wpdb->posts WHERE guid=%s AND post_type=%s ORDER BY ID ASC",
+				\esc_url( $guid ),
+				self::POST_TYPE
 			)
 		);
 
-		if ( empty( $duplicates ) ) {
+		if ( empty( $post_ids ) ) {
 			return false;
 		}
 
-		// Keep the first post, all others are duplicates.
-		$primary = array_shift( $duplicates );
+		// Keep the first (oldest) post as primary.
+		$primary_id = array_shift( $post_ids );
+		$primary    = \get_post( $primary_id );
 
-		foreach ( $duplicates as $duplicate ) {
-			$recipients = \get_post_meta( $duplicate->ID, '_activitypub_user_id', false );
-			self::add_recipients( $primary->ID, $recipients );
-			\wp_delete_post( $duplicate->ID, true );
+		// Merge recipients from duplicates into primary and delete duplicates.
+		foreach ( $post_ids as $duplicate_id ) {
+			$recipients = \get_post_meta( $duplicate_id, '_activitypub_user_id', false );
+			self::add_recipients( $primary_id, $recipients );
+			\wp_delete_post( $duplicate_id, true );
 		}
 
 		return $primary;

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -388,7 +388,7 @@ class Inbox {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$post_ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT ID FROM $wpdb->posts WHERE guid=%s AND post_type=%s ORDER BY ID ASC",
+				"SELECT ID FROM {$wpdb->posts} WHERE guid=%s AND post_type=%s ORDER BY ID ASC",
 				\esc_url( $guid ),
 				self::POST_TYPE
 			)

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -385,8 +385,7 @@ class Inbox {
 		global $wpdb;
 
 		// Query for all posts with this GUID directly (get_posts doesn't supports guid parameter).
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$post_ids = $wpdb->get_col(
+		$post_ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$wpdb->prepare(
 				"SELECT ID FROM {$wpdb->posts} WHERE guid=%s AND post_type=%s ORDER BY ID ASC",
 				\esc_url( $guid ),

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -723,4 +723,138 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$result = Inbox::deduplicate( 'https://remote.example.com/activities/non-existent' );
 		$this->assertFalse( $result );
 	}
+
+	/**
+	 * Test that deduplicate only processes posts with matching GUID.
+	 *
+	 * This test verifies that deduplicate() properly filters by GUID and doesn't
+	 * accidentally process all inbox posts.
+	 *
+	 * @covers ::deduplicate
+	 */
+	public function test_deduplicate_only_matches_specific_guid() {
+		$activity1 = new Activity();
+		$activity1->set_id( 'https://remote.example.com/activities/first-activity' );
+		$activity1->set_type( 'Create' );
+		$activity1->set_actor( 'https://remote.example.com/users/testuser' );
+
+		$object1 = new Base_Object();
+		$object1->set_id( 'https://remote.example.com/objects/first' );
+		$object1->set_type( 'Note' );
+		$activity1->set_object( $object1 );
+
+		$activity2 = new Activity();
+		$activity2->set_id( 'https://remote.example.com/activities/second-activity' );
+		$activity2->set_type( 'Like' );
+		$activity2->set_actor( 'https://remote.example.com/users/testuser' );
+		$activity2->set_object( 'https://example.com/post/123' );
+
+		// Create multiple posts with GUID 'first-activity' (duplicates).
+		$inbox_id_1a = \wp_insert_post(
+			array(
+				'post_type'    => Inbox::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => \wp_json_encode( $activity1->to_array() ),
+				'guid'         => 'https://remote.example.com/activities/first-activity',
+			)
+		);
+		\add_post_meta( $inbox_id_1a, '_activitypub_user_id', 1 );
+
+		$inbox_id_1b = \wp_insert_post(
+			array(
+				'post_type'    => Inbox::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => \wp_json_encode( $activity1->to_array() ),
+				'guid'         => 'https://remote.example.com/activities/first-activity',
+			)
+		);
+		\add_post_meta( $inbox_id_1b, '_activitypub_user_id', 2 );
+
+		$inbox_id_1c = \wp_insert_post(
+			array(
+				'post_type'    => Inbox::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => \wp_json_encode( $activity1->to_array() ),
+				'guid'         => 'https://remote.example.com/activities/first-activity',
+			)
+		);
+		\add_post_meta( $inbox_id_1c, '_activitypub_user_id', 3 );
+
+		// Create posts with DIFFERENT GUID 'second-activity' (should NOT be touched).
+		$inbox_id_2a = \wp_insert_post(
+			array(
+				'post_type'    => Inbox::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => \wp_json_encode( $activity2->to_array() ),
+				'guid'         => 'https://remote.example.com/activities/second-activity',
+			)
+		);
+		\add_post_meta( $inbox_id_2a, '_activitypub_user_id', 4 );
+
+		$inbox_id_2b = \wp_insert_post(
+			array(
+				'post_type'    => Inbox::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => \wp_json_encode( $activity2->to_array() ),
+				'guid'         => 'https://remote.example.com/activities/second-activity',
+			)
+		);
+		\add_post_meta( $inbox_id_2b, '_activitypub_user_id', 5 );
+
+		// Run deduplication for first-activity only.
+		$result = Inbox::deduplicate( 'https://remote.example.com/activities/first-activity' );
+
+		// Verify correct post was returned.
+		$this->assertInstanceOf( 'WP_Post', $result );
+		$this->assertEquals( $inbox_id_1a, $result->ID, 'Should return the first (oldest) post with matching GUID' );
+
+		// Verify recipients were merged from duplicates.
+		$recipients = Inbox::get_recipients( $inbox_id_1a );
+		$this->assertCount( 3, $recipients, 'Should have all recipients from first-activity duplicates' );
+		$this->assertContains( 1, $recipients );
+		$this->assertContains( 2, $recipients );
+		$this->assertContains( 3, $recipients );
+
+		// Verify duplicates of first-activity were deleted.
+		$this->assertNull( \get_post( $inbox_id_1b ), 'Duplicate 1b should be deleted' );
+		$this->assertNull( \get_post( $inbox_id_1c ), 'Duplicate 1c should be deleted' );
+
+		// CRITICAL: Verify second-activity posts were NOT touched.
+		$post_2a = \get_post( $inbox_id_2a );
+		$post_2b = \get_post( $inbox_id_2b );
+		$this->assertInstanceOf( 'WP_Post', $post_2a, 'second-activity post 2a should still exist' );
+		$this->assertInstanceOf( 'WP_Post', $post_2b, 'second-activity post 2b should still exist' );
+
+		// Verify second-activity posts still have only their original recipients.
+		$recipients_2a = Inbox::get_recipients( $inbox_id_2a );
+		$recipients_2b = Inbox::get_recipients( $inbox_id_2b );
+		$this->assertCount( 1, $recipients_2a, 'second-activity 2a should have only its original recipient' );
+		$this->assertCount( 1, $recipients_2b, 'second-activity 2b should have only its original recipient' );
+		$this->assertContains( 4, $recipients_2a );
+		$this->assertContains( 5, $recipients_2b );
+
+		// Verify only one post exists with first-activity GUID.
+		// Note: get_posts() doesn't support 'guid' parameter, so we use direct SQL query.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count_first = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM $wpdb->posts WHERE guid=%s AND post_type=%s",
+				\esc_url( 'https://remote.example.com/activities/first-activity' ),
+				Inbox::POST_TYPE
+			)
+		);
+		$this->assertEquals( 1, $count_first, 'Should have exactly one post with first-activity GUID' );
+
+		// Verify two posts still exist with second-activity GUID.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count_second = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM $wpdb->posts WHERE guid=%s AND post_type=%s",
+				\esc_url( 'https://remote.example.com/activities/second-activity' ),
+				Inbox::POST_TYPE
+			)
+		);
+		$this->assertEquals( 2, $count_second, 'Should still have two posts with second-activity GUID (not deduplicated)' );
+	}
 }

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -856,9 +856,9 @@ class Test_Inbox extends \WP_UnitTestCase {
 			)
 		);
 		$this->assertEquals( 2, $count_second, 'Should still have two posts with second-activity GUID (not deduplicated)' );
-  }
-  
-  /**
+	}
+
+	/**
 	 * Test adding Like activity with trailing slash in object URL.
 	 *
 	 * This test verifies that Like activities from Pixelfed and other platforms


### PR DESCRIPTION
This PR improves date handling consistency and code maintainability in the scheduler class. It adds namespace prefixes to WordPress scheduling functions and refactors the inbox purge date calculation to use DateTime objects with explicit timezone handling, matching the approach already used in the outbox purge function.

## Proposed changes:
- Adds namespace prefixes (`\`) to `wp_next_scheduled` and `wp_schedule_event` for consistency
- Refactors inbox purge date calculation from `gmdate()`/`time()` to DateTime/DateInterval pattern
- Aligns inbox purge implementation with the existing outbox purge approach
- Deduplication is now isolated to the specific activity being processed
- No accidental data corruption across different activities

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Made inbox cleanup more reliable and ensuring deduplication only affects the specific activity being removed.

</details>
