### PR TITLE
Add branch management rule to PR workflow skill

### DIFF
--- a/.claude/skills/activitypub-pr-workflow/SKILL.md
+++ b/.claude/skills/activitypub-pr-workflow/SKILL.md
@@ -66,6 +66,13 @@ This is a hard requirement for all PRs.
 - **Always add Fediverse** as reviewer.
 - Add other relevant reviewers if needed.
 
+### Branch Management
+
+**CRITICAL:** Never switch branches unless explicitly instructed by the user.
+- Always work on the current branch.
+- Only run `git checkout` when the user specifically asks.
+- If uncertain which branch to use, ask first.
+
 ## Changelog Management
 
 The repository uses Jetpack Changelogger for automated changelog generation.


### PR DESCRIPTION
## Proposed changes:
* Add critical rule about branch management to PR workflow skill
* Document that branches should never be switched unless explicitly instructed by the user
* Place rule in "Critical Rules" section for visibility

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Review the updated `.claude/skills/activitypub-pr-workflow/SKILL.md` file
* Verify the new "Branch Management" subsection is under "Critical Rules"
* Confirm the rule is clear and actionable
* Check that formatting is consistent with other critical rules

### Changelog entry

No changelog entry required for this PR.