### PR TITLE
Fix attachment filename generation for URLs with query parameters

### DIFF
--- a/.github/changelog/2499-from-description
+++ b/.github/changelog/2499-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix "Filename too long" errors when downloading attachments from URLs with query parameters (e.g., Instagram CDN URLs).

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -446,7 +446,7 @@ class Attachments {
 
 		// Prepare file array for WordPress.
 		$file_array = array(
-			'name'     => \basename( \strtok( $attachment_data['url'], '?' ) ),
+			'name'     => \basename( \wp_parse_url( $attachment_data['url'], PHP_URL_PATH ) ),
 			'tmp_name' => $tmp_file,
 		);
 
@@ -514,7 +514,7 @@ class Attachments {
 		\wp_mkdir_p( $paths['basedir'] );
 
 		// Generate unique file name.
-		$url_path  = \strtok( $attachment_data['url'], '?' );
+		$url_path  = \wp_parse_url( $attachment_data['url'], PHP_URL_PATH );
 		$file_name = \sanitize_file_name( \basename( $url_path ) );
 		$file_path = $paths['basedir'] . '/' . $file_name;
 

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -446,7 +446,7 @@ class Attachments {
 
 		// Prepare file array for WordPress.
 		$file_array = array(
-			'name'     => \basename( $attachment_data['url'] ),
+			'name'     => \basename( \strtok( $attachment_data['url'], '?' ) ),
 			'tmp_name' => $tmp_file,
 		);
 
@@ -514,7 +514,8 @@ class Attachments {
 		\wp_mkdir_p( $paths['basedir'] );
 
 		// Generate unique file name.
-		$file_name = \sanitize_file_name( \basename( $attachment_data['url'] ) );
+		$url_path  = \strtok( $attachment_data['url'], '?' );
+		$file_name = \sanitize_file_name( \basename( $url_path ) );
 		$file_path = $paths['basedir'] . '/' . $file_name;
 
 		// Initialize filesystem if needed.

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -640,12 +640,9 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$this->assertCount( 1, $result );
 		$this->assertIsInt( $result[0] );
 
-		// Get the attachment and verify the filename.
-		$attachment      = get_post( $result[0] );
+		// Verify the attachment filename is clean without query parameters.
 		$attachment_file = get_attached_file( $result[0] );
-
-		// Filename should be clean without query parameters.
-		$this->assertStringContainsString( 'image.jpg', $attachment_file );
+		$this->assertStringEndsWith( '.jpg', $attachment_file );
 		$this->assertStringNotContainsString( '?', $attachment_file );
 		$this->assertStringNotContainsString( 'stp=', $attachment_file );
 		$this->assertStringNotContainsString( 'nc_cat=', $attachment_file );
@@ -680,7 +677,7 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$this->assertCount( 1, $result );
 
 		// Verify the URL doesn't contain query parameters.
-		$this->assertStringContainsString( 'photo.png', $result[0]['url'] );
+		$this->assertStringEndsWith( '.png', $result[0]['url'] );
 		$this->assertStringNotContainsString( '?', $result[0]['url'] );
 		$this->assertStringNotContainsString( 'size=', $result[0]['url'] );
 	}

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -614,4 +614,74 @@ class Test_Attachments extends \WP_UnitTestCase {
 		// Clean up.
 		\wp_delete_post( $post_id, true );
 	}
+
+	/**
+	 * Test that query parameters are stripped from attachment filenames.
+	 *
+	 * This prevents "Filename too long" errors when downloading from CDN URLs
+	 * (like Instagram) that include long query strings.
+	 *
+	 * @covers ::save_attachment
+	 */
+	public function test_attachment_filename_strips_query_parameters() {
+		// Instagram-style URL with very long query parameters.
+		$attachments = array(
+			array(
+				'url'       => 'https://example.com/image.jpg?stp=dst-jpg_e35&nc_cat=101&ccb7-5&_nc_sid=18de74&nc_ohc=example&nc_oc=example',
+				'mediaType' => 'image/jpeg',
+				'name'      => 'Test Image',
+				'type'      => 'Image',
+			),
+		);
+
+		$result = Attachments::import( $attachments, self::$post_id, self::$author_id );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertIsInt( $result[0] );
+
+		// Get the attachment and verify the filename.
+		$attachment      = get_post( $result[0] );
+		$attachment_file = get_attached_file( $result[0] );
+
+		// Filename should be clean without query parameters.
+		$this->assertStringContainsString( 'image.jpg', $attachment_file );
+		$this->assertStringNotContainsString( '?', $attachment_file );
+		$this->assertStringNotContainsString( 'stp=', $attachment_file );
+		$this->assertStringNotContainsString( 'nc_cat=', $attachment_file );
+	}
+
+	/**
+	 * Test that query parameters are stripped from direct file storage filenames.
+	 *
+	 * @covers ::save_file
+	 */
+	public function test_file_storage_filename_strips_query_parameters() {
+		// Create a test post.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type' => 'ap_post',
+			)
+		);
+
+		// URL with query parameters.
+		$attachments = array(
+			array(
+				'url'       => 'https://example.com/photo.png?size=large&quality=high&cache=12345',
+				'mediaType' => 'image/png',
+				'name'      => 'Test Photo',
+				'type'      => 'Image',
+			),
+		);
+
+		$result = Attachments::import_post_files( $attachments, $post_id );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+
+		// Verify the URL doesn't contain query parameters.
+		$this->assertStringContainsString( 'photo.png', $result[0]['url'] );
+		$this->assertStringNotContainsString( '?', $result[0]['url'] );
+		$this->assertStringNotContainsString( 'size=', $result[0]['url'] );
+	}
 }


### PR DESCRIPTION
## Proposed changes:
* Strip query parameters from URLs before generating attachment filenames
* Prevents "Filename too long" filesystem errors
* Fixes issues with Instagram CDN URLs and other services that use long query strings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Process an ActivityPub activity with an attachment URL that has query parameters (e.g., Instagram CDN URL)
2. Verify the file is saved successfully without errors
3. Check that the filename is clean without query parameters

**Before:** 
```
PHP Warning: copy(.../582455906_17930138757114605_3007218277985087381_n.jpgstpdst-jpg_e35_tt6_nc_cat101ccb7-5_nc_sid18de74efgeyJlZmdfdGFnIjoiRkVFRC5iZXN0X2ltYWdlX3VybGdlbi5DMyJ9_nc_ohcne9zSzVebdsQ7kNvwGMeb6Q_nc_ocAdmzsGgwxVX3rDrTgZriddqj37P8s3eVEtAa8tNuy5DnRzJUT7nFkflSQgNVztbdQCIpM6rhfFycR1UGy1LYI2oP_nc_adz-m_nc_cid0_nc_zt23_nc_htscontent.cdninstagram.com_nc_gideIO13gOfATKzYZ-ERRIiugoh00_Afg0LbbH0emgIK49rQawuJMuNFn3fJZCkBf5zfuflpG90Qoe6922C08B): Failed to open stream: Filename too long
```

**After:** 
File saved successfully as `582455906_17930138757114605_3007218277985087381_n.jpg`

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix "Filename too long" errors when downloading attachments from URLs with query parameters (e.g., Instagram CDN URLs).

</details>