### PR TITLE
Add .gitattributes to exclude generated files from diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 build/** linguist-generated
+docs/** linguist-documentation
 package-lock.json linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+build/** linguist-generated
+package-lock.json linguist-generated


### PR DESCRIPTION
Uses `linguist-generated` attribute to hide build artifacts and package-lock.json from GitHub diffs and language statistics. This improves code review experience by focusing on actual source code changes.

Reference: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github