### PR TITLE
Prevent email notifications for comments on ap_post

### DIFF
--- a/.github/changelog/2527-from-description
+++ b/.github/changelog/2527-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Prevent email notifications for comments on ActivityPub custom post types

--- a/.github/changelog/2527-from-description
+++ b/.github/changelog/2527-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Prevent email notifications for comments on ActivityPub custom post types
+Prevent email notifications for comments on ActivityPub custom post types.

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -466,7 +466,7 @@ class Mailer {
 		}
 
 		// Only prevent if the create_posts option is enabled.
-		if ( '1' !== get_option( 'activitypub_create_posts', false ) ) {
+		if ( '1' !== \get_option( 'activitypub_create_posts', false ) ) {
 			return $maybe_notify;
 		}
 

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -449,15 +449,15 @@ class Mailer {
 	}
 
 	/**
-	 * Prevent email notifications for comments on ap_post.
+	 * Maybe prevent email notifications for comments.
 	 *
-	 * This filter prevents both post author and moderator notifications
-	 * for comments on ap_post custom post type.
+	 * This filter can prevent both post author and moderator notifications
+	 * for comments on specific post types, such as ActivityPub custom post types.
 	 *
 	 * @param bool $maybe_notify Whether to send the notification.
 	 * @param int  $comment_id   The comment ID.
 	 *
-	 * @return bool False if comment is on ap_post, original value otherwise.
+	 * @return bool False to prevent notification, original value otherwise.
 	 */
 	public static function maybe_prevent_comment_notification( $maybe_notify, $comment_id ) {
 		// If already disabled, respect that.

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -24,6 +24,9 @@ class Mailer {
 
 		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
 		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );  /** After @see \Activitypub\Handler\Create::handle_create() */
+
+		\add_filter( 'notify_post_author', array( self::class, 'prevent_ap_post_comment_notifications' ), 10, 2 );
+		\add_filter( 'notify_moderator', array( self::class, 'prevent_ap_post_comment_notifications' ), 10, 2 );
 	}
 
 	/**
@@ -442,5 +445,45 @@ class Mailer {
 		}
 
 		return $actor;
+	}
+
+	/**
+	 * Prevent email notifications for comments on ap_post.
+	 *
+	 * This filter prevents both post author and moderator notifications
+	 * for comments on ap_post custom post type.
+	 *
+	 * @param bool $maybe_notify Whether to send the notification.
+	 * @param int  $comment_id   The comment ID.
+	 *
+	 * @return bool False if comment is on ap_post, original value otherwise.
+	 */
+	public static function prevent_ap_post_comment_notifications( $maybe_notify, $comment_id ) {
+		// If already disabled, respect that.
+		if ( ! $maybe_notify ) {
+			return $maybe_notify;
+		}
+
+		// Only prevent if the create_posts option is enabled.
+		if ( '1' !== get_option( 'activitypub_create_posts', false ) ) {
+			return $maybe_notify;
+		}
+
+		$comment = \get_comment( $comment_id );
+		if ( ! $comment ) {
+			return $maybe_notify;
+		}
+
+		$post = \get_post( $comment->comment_post_ID );
+		if ( ! $post ) {
+			return $maybe_notify;
+		}
+
+		// Prevent notifications for comments on ap_post.
+		if ( Collection\Posts::POST_TYPE === $post->post_type ) {
+			return false;
+		}
+
+		return $maybe_notify;
 	}
 }

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -8,6 +8,7 @@
 namespace Activitypub;
 
 use Activitypub\Collection\Actors;
+use Activitypub\Collection\Posts;
 
 /**
  * Mailer Class.
@@ -25,8 +26,8 @@ class Mailer {
 		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
 		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );  /** After @see \Activitypub\Handler\Create::handle_create() */
 
-		\add_filter( 'notify_post_author', array( self::class, 'prevent_ap_post_comment_notifications' ), 10, 2 );
-		\add_filter( 'notify_moderator', array( self::class, 'prevent_ap_post_comment_notifications' ), 10, 2 );
+		\add_filter( 'notify_post_author', array( self::class, 'maybe_prevent_comment_notification' ), 10, 2 );
+		\add_filter( 'notify_moderator', array( self::class, 'maybe_prevent_comment_notification' ), 10, 2 );
 	}
 
 	/**
@@ -458,7 +459,7 @@ class Mailer {
 	 *
 	 * @return bool False if comment is on ap_post, original value otherwise.
 	 */
