### PR TITLE
Remove generic 'handle' prefix from Social Web UI function names

### DIFF
--- a/src/social-web/components/layout/index.tsx
+++ b/src/social-web/components/layout/index.tsx
@@ -76,29 +76,29 @@ export function Layout() {
 
 	// Listen for hash changes (back/forward navigation)
 	useEffect( () => {
-		const handleHashChange = () => {
+		const syncUrlToState = () => {
 			const { section, itemId } = parseHash();
 			setActiveSection( section );
 			setSelectedItemId( itemId );
 		};
 
-		window.addEventListener( 'hashchange', handleHashChange );
+		window.addEventListener( 'hashchange', syncUrlToState );
 		return () => {
-			window.removeEventListener( 'hashchange', handleHashChange );
+			window.removeEventListener( 'hashchange', syncUrlToState );
 		};
 	}, [] );
 
-	const handleSelectItem = ( id: string | number ) => {
+	const selectItem = ( id: string | number ) => {
 		setSelectedItemId( id );
 		updateHash( activeSection, id );
 	};
 
-	const handleCloseInspector = () => {
+	const closeInspector = () => {
 		setSelectedItemId( null );
 		updateHash( activeSection );
 	};
 
-	const handleNavigate = ( section: string ) => {
+	const navigate = ( section: string ) => {
 		setActiveSection( section );
 		setSelectedItemId( null );
 		updateHash( section );
@@ -106,7 +106,7 @@ export function Layout() {
 
 	// Render main content (stage) with Suspense for lazy loading
 	const renderStage = () => {
-		const props = { onSelectItem: handleSelectItem };
+		const props = { onSelectItem: selectItem };
 
 		let StageComponent;
 		switch ( activeSection ) {
@@ -145,7 +145,7 @@ export function Layout() {
 					return null;
 				}
 				InspectorComponent = FeedInspector;
-				props = { id: selectedItemId, onClose: handleCloseInspector };
+				props = { id: selectedItemId, onClose: closeInspector };
 		}
 
 		return (
@@ -169,7 +169,7 @@ export function Layout() {
 			<div className="app-content">
 				{ /* Sidebar - 240px fixed width (no Panel wrapper, stays dark) */ }
 				<div className="sidebar-region">
-					<Sidebar activeSection={ activeSection } onNavigate={ handleNavigate } />
+					<Sidebar activeSection={ activeSection } onNavigate={ navigate } />
 				</div>
 
 				{ /* Stage - main content area */ }

--- a/src/social-web/components/layout/index.tsx
+++ b/src/social-web/components/layout/index.tsx
@@ -74,7 +74,7 @@ export function Layout() {
 		setSelectedItemId( itemId );
 	}, [] );
 
-	// Listen for hash changes (back/forward navigation)
+	// Listen for hash changes (back/forward navigation).
 	useEffect( () => {
 		const syncUrlToState = () => {
 			const { section, itemId } = parseHash();

--- a/src/social-web/routes/feed/stage.tsx
+++ b/src/social-web/routes/feed/stage.tsx
@@ -81,7 +81,7 @@ export default function FeedStage( { onSelectItem }: FeedStageProps ) {
 		}
 	}, [ feed, selection ] );
 
-	const handleChangeSelection = useCallback(
+	const changeSelection = useCallback(
 		( nextSelection: string[] ) => {
 			setSelection( nextSelection );
 
@@ -116,7 +116,7 @@ export default function FeedStage( { onSelectItem }: FeedStageProps ) {
 				isItemClickable={ () => true }
 				getItemId={ ( item ) => item.id.toString() }
 				selection={ selection }
-				onChangeSelection={ handleChangeSelection }
+				onChangeSelection={ changeSelection }
 				empty={
 					<p>
 						{ view.search


### PR DESCRIPTION
## Summary

Refactored event handler function names in the Social Web UI to be more descriptive and meaningful by removing the generic 'handle' prefix.

### Changes

**`src/social-web/routes/feed/stage.tsx`:**
- `handleChangeSelection` → `changeSelection`

**`src/social-web/components/layout/index.tsx`:**
- `handleHashChange` → `syncUrlToState`
- `handleSelectItem` → `selectItem`
- `handleCloseInspector` → `closeInspector`
- `handleNavigate` → `navigate`

## Test Plan

- [ ] Verify feed page loads correctly
- [ ] Test selecting items from the feed opens the inspector
- [ ] Test closing the inspector works
- [ ] Test navigation between sections (Feed, Following, Interactions)
- [ ] Test browser back/forward buttons work correctly
- [ ] Verify no console errors