### PR TITLE
Refactor webfinger resolution to avoid code duplication

### DIFF
--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -452,17 +452,7 @@ class Remote_Actors {
 		}
 
 		if ( ! $actor->get_webfinger() ) {
-			$webfinger = \get_post_meta( $post->ID, '_activitypub_acct', true );
-
-			if ( ! $webfinger ) {
-				$acct = Webfinger::uri_to_acct( $actor->get_id() );
-				if ( \is_wp_error( $acct ) ) {
-					$acct = Webfinger::guess( $actor );
-				}
-				$webfinger = Sanitize::webfinger( $acct );
-			}
-
-			$actor->set_webfinger( $webfinger );
+			$actor->set_webfinger( self::get_acct( $post->ID ) );
 		}
 
 		return $actor;
@@ -645,8 +635,12 @@ class Remote_Actors {
 		$acct = Webfinger::uri_to_acct( $post->guid );
 
 		if ( \is_wp_error( $acct ) ) {
-			$actor = self::get_actor( $post );
-			$acct  = Webfinger::guess( $actor );
+			$actor = Actor::init_from_json( $post->post_content );
+			if ( \is_wp_error( $actor ) ) {
+				return '';
+			}
+
+			$acct = Webfinger::guess( $actor );
 		}
 
 		$acct = Sanitize::webfinger( $acct );

--- a/includes/wp-admin/table/class-blocked-actors.php
+++ b/includes/wp-admin/table/class-blocked-actors.php
@@ -234,7 +234,7 @@ class Blocked_Actors extends \WP_List_Table {
 				'post_title' => $actor->get_name() ?: $actor->get_preferred_username(),
 				'username'   => $actor->get_preferred_username(),
 				'url'        => object_to_uri( $actor->get_url() ?: $actor->get_id() ),
-				'webfinger'  => Remote_Actors::get_acct( $blocked_actor_post->ID ),
+				'webfinger'  => $actor->get_webfinger(),
 				'identifier' => $actor->get_id(),
 				'modified'   => $blocked_actor_post->post_modified_gmt,
 			);

--- a/includes/wp-admin/table/class-followers.php
+++ b/includes/wp-admin/table/class-followers.php
@@ -286,7 +286,7 @@ class Followers extends \WP_List_Table {
 				'post_title' => $actor->get_name() ?: $actor->get_preferred_username(),
 				'username'   => $actor->get_preferred_username(),
 				'url'        => object_to_uri( $actor->get_url() ?: $actor->get_id() ),
-				'webfinger'  => Remote_Actors::get_acct( $follower->ID ),
+				'webfinger'  => $actor->get_webfinger(),
 				'identifier' => $actor->get_id(),
 				'modified'   => $follower->post_modified_gmt,
 			);

--- a/includes/wp-admin/table/class-following.php
+++ b/includes/wp-admin/table/class-following.php
@@ -254,7 +254,7 @@ class Following extends \WP_List_Table {
 				'post_title' => $actor->get_name() ?: $actor->get_preferred_username(),
 				'username'   => $actor->get_preferred_username(),
 				'url'        => object_to_uri( $actor->get_url() ?: $actor->get_id() ),
-				'webfinger'  => Remote_Actors::get_acct( $following->ID ),
+				'webfinger'  => $actor->get_webfinger(),
 				'status'     => Following_Collection::check_status( $this->user_id, $following->ID ),
 				'identifier' => $actor->get_id(),
 				'modified'   => $following->post_modified_gmt,


### PR DESCRIPTION
## Summary

This PR refactors the webfinger resolution logic in response to review feedback on #2575:

- Refactors `get_acct()` to parse actor JSON directly (similar to `get_avatar_url()`), avoiding infinite loop with `get_actor()`
- Simplifies `get_actor()` to use `get_acct()` for webfinger resolution, removing duplicated logic
- Updates admin table classes to use `$actor->get_webfinger()` directly since it's now populated by `get_actor()`

This eliminates code duplication while ensuring the webfinger is stored and retrieved correctly.

## Test plan

- [x] PHPUnit tests pass for `Remote_Actors`
- [x] PHPUnit tests pass for `Webfinger`
- [x] Linting passes