### PR TITLE
Filter comment federation by comment type

### DIFF
--- a/.github/changelog/2494-from-description
+++ b/.github/changelog/2494-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevents unwanted comment types—like pingbacks, trackbacks, notes and custom system comments—from being federated, ensuring only real user comments are shared with the fediverse.

--- a/.github/changelog/2494-from-description
+++ b/.github/changelog/2494-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Prevents unwanted comment types—like pingbacks, trackbacks, notes and custom system comments—from being federated, ensuring only real user comments are shared with the fediverse.
+Prevents unwanted comment types—like pingbacks, trackbacks, notes and custom system comments, from being federated, ensuring only real user comments are shared with the fediverse.

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -56,6 +56,9 @@ class Comment {
 		 * Only federate registered ActivityPub comment types and standard WordPress comments.
 		 */
 		$allowed_types = Comment_Utils::get_comment_type_slugs();
+		if ( ! is_array( $allowed_types ) ) {
+			$allowed_types = array();
+		}
 
 		// Add core WordPress comment types.
 		$allowed_types[] = ''; // Empty string is default WordPress comment type.

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -52,7 +52,7 @@ class Comment {
 		}
 
 		/*
-		 * Check with supported comment types.
+		 * Check against supported comment types.
 		 * Only federate registered ActivityPub comment types and standard WordPress comments.
 		 */
 		$allowed_types = Comment_Utils::get_comment_type_slugs();

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -56,9 +56,6 @@ class Comment {
 		 * Only federate registered ActivityPub comment types and standard WordPress comments.
 		 */
 		$allowed_types = Comment_Utils::get_comment_type_slugs();
-		if ( ! is_array( $allowed_types ) ) {
-			$allowed_types = array();
-		}
 
 		// Add core WordPress comment types.
 		$allowed_types[] = ''; // Empty string is default WordPress comment type.

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -61,7 +61,6 @@ class Comment {
 		}
 
 		// Add core WordPress comment types.
-		$allowed_types[] = ''; // Empty string is default WordPress comment type.
 		$allowed_types[] = 'comment'; // Some plugins/themes use 'comment'.
 
 		// Check if comment type is in allowed list.

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -51,6 +51,24 @@ class Comment {
 			return;
 		}
 
+		/*
+		 * Check with supported comment types.
+		 * Only federate registered ActivityPub comment types and standard WordPress comments.
+		 */
+		$allowed_types = Comment_Utils::get_comment_type_slugs();
+		if ( ! is_array( $allowed_types ) ) {
+			$allowed_types = array();
+		}
+
+		// Add core WordPress comment types.
+		$allowed_types[] = ''; // Empty string is default WordPress comment type.
+		$allowed_types[] = 'comment'; // Some plugins/themes use 'comment'.
+
+		// Check if comment type is in allowed list.
+		if ( ! in_array( $comment->comment_type, $allowed_types, true ) ) {
+			return;
+		}
+
 		$type = false;
 
 		if (

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -55,13 +55,8 @@ class Comment {
 		 * Check against supported comment types.
 		 * Only federate registered ActivityPub comment types and standard WordPress comments.
 		 */
-		$allowed_types = Comment_Utils::get_comment_type_slugs();
-		if ( ! is_array( $allowed_types ) ) {
-			$allowed_types = array();
-		}
-
-		// Add core WordPress comment types.
-		$allowed_types[] = 'comment'; // Some plugins/themes use 'comment'.
+		$allowed_types   = Comment_Utils::get_comment_type_slugs();
+		$allowed_types[] = 'comment'; // Add core WordPress comment types.
 
 		// Check if comment type is in allowed list.
 		if ( ! in_array( $comment->comment_type, $allowed_types, true ) ) {

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -61,6 +61,7 @@ class Comment {
 		}
 
 		// Add core WordPress comment types.
+		$allowed_types[] = ''; // Empty string is default WordPress comment type.
 		$allowed_types[] = 'comment'; // Some plugins/themes use 'comment'.
 
 		// Check if comment type is in allowed list.

--- a/tests/phpunit/tests/includes/scheduler/class-test-comment.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-comment.php
@@ -105,6 +105,14 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 					),
 				),
 			),
+			'unsupported_comment_type_note'      => array(
+				array(
+					'comment_post_ID'  => self::$comment_post_ID,
+					'user_id'          => self::$user_id,
+					'comment_approved' => 1,
+					'comment_type'     => 'note',
+				),
+			),
 			'unsupported_comment_type_pingback'  => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,

--- a/tests/phpunit/tests/includes/scheduler/class-test-comment.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-comment.php
@@ -82,20 +82,20 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 */
 	public function no_activity_comment_provider() {
 		return array(
-			'unapproved_comment'  => array(
+			'unapproved_comment'              => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,
 					'user_id'          => self::$user_id,
 					'comment_approved' => 0,
 				),
 			),
-			'non_registered_user' => array(
+			'non_registered_user'             => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,
 					'comment_approved' => 1,
 				),
 			),
-			'federation_disabled' => array(
+			'federation_disabled'             => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,
 					'user_id'          => self::$user_id,
@@ -103,6 +103,22 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 					'comment_meta'     => array(
 						'protocol' => 'activitypub',
 					),
+				),
+			),
+			'unsupported_comment_type_note'   => array(
+				array(
+					'comment_post_ID'  => self::$comment_post_ID,
+					'user_id'          => self::$user_id,
+					'comment_approved' => 1,
+					'comment_type'     => 'note',
+				),
+			),
+			'unsupported_comment_type_custom' => array(
+				array(
+					'comment_post_ID'  => self::$comment_post_ID,
+					'user_id'          => self::$user_id,
+					'comment_approved' => 1,
+					'comment_type'     => 'custom_unsupported_type',
 				),
 			),
 		);
