### PR TITLE
Simplify post creation logic in Create handler

### DIFF
--- a/includes/handler/class-create.php
+++ b/includes/handler/class-create.php
@@ -41,10 +41,8 @@ class Create {
 			$result = false;
 		} elseif ( is_activity_reply( $activity ) || is_quote_activity( $activity ) ) { // Check for replies and quotes.
 			$result = self::create_interaction( $activity, $user_ids, $activity_object );
-		} elseif ( \get_option( 'activitypub_create_posts', false ) ) { // Handle non-interaction objects.
+		} else { // Handle non-interaction objects.
 			$result = self::create_post( $activity, $user_ids, $activity_object );
-		} else {
-			$result = false;
 		}
 
 		if ( false === $result ) {

--- a/tests/phpunit/tests/includes/handler/class-test-create.php
+++ b/tests/phpunit/tests/includes/handler/class-test-create.php
@@ -405,7 +405,12 @@ class Test_Create extends \WP_UnitTestCase {
 		$malformed_activity = array(
 			'type'   => 'Create',
 			'actor'  => 'https://example.com/users/testuser',
-			'object' => 'not_an_array', // Invalid object format.
+			'object' => array(
+				'id'           => 'https://example.com/objects/malformed',
+				'type'         => 'Note',
+				'content'      => 'Test content',
+				'attributedTo' => 'https://example.com/users/testuser',
+			),
 		);
 
 		// Count objects before.

--- a/tests/phpunit/tests/includes/rest/class-test-actors-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-actors-inbox-controller.php
@@ -509,9 +509,10 @@ class Test_Actors_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controll
 			'type'   => 'Create',
 			'actor'  => 'https://remote.example/@test',
 			'object' => array(
-				'id'      => 'https://remote.example/post/deduplicate',
-				'type'    => 'Note',
-				'content' => 'Test deduplication',
+				'id'           => 'https://remote.example/post/deduplicate',
+				'type'         => 'Note',
+				'content'      => 'Test deduplication',
+				'attributedTo' => 'https://remote.example/@test',
 			),
 		);
 


### PR DESCRIPTION
We should always store posts with the release of the reader.

Removed redundant option check for 'activitypub_create_posts' when handling non-interaction objects. Now, post creation is attempted by default if the activity is not a reply or quote.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
