### PR TITLE
Fix PHP 8.5 setAccessible() deprecation warnings

### DIFF
--- a/.github/changelog/2574-from-description
+++ b/.github/changelog/2574-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP 8.5 deprecation warnings for ReflectionProperty::setAccessible() and ReflectionMethod::setAccessible()

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -139,7 +139,9 @@ class Test_Attachments extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Attachments::class );
 		$method     = $reflection->getMethod( 'normalize_attachment' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( null, $attachment );
 
@@ -165,7 +167,9 @@ class Test_Attachments extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Attachments::class );
 		$method     = $reflection->getMethod( 'normalize_attachment' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( null, $attachment );
 
@@ -189,7 +193,9 @@ class Test_Attachments extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Attachments::class );
 		$method     = $reflection->getMethod( 'normalize_attachment' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( null, $attachment );
 
@@ -208,7 +214,9 @@ class Test_Attachments extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Attachments::class );
 		$method     = $reflection->getMethod( 'normalize_attachment' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( null, $attachment );
 

--- a/tests/phpunit/tests/includes/class-test-autoloader.php
+++ b/tests/phpunit/tests/includes/class-test-autoloader.php
@@ -26,17 +26,23 @@ class Test_Autoloader extends \WP_UnitTestCase {
 
 		$prefix = new \ReflectionProperty( '\Activitypub\Autoloader', 'prefix' );
 		$this->assertTrue( $prefix->isProtected() );
-		$prefix->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$prefix->setAccessible( true );
+		}
 		$this->assertSame( $prefix->getValue( $autoloader ), 'Activitypub' );
 
 		$prefix_length = new \ReflectionProperty( '\Activitypub\Autoloader', 'prefix_length' );
 		$this->assertTrue( $prefix_length->isProtected() );
-		$prefix_length->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$prefix_length->setAccessible( true );
+		}
 		$this->assertSame( $prefix_length->getValue( $autoloader ), strlen( 'Activitypub' ) );
 
 		$path = new \ReflectionProperty( '\Activitypub\Autoloader', 'path' );
 		$this->assertTrue( $path->isProtected() );
-		$path->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$path->setAccessible( true );
+		}
 		$this->assertSame( $path->getValue( $autoloader ), rtrim( __DIR__ . '/' ) );
 	}
 
