### PR TITLE
Add WP-CLI command to reprocess inbox items

### DIFF
--- a/includes/handler/class-create.php
+++ b/includes/handler/class-create.php
@@ -78,15 +78,7 @@ class Create {
 
 		// If comment exists, call update action.
 		if ( $check_dupe ) {
-			/**
-			 * Fires when a Create activity is received for an existing comment.
-			 *
-			 * @param array                          $activity        The activity-object.
-			 * @param int[]                          $user_ids        The ids of the local blog-users.
-			 * @param \Activitypub\Activity\Activity $activity_object The activity object.
-			 */
-			\do_action( 'activitypub_inbox_update', $activity, (array) $user_ids, $activity_object );
-			return false;
+			return Update::handle_update( $activity, (array) $user_ids, $activity_object );
 		}
 
 		if ( is_self_ping( $activity['object']['id'] ) ) {
@@ -116,15 +108,7 @@ class Create {
 
 		// If comment exists, call update action.
 		if ( ! \is_wp_error( $check_dupe ) ) {
-			/**
-			 * Fires when a Create activity is received for an existing object.
-			 *
-			 * @param array                          $activity        The activity-object.
-			 * @param int[]                          $user_ids        The id of the local blog-user.
-			 * @param \Activitypub\Activity\Activity $activity_object The activity object.
-			 */
-			\do_action( 'activitypub_inbox_update', $activity, (array) $user_ids, $activity_object );
-			return false;
+			return Update::handle_update( $activity, (array) $user_ids, $activity_object );
 		}
 
 		return Posts::add( $activity, $user_ids );

--- a/includes/handler/class-update.php
+++ b/includes/handler/class-update.php
@@ -104,15 +104,7 @@ class Update {
 
 		// There is no object to update, try to trigger create instead.
 		if ( ! $updated ) {
-			/**
-			 * Fires when a Create activity is received for an existing object.
-			 *
-			 * @param array                          $activity        The activity-object.
-			 * @param int[]                          $user_ids        The ids of the local blog-users.
-			 * @param \Activitypub\Activity\Activity $activity_object The activity object.
-			 */
-			\do_action( 'activitypub_inbox_create', $activity, $user_ids, $activity_object );
-			return false;
+			return Create::handle_create( $activity, $user_ids, $activity_object );
 		}
 
 		$success = ( $result && ! \is_wp_error( $result ) );

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -227,11 +227,11 @@ class Cli extends \WP_CLI_Command {
 		if ( isset( $activity_data['object'] ) && is_array( $activity_data['object'] ) && isset( $activity_data['object']['id'] ) ) {
 			$object_id = $activity_data['object']['id'];
 
-			$comment = Comment::object_id_to_comment( $object_id );
-			if ( $comment ) {
-				\wp_delete_comment( $comment->comment_ID, true );
+			$object_comment = Comment::object_id_to_comment( $object_id );
+			if ( $object_comment ) {
+				\wp_delete_comment( $object_comment->comment_ID, true );
 				++$deleted_comments;
-				\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: object ID)', $comment->comment_ID ) );
+				\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: object ID)', $object_comment->comment_ID ) );
 			}
 
 			// Delete ap_post with GUID matching the object ID.

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -210,42 +210,48 @@ class Cli extends \WP_CLI_Command {
 			\WP_CLI::error( 'Failed to decode activity data.' );
 		}
 
-		// Delete existing comments created from this activity.
+		// Only delete existing artifacts for activity types that create new ones.
+		$should_delete = isset( $activity_data['type'] ) && in_array( $activity_data['type'], array( 'Create', 'Like', 'Announce' ), true );
+
 		$deleted_comments = 0;
 		$deleted_posts    = 0;
 
-		// Delete comments with source_id matching the activity ID.
-		$comment = Comment::object_id_to_comment( $activity_id );
-		if ( $comment ) {
-			\wp_delete_comment( $comment->comment_ID, true );
-			++$deleted_comments;
-			\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: activity ID)', $comment->comment_ID ) );
-		}
-
-		// Delete comments and posts with source_id/GUID matching the activity object ID.
-		if ( isset( $activity_data['object'] ) && is_array( $activity_data['object'] ) && isset( $activity_data['object']['id'] ) ) {
-			$object_id = $activity_data['object']['id'];
-
-			$object_comment = Comment::object_id_to_comment( $object_id );
-			if ( $object_comment ) {
-				\wp_delete_comment( $object_comment->comment_ID, true );
+		if ( $should_delete ) {
+			// Delete comments with source_id matching the activity ID.
+			$comment = Comment::object_id_to_comment( $activity_id );
+			if ( $comment ) {
+				\wp_delete_comment( $comment->comment_ID, true );
 				++$deleted_comments;
-				\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: object ID)', $object_comment->comment_ID ) );
+				\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: activity ID)', $comment->comment_ID ) );
 			}
 
-			// Delete ap_post with GUID matching the object ID.
-			$ap_post = Posts::get_by_guid( $object_id );
-			if ( ! \is_wp_error( $ap_post ) ) {
-				\wp_delete_post( $ap_post->ID, true );
-				++$deleted_posts;
-				\WP_CLI::log( sprintf( 'Deleted ap_post %d (GUID: object ID)', $ap_post->ID ) );
-			}
-		}
+			// Delete comments and posts with source_id/GUID matching the activity object ID.
+			if ( isset( $activity_data['object']['id'] ) && is_array( $activity_data['object'] ) ) {
+				$object_id = $activity_data['object']['id'];
 
-		if ( $deleted_comments > 0 || $deleted_posts > 0 ) {
-			\WP_CLI::log( sprintf( 'Deleted %d comment(s) and %d post(s).', $deleted_comments, $deleted_posts ) );
+				$object_comment = Comment::object_id_to_comment( $object_id );
+				if ( $object_comment ) {
+					\wp_delete_comment( $object_comment->comment_ID, true );
+					++$deleted_comments;
+					\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: object ID)', $object_comment->comment_ID ) );
+				}
+
+				// Delete ap_post with GUID matching the object ID.
+				$ap_post = Posts::get_by_guid( $object_id );
+				if ( ! \is_wp_error( $ap_post ) ) {
+					\wp_delete_post( $ap_post->ID, true );
+					++$deleted_posts;
+					\WP_CLI::log( sprintf( 'Deleted ap_post %d (GUID: object ID)', $ap_post->ID ) );
+				}
+			}
+
+			if ( $deleted_comments > 0 || $deleted_posts > 0 ) {
+				\WP_CLI::log( sprintf( 'Deleted %d comment(s) and %d post(s).', $deleted_comments, $deleted_posts ) );
+			} else {
+				\WP_CLI::log( 'No existing comments or posts found to delete.' );
+			}
 		} else {
-			\WP_CLI::log( 'No existing comments or posts found to delete.' );
+			\WP_CLI::log( sprintf( 'Skipping deletion for %s activity type.', $activity_data['type'] ) );
 		}
 
 		// Bypass signature verification for internal reprocessing.
@@ -261,16 +267,12 @@ class Cli extends \WP_CLI_Command {
 
 		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
-		if ( \is_wp_error( $response ) ) {
-			\WP_CLI::error( sprintf( 'Failed to reprocess: %s', $response->get_error_message() ) );
-		}
-
 		$status = $response->get_status();
 		if ( $status >= 200 && $status < 300 ) {
 			\WP_CLI::success( sprintf( 'Inbox item %d has been reprocessed as %s activity.', $post_id, $activity_data['type'] ) );
 		} else {
 			$data          = $response->get_data();
-			$error_message = isset( $data['message'] ) ? $data['message'] : 'Unknown error';
+			$error_message = $data['message'] ?? 'Unknown error';
 			\WP_CLI::error( sprintf( 'Failed to reprocess (HTTP %d): %s', $status, $error_message ) );
 		}
 	}

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -7,11 +7,13 @@
 
 namespace Activitypub\Development;
 
+use Activitypub\Activity\Activity;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Posts;
 use Activitypub\Comment;
 
+use function Activitypub\camel_to_snake_case;
 use function WP_CLI\Utils\get_flag_value;
 use function WP_CLI\Utils\make_progress_bar;
 
@@ -202,78 +204,80 @@ class Cli extends \WP_CLI_Command {
 
 		\WP_CLI::log( sprintf( 'Reprocessing inbox item %d...', $post_id ) );
 
-		// Get the activity ID (GUID) and activity data.
-		$activity_id   = $post->guid;
+		// Get the activity data from the inbox post.
 		$activity_data = json_decode( $post->post_content, true );
 
 		if ( ! $activity_data ) {
 			\WP_CLI::error( 'Failed to decode activity data.' );
 		}
 
-		// Only delete existing artifacts for activity types that create new ones.
-		$should_delete = isset( $activity_data['type'] ) && in_array( $activity_data['type'], array( 'Create', 'Like', 'Announce' ), true );
+		// Get the activity type.
+		if ( ! isset( $activity_data['type'] ) ) {
+			\WP_CLI::error( 'Activity data does not contain a type field.' );
+		}
 
+		$type = camel_to_snake_case( $activity_data['type'] );
+
+		// Get recipients from post meta.
+		$user_ids = Inbox::get_recipients( $post_id );
+
+		if ( empty( $user_ids ) ) {
+			\WP_CLI::error( 'No recipients found for this inbox item.' );
+		}
+
+		// Delete existing artifacts before reprocessing.
+		// Activity handlers check for duplicates and skip creation if they exist.
+		$activity_id      = $post->guid;
 		$deleted_comments = 0;
 		$deleted_posts    = 0;
 
-		if ( $should_delete ) {
-			// Delete comments with source_id matching the activity ID.
-			$comment = Comment::object_id_to_comment( $activity_id );
-			if ( $comment ) {
-				\wp_delete_comment( $comment->comment_ID, true );
+		// Delete comments with source_id matching the activity ID.
+		$comment = Comment::object_id_to_comment( $activity_id );
+		if ( $comment ) {
+			\wp_delete_comment( $comment->comment_ID, true );
+			++$deleted_comments;
+			\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: activity ID)', $comment->comment_ID ) );
+		}
+
+		// Delete comments and posts with source_id/GUID matching the activity object ID.
+		if ( isset( $activity_data['object']['id'] ) && is_array( $activity_data['object'] ) ) {
+			$object_id = $activity_data['object']['id'];
+
+			$object_comment = Comment::object_id_to_comment( $object_id );
+			if ( $object_comment ) {
+				\wp_delete_comment( $object_comment->comment_ID, true );
 				++$deleted_comments;
-				\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: activity ID)', $comment->comment_ID ) );
+				\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: object ID)', $object_comment->comment_ID ) );
 			}
 
-			// Delete comments and posts with source_id/GUID matching the activity object ID.
-			if ( isset( $activity_data['object']['id'] ) && is_array( $activity_data['object'] ) ) {
-				$object_id = $activity_data['object']['id'];
-
-				$object_comment = Comment::object_id_to_comment( $object_id );
-				if ( $object_comment ) {
-					\wp_delete_comment( $object_comment->comment_ID, true );
-					++$deleted_comments;
-					\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: object ID)', $object_comment->comment_ID ) );
-				}
-
-				// Delete ap_post with GUID matching the object ID.
-				$ap_post = Posts::get_by_guid( $object_id );
-				if ( ! \is_wp_error( $ap_post ) ) {
-					\wp_delete_post( $ap_post->ID, true );
-					++$deleted_posts;
-					\WP_CLI::log( sprintf( 'Deleted ap_post %d (GUID: object ID)', $ap_post->ID ) );
-				}
+			// Delete ap_post with GUID matching the object ID.
+			$ap_post = Posts::get_by_guid( $object_id );
+			if ( ! \is_wp_error( $ap_post ) ) {
+				\wp_delete_post( $ap_post->ID, true );
+				++$deleted_posts;
+				\WP_CLI::log( sprintf( 'Deleted ap_post %d (GUID: object ID)', $ap_post->ID ) );
 			}
-
-			if ( $deleted_comments > 0 || $deleted_posts > 0 ) {
-				\WP_CLI::log( sprintf( 'Deleted %d comment(s) and %d post(s).', $deleted_comments, $deleted_posts ) );
-			} else {
-				\WP_CLI::log( 'No existing comments or posts found to delete.' );
-			}
-		} else {
-			\WP_CLI::log( sprintf( 'Skipping deletion for %s activity type.', $activity_data['type'] ) );
 		}
 
-		// Bypass signature verification for internal reprocessing.
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
-
-		// Create internal REST request to the shared inbox endpoint.
-		$request = new \WP_REST_Request( 'POST', '/' . \ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
-		$request->set_header( 'Content-Type', 'application/activity+json' );
-		$request->set_body( \wp_json_encode( $activity_data ) );
-
-		// Dispatch the request through the REST API.
-		$response = \rest_do_request( $request );
-
-		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
-
-		$status = $response->get_status();
-		if ( $status >= 200 && $status < 300 ) {
-			\WP_CLI::success( sprintf( 'Inbox item %d has been reprocessed as %s activity.', $post_id, $activity_data['type'] ) );
-		} else {
-			$data          = $response->get_data();
-			$error_message = $data['message'] ?? 'Unknown error';
-			\WP_CLI::error( sprintf( 'Failed to reprocess (HTTP %d): %s', $status, $error_message ) );
+		if ( $deleted_comments > 0 || $deleted_posts > 0 ) {
+			\WP_CLI::log( sprintf( 'Deleted %d comment(s) and %d post(s).', $deleted_comments, $deleted_posts ) );
 		}
+
+		// Create Activity object from the activity data.
+		$activity = Activity::init_from_array( $activity_data );
+
+		if ( \is_wp_error( $activity ) ) {
+			\WP_CLI::error( sprintf( 'Failed to initialize activity: %s', $activity->get_error_message() ) );
+		}
+
+		// Trigger both sets of action hooks that handlers may be registered on.
+		// Some handlers use activitypub_inbox_{type} (Like, Announce, Delete, Undo)
+		// Others use activitypub_handled_inbox_{type} (Create, Update)
+		\do_action( 'activitypub_inbox', $activity_data, $user_ids, $type, $activity, Inbox::CONTEXT_INBOX );
+		\do_action( 'activitypub_inbox_' . $type, $activity_data, $user_ids, $activity, Inbox::CONTEXT_INBOX );
+		\do_action( 'activitypub_handled_inbox', $activity_data, $user_ids, $type, $activity, $post_id, Inbox::CONTEXT_INBOX );
+		\do_action( 'activitypub_handled_inbox_' . $type, $activity_data, $user_ids, $activity, $post_id, Inbox::CONTEXT_INBOX );
+
+		\WP_CLI::success( sprintf( 'Inbox item %d has been reprocessed as %s activity.', $post_id, $activity_data['type'] ) );
 	}
 }

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -8,7 +8,10 @@
 namespace Activitypub\Development;
 
 use Activitypub\Collection\Followers;
+use Activitypub\Collection\Inbox;
+use Activitypub\Collection\Posts;
 use Activitypub\Comment;
+use Activitypub\Rest\Actors_Inbox_Controller;
 
 use function WP_CLI\Utils\get_flag_value;
 use function WP_CLI\Utils\make_progress_bar;
@@ -167,5 +170,88 @@ class Cli extends \WP_CLI_Command {
 		if ( 'progress' === $format ) {
 			$notify->finish();
 		}
+	}
+
+	/**
+	 * Reprocess an inbox item.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : The post ID of the ap_inbox item to reprocess.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Reprocess inbox item with ID 123
+	 *     $ wp activitypub reprocess_inbox 123
+	 *     Success: Inbox item 123 has been reprocessed.
+	 *
+	 * @param array $args The arguments.
+	 */
+	public function reprocess_inbox( $args ) {
+		$post_id = absint( $args[0] );
+
+		if ( ! $post_id ) {
+			\WP_CLI::error( 'Invalid post ID provided.' );
+		}
+
+		$post = Inbox::get( $post_id );
+
+		if ( ! $post ) {
+			\WP_CLI::error( sprintf( 'Post with ID %d not found.', $post_id ) );
+		}
+
+		\WP_CLI::log( sprintf( 'Reprocessing inbox item %d...', $post_id ) );
+
+		// Get the activity ID (GUID) and activity data.
+		$activity_id   = $post->guid;
+		$activity_data = json_decode( $post->post_content, true );
+
+		if ( ! $activity_data ) {
+			\WP_CLI::error( 'Failed to decode activity data.' );
+		}
+
+		// Delete existing comments created from this activity.
+		$deleted_comments = 0;
+		$deleted_posts    = 0;
+
+		// Delete comments with source_id matching the activity ID.
+		$comment = Comment::object_id_to_comment( $activity_id );
+		if ( $comment ) {
+			\wp_delete_comment( $comment->comment_ID, true );
+			++$deleted_comments;
+			\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: activity ID)', $comment->comment_ID ) );
+		}
+
+		// Delete comments and posts with source_id/GUID matching the activity object ID.
+		if ( isset( $activity_data['object'] ) && is_array( $activity_data['object'] ) && isset( $activity_data['object']['id'] ) ) {
+			$object_id = $activity_data['object']['id'];
+
+			$comment = Comment::object_id_to_comment( $object_id );
+			if ( $comment ) {
+				\wp_delete_comment( $comment->comment_ID, true );
+				++$deleted_comments;
+				\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: object ID)', $comment->comment_ID ) );
+			}
+
+			// Delete ap_post with GUID matching the object ID.
+			$ap_post = Posts::get_by_guid( $object_id );
+			if ( ! \is_wp_error( $ap_post ) ) {
+				\wp_delete_post( $ap_post->ID, true );
+				++$deleted_posts;
+				\WP_CLI::log( sprintf( 'Deleted ap_post %d (GUID: object ID)', $ap_post->ID ) );
+			}
+		}
+
+		if ( $deleted_comments > 0 || $deleted_posts > 0 ) {
+			\WP_CLI::log( sprintf( 'Deleted %d comment(s) and %d post(s).', $deleted_comments, $deleted_posts ) );
+		} else {
+			\WP_CLI::log( 'No existing comments or posts found to delete.' );
+		}
+
+		// Call the process_create_item method to reprocess.
+		Actors_Inbox_Controller::process_create_item( $activity_id );
+
+		\WP_CLI::success( sprintf( 'Inbox item %d has been reprocessed.', $post_id ) );
 	}
 }

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -10,7 +10,6 @@ namespace Activitypub\Development;
 use Activitypub\Activity\Activity;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Inbox;
