### PR TITLE
Fix Pixelfed interactions (Likes)

### DIFF
--- a/.github/changelog/2448-from-description
+++ b/.github/changelog/2448-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed compatibility with Pixelfed and similar platforms by treating activities without recipients as public, ensuring boosts and reposts work correctly.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -39,7 +39,7 @@ class Interactions {
 		}
 
 		$in_reply_to       = object_to_uri( $activity['object']['inReplyTo'] );
-		$in_reply_to       = \esc_url_raw( $in_reply_to );
+		$in_reply_to       = \untrailingslashit( \esc_url_raw( $in_reply_to ) );
 		$comment_post_id   = \url_to_postid( $in_reply_to );
 		$parent_comment_id = url_to_commentid( $in_reply_to );
 
@@ -93,6 +93,7 @@ class Interactions {
 	 */
 	public static function add_reaction( $activity ) {
 		$url               = object_to_uri( $activity['object'] );
+		$url               = \untrailingslashit( $url );
 		$comment_post_id   = \url_to_postid( $url );
 		$parent_comment_id = url_to_commentid( $url );
 

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -39,7 +39,7 @@ class Interactions {
 		}
 
 		$in_reply_to       = object_to_uri( $activity['object']['inReplyTo'] );
-		$in_reply_to       = \untrailingslashit( \esc_url_raw( $in_reply_to ) );
+		$in_reply_to       = \esc_url_raw( $in_reply_to );
 		$comment_post_id   = \url_to_postid( $in_reply_to );
 		$parent_comment_id = url_to_commentid( $in_reply_to );
 
@@ -93,7 +93,6 @@ class Interactions {
 	 */
 	public static function add_reaction( $activity ) {
 		$url               = object_to_uri( $activity['object'] );
-		$url               = \untrailingslashit( $url );
 		$comment_post_id   = \url_to_postid( $url );
 		$parent_comment_id = url_to_commentid( $url );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -607,6 +607,10 @@ function is_activity_public( $data ) {
 
 	$recipients = extract_recipients_from_activity( $data );
 
+	if ( empty( $recipients ) ) {
+		return true;
+	}
+
 	return ! empty( array_intersect( $recipients, ACTIVITYPUB_PUBLIC_AUDIENCE_IDENTIFIERS ) );
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -588,6 +588,12 @@ function get_activity_visibility( $activity ) {
 		return ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC;
 	}
 
+	// Activities with no recipients are treated as public.
+	$recipients = extract_recipients_from_activity( $activity );
+	if ( empty( $recipients ) ) {
+		return ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
+	}
+
 	return ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE;
 }
 

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -1003,7 +1003,7 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 						'monkey' => 'https://www.w3.org/ns/activitystreams#Public',
 					),
 				),
-				false,
+				true,
 			),
 			array(
 				array(

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -1334,13 +1334,13 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 				'expected'    => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
 				'description' => 'Public visibility via as:Public identifier',
 			),
-			// Empty activity.
+			// Empty activity - no recipients means public.
 			array(
 				'activity'    => array(
 					'type' => 'Create',
 				),
-				'expected'    => ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE,
-				'description' => 'Empty activity defaults to private',
+				'expected'    => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
+				'description' => 'Empty activity (no recipients) is treated as public',
 			),
 		);
 	}

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -75,7 +75,6 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$remote_actor_meta = \get_post_meta( $inbox_id, '_activitypub_activity_remote_actor', true );
 		$this->assertEquals( 'https://remote.example.com/users/testuser', $remote_actor_meta );
 
-		// Test activitypub_content_visibility meta.
 		// Activities with no recipients are treated as public.
 		$visibility_meta = \get_post_meta( $inbox_id, 'activitypub_content_visibility', true );
 		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, $visibility_meta );

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -723,4 +723,60 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$result = Inbox::deduplicate( 'https://remote.example.com/activities/non-existent' );
 		$this->assertFalse( $result );
 	}
+
+	/**
+	 * Test adding Like activity with trailing slash in object URL.
+	 *
+	 * This test verifies that Like activities from Pixelfed and other platforms
+	 * that include trailing slashes in object URLs are stored correctly in the inbox.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_like_activity_with_trailing_slash() {
+		// Create a post to be liked.
+		$post_id        = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post for Like',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		$post_permalink = \get_permalink( $post_id );
+
+		// Create a Like activity with trailing slash in object URL (as Pixelfed sends).
+		$activity = new Activity();
+		$activity->set_id( 'https://pixelfed.social/users/pfefferle#likes/30434186' );
+		$activity->set_type( 'Like' );
+		$activity->set_actor( 'https://pixelfed.social/users/pfefferle' );
+		$activity->set_object( $post_permalink . '/' ); // Add trailing slash.
+
+		$user_id = 1;
+
+		// Add activity to inbox.
+		$inbox_id = Inbox::add( $activity, $user_id );
+
+		$this->assertIsInt( $inbox_id );
+		$this->assertGreaterThan( 0, $inbox_id );
+
+		// Verify the post was created.
+		$post = \get_post( $inbox_id );
+		$this->assertInstanceOf( 'WP_Post', $post );
+		$this->assertEquals( Inbox::POST_TYPE, $post->post_type );
+
+		// Test _activitypub_object_id meta - should preserve the trailing slash as-is.
+		$object_id_meta = \get_post_meta( $inbox_id, '_activitypub_object_id', true );
+		$this->assertEquals( $post_permalink . '/', $object_id_meta );
+
+		// Test _activitypub_activity_type meta.
+		$activity_type_meta = \get_post_meta( $inbox_id, '_activitypub_activity_type', true );
+		$this->assertEquals( 'Like', $activity_type_meta );
+
+		// Test _activitypub_user_id meta.
+		$user_id_meta = \get_post_meta( $inbox_id, '_activitypub_user_id', true );
+		$this->assertEquals( $user_id, $user_id_meta );
+
+		// Test _activitypub_activity_remote_actor meta.
+		$remote_actor_meta = \get_post_meta( $inbox_id, '_activitypub_activity_remote_actor', true );
+		$this->assertEquals( 'https://pixelfed.social/users/pfefferle', $remote_actor_meta );
+	}
 }

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -76,8 +76,9 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$this->assertEquals( 'https://remote.example.com/users/testuser', $remote_actor_meta );
 
 		// Test activitypub_content_visibility meta.
+		// Activities with no recipients are treated as public.
 		$visibility_meta = \get_post_meta( $inbox_id, 'activitypub_content_visibility', true );
-		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility_meta );
+		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, $visibility_meta );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -475,7 +475,9 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
-		$this->assertEmpty( $result, 'Should return empty array when no recipients' );
+		// Activities with no recipients are treated as public and delivered to all local actors.
+		$this->assertNotEmpty( $result, 'Should return all local actors when no recipients (treated as public)' );
+		$this->assertEquals( Actors::get_all_ids(), $result, 'Should match all local actor IDs' );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes handling of ActivityPub activities from Pixelfed and other platforms by treating activities with no recipients as public, which aligns with the ActivityPub specification.

Fixes https://wordpress.org/support/topic/boosts-reposts-not-working-in-pixelfed/

## Proposed changes:
- Updated `is_activity_public()` function to return `true` when an activity has no recipients
- Added test coverage for Like activities with trailing slashes in object URLs (common with Pixelfed)
- Updated existing tests to reflect the new behavior where activities without recipients are treated as public

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed compatibility with Pixelfed and similar platforms by treating activities without recipients as public, ensuring boosts and reposts work correctly.

</details>
