### PR TITLE
Preserve ActivityPub activity timestamps when creating posts and comments

### DIFF
--- a/.github/changelog/2498-from-description
+++ b/.github/changelog/2498-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Preserve original ActivityPub activity timestamps when creating posts and comments instead of using current time.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -343,7 +343,8 @@ class Interactions {
 			$webfinger = str_replace( 'acct:', '', $webfinger );
 		}
 
-		$date = $activity['object']['published'] ?? 'now';
+		$published = $activity['object']['published'] ?? $activity['published'] ?? 'now';
+		$gm_date   = \gmdate( 'Y-m-d H:i:s', \strtotime( $published ) );
 
 		$comment_data = array(
 			'comment_author'       => $comment_author ?? __( 'Anonymous', 'activitypub' ),
@@ -351,8 +352,8 @@ class Interactions {
 			'comment_content'      => $comment_content,
 			'comment_type'         => 'comment',
 			'comment_author_email' => $webfinger,
-			'comment_date'         => \get_date_from_gmt( \gmdate( 'Y-m-d H:i:s', \strtotime( $date ) ) ),
-			'comment_date_gmt'     => \gmdate( 'Y-m-d H:i:s', \strtotime( $date ) ),
+			'comment_date'         => \get_date_from_gmt( $gm_date ),
+			'comment_date_gmt'     => $gm_date,
 			'comment_meta'         => array(
 				'source_id' => \esc_url_raw( object_to_uri( $activity['object'] ) ),
 				'protocol'  => 'activitypub',

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -10,6 +10,7 @@ namespace Activitypub\Collection;
 use Activitypub\Attachments;
 use Activitypub\Sanitize;
 
+use function Activitypub\generate_post_summary;
 use function Activitypub\object_to_uri;
 
 /**
@@ -187,13 +188,18 @@ class Posts {
 			return new \WP_Error( 'invalid_activity', __( 'Invalid activity format', 'activitypub' ) );
 		}
 
+		$published = $activity['object']['published'] ?? $activity['published'] ?? 'now';
+		$gm_date   = \gmdate( 'Y-m-d H:i:s', \strtotime( $published ) );
+
 		return array(
-			'post_title'   => isset( $activity['name'] ) ? \wp_strip_all_tags( $activity['name'] ) : '',
-			'post_content' => isset( $activity['content'] ) ? Sanitize::content( $activity['content'] ) : '',
-			'post_excerpt' => isset( $activity['summary'] ) ? \wp_strip_all_tags( $activity['summary'] ) : '',
-			'post_status'  => 'publish',
-			'post_type'    => self::POST_TYPE,
-			'guid'         => isset( $activity['id'] ) ? \esc_url_raw( $activity['id'] ) : '',
+			'post_title'    => isset( $activity['name'] ) ? \wp_strip_all_tags( $activity['name'] ) : '',
+			'post_content'  => isset( $activity['content'] ) ? Sanitize::content( $activity['content'] ) : '',
+			'post_excerpt'  => isset( $activity['summary'] ) ? \wp_strip_all_tags( $activity['summary'] ) : generate_post_summary( $activity['content'] ),
+			'post_status'   => 'publish',
+			'post_type'     => self::POST_TYPE,
+			'post_date_gmt' => $gm_date,
+			'post_date'     => \get_date_from_gmt( $gm_date ),
+			'guid'          => isset( $activity['id'] ) ? \esc_url_raw( $activity['id'] ) : '',
 		);
 	}
 

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -188,13 +188,12 @@ class Posts {
 			return new \WP_Error( 'invalid_activity', __( 'Invalid activity format', 'activitypub' ) );
 		}
 
-		$published = $activity['object']['published'] ?? $activity['published'] ?? 'now';
-		$gm_date   = \gmdate( 'Y-m-d H:i:s', \strtotime( $published ) );
+		$gm_date = \gmdate( 'Y-m-d H:i:s', \strtotime( $activity['published'] ?? 'now' ) );
 
 		return array(
 			'post_title'    => isset( $activity['name'] ) ? \wp_strip_all_tags( $activity['name'] ) : '',
 			'post_content'  => isset( $activity['content'] ) ? Sanitize::content( $activity['content'] ) : '',
-			'post_excerpt'  => isset( $activity['summary'] ) ? \wp_strip_all_tags( $activity['summary'] ) : generate_post_summary( $activity['content'] ),
+			'post_excerpt'  => isset( $activity['summary'] ) ? \wp_strip_all_tags( $activity['summary'] ) : generate_post_summary( $activity['content'] ?? '' ),
 			'post_status'   => 'publish',
 			'post_type'     => self::POST_TYPE,
 			'post_date_gmt' => $gm_date,


### PR DESCRIPTION
## Proposed changes:
* Preserve original `published` timestamps from ActivityPub activities when creating posts and comments
* Use `activity.published` or `activity.object.published` instead of current time
* Ensures reprocessed activities maintain chronological accuracy

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Process an ActivityPub activity (Create, Like, or Announce) with a `published` field
2. Verify the created post/comment has a `post_date`/`comment_date` matching the activity's `published` timestamp
3. For testing reprocessing: use the WP-CLI reprocess_inbox command (separate PR) to reprocess an old inbox item and verify the timestamp is preserved

**Before:** Posts and comments created from ActivityPub activities would use the current time, making reprocessed items appear as new content.

**After:** Posts and comments preserve the original `published` timestamp from the activity, maintaining proper chronological order.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Preserve original ActivityPub activity timestamps when creating posts and comments instead of using current time.

</details>