-use Activitypub\Collection\Posts;
 use Activitypub\Comment;
 
 use function Activitypub\camel_to_snake_case;
@@ -223,44 +222,6 @@ class Cli extends \WP_CLI_Command {
 
 		if ( empty( $user_ids ) ) {
 			\WP_CLI::error( 'No recipients found for this inbox item.' );
-		}
-
-		// Delete existing artifacts before reprocessing.
-		// Activity handlers check for duplicates and skip creation if they exist.
-		$activity_id      = $post->guid;
-		$deleted_comments = 0;
-		$deleted_posts    = 0;
-
-		// Delete comments with source_id matching the activity ID.
-		$comment = Comment::object_id_to_comment( $activity_id );
-		if ( $comment ) {
-			\wp_delete_comment( $comment->comment_ID, true );
-			++$deleted_comments;
-			\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: activity ID)', $comment->comment_ID ) );
-		}
-
-		// Delete comments and posts with source_id/GUID matching the activity object ID.
-		if ( isset( $activity_data['object']['id'] ) && is_array( $activity_data['object'] ) ) {
-			$object_id = $activity_data['object']['id'];
-
-			$object_comment = Comment::object_id_to_comment( $object_id );
-			if ( $object_comment ) {
-				\wp_delete_comment( $object_comment->comment_ID, true );
-				++$deleted_comments;
-				\WP_CLI::log( sprintf( 'Deleted comment %d (source_id: object ID)', $object_comment->comment_ID ) );
-			}
-
-			// Delete ap_post with GUID matching the object ID.
-			$ap_post = Posts::get_by_guid( $object_id );
-			if ( ! \is_wp_error( $ap_post ) ) {
-				\wp_delete_post( $ap_post->ID, true );
-				++$deleted_posts;
-				\WP_CLI::log( sprintf( 'Deleted ap_post %d (GUID: object ID)', $ap_post->ID ) );
-			}
-		}
-
-		if ( $deleted_comments > 0 || $deleted_posts > 0 ) {
-			\WP_CLI::log( sprintf( 'Deleted %d comment(s) and %d post(s).', $deleted_comments, $deleted_posts ) );
 		}
 
 		// Create Activity object from the activity data.

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -11,7 +11,6 @@ use Activitypub\Collection\Followers;
 use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Posts;
 use Activitypub\Comment;
