### PR TITLE
Use private post status for private inbox Create and Update activities

### DIFF
--- a/.github/changelog/2462-from-description
+++ b/.github/changelog/2462-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Private inbox Create and Update activities now use private post status to accurately reflect their visibility.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -11,6 +11,7 @@ use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
+use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Transformer\Factory;
@@ -213,6 +214,10 @@ class Migration {
 		if ( \version_compare( $version_from_db, '7.6.0', '<' ) ) {
 			self::clean_up_inbox();
 			\wp_schedule_single_event( \time(), 'activitypub_migrate_avatar_to_remote_actors' );
+		}
+
+		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
+			self::update_inbox_post_status();
 		}
 
 		// Ensure all required cron schedules are registered.
@@ -1154,5 +1159,41 @@ class Migration {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Update ap_inbox post_status for private Create and Update activities.
+	 *
+	 * Sets post_status to 'private' for existing Create and Update activities that have private visibility
+	 * to prevent them from being publicly accessible via the REST API.
+	 */
+	private static function update_inbox_post_status() {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery
+		$inbox_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT p.ID
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} pm1 ON p.ID = pm1.post_id AND pm1.meta_key = '_activitypub_activity_type'
+				INNER JOIN {$wpdb->postmeta} pm2 ON p.ID = pm2.post_id AND pm2.meta_key = 'activitypub_content_visibility'
+				WHERE p.post_type = %s
+				AND p.post_status = 'publish'
+				AND pm1.meta_value IN ('Create', 'Update')
+				AND pm2.meta_value = 'private'",
+				Inbox::POST_TYPE
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery
+
+		// Update each matching post to have 'private' status.
+		foreach ( $inbox_ids as $post_id ) {
+			\wp_update_post(
+				array(
+					'ID'          => $post_id,
+					'post_status' => 'private',
+				)
+			);
+		}
 	}
 }

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -83,21 +83,33 @@ class Inbox {
 		$title      = self::get_object_title( $activity->get_object() );
 		$visibility = is_activity_public( $activity ) ? ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC : ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE;
 
+		/*
+		 * Determine post status based on activity type and visibility.
+		 *
+		 * For Create and Update activities, use 'private' status for private activities to prevent them from being
+		 * publicly accessible via REST API. All other activities use 'publish' status regardless of visibility.
+		 */
+		$activity_type = $activity->get_type();
+		$post_status   = 'publish';
+		if ( \in_array( $activity_type, array( 'Create', 'Update' ), true ) && ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE === $visibility ) {
+			$post_status = 'private';
+		}
+
 		$inbox_item = array(
 			'post_type'    => self::POST_TYPE,
 			'post_title'   => sprintf(
 				/* translators: 1. Activity type, 2. Object Title or Excerpt */
 				\__( '[%1$s] %2$s', 'activitypub' ),
-				$activity->get_type(),
+				$activity_type,
 				\wp_trim_words( $title, 5 )
 			),
 			'post_content' => wp_slash( $activity->to_json() ),
 			'post_author'  => 0, // No specific author, recipients stored in meta.
-			'post_status'  => 'publish',
+			'post_status'  => $post_status,
 			'guid'         => $activity->get_id(),
 			'meta_input'   => array(
 				'_activitypub_object_id'             => object_to_uri( $activity->get_object() ),
-				'_activitypub_activity_type'         => $activity->get_type(),
+				'_activitypub_activity_type'         => $activity_type,
 				'_activitypub_activity_remote_actor' => object_to_uri( $activity->get_actor() ),
 				'activitypub_content_visibility'     => $visibility,
 			),

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -106,9 +106,16 @@ class Test_Inbox extends \WP_UnitTestCase {
 
 		$this->assertIsInt( $inbox_id );
 
+		// Verify the post was created.
+		$post = \get_post( $inbox_id );
+		$this->assertInstanceOf( 'WP_Post', $post );
+
 		// Test visibility is set to private.
 		$visibility_meta = \get_post_meta( $inbox_id, 'activitypub_content_visibility', true );
 		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility_meta );
+
+		// Test post status is set to private for Create activities.
+		$this->assertEquals( 'private', $post->post_status );
 	}
 
 	/**
@@ -912,5 +919,117 @@ class Test_Inbox extends \WP_UnitTestCase {
 		// Test _activitypub_activity_remote_actor meta.
 		$remote_actor_meta = \get_post_meta( $inbox_id, '_activitypub_activity_remote_actor', true );
 		$this->assertEquals( 'https://pixelfed.social/users/pfefferle', $remote_actor_meta );
+	}
+
+	/**
+	 * Test post_status for private Create and Update activities.
+	 *
+	 * Verifies that private Create and Update activities get 'private' post_status
+	 * to prevent them from being publicly accessible via REST API, while other
+	 * activity types remain 'publish' regardless of visibility.
+	 *
+	 * @covers ::add
+	 */
+	public function test_post_status_for_private_activities() {
+		// Test private Create activity - should have 'private' post_status.
+		$create_activity = new Activity();
+		$create_activity->set_id( 'https://remote.example.com/activities/private-create' );
+		$create_activity->set_type( 'Create' );
+		$create_activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$create_activity->set_to( array( 'https://example.com/users/1' ) ); // Private (not public).
+
+		$object = new Base_Object();
+		$object->set_id( 'https://remote.example.com/objects/private-create' );
+		$object->set_type( 'Note' );
+		$object->set_content( 'Private create content' );
+		$create_activity->set_object( $object );
+
+		$create_id   = Inbox::add( $create_activity, 1 );
+		$create_post = \get_post( $create_id );
+		$this->assertEquals( 'private', $create_post->post_status, 'Private Create activity should have private post_status' );
+
+		// Test private Update activity - should have 'private' post_status.
+		$update_activity = new Activity();
+		$update_activity->set_id( 'https://remote.example.com/activities/private-update' );
+		$update_activity->set_type( 'Update' );
+		$update_activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$update_activity->set_to( array( 'https://example.com/users/1' ) ); // Private (not public).
+
+		$object2 = new Base_Object();
+		$object2->set_id( 'https://remote.example.com/objects/private-update' );
+		$object2->set_type( 'Note' );
+		$object2->set_content( 'Private update content' );
+		$update_activity->set_object( $object2 );
+
+		$update_id   = Inbox::add( $update_activity, 1 );
+		$update_post = \get_post( $update_id );
+		$this->assertEquals( 'private', $update_post->post_status, 'Private Update activity should have private post_status' );
+
+		// Test private Follow activity - should remain 'publish' (not Create/Update).
+		$follow_activity = new Activity();
+		$follow_activity->set_id( 'https://remote.example.com/activities/private-follow' );
+		$follow_activity->set_type( 'Follow' );
+		$follow_activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$follow_activity->set_to( array( 'https://example.com/users/1' ) ); // Private.
+		$follow_activity->set_object( 'https://example.com/users/1' );
+
+		$follow_id   = Inbox::add( $follow_activity, 1 );
+		$follow_post = \get_post( $follow_id );
+		$this->assertEquals( 'publish', $follow_post->post_status, 'Private Follow activity should remain publish' );
+
+		// Test private Like activity - should remain 'publish' (not Create/Update).
+		$like_activity = new Activity();
+		$like_activity->set_id( 'https://remote.example.com/activities/private-like' );
+		$like_activity->set_type( 'Like' );
+		$like_activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$like_activity->set_to( array( 'https://example.com/users/1' ) ); // Private.
+		$like_activity->set_object( 'https://example.com/post/123' );
+
+		$like_id   = Inbox::add( $like_activity, 1 );
+		$like_post = \get_post( $like_id );
+		$this->assertEquals( 'publish', $like_post->post_status, 'Private Like activity should remain publish' );
+	}
+
+	/**
+	 * Test post_status for public Create and Update activities.
+	 *
+	 * Verifies that public Create and Update activities get 'publish' post_status.
+	 *
+	 * @covers ::add
+	 */
+	public function test_post_status_for_public_activities() {
+		// Test public Create activity - should have 'publish' post_status.
+		$create_activity = new Activity();
+		$create_activity->set_id( 'https://remote.example.com/activities/public-create' );
+		$create_activity->set_type( 'Create' );
+		$create_activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$create_activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) ); // Public.
+
+		$object = new Base_Object();
+		$object->set_id( 'https://remote.example.com/objects/public-create' );
+		$object->set_type( 'Note' );
+		$object->set_content( 'Public create content' );
+		$create_activity->set_object( $object );
+
+		$create_id   = Inbox::add( $create_activity, 1 );
+		$create_post = \get_post( $create_id );
+		$this->assertEquals( 'publish', $create_post->post_status, 'Public Create activity should have publish post_status' );
+
+		// Test public Update activity - should have 'publish' post_status.
+		$update_activity = new Activity();
+		$update_activity->set_id( 'https://remote.example.com/activities/public-update' );
+		$update_activity->set_type( 'Update' );
+		$update_activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$update_activity->set_cc( array( 'https://www.w3.org/ns/activitystreams#Public' ) ); // Quiet public.
+
+		$object2 = new Base_Object();
+		$object2->set_id( 'https://remote.example.com/objects/public-update' );
+		$object2->set_type( 'Note' );
+		$object2->set_content( 'Public update content' );
+		$update_activity->set_object( $object2 );
+
+		$update_id   = Inbox::add( $update_activity, 1 );
+		$update_post = \get_post( $update_id );
+		$this->assertEquals( 'publish', $update_post->post_status, 'Quiet public Update activity should have publish post_status' );
 	}
 }

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -936,7 +936,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$create_activity->set_id( 'https://remote.example.com/activities/private-create' );
 		$create_activity->set_type( 'Create' );
 		$create_activity->set_actor( 'https://remote.example.com/users/testuser' );
