### PR TITLE
Change: App Loader logic

### DIFF
--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\WP_Admin;
 
+use function Activitypub\site_supports_blocks;
 use function Activitypub\user_can_activitypub;
 
 /**
@@ -35,16 +36,19 @@ class Menu {
 		if ( user_can_activitypub( \get_current_user_id() ) ) {
 			$capability = ACTIVITYPUB_BLOG_MODE === \get_option( 'activitypub_actor_mode' ) ? 'manage_options' : 'activitypub';
 
-			$social_web_hook = \add_dashboard_page(
-				\__( 'Social Web', 'activitypub' ),
-				\__( 'Social Web', 'activitypub' ),
-				$capability,
-				'activitypub-social-web',
-				array( Social_Web::class, 'render_page' )
-			);
+			// Check for block support and WP version.
+			if ( site_supports_blocks() && \version_compare( \get_bloginfo( 'version' ), '6.9', '>=' ) ) {
+				$app_hook = \add_dashboard_page(
+					\__( 'Social Web', 'activitypub' ),
+					\__( 'Social Web', 'activitypub' ),
+					$capability,
+					'activitypub-social-web',
+					array( Social_Web::class, 'render_page' )
+				);
 
-			\add_action( 'load-' . $social_web_hook, array( Social_Web::class, 'remove_admin_notices' ) );
-			\add_action( 'admin_print_scripts-' . $social_web_hook, array( Social_Web::class, 'enqueue_scripts' ) );
+				\add_action( 'load-' . $app_hook, array( Social_Web::class, 'remove_admin_notices' ) );
+				\add_action( 'admin_print_scripts-' . $app_hook, array( Social_Web::class, 'enqueue_scripts' ) );
+			}
 
 			$followers_list_page = \add_users_page(
 				\__( 'Followers ⁂', 'activitypub' ),


### PR DESCRIPTION
At this stage, the implementation functions correctly only when block support is enabled and the site is running WP 6.9+.

This PR introduces "Social Web," a comprehensive React-based admin interface for ActivityPub. It represents a significant architectural enhancement that adds a modern, interactive feed reader and follower management UI to the ActivityPub plugin. The implementation is conditional on WordPress 6.9+ and block theme support, ensuring it only loads in compatible environments.

## Proposed changes:
- New React-based Social Web admin application with TypeScript support
- Custom webpack configuration for optimized chunk splitting
- Enhanced REST API with admin actions controller and expanded post/actor endpoints
- Removal of `activitypub_create_posts` option check (now creates posts unconditionally)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
