### PR TITLE
Improve Create handler: Maintain consistent return values

### DIFF
--- a/.github/changelog/2507-from-description
+++ b/.github/changelog/2507-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Maintain consistent return values in Create handler.


### PR DESCRIPTION
Follow-up to [`8798394` (#2500)](https://github.com/Automattic/wordpress-activitypub/pull/2500/commits/8798394844b7e198fc93e3ac8da46424382c2a1b)

## Proposed changes:
- Return `false` after calling `Update::handle_update()` for existing comments/posts to prevent duplicate notifications via the `activitypub_handled_create` action
- Rename `$check_dupe` to `$existing_comment` and `$existing_post` for improved code readability
- Use `instanceof \WP_Post` instead of `! \is_wp_error()` for more accurate type checking
- Update docblocks to clarify that `false` is returned when duplicates are found
- Fix comment from "If comment exists" to "If post exists" in `create_post()`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Send duplicate Create activities for both comments and posts
* Verify that `Update::handle_update()` is called
* Confirm that no duplicate notifications are triggered (check that `activitypub_handled_create` action doesn't fire for duplicates)
* Verify existing comments/posts are properly updated

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [x] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [ ] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Maintain consistent return values in Create handler.

</details>