-use Activitypub\Rest\Actors_Inbox_Controller;
 
 use function WP_CLI\Utils\get_flag_value;
 use function WP_CLI\Utils\make_progress_bar;
@@ -249,9 +248,30 @@ class Cli extends \WP_CLI_Command {
 			\WP_CLI::log( 'No existing comments or posts found to delete.' );
 		}
 
-		// Call the process_create_item method to reprocess.
-		Actors_Inbox_Controller::process_create_item( $activity_id );
+		// Bypass signature verification for internal reprocessing.
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 
-		\WP_CLI::success( sprintf( 'Inbox item %d has been reprocessed.', $post_id ) );
+		// Create internal REST request to the shared inbox endpoint.
+		$request = new \WP_REST_Request( 'POST', '/' . \ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $activity_data ) );
+
+		// Dispatch the request through the REST API.
+		$response = \rest_do_request( $request );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		if ( \is_wp_error( $response ) ) {
+			\WP_CLI::error( sprintf( 'Failed to reprocess: %s', $response->get_error_message() ) );
+		}
+
+		$status = $response->get_status();
+		if ( $status >= 200 && $status < 300 ) {
+			\WP_CLI::success( sprintf( 'Inbox item %d has been reprocessed as %s activity.', $post_id, $activity_data['type'] ) );
+		} else {
+			$data          = $response->get_data();
+			$error_message = isset( $data['message'] ) ? $data['message'] : 'Unknown error';
+			\WP_CLI::error( sprintf( 'Failed to reprocess (HTTP %d): %s', $status, $error_message ) );
+		}
 	}
 }

