### PR TITLE
Fix reply block showing empty div when embed fails

### DIFF
--- a/.github/changelog/2571-from-description
+++ b/.github/changelog/2571-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reply block now shows fallback link when oEmbed fails instead of empty div.

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -204,6 +204,7 @@ class Blocks {
 		$html = '<div ' . $wrapper_attrs . '>';
 
 		// Try to get and append the embed if requested.
+		$embed = null;
 		if ( $show_embed ) {
 			$embed = wp_oembed_get( $attrs['url'] );
 			if ( $embed ) {
@@ -212,8 +213,8 @@ class Blocks {
 			}
 		}
 
-		// Only show the link if we're not showing the embed.
-		if ( ! $show_embed ) {
+		// Show the link if embed is not requested or if embed failed.
+		if ( ! $show_embed || ! $embed ) {
 			$html .= sprintf(
 				'<p><a title="%2$s" aria-label="%2$s" href="%1$s" class="u-in-reply-to" target="_blank">%3$s</a></p>',
 				esc_url( $attrs['url'] ),


### PR DESCRIPTION
See https://wordpress.org/support/topic/import-mastodon-beta/

## Proposed changes:
* Fix reply block showing empty `<div>` when oEmbed fails by showing fallback link instead

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create or import a post with an `activitypub/reply` block pointing to a URL that has no oEmbed support and returns an error for ActivityPub requests (e.g., `https://obenland.it/404`)
* View the post on the frontend
* Verify the fallback link is shown instead of an empty div

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Reply block now shows fallback link when oEmbed fails instead of empty div.

</details>