@@ -51,7 +57,9 @@ class Test_Autoloader extends \WP_UnitTestCase {
 		foreach ( spl_autoload_functions() as $function ) {
 			if ( is_array( $function ) && $function[0] instanceof Autoloader ) {
 				$path = new \ReflectionProperty( '\Activitypub\Autoloader', 'path' );
-				$path->setAccessible( true );
+				if ( \PHP_VERSION_ID < 80100 ) {
+					$path->setAccessible( true );
+				}
 
 				if ( $path->getValue( $function[0] ) === rtrim( __DIR__ . '/' ) ) {
 					$this->assertTrue( true );

--- a/tests/phpunit/tests/includes/class-test-dispatcher.php
+++ b/tests/phpunit/tests/includes/class-test-dispatcher.php
@@ -121,7 +121,9 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		\add_filter( 'pre_http_request', $mock_callback, 10, 3 );
 
 		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
-		$send_to_inboxes->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$send_to_inboxes->setAccessible( true );
+		}
 
 		// Invoke the method.
 		try {
@@ -153,7 +155,9 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 
 		// Make `Dispatcher::send_to_additional_inboxes` a public method.
 		$send_to_additional_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_additional_inboxes' );
-		$send_to_additional_inboxes->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$send_to_additional_inboxes->setAccessible( true );
+		}
 
 		try {
 			$send_to_additional_inboxes->invoke( null, $this->get_activity_mock(), Actors::get_by_id( self::$user_id ), $outbox_item );
@@ -231,7 +235,9 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		$activity    = Outbox::get_activity( $outbox_item );
 
 		$should_send = new \ReflectionMethod( Dispatcher::class, 'should_send_to_followers' );
-		$should_send->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$should_send->setAccessible( true );
+		}
 
 		// No followers, so should not send.
 		try {
@@ -523,7 +529,9 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 
 		// Make the method accessible.
 		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
-		$send_to_inboxes->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$send_to_inboxes->setAccessible( true );
+		}
 
 		// Invoke the method.
 		try {
@@ -570,7 +578,9 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 
 		// Make the method accessible.
 		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
-		$send_to_inboxes->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$send_to_inboxes->setAccessible( true );
+		}
 
 		// Invoke the method.
 		try {
@@ -613,7 +623,9 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 
 		// Make the method accessible.
 		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
-		$send_to_inboxes->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$send_to_inboxes->setAccessible( true );
+		}
 
 		// Invoke the method.
 		try {

--- a/tests/phpunit/tests/includes/class-test-migration.php
+++ b/tests/phpunit/tests/includes/class-test-migration.php
@@ -633,7 +633,9 @@ class Test_Migration extends \WP_UnitTestCase {
 		// Run the private method over Reflection.
 		$reflection = new \ReflectionClass( Migration::class );
 		$method     = $reflection->getMethod( 'add_default_extra_field' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( null );
 
 		// Check the extra field for the user.
@@ -675,7 +677,9 @@ class Test_Migration extends \WP_UnitTestCase {
 		// Run the private method over Reflection.
 		$reflection = new \ReflectionClass( Migration::class );
 		$method     = $reflection->getMethod( 'add_default_extra_field' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( null );
 
 		// Check that the user without ActivityPub permission has no extra field.
@@ -1160,7 +1164,9 @@ class Test_Migration extends \WP_UnitTestCase {
 		// Run the cleanup migration using reflection to access private method.
 		$reflection = new \ReflectionClass( \Activitypub\Migration::class );
 		$method     = $reflection->getMethod( 'clean_up_inbox' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( null );
 
 		// Verify all inbox items are deleted.

--- a/tests/phpunit/tests/includes/class-test-query.php
+++ b/tests/phpunit/tests/includes/class-test-query.php
@@ -223,7 +223,9 @@ class Test_Query extends \WP_UnitTestCase {
 	public function test_maybe_get_virtual_object() {
 		$reflection = new \ReflectionClass( Query::class );
 		$method     = $reflection->getMethod( 'maybe_get_virtual_object' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$query = Query::get_instance();
 
@@ -494,7 +496,9 @@ class Test_Query extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Query::class );
 		$method     = $reflection->getMethod( 'maybe_get_stamp' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$query  = Query::get_instance();
 		$result = $method->invoke( $query );
@@ -526,7 +530,9 @@ class Test_Query extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Query::class );
 		$method     = $reflection->getMethod( 'maybe_get_stamp' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$query  = Query::get_instance();
 		$result = $method->invoke( $query );

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -78,7 +78,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		\add_filter( 'schedule_event', $schedule_event_callback );
 
 		$schedule_retry = new \ReflectionMethod( Dispatcher::class, 'schedule_retry' );
-		$schedule_retry->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$schedule_retry->setAccessible( true );
+		}
 
 		// Invoke the method.
 		$schedule_retry->invoke( null, array( 'https://example.com/inbox' ), $create_item_id ); // null for static methods.

--- a/tests/phpunit/tests/includes/class-test-search.php
+++ b/tests/phpunit/tests/includes/class-test-search.php
@@ -92,7 +92,9 @@ class Test_Search extends \WP_UnitTestCase {
 	private function try_import_activitypub_object_accessible( $url ) {
 		$reflection = new \ReflectionClass( 'Activitypub\Search' );
 		$method     = $reflection->getMethod( 'try_import_activitypub_object' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		return $method->invoke( null, $url );
 	}

--- a/tests/phpunit/tests/includes/class-test-signature.php
+++ b/tests/phpunit/tests/includes/class-test-signature.php
@@ -710,7 +710,9 @@ class Test_Signature extends \WP_UnitTestCase {
 
 		// Test domain is not unsupported.
 		$could_support_rfc9421 = new \ReflectionMethod( Signature::class, 'could_support_rfc9421' );
-		$could_support_rfc9421->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$could_support_rfc9421->setAccessible( true );
+		}
 		$this->assertTrue( $could_support_rfc9421->invoke( null, $url ) );
 
 		$mock_callback = function ( $response, $args, $url ) {

--- a/tests/phpunit/tests/includes/class-test-tombstone.php
+++ b/tests/phpunit/tests/includes/class-test-tombstone.php
@@ -117,7 +117,9 @@ class Test_Tombstone extends \WP_UnitTestCase {
 		// Use reflection to access the private method.
 		$reflection = new \ReflectionClass( Tombstone::class );
 		$method     = $reflection->getMethod( 'check_array' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$response = $method->invokeArgs( null, array( array( 'type' => 'Tombstone' ) ) );
 		$this->assertTrue( $response );
@@ -135,7 +137,9 @@ class Test_Tombstone extends \WP_UnitTestCase {
 		// Use reflection to access the private method.
 		$reflection = new \ReflectionClass( Tombstone::class );
 		$method     = $reflection->getMethod( 'check_object' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$response = $method->invokeArgs( null, array( (object) array( 'type' => 'Tombstone' ) ) );
 		$this->assertTrue( $response );

--- a/tests/phpunit/tests/includes/collection/class-test-outbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-outbox.php
@@ -298,7 +298,9 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	public function test_get_object_id( $activity, $expected ) {
 		// Get the object ID using reflection since it's a private method.
 		$get_object_id = new \ReflectionMethod( Outbox::class, 'get_object_id' );
-		$get_object_id->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$get_object_id->setAccessible( true );
+		}
 
 		$result = $get_object_id->invoke( null, $activity );
 

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -259,7 +259,9 @@ class Test_Posts extends \WP_UnitTestCase {
 		// Use reflection to access the private method.
 		$reflection = new \ReflectionClass( Posts::class );
 		$method     = $reflection->getMethod( 'activity_to_post' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		try {
 			$result = $method->invoke( null, $activity );
@@ -285,7 +287,9 @@ class Test_Posts extends \WP_UnitTestCase {
 		// Use reflection to access the private method.
 		$reflection = new \ReflectionClass( Posts::class );
 		$method     = $reflection->getMethod( 'activity_to_post' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		try {
 			$result = $method->invoke( null, 'invalid_data' );
@@ -309,7 +313,9 @@ class Test_Posts extends \WP_UnitTestCase {
 		// Use reflection to access the private method.
 		$reflection = new \ReflectionClass( Posts::class );
 		$method     = $reflection->getMethod( 'activity_to_post' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		try {
 			$result = $method->invoke( null, $activity );
@@ -365,7 +371,9 @@ class Test_Posts extends \WP_UnitTestCase {
 		// Use reflection to access the private method.
 		$reflection = new \ReflectionClass( Posts::class );
 		$method     = $reflection->getMethod( 'activity_to_post' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		try {
 			$result = $method->invoke( null, $activity );
@@ -1088,7 +1096,9 @@ class Test_Posts extends \WP_UnitTestCase {
 		// Use reflection to access the private method.
 		$reflection = new \ReflectionClass( Posts::class );
 		$method     = $reflection->getMethod( 'activity_to_post' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( null, $activity );
 

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -493,7 +493,9 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		// Use reflection to test the private method.
 		$reflection = new \ReflectionClass( $this->inbox_controller );
 		$method     = $reflection->getMethod( 'get_local_recipients' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
 		// Activities with no recipients are treated as public and delivered to followers only.
@@ -520,7 +522,9 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		// Use reflection to test the private method.
 		$reflection = new \ReflectionClass( $this->inbox_controller );
 		$method     = $reflection->getMethod( 'get_local_recipients' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
 		$this->assertEmpty( $result, 'Should return empty array for external recipients only' );
@@ -545,7 +549,9 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		// Use reflection to test the private method.
 		$reflection = new \ReflectionClass( $this->inbox_controller );
 		$method     = $reflection->getMethod( 'get_local_recipients' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
 		$this->assertContains( self::$user_id, $result, 'Should contain local user ID' );
@@ -570,7 +576,9 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		// Use reflection to test the private method.
 		$reflection = new \ReflectionClass( $this->inbox_controller );
 		$method     = $reflection->getMethod( 'get_local_recipients' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
 		$this->assertEmpty( $result, 'Should handle malformed URLs gracefully' );
@@ -628,7 +636,9 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		// Use reflection to test the private method.
 		$reflection = new \ReflectionClass( $this->inbox_controller );
 		$method     = $reflection->getMethod( 'get_local_recipients' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
 
@@ -697,7 +707,9 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		// Use reflection to test the private method.
 		$reflection = new \ReflectionClass( $this->inbox_controller );
 		$method     = $reflection->getMethod( 'get_local_recipients' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
 

--- a/tests/phpunit/tests/includes/transformer/class-test-activity-object.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-activity-object.php
@@ -200,7 +200,9 @@ class Test_Activity_Object extends WP_UnitTestCase {
 	protected function get_protected_method( $obj, $method_name, $parameters = array() ) {
 		$reflection = new \ReflectionClass( get_class( $obj ) );
 		$method     = $reflection->getMethod( $method_name );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		return $method->invokeArgs( $obj, $parameters );
 	}

--- a/tests/phpunit/tests/includes/transformer/class-test-attachment.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-attachment.php
@@ -154,7 +154,9 @@ class Test_Attachment extends WP_UnitTestCase {
 	protected function get_protected_method( $obj, $method_name, $parameters = array() ) {
 		$reflection = new \ReflectionClass( get_class( $obj ) );
 		$method     = $reflection->getMethod( $method_name );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		return $method->invokeArgs( $obj, $parameters );
 	}

--- a/tests/phpunit/tests/includes/transformer/class-test-base.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-base.php
@@ -123,7 +123,9 @@ class Test_Base extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionObject( $transformer );
 		$method     = $reflection->getMethod( 'set_audience' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$transformed_object = $method->invoke( $transformer, new Generic_Object() );
 

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -34,7 +34,9 @@ class Test_Post extends \WP_UnitTestCase {
 		// Set up reflection method.
 		$reflection              = new \ReflectionClass( Post::class );
 		$this->reflection_method = $reflection->getMethod( 'get_type' );
-		$this->reflection_method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$this->reflection_method->setAccessible( true );
+		}
 	}
 
 	/**
@@ -383,7 +385,9 @@ class Test_Post extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Post::class );
 		$method     = $reflection->getMethod( 'get_media_from_blocks' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$blocks = parse_blocks( $post->post_content );
 		$result = $method->invoke( $transformer, $blocks, $media );
@@ -411,7 +415,9 @@ class Test_Post extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Post::class );
 		$method     = $reflection->getMethod( 'get_attachment' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $transformer );
 
@@ -446,7 +452,9 @@ class Test_Post extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Post::class );
 		$method     = $reflection->getMethod( 'get_media_from_blocks' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$blocks = parse_blocks( $post->post_content );
 		$result = $method->invoke( $transformer, $blocks, $media );
@@ -478,7 +486,9 @@ class Test_Post extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Post::class );
 		$method     = $reflection->getMethod( 'get_media_from_blocks' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$blocks = parse_blocks( $post->post_content );
 		$result = $method->invoke( $transformer, $blocks, $media );
@@ -510,7 +520,9 @@ class Test_Post extends \WP_UnitTestCase {
 		// Set up reflection method.
 		$reflection = new \ReflectionClass( Post::class );
 		$method     = $reflection->getMethod( 'get_icon' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		// Test with featured image.
 		set_post_thumbnail( $post_id, $attachment_id );
@@ -734,7 +746,9 @@ class Test_Post extends \WP_UnitTestCase {
 		$object      = new Base_Object();
 		$get_content = new \ReflectionMethod( Post::class, 'transform_object_properties' );
 
-		$get_content->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$get_content->setAccessible( true );
+		}
 
 		$object = $get_content->invoke( new Post( $post ), $object );
 
@@ -1073,7 +1087,9 @@ class Test_Post extends \WP_UnitTestCase {
 		$transformer = new Post( $post );
 		$reflection  = new \ReflectionClass( Post::class );
 		$method      = $reflection->getMethod( 'get_post_content_template' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$template = $method->invoke( $transformer );
 

--- a/tests/phpunit/tests/includes/wp-admin/class-test-welcome-fields.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-welcome-fields.php
@@ -32,7 +32,9 @@ class Test_Welcome_Fields extends \WP_UnitTestCase {
 	 */
 	public function test_get_completed_steps_count() {
 		$get_completed_steps_count = new \ReflectionMethod( Welcome_Fields::class, 'get_completed_steps_count' );
-		$get_completed_steps_count->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$get_completed_steps_count->setAccessible( true );
+		}
 
 		$completed = 1; // Plugin is already installed.
 
@@ -60,7 +62,9 @@ class Test_Welcome_Fields extends \WP_UnitTestCase {
 	 */
 	public function test_get_total_steps_count() {
 		$get_total_steps_count = new \ReflectionMethod( Welcome_Fields::class, 'get_total_steps_count' );
-		$get_total_steps_count->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$get_total_steps_count->setAccessible( true );
+		}
 
 		$steps = 6;
 
@@ -83,7 +87,9 @@ class Test_Welcome_Fields extends \WP_UnitTestCase {
 	 */
 	public function test_get_next_incomplete_step() {
 		$get_next_incomplete_step = new \ReflectionMethod( Welcome_Fields::class, 'get_next_incomplete_step' );
-		$get_next_incomplete_step->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$get_next_incomplete_step->setAccessible( true );
+		}
 
 		$this->assertSame( 'site_health', $get_next_incomplete_step->invoke( null ) ); // Null for static methods.
 

--- a/tests/phpunit/tests/includes/wp-admin/import/class-test-mastodon.php
+++ b/tests/phpunit/tests/includes/wp-admin/import/class-test-mastodon.php
@@ -104,15 +104,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		/*
@@ -188,15 +194,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		ob_start();
@@ -259,15 +271,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		ob_start();
@@ -331,15 +349,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		ob_start();
@@ -397,15 +421,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		ob_start();
@@ -461,15 +491,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		// Should not throw an error about missing 'tag' key.
@@ -524,15 +560,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		ob_start();
@@ -592,15 +634,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		// First import.
@@ -702,15 +750,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		ob_start();
@@ -776,15 +830,21 @@ class Test_Mastodon extends \WP_UnitTestCase {
 		$reflection = new ReflectionClass( Mastodon::class );
 
 		$outbox_property = $reflection->getProperty( 'outbox' );
-		$outbox_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$outbox_property->setAccessible( true );
+		}
 		$outbox_property->setValue( null, $outbox );
 
 		$author_property = $reflection->getProperty( 'author' );
-		$author_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$author_property->setAccessible( true );
+		}
 		$author_property->setValue( null, $this->user_id );
 
 		$fetch_attachments_property = $reflection->getProperty( 'fetch_attachments' );
-		$fetch_attachments_property->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$fetch_attachments_property->setAccessible( true );
+		}
 		$fetch_attachments_property->setValue( null, false );
 
 		ob_start();

--- a/tests/phpunit/tests/integration/class-test-stream-connector.php
+++ b/tests/phpunit/tests/integration/class-test-stream-connector.php
@@ -462,7 +462,9 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Connector::class );
 		$method     = $reflection->getMethod( 'prepare_outbox_data_for_response' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->stream_connector, $outbox_post );
 
@@ -521,7 +523,9 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Connector::class );
 		$method     = $reflection->getMethod( 'prepare_outbox_data_for_response' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->stream_connector, $outbox_post );
 
@@ -553,7 +557,9 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Connector::class );
 		$method     = $reflection->getMethod( 'prepare_outbox_data_for_response' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->stream_connector, $outbox_post );
 
@@ -609,7 +615,9 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Connector::class );
 		$method     = $reflection->getMethod( 'prepare_outbox_data_for_response' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->stream_connector, $outbox_post );
 
@@ -648,7 +656,9 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 
 		$reflection = new \ReflectionClass( Connector::class );
 		$method     = $reflection->getMethod( 'prepare_outbox_data_for_response' );
-		$method->setAccessible( true );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$result = $method->invoke( $this->stream_connector, $outbox_post );
 


### PR DESCRIPTION
## Proposed changes:
* Wrap all `ReflectionMethod::setAccessible()` and `ReflectionProperty::setAccessible()` calls with `PHP_VERSION_ID < 80100` checks
* These methods became no-ops in PHP 8.1 (reflection members are accessible by default)
* In PHP 8.5, these methods are deprecated and trigger warnings

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Tests should pass on all PHP versions from 7.2 to 8.5
* On PHP 8.5, there should be no deprecation warnings related to `setAccessible()`
* Verify that the tests still access private/protected methods and properties correctly

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [x] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Fix PHP 8.5 deprecation warnings for ReflectionProperty::setAccessible() and ReflectionMethod::setAccessible()

</details>