@@ -125,7 +141,22 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$comment_id    = self::factory()->comment->create( $comment_data );
 		$activitpub_id = Comment::generate_id( $comment_id );
 
-		$this->assertNull( $this->get_latest_outbox_item( $activitpub_id ) );
+		// Check that no outbox item was created for this specific comment.
+		$outbox_posts = \get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => array( 'publish', 'draft', 'pending', 'private' ),
+				'numberposts' => -1,
+				'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					array(
+						'key'   => '_activitypub_object_id',
+						'value' => $activitpub_id,
+					),
+				),
+			)
+		);
+
+		$this->assertEmpty( $outbox_posts, 'No outbox item should be created for this comment' );
 
 		\wp_delete_comment( $comment_id, true );
 	}

--- a/tests/phpunit/tests/includes/scheduler/class-test-comment.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-comment.php
@@ -82,20 +82,20 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 */
 	public function no_activity_comment_provider() {
 		return array(
-			'unapproved_comment'              => array(
+			'unapproved_comment'                 => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,
 					'user_id'          => self::$user_id,
 					'comment_approved' => 0,
 				),
 			),
-			'non_registered_user'             => array(
+			'non_registered_user'                => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,
 					'comment_approved' => 1,
 				),
 			),
-			'federation_disabled'             => array(
+			'federation_disabled'                => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,
 					'user_id'          => self::$user_id,
@@ -105,20 +105,20 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 					),
 				),
 			),
-			'unsupported_comment_type_note'   => array(
+			'unsupported_comment_type_pingback'  => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,
 					'user_id'          => self::$user_id,
 					'comment_approved' => 1,
-					'comment_type'     => 'note',
+					'comment_type'     => 'pingback',
 				),
 			),
-			'unsupported_comment_type_custom' => array(
+			'unsupported_comment_type_trackback' => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,
 					'user_id'          => self::$user_id,
 					'comment_approved' => 1,
-					'comment_type'     => 'custom_unsupported_type',
+					'comment_type'     => 'trackback',
 				),
 			),
 		);

--- a/tests/phpunit/tests/includes/scheduler/class-test-comment.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-comment.php
@@ -105,14 +105,6 @@ class Test_Comment extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 					),
 				),
 			),
-			'unsupported_comment_type_note'      => array(
-				array(
-					'comment_post_ID'  => self::$comment_post_ID,
-					'user_id'          => self::$user_id,
-					'comment_approved' => 1,
-					'comment_type'     => 'note',
-				),
-			),
 			'unsupported_comment_type_pingback'  => array(
 				array(
 					'comment_post_ID'  => self::$comment_post_ID,


### PR DESCRIPTION
Only federate comments with supported comment types to prevent federation of special comment types like pingbacks, trackbacks, and custom types that should not be published to the fediverse.

<!--- Provide a general summary of your changes in the Title above -->

Fixes #2492

## Proposed changes:
- Add comment type filtering to Comment scheduler
- Only allow registered ActivityPub comment types and standard WordPress comment types (empty string and 'comment')
- Add test cases for unsupported comment types ('note' and 'custom_unsupported_type')
- Fix test assertion to properly query outbox items by object ID meta instead of post title

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Prevents unwanted comment types—like pingbacks, trackbacks, notes and custom system comments, from being federated, ensuring only real user comments are shared with the fediverse.

</details>
