### PR TITLE
Fix make_clickable corrupting existing anchor tags

### DIFF
--- a/.github/changelog/2517-from-description
+++ b/.github/changelog/2517-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix make_clickable corrupting existing anchor tags in ActivityPub content

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -191,7 +191,11 @@ class Sanitize {
 	 * @return string The converted content.
 	 */
 	public static function content( $content ) {
-		$content = \make_clickable( $content );
+		// Only make URLs clickable if no anchor tags exist, to avoid corrupting existing links.
+		if ( false === \strpos( $content, '<a ' ) ) {
+			$content = \make_clickable( $content );
+		}
+
 		$content = \wpautop( $content );
 		$content = \wp_kses_post( $content );
 

--- a/tests/phpunit/tests/includes/class-test-sanitize.php
+++ b/tests/phpunit/tests/includes/class-test-sanitize.php
@@ -232,6 +232,20 @@ class Test_Sanitize extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test content sanitization preserves existing links with Mastodon-style spans.
+	 *
+	 * @covers ::content
+	 */
+	public function test_content_preserves_existing_links() {
+		$content = '<p><a href="https://www.example.com/path/to/article?param=value&amp;utm_source=mastodon" target="_blank" rel="nofollow noopener" translate="no"><span class="invisible">https://www.</span><span class="ellipsis">example.com/path/to/art</span><span class="invisible">icle?param=value&amp;utm_source=mastodon</span></a></p>';
+		$result  = Sanitize::content( $content );
+
+		// Should preserve existing link structure without double-linking.
+		$this->assertSame( 1, \substr_count( $result, '<a ' ), 'Should have exactly one anchor tag' );
+		$this->assertStringContainsString( 'href="https://www.example.com/path/', $result );
+	}
+
+	/**
 	 * Test content sanitization with empty content.
 	 *
 	 * @covers ::content


### PR DESCRIPTION
Fixes Mastodon links with span elements within them getting their http://www part linked and breaking the full link.

<img width="396" height="92" alt="Screenshot 2025-11-21 at 8 27 17 AM" src="https://github.com/user-attachments/assets/f0351ee0-1b4a-4567-831a-a115a5f09b63" />



## Proposed changes:
* Skip `make_clickable` when content already contains anchor tags to prevent corrupting Mastodon-style links with span elements inside them (e.g., `<span class="invisible">` and `<span class="ellipsis">`)

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Import an ActivityPub post that contains a Mastodon-style link with spans inside the anchor tag
* Verify the link is preserved correctly without being double-linked or corrupted

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix make_clickable corrupting existing anchor tags in ActivityPub content

</details>