### PR TITLE
Remove fediverse reply link for received comments

### DIFF
--- a/.github/changelog/2461-from-description
+++ b/.github/changelog/2461-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Simplified reply links by removing special handling for federated comments, making replies work the same for all comments where replying is allowed.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -69,10 +69,6 @@ class Comment {
 	 */
 	public static function comment_reply_link( $link, $args, $comment ) {
 		if ( self::are_comments_allowed( $comment ) ) {
-			if ( \current_user_can( 'activitypub' ) && self::was_received( $comment ) ) {
-				return self::create_fediverse_reply_link( $link, $args );
-			}
-
 			return $link;
 		}
 
@@ -93,28 +89,6 @@ class Comment {
 		 * @param string $block The HTML markup for the remote reply container.
 		 */
 		return \apply_filters( 'activitypub_comment_reply_link', $block );
-	}
-
-	/**
-	 * Create a link to reply to a federated comment.
-	 *
-	 * This function adds a title attribute to the reply link to inform the user
-	 * that the comment was received from the fediverse and the reply will be sent
-	 * to the original author.
-	 *
-	 * @param string $link The HTML markup for the comment reply link.
-	 * @param array  $args The args provided by the `comment_reply_link` filter.
-	 *
-	 * @return string The modified HTML markup for the comment reply link.
-	 */
-	private static function create_fediverse_reply_link( $link, $args ) {
-		$str_to_replace = sprintf( '>%s<', $args['reply_text'] );
-		$replace_with   = sprintf(
-			' title="%s">%s<',
-			esc_attr__( 'This comment was received from the fediverse and your reply will be sent to the original author', 'activitypub' ),
-			esc_html__( 'Reply with federation', 'activitypub' )
-		);
-		return str_replace( $str_to_replace, $replace_with, $link );
 	}
 
 	/**


### PR DESCRIPTION
Eliminated logic and helper function for creating a special reply link for comments received from the fediverse. The reply link now behaves uniformly regardless of comment origin.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #2427

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed conditional logic that created a special "Reply with federation" link for federated comments
* Deleted the `create_fediverse_reply_link()` helper function that modified reply link attributes


### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Simplified reply links by removing special handling for federated comments, making replies work the same for all comments where replying is allowed.

</details>
