### PR TITLE
Fix `get_object_title()`

### DIFF
--- a/.github/changelog/2502-from-description
+++ b/.github/changelog/2502-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved handling of unusual activity data to avoid errors when activities contain unexpected formats.

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -139,12 +139,12 @@ class Inbox {
 	/**
 	 * Get the title of an activity recursively.
 	 *
-	 * @param Activity|Base_Object $activity_object The activity object.
+	 * @param Activity|Base_Object|array $activity_object The activity object.
 	 *
 	 * @return string The title.
 	 */
 	private static function get_object_title( $activity_object ) {
-		if ( ! $activity_object ) {
+		if ( ! $activity_object || is_array( $activity_object ) ) {
 			return '';
 		}
 

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -901,6 +901,48 @@ class Test_Inbox extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test adding Flag activity with array of URLs as object.
+	 *
+	 * This test verifies that the inbox can handle Flag activities (used for
+	 * reporting content) where the object is an array of URLs, which is a
+	 * real-world scenario from Mastodon moderation reports.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_flag_activity_with_url_array() {
+		// Create a Flag activity based on real-world Mastodon moderation report.
+		$activity = new Activity();
+		$activity->set_id( 'https://mastodon.social/c35aa724-e6b6-4266-b85f-f27d84b166f9' );
+		$activity->set_type( 'Flag' );
+		$activity->set_actor( 'https://mastodon.social/actor' );
+		$activity->set_content( '' ); // Flag activities often have empty content.
+
+		// Set object as an array of URLs (actor being reported + content being reported).
+		$activity->set_object(
+			array(
+				'https://skydancingblog.com/@skydancingblog.com',
+				'https://skydancingblog.com/?p=211771',
+			)
+		);
+
+		$user_id = 1;
+
+		// Add activity to inbox - should not throw an error despite array object.
+		$inbox_id = Inbox::add( $activity, $user_id );
+
+		$this->assertIsInt( $inbox_id );
+		$this->assertGreaterThan( 0, $inbox_id );
+
+		// Verify the post was created.
+		$post = \get_post( $inbox_id );
+		$this->assertInstanceOf( 'WP_Post', $post );
+		$this->assertEquals( Inbox::POST_TYPE, $post->post_type );
+
+		// Post title should be "[Flag] " (activity type with no object title from array).
+		$this->assertStringStartsWith( '[Flag]', $post->post_title );
+	}
+
+	/**
 	 * Test adding activity when object is null.
 	 *
 	 * @covers ::add

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -910,18 +910,18 @@ class Test_Inbox extends \WP_UnitTestCase {
 	 * @covers ::add
 	 */
 	public function test_add_flag_activity_with_url_array() {
-		// Create a Flag activity based on real-world Mastodon moderation report.
+		// Create a Flag activity similar to moderation reports.
 		$activity = new Activity();
-		$activity->set_id( 'https://mastodon.social/c35aa724-e6b6-4266-b85f-f27d84b166f9' );
+		$activity->set_id( 'https://remote.example.com/activities/flag-report' );
 		$activity->set_type( 'Flag' );
-		$activity->set_actor( 'https://mastodon.social/actor' );
+		$activity->set_actor( 'https://remote.example.com/users/reporter' );
 		$activity->set_content( '' ); // Flag activities often have empty content.
 
 		// Set object as an array of URLs (actor being reported + content being reported).
 		$activity->set_object(
 			array(
-				'https://skydancingblog.com/@skydancingblog.com',
-				'https://skydancingblog.com/?p=211771',
+				'https://example.org/users/reported-user',
+				'https://example.org/posts/12345',
 			)
 		);
 

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -859,6 +859,153 @@ class Test_Inbox extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test adding activity when object is an array.
+	 *
+	 * This test verifies that the inbox can handle activities where get_object()
+	 * returns an array instead of an object, which can happen with certain
+	 * ActivityPub implementations.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_activity_with_array_object() {
+		// Create an activity with an array as the object.
+		$activity = new Activity();
+		$activity->set_id( 'https://remote.example.com/activities/array-object' );
+		$activity->set_type( 'Create' );
+		$activity->set_actor( 'https://remote.example.com/users/testuser' );
+
+		// Set object as an array (this can happen with certain implementations).
+		$activity->set_object(
+			array(
+				'id'      => 'https://remote.example.com/objects/array-test',
+				'type'    => 'Note',
+				'content' => 'Test content',
+			)
+		);
+
+		$user_id = 1;
+
+		// Add activity to inbox - should not throw an error.
+		$inbox_id = Inbox::add( $activity, $user_id );
+
+		$this->assertIsInt( $inbox_id );
+		$this->assertGreaterThan( 0, $inbox_id );
+
+		// Verify the post was created with empty title (since array doesn't have get_name()).
+		$post = \get_post( $inbox_id );
+		$this->assertInstanceOf( 'WP_Post', $post );
+		$this->assertEquals( Inbox::POST_TYPE, $post->post_type );
+
+		// Post title should be "[Create] " (activity type with no object title).
+		$this->assertStringStartsWith( '[Create]', $post->post_title );
+	}
+
+	/**
+	 * Test adding activity when object is null.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_activity_with_null_object() {
+		$activity = new Activity();
+		$activity->set_id( 'https://remote.example.com/activities/null-object' );
+		$activity->set_type( 'Delete' );
+		$activity->set_actor( 'https://remote.example.com/users/testuser' );
+		// Don't set any object - it will be null.
+
+		$inbox_id = Inbox::add( $activity, 1 );
+
+		$this->assertIsInt( $inbox_id );
+		$this->assertGreaterThan( 0, $inbox_id );
+
+		// Post title should be "[Delete] " with no object title.
+		$post = \get_post( $inbox_id );
+		$this->assertStringStartsWith( '[Delete]', $post->post_title );
+	}
+
+	/**
+	 * Test adding activity when object is a string URL.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_activity_with_string_object() {
+		// Create a post to reference.
+		$post_id  = self::factory()->post->create(
+			array(
+				'post_title'  => 'Referenced Post',
+				'post_status' => 'publish',
+			)
+		);
+		$post_url = \get_permalink( $post_id );
+
+		$activity = new Activity();
+		$activity->set_id( 'https://remote.example.com/activities/string-object' );
+		$activity->set_type( 'Like' );
+		$activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$activity->set_object( $post_url ); // String URL.
+
+		$inbox_id = Inbox::add( $activity, 1 );
+
+		$this->assertIsInt( $inbox_id );
+
+		// Post title should include the referenced post title.
+		$post = \get_post( $inbox_id );
+		$this->assertStringContainsString( 'Referenced Post', $post->post_title );
+	}
+
+	/**
+	 * Test adding activity with object that has name property.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_activity_with_object_name() {
+		$activity = new Activity();
+		$activity->set_id( 'https://remote.example.com/activities/object-name' );
+		$activity->set_type( 'Create' );
+		$activity->set_actor( 'https://remote.example.com/users/testuser' );
+
+		$object = new Base_Object();
+		$object->set_id( 'https://remote.example.com/objects/named' );
+		$object->set_type( 'Note' );
+		$object->set_name( 'My Note Title' );
+		$object->set_content( 'This is the content' );
+		$activity->set_object( $object );
+
+		$inbox_id = Inbox::add( $activity, 1 );
+
+		$this->assertIsInt( $inbox_id );
+
+		// Post title should include the object name.
+		$post = \get_post( $inbox_id );
+		$this->assertStringContainsString( 'My Note Title', $post->post_title );
+	}
+
+	/**
+	 * Test adding activity with object that has content but no name.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_activity_with_object_content_no_name() {
+		$activity = new Activity();
+		$activity->set_id( 'https://remote.example.com/activities/object-content' );
+		$activity->set_type( 'Create' );
+		$activity->set_actor( 'https://remote.example.com/users/testuser' );
+
+		$object = new Base_Object();
+		$object->set_id( 'https://remote.example.com/objects/content-only' );
+		$object->set_type( 'Note' );
+		$object->set_content( 'This is the content without a name' );
+		$activity->set_object( $object );
+
+		$inbox_id = Inbox::add( $activity, 1 );
+
+		$this->assertIsInt( $inbox_id );
+
+		// Post title should include part of the content (since no name).
+		$post = \get_post( $inbox_id );
+		$this->assertStringContainsString( 'This is the content', $post->post_title );
+	}
+
+	/**
 	 * Test adding Like activity with trailing slash in object URL.
 	 *
 	 * This test verifies that Like activities from Pixelfed and other platforms


### PR DESCRIPTION
There is an option that `Activity::get_object()` or `Base_Object::get_object()` returns an array. This PR checks for that special case.

Updated get_object_title to return an empty string if the input is an array, improving robustness when handling different types of activity objects.

## Proposed changes:
- Added array type check to `get_object_title()` to return empty string when object is an array
- Updated PHPDoc to reflect that the method can accept arrays
- Added comprehensive test coverage for array, null, string, and object inputs


### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Improved handling of unusual activity data to avoid errors when activities contain unexpected formats.

</details>
