### PR TITLE
Fix Mastodon import for archives with nested root folder

### DIFF
--- a/.github/changelog/2581-from-description
+++ b/.github/changelog/2581-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix Mastodon import for archives with nested root folder.
+Mastodon importer now unpacks nested archives instead of getting confused by the extra folder.

--- a/.github/changelog/2581-from-description
+++ b/.github/changelog/2581-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Mastodon import for archives with nested root folder.

--- a/includes/wp-admin/import/class-mastodon.php
+++ b/includes/wp-admin/import/class-mastodon.php
@@ -230,6 +230,7 @@ class Mastodon {
 		if ( ! $wp_filesystem->exists( self::$archive . '/outbox.json' ) ) {
 			echo '<p><strong>' . \esc_html( $error_message ) . '</strong><br />';
 			echo \esc_html__( 'The archive does not contain an Outbox file, please try again.', 'activitypub' ) . '</p>';
+			return;
 		}
 
 		self::$outbox = \json_decode( $wp_filesystem->get_contents( self::$archive . '/outbox.json' ), true );

--- a/includes/wp-admin/import/class-mastodon.php
+++ b/includes/wp-admin/import/class-mastodon.php
@@ -225,15 +225,14 @@ class Mastodon {
 
 		// Unzip package to working directory.
 		\unzip_file( $file, self::$archive );
-		$files = $wp_filesystem->dirlist( self::$archive );
+		self::maybe_unwrap_archive();
 
-		if ( ! isset( $files['outbox.json'] ) ) {
+		if ( ! $wp_filesystem->exists( self::$archive . '/outbox.json' ) ) {
 			echo '<p><strong>' . \esc_html( $error_message ) . '</strong><br />';
 			echo \esc_html__( 'The archive does not contain an Outbox file, please try again.', 'activitypub' ) . '</p>';
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		self::$outbox = \json_decode( \file_get_contents( self::$archive . '/outbox.json' ), true );
+		self::$outbox = \json_decode( $wp_filesystem->get_contents( self::$archive . '/outbox.json' ), true );
 
 		\wp_suspend_cache_invalidation();
 		\wp_defer_term_counting( true );
@@ -433,5 +432,33 @@ class Mastodon {
 		}
 
 		return $attachment;
+	}
+
+	/**
+	 * Detect and unwrap single nested directory in archive.
+	 *
+	 * Some Mastodon exports wrap all files in a root folder. This method
+	 * detects this pattern and updates the archive path to point inside it.
+	 */
+	private static function maybe_unwrap_archive() {
+		global $wp_filesystem;
+
+		$files = $wp_filesystem->dirlist( self::$archive );
+
+		// Check if there's exactly one directory at root level.
+		if ( count( $files ) !== 1 ) {
+			return;
+		}
+
+		$first = reset( $files );
+		if ( 'd' !== $first['type'] ) {
+			return;
+		}
+
+		// Check if outbox.json exists inside the nested directory.
+		$nested_path = self::$archive . '/' . $first['name'];
+		if ( $wp_filesystem->exists( $nested_path . '/outbox.json' ) ) {
+			self::$archive = $nested_path;
+		}
 	}
 }

--- a/tests/phpunit/tests/includes/wp-admin/import/class-test-mastodon.php
+++ b/tests/phpunit/tests/includes/wp-admin/import/class-test-mastodon.php
@@ -856,4 +856,41 @@ class Test_Mastodon extends \WP_UnitTestCase {
 
 		remove_filter( 'activitypub_import_mastodon_post_data', $filter_callback );
 	}
+
+	/**
+	 * Test maybe_unwrap_archive() unwraps nested folder structure.
+	 */
+	public function test_maybe_unwrap_archive_with_nested_folder() {
+		\WP_Filesystem();
+		global $wp_filesystem;
+
+		// Create temp directory structure: archive/nested-folder/outbox.json.
+		$temp_dir   = \get_temp_dir() . 'activitypub-test-' . \uniqid();
+		$nested_dir = $temp_dir . '/nested-folder';
+
+		\wp_mkdir_p( $nested_dir );
+		$wp_filesystem->put_contents( $nested_dir . '/outbox.json', '{}' );
+
+		// Set self::$archive via Reflection.
+		$reflection = new ReflectionClass( Mastodon::class );
+
+		$archive_property = $reflection->getProperty( 'archive' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$archive_property->setAccessible( true );
+		}
+		$archive_property->setValue( null, $temp_dir );
+
+		// Call private method via Reflection.
+		$method = $reflection->getMethod( 'maybe_unwrap_archive' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( null );
+
+		// Assert archive path was updated to nested folder.
+		$this->assertSame( $nested_dir, $archive_property->getValue() );
+
+		// Cleanup.
+		$wp_filesystem->delete( $temp_dir, true );
+	}
 }


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/import-mastodon-beta/page/2/#post-18741275

## Proposed changes:

* Handle Mastodon archive exports that wrap all files in a root folder (e.g., `archive-name/outbox.json` instead of `outbox.json` at root level).
* Use `$wp_filesystem->exists()` instead of `dirlist()` for checking `outbox.json` existence (more efficient).
* Use `$wp_filesystem->get_contents()` instead of `file_get_contents()` for consistency with the rest of the codebase and to remove phpcs ignore comment.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Export your archive from Mastodon (Preferences > Import and Export > Request your archive).
2. Go to Tools > Import > Mastodon.
3. Upload a Mastodon archive ZIP that has files nested in a root folder.
4. Verify the import proceeds without "The archive does not contain an Outbox file" error.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix Mastodon import for archives with nested root folder.

</details>