### PR TITLE
Update test factory usage to static method calls

### DIFF
--- a/tests/phpunit/tests/includes/class-test-search.php
+++ b/tests/phpunit/tests/includes/class-test-search.php
@@ -18,7 +18,7 @@ class Test_Search extends \WP_UnitTestCase {
 	 */
 	public function test_regular_search_unchanged() {
 		// Create a test post.
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Test Post About Cats',
 				'post_content' => 'This is a test post about cats and dogs.',

--- a/tests/phpunit/tests/includes/handler/class-test-accept.php
+++ b/tests/phpunit/tests/includes/handler/class-test-accept.php
@@ -122,7 +122,7 @@ class Test_Accept extends \WP_UnitTestCase {
 		$object_guid = 'https://example.com/actor/123';
 		$outbox_guid = 'https://example.com/outbox/123';
 
-		$outbox_post_id = $this->factory->post->create(
+		$outbox_post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'ap_outbox',
 				'post_status' => 'publish',
@@ -133,7 +133,7 @@ class Test_Accept extends \WP_UnitTestCase {
 		\add_post_meta( $outbox_post_id, '_activitypub_activity_type', 'Follow' );
 
 		// Create remote actor post.
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Remote_Actors::POST_TYPE,
 				'post_status' => 'publish',

--- a/tests/phpunit/tests/includes/handler/class-test-reject.php
+++ b/tests/phpunit/tests/includes/handler/class-test-reject.php
@@ -123,7 +123,7 @@ class Test_Reject extends \WP_UnitTestCase {
 		$object_guid = 'https://example.com/actor/123';
 		$outbox_guid = 'https://example.com/outbox/123';
 
-		$outbox_post_id = $this->factory->post->create(
+		$outbox_post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
@@ -134,7 +134,7 @@ class Test_Reject extends \WP_UnitTestCase {
 		\add_post_meta( $outbox_post_id, '_activitypub_activity_type', 'Follow' );
 
 		// Create remote actor post.
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Remote_Actors::POST_TYPE,
 				'post_status' => 'publish',

--- a/tests/phpunit/tests/includes/handler/class-test-undo.php
+++ b/tests/phpunit/tests/includes/handler/class-test-undo.php
@@ -175,7 +175,7 @@ class Test_Undo extends \WP_UnitTestCase {
 		\add_filter( 'pre_get_remote_metadata_by_actor', $mock_actor_metadata );
 
 		// Create a test post.
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_author' => self::$user_id,
 				'post_title'  => 'Test Post for ' . $description,

--- a/tests/phpunit/tests/includes/transformer/class-test-base.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-base.php
@@ -84,7 +84,7 @@ class Test_Base extends \WP_UnitTestCase {
 	 * @param array  $expected_audience  The expected audience.
 	 */
 	public function test_set_audience( $content_visibility, $object_attributes, $expected_audience ) {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Test Post',
 				'post_content' => 'Test content that is longer than the note length limit',

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -55,7 +55,7 @@ class Test_Post extends \WP_UnitTestCase {
 	public function test_get_type_returns_configured_type_when_option_set() {
 		update_option( 'activitypub_object_type', 'Article' );
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Test Post',
 				'post_content' => 'Test content that is longer than the note length limit',
@@ -81,7 +81,7 @@ class Test_Post extends \WP_UnitTestCase {
 	 * @param string $description    Description of the test case.
 	 */
 	public function test_get_type( $post_data, $post_format, $expected_type, $description ) {
-		$post_id = $this->factory->post->create( $post_data );
+		$post_id = self::factory()->post->create( $post_data );
 
 		if ( $post_format ) {
 			set_post_format( $post_id, $post_format );
@@ -180,7 +180,7 @@ class Test_Post extends \WP_UnitTestCase {
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Test Post',
 				'post_content' => str_repeat( 'Long content. ', 100 ),
@@ -213,7 +213,7 @@ class Test_Post extends \WP_UnitTestCase {
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Test Post',
 				'post_content' => str_repeat( 'Long content. ', 100 ),
@@ -496,7 +496,7 @@ class Test_Post extends \WP_UnitTestCase {
 	 * @covers ::get_icon
 	 */
 	public function test_get_icon() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Test Post',
 				'post_content' => 'Test content',
@@ -620,7 +620,7 @@ class Test_Post extends \WP_UnitTestCase {
 	 */
 	public function test_preview_property() {
 		// Create a test post of type "Article".
-		$post = $this->factory->post->create_and_get(
+		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'Test Article',
 				'post_content' => str_repeat( 'Long content. ', 100 ),
@@ -638,7 +638,7 @@ class Test_Post extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $preview['content'] );
 
 		// Create a test post of type "Note" (short content).
-		$note_post = $this->factory->post->create_and_get(
+		$note_post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => '',
 				'post_content' => 'Short note content',

--- a/tests/phpunit/tests/integration/class-test-akismet.php
+++ b/tests/phpunit/tests/integration/class-test-akismet.php
@@ -40,7 +40,7 @@ class Test_Akismet extends WP_UnitTestCase {
 	 */
 	public function test_comment_row_actions() {
 		// Create a normal comment.
-		$normal_comment_id = $this->factory->comment->create(
+		$normal_comment_id = self::factory()->comment->create(
 			array(
 				'comment_post_ID' => self::$post_id,
 				'comment_content' => 'Normal comment',
@@ -48,7 +48,7 @@ class Test_Akismet extends WP_UnitTestCase {
 		);
 
 		// Create an ActivityPub comment.
-		$ap_comment_id = $this->factory->comment->create(
+		$ap_comment_id = self::factory()->comment->create(
 			array(
 				'comment_post_ID' => self::$post_id,
 				'comment_content' => 'ActivityPub comment',

--- a/tests/phpunit/tests/integration/class-test-stream-connector.php
+++ b/tests/phpunit/tests/integration/class-test-stream-connector.php
@@ -343,7 +343,7 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 		}
 
 		// Create a mock outbox post.
-		$outbox_post_id = $this->factory->post->create(
+		$outbox_post_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'ap_outbox',
 				'post_title' => get_permalink( self::$post_id ),
@@ -394,7 +394,7 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 		}
 
 		// Create a mock outbox post.
-		$outbox_post_id = $this->factory->post->create(
+		$outbox_post_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'ap_outbox',
 				'post_title' => get_permalink( self::$post_id ),


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Replace $this->factory with self::factory() in test files to follow PHPUnit best practices

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run the test suite with `npm run env-test`
* Verify all tests pass with the updated factory syntax

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>