### PR TITLE
Fix local comment boosts being incorrectly processed

### DIFF
--- a/.github/changelog/2450-from-description
+++ b/.github/changelog/2450-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed local comment boosts being incorrectly added to posts.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -96,6 +96,15 @@ class Interactions {
 		$comment_post_id   = \url_to_postid( $url );
 		$parent_comment_id = url_to_commentid( $url );
 
+		// Skip reactions to local comments since we don't support reactions on comments yet.
+		if ( $parent_comment_id ) {
+			$comment = \get_comment( $parent_comment_id );
+			if ( $comment && Comment::is_local( $comment ) ) {
+				// This is a reaction to a local comment, skip processing.
+				return false;
+			}
+		}
+
 		if ( ! $comment_post_id && $parent_comment_id ) {
 			$parent_comment  = \get_comment( $parent_comment_id );
 			$comment_post_id = $parent_comment->comment_post_ID;

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -97,12 +97,8 @@ class Interactions {
 		$parent_comment_id = url_to_commentid( $url );
 
 		// Skip reactions to local comments since we don't support reactions on comments yet.
-		if ( $parent_comment_id ) {
-			$comment = \get_comment( $parent_comment_id );
-			if ( $comment && Comment::is_local( $comment ) ) {
-				// This is a reaction to a local comment, skip processing.
-				return false;
-			}
+		if ( $parent_comment_id && Comment::is_local( $parent_comment_id ) ) {
+			return false;
 		}
 
 		if ( ! $comment_post_id && $parent_comment_id ) {

--- a/tests/phpunit/tests/includes/collection/class-test-interactions.php
+++ b/tests/phpunit/tests/includes/collection/class-test-interactions.php
@@ -8,7 +8,9 @@
 namespace Activitypub\Tests\Collection;
 
 use Activitypub\Collection\Interactions;
-use Activitypub\Comment;
+use Activitypub\Collection\Remote_Actors;
+
+use function Activitypub\object_id_to_comment;
 
 /**
  * Test class for Activitypub Interactions.
@@ -55,7 +57,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 	/**
 	 * Create fake data before tests run.
 	 *
-	 * @param WP_UnitTest_Factory $factory Helper that creates fake data.
+	 * @param \WP_UnitTest_Factory $factory Helper that creates fake data.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$user_id = $factory->user->create(
@@ -164,7 +166,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 				'id'        => $id,
 				'url'       => 'https://example.com/example',
 				'inReplyTo' => self::$post_permalink,
-				'content'   => 'Hello<br />example<p>example</p><img src="https://example.com/image.jpg" />',
+				'content'   => 'Hello<br />example<p>example</p><img src="https://example.com/image.jpg" alt="" />',
 			),
 		);
 	}
@@ -214,7 +216,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 			'inbox'             => 'https://example.com/inbox',
 		);
 
-		$remote_actor_id = \Activitypub\Collection\Remote_Actors::upsert( $actor_data );
+		$remote_actor_id = Remote_Actors::upsert( $actor_data );
 		$this->assertIsInt( $remote_actor_id );
 
 		// Create a comment from this actor.
@@ -229,7 +231,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 		$this->assertEquals( $remote_actor_id, $stored_actor_id );
 
 		// Verify avatar URL is stored on the remote actor.
-		$avatar_url = \Activitypub\Collection\Remote_Actors::get_avatar_url( $remote_actor_id );
+		$avatar_url = Remote_Actors::get_avatar_url( $remote_actor_id );
 		$this->assertEquals( 'https://example.com/avatar.jpg', $avatar_url );
 
 		// Clean up.
@@ -282,7 +284,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 		$object = $this->create_test_object( 'https://example.com/test_convert_object_to_comment_already_exists_rejected' );
 		Interactions::add_comment( $object );
 		$converted = Interactions::add_comment( $object );
-		$this->assertEquals( $converted->get_error_code(), 'comment_duplicate' );
+		$this->assertEquals( 'comment_duplicate', $converted->get_error_code() );
 	}
 
 	/**
@@ -294,7 +296,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 		$id     = 'https://example.com/test_convert_object_to_comment_reply_to_comment';
 		$object = $this->create_test_object( $id );
 		Interactions::add_comment( $object );
-		$comment = \Activitypub\object_id_to_comment( $id );
+		$comment = object_id_to_comment( $id );
 
 		$object['object']['inReplyTo'] = $id;
 		$object['object']['id']        = 'https://example.com/234';
@@ -327,7 +329,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 		$id     = 'https://example.com/test_handle_create_basic';
 		$object = $this->create_test_object( $id );
 		Interactions::add_comment( $object );
-		$comment = \Activitypub\object_id_to_comment( $id );
+		$comment = object_id_to_comment( $id );
 		$this->assertInstanceOf( \WP_Comment::class, $comment );
 	}
 
@@ -343,12 +345,12 @@ class Test_Interactions extends \WP_UnitTestCase {
 		$object['object']['url'] = $url;
 
 		Interactions::add_comment( $object );
-		$comment      = \Activitypub\object_id_to_comment( $id );
+		$comment      = object_id_to_comment( $id );
 		$interactions = Interactions::get_by_id( $id );
 		$this->assertIsArray( $interactions );
 		$this->assertEquals( $comment->comment_ID, $interactions[0]->comment_ID );
 
-		$comment      = \Activitypub\object_id_to_comment( $id );
+		$comment      = object_id_to_comment( $id );
 		$interactions = Interactions::get_by_id( $url );
 		$this->assertIsArray( $interactions );
 		$this->assertEquals( $comment->comment_ID, $interactions[0]->comment_ID );
@@ -375,7 +377,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 			'url'               => $actor_url,
 		);
 
-		$remote_actor_id = \Activitypub\Collection\Remote_Actors::upsert( $actor_data );
+		$remote_actor_id = Remote_Actors::upsert( $actor_data );
 		$this->assertIsInt( $remote_actor_id );
 
 		// Add a filter to return proper metadata for this specific actor.
@@ -508,7 +510,7 @@ class Test_Interactions extends \WP_UnitTestCase {
 			'url'               => $actor_url,
 		);
 
-		$remote_actor_id = \Activitypub\Collection\Remote_Actors::upsert( $actor_data );
+		$remote_actor_id = Remote_Actors::upsert( $actor_data );
 
 		// Add metadata filter.
 		add_filter(

--- a/tests/phpunit/tests/includes/collection/class-test-interactions.php
+++ b/tests/phpunit/tests/includes/collection/class-test-interactions.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Tests\Collection;
 
 use Activitypub\Collection\Interactions;
+use Activitypub\Comment;
 
 /**
  * Test class for Activitypub Interactions.
@@ -883,5 +884,109 @@ class Test_Interactions extends \WP_UnitTestCase {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Test that announcements (boosts) of local comments are filtered out.
+	 *
+	 * @covers ::add_reaction
+	 */
+	public function test_add_reaction_filters_local_comment_announcement() {
+		// Create a local comment on a post.
+		$local_comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => self::$post_id,
+				'comment_author'       => 'Local User',
+				'comment_author_email' => 'local@example.com',
+				'comment_content'      => 'This is a local comment',
+				'comment_type'         => 'comment',
+				'comment_approved'     => 1,
+			)
+		);
+		$this->assertIsInt( $local_comment_id, 'Local comment should be created' );
+
+		// Get the comment URL with the 'c' parameter that url_to_commentid expects.
+		$comment_url = add_query_arg( 'c', $local_comment_id, self::$post_permalink );
+
+		// Create an announcement (boost) activity for this local comment.
+		$activity = array(
+			'type'   => 'Announce',
+			'actor'  => 'https://example.com/users/remote-user',
+			'object' => $comment_url,
+			'id'     => 'https://example.com/activities/announce/local-comment',
+		);
+
+		// Mock actor metadata for the remote user.
+		add_filter(
+			'pre_get_remote_metadata_by_actor',
+			function () {
+				return array(
+					'name'              => 'Remote User',
+					'preferredUsername' => 'remote',
+					'id'                => 'https://example.com/users/remote-user',
+					'url'               => 'https://example.com/@remote',
+				);
+			}
+		);
+
+		// Try to add the announcement as a reaction.
+		$result = Interactions::add_reaction( $activity );
+
+		// The result should be false because we're filtering out announcements of local comments.
+		$this->assertFalse( $result, 'Announcement of local comment should be filtered out' );
+
+		// Verify that no repost comment was created.
+		$args    = array(
+			'post_id' => self::$post_id,
+			'type'    => 'repost',
+			'status'  => 'all',
+		);
+		$reposts = get_comments( $args );
+
+		// Filter out any reposts that might be from other tests.
+		$reposts = array_filter(
+			$reposts,
+			function ( $comment ) use ( $activity ) {
+				$source_id = get_comment_meta( $comment->comment_ID, 'source_id', true );
+				return $source_id === $activity['id'];
+			}
+		);
+
+		$this->assertEmpty( $reposts, 'No repost comment should be created for local comment announcement' );
+
+		// Now test that remote comment announcements still work.
+		// Create an announcement for a remote comment URL.
+		$remote_activity = array(
+			'type'   => 'Announce',
+			'actor'  => 'https://example.com/users/remote-user',
+			'object' => 'https://remote.example.com/comments/123',
+			'id'     => 'https://example.com/activities/announce/remote-comment',
+		);
+
+		// This should return false because it's not a local post/comment.
+		$remote_result = Interactions::add_reaction( $remote_activity );
+		$this->assertFalse( $remote_result, 'Announcement of non-existent remote comment should return false' );
+
+		// Test announcement of a local post (should work).
+		$post_activity = array(
+			'type'   => 'Announce',
+			'actor'  => 'https://example.com/users/remote-user',
+			'object' => self::$post_permalink,
+			'id'     => 'https://example.com/activities/announce/post',
+		);
+
+		// Enable reposts for this test.
+		\update_option( 'activitypub_allow_reposts', true );
+
+		$post_result = Interactions::add_reaction( $post_activity );
+		$this->assertNotFalse( $post_result, 'Announcement of local post should be allowed' );
+
+		// Clean up.
+		\delete_option( 'activitypub_allow_reposts' );
+		remove_all_filters( 'pre_get_remote_metadata_by_actor' );
+		wp_delete_comment( $local_comment_id, true );
+		if ( $post_result && ! is_wp_error( $post_result ) ) {
+			wp_delete_comment( $post_result, true );
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2428

## Proposed changes:
* Add check to skip processing of announcements (boosts) for local comments
* This prevents local comment announcements from being incorrectly added to posts
* Since reactions on comments are not yet supported, these should be filtered out

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a local post in WordPress
* Write some comments on the post
* Trigger blog actor to announce the locally-made comments (this may happen automatically depending on configuration)
* Verify that these local comment announcements are now ignored and not shown as false boosts in the post's comments section
* Verify that remote announcements (boosts from external ActivityPub actors) continue to work correctly

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fixed local comment boosts being incorrectly added to posts.

</details>