-	public static function prevent_ap_post_comment_notifications( $maybe_notify, $comment_id ) {
+	public static function maybe_prevent_comment_notification( $maybe_notify, $comment_id ) {
 		// If already disabled, respect that.
 		if ( ! $maybe_notify ) {
 			return $maybe_notify;
@@ -480,7 +481,7 @@ class Mailer {
 		}
 
 		// Prevent notifications for comments on ap_post.
-		if ( Collection\Posts::POST_TYPE === $post->post_type ) {
+		if ( Posts::POST_TYPE === $post->post_type ) {
 			return false;
 		}
 

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -1018,4 +1018,147 @@ class Test_Mailer extends WP_UnitTestCase {
 		\remove_all_filters( 'wp_mail' );
 		\wp_delete_user( $other_user_id );
 	}
+
+	/**
+	 * Test that email notifications are prevented for comments on ap_post.
+	 *
+	 * @covers ::prevent_ap_post_comment_notifications
+	 */
+	public function test_prevent_email_notifications_for_ap_post_comments() {
+		// Enable the create_posts option.
+		\update_option( 'activitypub_create_posts', '1' );
+
+		// Create an ap_post.
+		$ap_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'ap_post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create a comment on the ap_post.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $ap_post_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		// Test notify_post_author filter.
+		$notify_author = \apply_filters( 'notify_post_author', true, $comment_id );
+		$this->assertFalse( $notify_author, 'Email notifications to post author should be prevented for ap_post comments' );
+
+		// Test notify_moderator filter.
+		$notify_moderator = \apply_filters( 'notify_moderator', true, $comment_id );
+		$this->assertFalse( $notify_moderator, 'Email notifications to moderator should be prevented for ap_post comments' );
+
+		// Clean up.
+		\delete_option( 'activitypub_create_posts' );
+	}
+
+	/**
+	 * Test that email notifications are NOT prevented for comments on regular posts.
+	 *
+	 * @covers ::prevent_ap_post_comment_notifications
+	 */
+	public function test_allow_email_notifications_for_regular_post_comments() {
+		// Enable the create_posts option.
+		\update_option( 'activitypub_create_posts', '1' );
+
+		// Create a regular post.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => 1,
+			)
+		);
+
+		// Create a comment on the regular post.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		// Test notify_post_author filter.
+		$notify_author = \apply_filters( 'notify_post_author', true, $comment_id );
+		$this->assertTrue( $notify_author, 'Email notifications to post author should be allowed for regular post comments' );
+
+		// Test notify_moderator filter.
+		$notify_moderator = \apply_filters( 'notify_moderator', true, $comment_id );
+		$this->assertTrue( $notify_moderator, 'Email notifications to moderator should be allowed for regular post comments' );
+
+		// Clean up.
+		\delete_option( 'activitypub_create_posts' );
+	}
+
+	/**
+	 * Test that email notifications are allowed for ap_post when option is disabled.
+	 *
+	 * @covers ::prevent_ap_post_comment_notifications
+	 */
+	public function test_allow_email_notifications_when_option_disabled() {
+		// Ensure the create_posts option is disabled.
+		\delete_option( 'activitypub_create_posts' );
+
+		// Create an ap_post.
+		$ap_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'ap_post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create a comment on the ap_post.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $ap_post_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		// Test notify_post_author filter.
+		$notify_author = \apply_filters( 'notify_post_author', true, $comment_id );
+		$this->assertTrue( $notify_author, 'Email notifications should be allowed when option is disabled' );
+
+		// Test notify_moderator filter.
+		$notify_moderator = \apply_filters( 'notify_moderator', true, $comment_id );
+		$this->assertTrue( $notify_moderator, 'Email notifications should be allowed when option is disabled' );
+	}
+
+	/**
+	 * Test that email notifications respect existing false values.
+	 *
+	 * @covers ::prevent_ap_post_comment_notifications
+	 */
+	public function test_respect_existing_notification_settings() {
+		// Enable the create_posts option.
+		\update_option( 'activitypub_create_posts', '1' );
+
+		// Create an ap_post.
+		$ap_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'ap_post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create a comment on the ap_post.
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $ap_post_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		// Test that if notifications are already disabled, they stay disabled.
+		$notify_author = \apply_filters( 'notify_post_author', false, $comment_id );
+		$this->assertFalse( $notify_author, 'Should respect already disabled notifications' );
+
+		$notify_moderator = \apply_filters( 'notify_moderator', false, $comment_id );
+		$this->assertFalse( $notify_moderator, 'Should respect already disabled notifications' );
+
+		// Clean up.
+		\delete_option( 'activitypub_create_posts' );
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -1022,7 +1022,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test that email notifications are prevented for comments on ap_post.
 	 *
-	 * @covers ::prevent_ap_post_comment_notifications
+	 * @covers ::maybe_prevent_comment_notification
 	 */
 	public function test_prevent_email_notifications_for_ap_post_comments() {
 		// Enable the create_posts option.
@@ -1059,7 +1059,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test that email notifications are NOT prevented for comments on regular posts.
 	 *
-	 * @covers ::prevent_ap_post_comment_notifications
+	 * @covers ::maybe_prevent_comment_notification
 	 */
 	public function test_allow_email_notifications_for_regular_post_comments() {
 		// Enable the create_posts option.
@@ -1095,7 +1095,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test that email notifications are allowed for ap_post when option is disabled.
 	 *
-	 * @covers ::prevent_ap_post_comment_notifications
+	 * @covers ::maybe_prevent_comment_notification
 	 */
 	public function test_allow_email_notifications_when_option_disabled() {
 		// Ensure the create_posts option is disabled.
@@ -1129,7 +1129,7 @@ class Test_Mailer extends WP_UnitTestCase {
 	/**
 	 * Test that email notifications respect existing false values.
 	 *
-	 * @covers ::prevent_ap_post_comment_notifications
+	 * @covers ::maybe_prevent_comment_notification
 	 */
 	public function test_respect_existing_notification_settings() {
 		// Enable the create_posts option.


### PR DESCRIPTION
## Proposed changes:
* Prevents WordPress from sending email notifications (both to post authors and moderators) for comments on ActivityPub custom post types when the `activitypub_create_posts` option is enabled
* Adds `maybe_prevent_comment_notification()` method in the Mailer class that filters `notify_post_author` and `notify_moderator` hooks
* The implementation respects existing notification settings and only applies when the option is enabled

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Enable the "Create posts" option in ActivityPub settings (`activitypub_create_posts` option)
2. Create or have an existing `ap_post` custom post type
3. Add a comment to the `ap_post` (either manually or via ActivityPub)
4. Verify that no email notification is sent to the post author or moderators
5. Create a regular post and add a comment
6. Verify that email notifications for regular posts still work normally
7. Disable the "Create posts" option
8. Add another comment to an `ap_post`
9. Verify that email notifications are sent (since the option is disabled)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Added - for new features

#### Message

Prevent email notifications for comments on ActivityPub custom post types.

</details>