### PR TITLE
Fix flaky test_update_comment_author_emails_batching test

### DIFF
--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -655,6 +655,7 @@ class Migration {
 			array(
 				'number'     => $batch_size,
 				'offset'     => $offset,
+				'orderby'    => 'comment_ID',
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query' => array(
 					array(


### PR DESCRIPTION
## Proposed changes:
* Remove unnecessary `_delete_all_data()` call from test cleanup
* Simplify comment creation using `create_many()` factory method
* Add explicit `orderby` parameter to migration function for consistent batching
* Add `parent::tear_down()` call to ensure proper cleanup chain

### Other information:

- [x] Have you written new tests for your changes, if applicable? (N/A - improving existing test)

## Testing instructions:

1. Run the test suite with: `composer test:unit`
2. Specifically run the migration tests: `composer test -- tests/phpunit/tests/includes/class-test-migration.php`
3. Verify that `test_update_comment_author_emails_batching` passes consistently
4. Run the test multiple times to ensure it's not flaky

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.