### PR TITLE
Fix reviewer team name in PR workflow skill

### DIFF
--- a/.claude/skills/activitypub-pr-workflow/SKILL.md
+++ b/.claude/skills/activitypub-pr-workflow/SKILL.md
@@ -35,7 +35,7 @@ try/{idea}       # Experimental ideas.
 git checkout -b add/new-feature
 
 # Create PR with GitHub CLI.
-gh pr create --assignee @me --reviewer Fediverse
+gh pr create --assignee @me --reviewer Automattic/fediverse
 
 # Check PR status and CI.
 gh pr status


### PR DESCRIPTION
## Proposed changes:

* Fix the `gh pr create` command example in the PR workflow skill to use `Automattic/fediverse` instead of `Fediverse`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* N/A - documentation only change.