### PR TITLE
Auto-approve reactions for `ap_post` type

### DIFF
--- a/.github/changelog/2526-from-description
+++ b/.github/changelog/2526-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Automatically approves reactions on ActivityPub posts in the Reader view for a smoother, more seamless interaction experience.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -768,7 +768,7 @@ class Comment {
 		}
 
 		// Auto approve reactions to an `ap_post`.
-		if ( '1' === get_option( 'activitypub_create_posts', false ) ) {
+		if ( '1' === \get_option( 'activitypub_create_posts', false ) ) {
 			$post_id = $comment_data['comment_post_ID'];
 			$post    = \get_post( $post_id );
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -768,7 +768,7 @@ class Comment {
 		}
 
 		// Auto approve reactions to an `ap_post`.
-		if ( '1' === \get_option( 'activitypub_create_posts', false ) ) {
+		if ( \get_option( 'activitypub_create_posts', false ) ) {
 			$post_id = $comment_data['comment_post_ID'];
 			$post    = \get_post( $post_id );
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -767,6 +767,16 @@ class Comment {
 			return 1;
 		}
 
+		// Auto approve reactions to an `ap_post`.
+		if ( '1' === get_option( 'activitypub_create_posts', false ) ) {
+			$post_id = $comment_data['comment_post_ID'];
+			$post    = \get_post( $post_id );
+
+			if ( $post && Posts::POST_TYPE === $post->post_type ) {
+				return 1;
+			}
+		}
+
 		return $approved;
 	}
 

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -834,6 +834,184 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test auto-approving comments on ap_post when option is enabled.
+	 *
+	 * @covers ::pre_comment_approved
+	 */
+	public function test_auto_approve_comments_on_ap_post_when_enabled() {
+		// Disable flood control.
+		\remove_action( 'check_comment_flood', 'check_comment_flood_db', 10 );
+
+		// Enable the create_posts option.
+		\update_option( 'activitypub_create_posts', '1' );
+
+		// Create an ap_post.
+		$ap_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'ap_post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create a comment on the ap_post with activitypub protocol.
+		$comment_id = \wp_new_comment(
+			array(
+				'comment_type'         => 'comment',
+				'comment_content'      => 'This is a comment on ap_post.',
+				'comment_author'       => 'Test User',
+				'comment_author_url'   => 'https://example.com/@testuser',
+				'comment_post_ID'      => $ap_post_id,
+				'comment_author_email' => '',
+				'comment_meta'         => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+
+		// The comment should be auto-approved.
+		$comment = \get_comment( $comment_id );
+		$this->assertEquals( '1', $comment->comment_approved, 'Comment on ap_post should be auto-approved when option is enabled' );
+
+		// Clean up.
+		\delete_option( 'activitypub_create_posts' );
+		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
+	}
+
+	/**
+	 * Test not auto-approving comments on ap_post when option is disabled.
+	 *
+	 * @covers ::pre_comment_approved
+	 */
+	public function test_no_auto_approve_comments_on_ap_post_when_disabled() {
+		// Disable flood control.
+		\remove_action( 'check_comment_flood', 'check_comment_flood_db', 10 );
+
+		// Ensure the create_posts option is disabled.
+		\delete_option( 'activitypub_create_posts' );
+
+		// Create an ap_post.
+		$ap_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'ap_post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create a comment on the ap_post with activitypub protocol.
+		$comment_id = \wp_new_comment(
+			array(
+				'comment_type'         => 'comment',
+				'comment_content'      => 'This is a comment on ap_post.',
+				'comment_author'       => 'Test User',
+				'comment_author_url'   => 'https://example.com/@testuser',
+				'comment_post_ID'      => $ap_post_id,
+				'comment_author_email' => '',
+				'comment_meta'         => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+
+		// The comment should NOT be auto-approved.
+		$comment = \get_comment( $comment_id );
+		$this->assertEquals( '0', $comment->comment_approved, 'Comment on ap_post should not be auto-approved when option is disabled' );
+
+		// Clean up.
+		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
+	}
+
+	/**
+	 * Test not auto-approving comments on regular posts (even with option enabled).
+	 *
+	 * @covers ::pre_comment_approved
+	 */
+	public function test_no_auto_approve_comments_on_regular_posts() {
+		// Disable flood control.
+		\remove_action( 'check_comment_flood', 'check_comment_flood_db', 10 );
+
+		// Enable the create_posts option.
+		\update_option( 'activitypub_create_posts', '1' );
+
+		// Create a regular post.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => 1,
+			)
+		);
+
+		// Create a comment on the regular post with activitypub protocol.
+		$comment_id = \wp_new_comment(
+			array(
+				'comment_type'         => 'comment',
+				'comment_content'      => 'This is a comment on regular post.',
+				'comment_author'       => 'Test User',
+				'comment_author_url'   => 'https://example.com/@testuser',
+				'comment_post_ID'      => $post_id,
+				'comment_author_email' => '',
+				'comment_meta'         => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+
+		// The comment should NOT be auto-approved (regular posts are not affected).
+		$comment = \get_comment( $comment_id );
+		$this->assertEquals( '0', $comment->comment_approved, 'Comment on regular post should not be auto-approved' );
+
+		// Clean up.
+		\delete_option( 'activitypub_create_posts' );
+		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
+	}
+
+	/**
+	 * Test auto-approving different comment types on ap_post.
+	 *
+	 * @covers ::pre_comment_approved
+	 */
+	public function test_auto_approve_different_comment_types_on_ap_post() {
+		// Disable flood control.
+		\remove_action( 'check_comment_flood', 'check_comment_flood_db', 10 );
+
+		// Enable the create_posts option.
+		\update_option( 'activitypub_create_posts', '1' );
+
+		// Create an ap_post.
+		$ap_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'ap_post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Test different comment types.
+		$comment_types = array( 'comment', 'like', 'repost' );
+
+		foreach ( $comment_types as $comment_type ) {
+			$comment_id = \wp_new_comment(
+				array(
+					'comment_type'         => $comment_type,
+					'comment_content'      => "This is a {$comment_type} on ap_post.",
+					'comment_author'       => 'Test User',
+					'comment_author_url'   => 'https://example.com/@testuser',
+					'comment_post_ID'      => $ap_post_id,
+					'comment_author_email' => '',
+					'comment_meta'         => array(
+						'protocol' => 'activitypub',
+					),
+				)
+			);
+
+			// All comment types should be auto-approved on ap_post.
+			$comment = \get_comment( $comment_id );
+			$this->assertEquals( '1', $comment->comment_approved, "Comment type '{$comment_type}' on ap_post should be auto-approved" );
+		}
+
+		// Clean up.
+		\delete_option( 'activitypub_create_posts' );
+		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
+	}
+
+	/**
 	 * Test that multiple ap_post comments are excluded while regular comments remain.
 	 *
 	 * @covers ::comment_query


### PR DESCRIPTION
Adds logic to automatically approve reactions to posts of type `ap_post` when the ActivityPub create posts option is enabled. This streamlines moderation for ActivityPub content.

## Proposed changes:
- Added auto-approval logic in the `pre_comment_approved` filter to automatically approve comments on `ap_post` type posts when `activitypub_create_posts` option is enabled
- The logic is placed after the "previously approved author" check, ensuring it only applies when that check doesn't already approve the comment

### Other information:

- [X] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [X] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Automatically approves reactions on ActivityPub posts in the Reader view for a smoother, more seamless interaction experience.

</details>
