### PR TITLE
Add Audio, Document, and Video type support to object_to_uri

### DIFF
--- a/.github/changelog/2544-from-description
+++ b/.github/changelog/2544-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve support for media attachments by handling Audio, Document, and Video object types in addition to Images.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -803,11 +803,13 @@ function object_to_uri( $data ) {
 
 	// Return part of Object that makes most sense.
 	switch ( $type ) {
-		case 'Image':
-			// See https://www.w3.org/TR/activitystreams-vocabulary/#dfn-image.
+		case 'Audio':    // See https://www.w3.org/TR/activitystreams-vocabulary/#dfn-audio.
+		case 'Document': // See https://www.w3.org/TR/activitystreams-vocabulary/#dfn-document.
+		case 'Image':    // See https://www.w3.org/TR/activitystreams-vocabulary/#dfn-image.
+		case 'Video':    // See https://www.w3.org/TR/activitystreams-vocabulary/#dfn-video.
 			$data = object_to_uri( $data['url'] );
 			break;
-		case 'Link':
+		case 'Link':     // See https://www.w3.org/TR/activitystreams-vocabulary/#dfn-link.
 			$data = $data['href'];
 			break;
 		default:

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -231,6 +231,213 @@ class Test_Functions extends ActivityPub_TestCase_Cache_HTTP {
 				),
 				'https://example.com',
 			),
+			// Test Audio with simple string URL.
+			array(
+				array(
+					'type' => 'Audio',
+					'url'  => 'https://example.com/audio.mp3',
+				),
+				'https://example.com/audio.mp3',
+			),
+			// Test Audio with Link object.
+			array(
+				array(
+					'type' => 'Audio',
+					'url'  => array(
+						'type' => 'Link',
+						'href' => 'https://example.com/audio.mp3',
+					),
+				),
+				'https://example.com/audio.mp3',
+			),
+			// Test Audio with array of Link objects.
+			array(
+				array(
+					'type' => 'Audio',
+					'url'  => array(
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/audio.mp3',
+							'mediaType' => 'audio/mpeg',
+						),
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/audio.ogg',
+							'mediaType' => 'audio/ogg',
+						),
+					),
+				),
+				'https://example.com/audio.mp3',
+			),
+			// Test Document with simple string URL.
+			array(
+				array(
+					'type' => 'Document',
+					'url'  => 'https://example.com/document.pdf',
+				),
+				'https://example.com/document.pdf',
+			),
+			// Test Document with Link object.
+			array(
+				array(
+					'type' => 'Document',
+					'url'  => array(
+						'type' => 'Link',
+						'href' => 'https://example.com/document.pdf',
+					),
+				),
+				'https://example.com/document.pdf',
+			),
+			// Test Document with array of Link objects.
+			array(
+				array(
+					'type' => 'Document',
+					'url'  => array(
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/document.pdf',
+							'mediaType' => 'application/pdf',
+						),
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/document.docx',
+							'mediaType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+						),
+					),
+				),
+				'https://example.com/document.pdf',
+			),
+			// Test Video with simple string URL.
+			array(
+				array(
+					'type' => 'Video',
+					'url'  => 'https://example.com/video.mp4',
+				),
+				'https://example.com/video.mp4',
+			),
+			// Test Video with Link object.
+			array(
+				array(
+					'type' => 'Video',
+					'url'  => array(
+						'type' => 'Link',
+						'href' => 'https://example.com/video.mp4',
+					),
+				),
+				'https://example.com/video.mp4',
+			),
+			// Test Video with array of Link objects.
+			array(
+				array(
+					'type' => 'Video',
+					'url'  => array(
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/video.mp4',
+							'mediaType' => 'video/mp4',
+						),
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/video.webm',
+							'mediaType' => 'video/webm',
+						),
+					),
+				),
+				'https://example.com/video.mp4',
+			),
+			// Test complex Image with array of Link objects (user's example).
+			array(
+				array(
+					'@context' => 'https://www.w3.org/ns/activitystreams',
+					'type'     => 'Image',
+					'name'     => 'Cat Jumping on Wagon',
+					'url'      => array(
+						array(
+							'type'      => 'Link',
+							'href'      => 'http://example.org/image.jpeg',
+							'mediaType' => 'image/jpeg',
+						),
+						array(
+							'type'      => 'Link',
+							'href'      => 'http://example.org/image.png',
+							'mediaType' => 'image/png',
+						),
+					),
+				),
+				'http://example.org/image.jpeg',
+			),
+			// Test complex Audio with full metadata and array of Link objects.
+			array(
+				array(
+					'@context'     => 'https://www.w3.org/ns/activitystreams',
+					'type'         => 'Audio',
+					'name'         => 'Podcast Episode',
+					'duration'     => 'PT1H30M',
+					'attributedTo' => 'https://example.com/users/podcaster',
+					'url'          => array(
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/podcast.mp3',
+							'mediaType' => 'audio/mpeg',
+						),
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/podcast.ogg',
+							'mediaType' => 'audio/ogg',
+						),
+					),
+				),
+				'https://example.com/podcast.mp3',
+			),
+			// Test complex Document with full metadata and array of Link objects.
+			array(
+				array(
+					'@context'     => 'https://www.w3.org/ns/activitystreams',
+					'type'         => 'Document',
+					'name'         => 'Annual Report',
+					'attributedTo' => 'https://example.com/users/author',
+					'url'          => array(
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/report.pdf',
+							'mediaType' => 'application/pdf',
+						),
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/report.docx',
+							'mediaType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+						),
+					),
+				),
+				'https://example.com/report.pdf',
+			),
+			// Test complex Video with full metadata and array of Link objects.
+			array(
+				array(
+					'@context'     => 'https://www.w3.org/ns/activitystreams',
+					'type'         => 'Video',
+					'name'         => 'Conference Talk',
+					'duration'     => 'PT45M',
+					'attributedTo' => 'https://example.com/users/speaker',
+					'url'          => array(
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/talk.mp4',
+							'mediaType' => 'video/mp4',
+							'width'     => 1920,
+							'height'    => 1080,
+						),
+						array(
+							'type'      => 'Link',
+							'href'      => 'https://example.com/talk.webm',
+							'mediaType' => 'video/webm',
+							'width'     => 1920,
+							'height'    => 1080,
+						),
+					),
+				),
+				'https://example.com/talk.mp4',
+			),
 		);
 	}
 


### PR DESCRIPTION
## What does this PR do?

Extends `object_to_uri()` to handle `Audio`, `Document`, and `Video` ActivityStreams types alongside the existing `Image` support. All media types now consistently extract the URL from their object representation.

## Testing

Tested with various ActivityStreams object types to ensure proper URL extraction for:
- Audio objects
- Document objects  
- Video objects
- Image objects (existing)
- Link objects (existing)