### PR TITLE
Deliver public activities to followers only

### DIFF
--- a/.github/changelog/fix-public-activity-delivery-followers-only
+++ b/.github/changelog/fix-public-activity-delivery-followers-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deliver public activities to followers only.

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -368,9 +368,8 @@ class Inbox_Controller extends \WP_REST_Controller {
 	 * @return array An array of user IDs who are the recipients of the activity.
 	 */
 	private function get_local_recipients( $activity ) {
-		// Public activity, deliver to all local ActivityPub users.
-		if ( is_activity_public( $activity ) ) {
-			return Actors::get_all_ids();
+		if ( is_activity_public( $activity ) ) { // Public activity, deliver to followers of the actor.
+			return Following::get_follower_ids( $activity['actor'] );
 		}
 
 		$recipients = extract_recipients_from_activity( $activity );

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -458,8 +458,36 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 	 * @covers ::get_local_recipients
 	 */
 	public function test_get_local_recipients_no_recipients() {
+		// Enable actor mode to allow user actors.
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		// Create a remote actor and make a user follow them.
+		$remote_actor_url = 'https://example.com/actor/no-recipients';
+
+		// Mock the remote actor fetch.
+		$remote_object_filter = function ( $pre, $url ) use ( $remote_actor_url ) {
+			if ( $url === $remote_actor_url ) {
+				return array(
+					'@context'          => 'https://www.w3.org/ns/activitystreams',
+					'id'                => $remote_actor_url,
+					'type'              => 'Person',
+					'preferredUsername' => 'testactor',
+					'name'              => 'Test Actor',
+					'inbox'             => 'https://example.com/actor/1/inbox',
+				);
+			}
+			return $pre;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter, 10, 2 );
+
+		$remote_actor = \Activitypub\Collection\Remote_Actors::fetch_by_uri( $remote_actor_url );
+
+		// Make test user follow the remote actor.
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', self::$user_id );
+
 		$activity = array(
-			'type' => 'Create',
+			'type'  => 'Create',
+			'actor' => $remote_actor_url,
 		);
 
 		// Use reflection to test the private method.
@@ -468,9 +496,13 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
-		// Activities with no recipients are treated as public and delivered to all local actors.
-		$this->assertNotEmpty( $result, 'Should return all local actors when no recipients (treated as public)' );
-		$this->assertEquals( Actors::get_all_ids(), $result, 'Should match all local actor IDs' );
+		// Activities with no recipients are treated as public and delivered to followers only.
+		$this->assertNotEmpty( $result, 'Should return followers when no recipients (treated as public)' );
+		$this->assertContains( self::$user_id, $result, 'Should contain the follower' );
+
+		// Clean up.
+		\delete_option( 'activitypub_actor_mode' );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter );
 	}
 
 	/**
@@ -580,10 +612,10 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$remote_actor = \Activitypub\Collection\Remote_Actors::fetch_by_uri( $remote_actor_url );
 
 		// Make users follow the remote actor.
-		\add_post_meta( $remote_actor->ID, '_activitypub_followers', self::$user_id );
-		\add_post_meta( $remote_actor->ID, '_activitypub_followers', $user_id_1 );
-		\add_post_meta( $remote_actor->ID, '_activitypub_followers', $user_id_2 );
-		\add_post_meta( $remote_actor->ID, '_activitypub_followers', $user_id_3 );
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', self::$user_id );
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', $user_id_1 );
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', $user_id_2 );
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', $user_id_3 );
 
 		// Public activity with "to" containing the public collection.
 		$activity = array(
@@ -651,8 +683,8 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		$remote_actor = \Activitypub\Collection\Remote_Actors::fetch_by_uri( $remote_actor_url );
 
 		// Make users follow the remote actor.
-		\add_post_meta( $remote_actor->ID, '_activitypub_followers', self::$user_id );
-		\add_post_meta( $remote_actor->ID, '_activitypub_followers', $user_id );
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', self::$user_id );
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', $user_id );
 
 		// Public activity with "cc" containing the public collection.
 		$activity = array(


### PR DESCRIPTION
## Description

Changes public activity delivery behavior to target only followers of the sending actor, rather than all local ActivityPub users.

Previously, when a public activity was received, it was delivered to all local ActivityPub users regardless of whether they followed the sending actor. This created noise in users' timelines with posts from accounts they didn't subscribe to.

With this change, public activities are now delivered only to local users who actually follow the sending actor, aligning with user expectations.

## Changes

- Modified `get_local_recipients()` in `Inbox_Controller` to return follower IDs directly for public activities
- Updated `test_get_local_recipients_no_recipients()` to properly test the new follower-only behavior
- Fixed incorrect meta key usage in tests: changed `_activitypub_followers` to `_activitypub_followed_by`
- All 21 inbox controller tests passing

## Testing

- ✅ All 1377 tests pass (3767 assertions)
- ✅ Inbox controller tests specifically verified with correct follower relationships

## Checklist

- [x] Automatically create a changelog entry from the PR title
- [x] Tests added/updated
- [x] All tests passing

Fixes https://github.com/Automattic/wordpress-activitypub/issues/2537