### PR TITLE
Add admin CSS styling for quote comments

### DIFF
--- a/.github/changelog/2584-from-description
+++ b/.github/changelog/2584-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix admin styling for quote comments to match likes and reposts

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -230,15 +230,11 @@ input.blog-user-identifier {
 	font-family: dashicons;
 }
 
-.like .dashboard-comment-wrap,
-.quote .dashboard-comment-wrap,
-.repost .dashboard-comment-wrap {
+.activitypub-comment .dashboard-comment-wrap {
 	padding-inline-start: 63px;
 }
 
-.like .dashboard-comment-wrap .comment-author,
-.quote .dashboard-comment-wrap .comment-author,
-.repost .dashboard-comment-wrap .comment-author {
+.activitypub-comment .dashboard-comment-wrap .comment-author {
 	margin-block: 0;
 }
 

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -230,13 +230,15 @@ input.blog-user-identifier {
 	font-family: dashicons;
 }
 
-.repost .dashboard-comment-wrap,
-.like .dashboard-comment-wrap {
+.like .dashboard-comment-wrap,
+.quote .dashboard-comment-wrap,
+.repost .dashboard-comment-wrap {
 	padding-inline-start: 63px;
 }
 
-.repost .dashboard-comment-wrap .comment-author,
-.like .dashboard-comment-wrap .comment-author {
+.like .dashboard-comment-wrap .comment-author,
+.quote .dashboard-comment-wrap .comment-author,
+.repost .dashboard-comment-wrap .comment-author {
 	margin-block: 0;
 }
 


### PR DESCRIPTION
## Proposed changes:
* Add `.quote` selector to admin CSS rules for consistent comment styling
* Ensure quote comments display with the same indentation and spacing as likes and reposts
* Maintain alphabetical ordering of selectors (like, quote, repost)

| Before | After |
|---|---|
| <img width="614" height="125" alt="Screenshot 2025-12-04 at 09 25 02" src="https://github.com/user-attachments/assets/7a324157-ed97-448b-a2c7-6d8e8d912555" /> | <img width="605" height="90" alt="Screenshot 2025-12-04 at 09 25 12" src="https://github.com/user-attachments/assets/d37e7fbd-c001-4f88-b6d7-3343a9b26b71" /> |


### Other information:

- [ ] Have you written new tests for your changes, if applicable?

N/A - CSS styling change

## Testing instructions:

1. Create or receive a quote comment on a post (a quote is when someone quotes your post in their own post)
2. Go to **Comments** in WordPress admin
3. Locate a quote comment in the list
4. Verify that quote comments have:
   - Proper left padding (63px) matching likes and reposts
   - Proper comment author margin matching other interaction types
5. Compare the visual styling with likes and reposts to ensure consistency

**Before:** Quote comments may have had inconsistent spacing/indentation compared to likes and reposts

**After:** Quote comments display with identical spacing and indentation as other interaction types

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix admin styling for quote comments to match likes and reposts

</details>