--- a/local/class-cli.php
+++ b/local/class-cli.php
@@ -271,8 +271,6 @@ class Cli extends \WP_CLI_Command {
 		}
 
 		// Trigger both sets of action hooks that handlers may be registered on.
-		// Some handlers use activitypub_inbox_{type} (Like, Announce, Delete, Undo)
-		// Others use activitypub_handled_inbox_{type} (Create, Update)
 		\do_action( 'activitypub_inbox', $activity_data, $user_ids, $type, $activity, Inbox::CONTEXT_INBOX );
 		\do_action( 'activitypub_inbox_' . $type, $activity_data, $user_ids, $activity, Inbox::CONTEXT_INBOX );
 		\do_action( 'activitypub_handled_inbox', $activity_data, $user_ids, $type, $activity, $post_id, Inbox::CONTEXT_INBOX );

--- a/local/load.php
+++ b/local/load.php
@@ -34,3 +34,5 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 // Defer signature verification on local development to better test API requests.
 \add_filter( 'activitypub_defer_signature_verification', '__return_true', 20 );
+
+\add_filter( 'option_activitypub_create_posts', '__return_true' );

--- a/tests/phpunit/tests/includes/handler/class-test-update.php
+++ b/tests/phpunit/tests/includes/handler/class-test-update.php
@@ -20,7 +20,7 @@ use Activitypub\Handler\Update;
 class Test_Update extends \WP_UnitTestCase {
 
 	/**
-	 * Test that the activitypub_inbox_create fallback is triggered.
+	 * Test that the activitypub_handled_create fallback is triggered.
 	 */
 	public function test_activitypub_inbox_create_fallback() {
 		\update_option( 'activitypub_create_posts', true );
@@ -35,31 +35,32 @@ class Test_Update extends \WP_UnitTestCase {
 			'type'   => 'Update',
 			'actor'  => $test_actor,
 			'object' => array(
-				'id'      => 'https://example.com/objects/12345',
-				'type'    => 'Note',
-				'content' => 'Test note',
+				'id'           => 'https://example.com/objects/12345',
+				'type'         => 'Note',
+				'content'      => 'Test note',
+				'attributedTo' => $test_actor,
 			),
 		);
 
 		// Add a fallback handler for the action.
 		\add_action(
-			'activitypub_inbox_create',
+			'activitypub_handled_create',
 			function ( $activity_data ) use ( &$called, $test_actor ) {
 				if ( isset( $activity_data['actor'] ) && $activity_data['actor'] === $test_actor ) {
 					$called = true;
 				}
 			},
 			10,
-			3
+			4
 		);
 
-		// Call the handler via the new handled_inbox_update hook.
+		// Call the handler via the handled_inbox_update hook.
 		\do_action( 'activitypub_handled_inbox_update', $activity, array( $this->user_id ), null );
 
-		$this->assertTrue( $called, 'The fallback activitypub_inbox_create action should be triggered.' );
+		$this->assertTrue( $called, 'The fallback activitypub_handled_create action should be triggered.' );
 
 		// Clean up by removing the action.
-		\remove_all_actions( 'activitypub_inbox_create' );
+		\remove_all_actions( 'activitypub_handled_create' );
 		\remove_all_actions( 'activitypub_handled_inbox_update' );
 		\delete_option( 'activitypub_create_posts' );
 	}


### PR DESCRIPTION
## Proposed changes:
* Add `wp activitypub reprocess_inbox` command for local development
* Delete existing comments/posts before reprocessing to ensure clean state
* Enable `activitypub_create_posts` option in local development for testing

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Set up local development environment with WP-CLI
2. Process an ActivityPub activity to create an inbox item
3. Run `wp activitypub reprocess_inbox <post_id>` where `<post_id>` is an ap_inbox post ID
4. Verify that:
   - Existing comments/posts are deleted
   - The activity is reprocessed
   - New comments/posts are created with the original timestamps

**Example usage:**
```bash
# Reprocess inbox item with ID 123
wp activitypub reprocess_inbox 123
```

**Expected output:**
```
Reprocessing inbox item 123...
Deleted comment 456 (source_id: object ID)
Deleted 1 comment(s) and 0 post(s).
Success: Inbox item 123 has been reprocessed.
```

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.