-		$create_activity->set_to( array( 'https://example.com/users/1' ) ); // Private (not public).
+		$create_activity->set_to( array( 'https://example.com/users/1' ) ); // Private.
 
 		$object = new Base_Object();
 		$object->set_id( 'https://remote.example.com/objects/private-create' );
@@ -953,7 +953,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$update_activity->set_id( 'https://remote.example.com/activities/private-update' );
 		$update_activity->set_type( 'Update' );
 		$update_activity->set_actor( 'https://remote.example.com/users/testuser' );
-		$update_activity->set_to( array( 'https://example.com/users/1' ) ); // Private (not public).
+		$update_activity->set_to( array( 'https://example.com/users/1' ) ); // Private.
 
 		$object2 = new Base_Object();
 		$object2->set_id( 'https://remote.example.com/objects/private-update' );


### PR DESCRIPTION

  ## Proposed changes:
  - Sets `post_status` to `'private'` for Create and Update activities that have private visibility
  - Other activity types (Follow, Like, Accept, etc.) remain `'publish'` regardless of visibility
  - Includes migration to update existing private Create/Update activities

  ## Details

  **Updated `Inbox::add()` method** (`includes/collection/class-inbox.php`)
  - Dynamically sets post_status based on activity type and visibility
  - Private Create/Update activities get `'private'` status
  - All other activities get `'publish'` status

  **Added migration** (`includes/class-migration.php`)
  - Migrates existing private Create/Update activities to private status
  - Uses efficient JOIN query to find matching posts

  **Added comprehensive tests** (`tests/phpunit/tests/includes/collection/class-test-inbox.php`)
  - Tests private Create/Update get `'private'` status
  - Tests public Create/Update get `'publish'` status  
  - Tests other activity types remain `'publish'`

  ### Other information:

  - [x] Have you written new tests for your changes, if applicable?

  ## Testing instructions:

  * Run `npm run env-test -- --filter=Test_Inbox`
  * All 56 tests should pass
  * Verify private Create/Update activities work correctly
  * Verify public activities continue to work as before

  ### Changelog entry

  - [x] Automatically create a changelog entry from the details below.

  <details>

  <summary>Changelog Entry Details</summary>

  #### Significance

  - [x] Patch
  - [ ] Minor
  - [ ] Major

  #### Type

  - [ ] Added - for new features
  - [ ] Changed - for changes in existing functionality
  - [ ] Deprecated - for soon-to-be removed features
  - [ ] Removed - for now removed features
  - [x] Fixed - for any bug fixes
  - [ ] Security - in case of vulnerabilities

  #### Message

  Private inbox Create and Update activities now use private post status to accurately reflect their visibility.

  </details>