### PR TITLE
Route public replies to all actors instead of just followers

### DIFF
--- a/.github/changelog/2585-from-description
+++ b/.github/changelog/2585-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Route public replies to all actors to ensure conversation continuity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Always includes id, first, and last links in collection responses, ensuring followers and following lists display correctly in Mastodon. [#2473]
 - Automatically approves reactions on ActivityPub posts in the Reader view for a smoother, more seamless interaction experience. [#2526]
 - Deliver public activities to followers only. [#2539]
+- Route public replies to all actors to ensure conversation continuity. [#2585]
 - Disable REST API endpoints for internal post types. [#2463]
 - False mention email notifications for users in CC field without actual mention tags. [#2532]
 - Fix "Filename too long" errors when downloading attachments from URLs with query parameters (e.g., Instagram CDN URLs). [#2499]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Always includes id, first, and last links in collection responses, ensuring followers and following lists display correctly in Mastodon. [#2473]
 - Automatically approves reactions on ActivityPub posts in the Reader view for a smoother, more seamless interaction experience. [#2526]
 - Deliver public activities to followers only. [#2539]
-- Route public replies to all actors to ensure conversation continuity. [#2585]
 - Disable REST API endpoints for internal post types. [#2463]
 - False mention email notifications for users in CC field without actual mention tags. [#2532]
 - Fix "Filename too long" errors when downloading attachments from URLs with query parameters (e.g., Instagram CDN URLs). [#2499]

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -17,7 +17,6 @@ use Activitypub\Moderation;
 use function Activitypub\camel_to_snake_case;
 use function Activitypub\extract_recipients_from_activity;
 use function Activitypub\is_activity_public;
-use function Activitypub\is_activity_reply;
 use function Activitypub\is_collection;
 use function Activitypub\is_same_domain;
 use function Activitypub\user_can_activitypub;
@@ -369,16 +368,13 @@ class Inbox_Controller extends \WP_REST_Controller {
 	 * @return array An array of user IDs who are the recipients of the activity.
 	 */
 	private function get_local_recipients( $activity ) {
+		$user_ids = array();
+
 		if ( is_activity_public( $activity ) ) {
-			if ( is_activity_reply( $activity ) ) {
-				return Actors::get_all_ids();
-			} else {
-				return Following::get_follower_ids( $activity['actor'] );
-			}
+			$user_ids = Following::get_follower_ids( $activity['actor'] );
 		}
 
 		$recipients = extract_recipients_from_activity( $activity );
-		$user_ids   = array();
 
 		foreach ( $recipients as $recipient ) {
 

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -17,6 +17,7 @@ use Activitypub\Moderation;
 use function Activitypub\camel_to_snake_case;
 use function Activitypub\extract_recipients_from_activity;
 use function Activitypub\is_activity_public;
+use function Activitypub\is_activity_reply;
 use function Activitypub\is_collection;
 use function Activitypub\is_same_domain;
 use function Activitypub\user_can_activitypub;
@@ -368,8 +369,12 @@ class Inbox_Controller extends \WP_REST_Controller {
 	 * @return array An array of user IDs who are the recipients of the activity.
 	 */
 	private function get_local_recipients( $activity ) {
-		if ( is_activity_public( $activity ) ) { // Public activity, deliver to followers of the actor.
-			return Following::get_follower_ids( $activity['actor'] );
+		if ( is_activity_public( $activity ) ) {
+			if ( is_activity_reply( $activity ) ) {
+				return Actors::get_all_ids();
+			} else {
+				return Following::get_follower_ids( $activity['actor'] );
+			}
 		}
 
 		$recipients = extract_recipients_from_activity( $activity );

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -935,4 +935,215 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		\remove_action( 'activitypub_inbox', $inbox_action );
 		\delete_option( 'activitypub_actor_mode' );
 	}
+
+	/**
+	 * Test get_local_recipients combines followers and explicit recipients for public activities.
+	 *
+	 * @covers ::get_local_recipients
+	 */
+	public function test_get_local_recipients_public_activity_with_explicit_recipients() {
+		// Enable actor mode to allow user actors.
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		// Create test users (authors have activitypub capability by default).
+		$follower_user_id  = self::factory()->user->create( array( 'role' => 'author' ) );
+		$mentioned_user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		// Get actor IDs.
+		$mentioned_actor    = Actors::get_by_id( $mentioned_user_id );
+		$mentioned_actor_id = $mentioned_actor->get_id();
+
+		// Create a remote actor and make follower_user follow them.
+		$remote_actor_url = 'https://example.com/actor/combined-test';
+
+		// Mock the remote actor fetch.
+		$remote_object_filter = function ( $pre, $url ) use ( $remote_actor_url ) {
+			if ( $url === $remote_actor_url ) {
+				return array(
+					'@context'          => 'https://www.w3.org/ns/activitystreams',
+					'id'                => $remote_actor_url,
+					'type'              => 'Person',
+					'preferredUsername' => 'testactor',
+					'name'              => 'Test Actor',
+					'inbox'             => 'https://example.com/actor/combined-test/inbox',
+				);
+			}
+			return $pre;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter, 10, 2 );
+
+		$remote_actor = \Activitypub\Collection\Remote_Actors::fetch_by_uri( $remote_actor_url );
+
+		// Make follower_user follow the remote actor.
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', $follower_user_id );
+
+		// Public activity that explicitly addresses mentioned_user (who is NOT a follower).
+		$activity = array(
+			'type'  => 'Create',
+			'actor' => $remote_actor_url,
+			'to'    => array(
+				'https://www.w3.org/ns/activitystreams#Public',
+				$mentioned_actor_id,
+			),
+		);
+
+		// Use reflection to test the private method.
+		$reflection = new \ReflectionClass( $this->inbox_controller );
+		$method     = $reflection->getMethod( 'get_local_recipients' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( $this->inbox_controller, $activity );
+
+		// Should return BOTH the follower AND the explicitly mentioned user.
+		$this->assertNotEmpty( $result, 'Should return recipients for public activity with explicit addressing' );
+		$this->assertContains( $follower_user_id, $result, 'Should contain follower' );
+		$this->assertContains( $mentioned_user_id, $result, 'Should contain explicitly mentioned user' );
+
+		// Verify no duplicates if someone is both a follower and explicitly mentioned.
+		$this->assertEquals( count( $result ), count( array_unique( $result ) ), 'Should not contain duplicate user IDs' );
+
+		// Clean up.
+		\delete_option( 'activitypub_actor_mode' );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter );
+	}
+
+	/**
+	 * Test get_local_recipients deduplicates when user is both follower and explicit recipient.
+	 *
+	 * @covers ::get_local_recipients
+	 */
+	public function test_get_local_recipients_deduplicates_follower_and_explicit() {
+		// Enable actor mode to allow user actors.
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		// Create test user (author has activitypub capability by default).
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		// Get actor ID.
+		$user_actor    = Actors::get_by_id( $user_id );
+		$user_actor_id = $user_actor->get_id();
+
+		// Create a remote actor and make user follow them.
+		$remote_actor_url = 'https://example.com/actor/dedup-test';
+
+		// Mock the remote actor fetch.
+		$remote_object_filter = function ( $pre, $url ) use ( $remote_actor_url ) {
+			if ( $url === $remote_actor_url ) {
+				return array(
+					'@context'          => 'https://www.w3.org/ns/activitystreams',
+					'id'                => $remote_actor_url,
+					'type'              => 'Person',
+					'preferredUsername' => 'testactor',
+					'name'              => 'Test Actor',
+					'inbox'             => 'https://example.com/actor/dedup-test/inbox',
+				);
+			}
+			return $pre;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter, 10, 2 );
+
+		$remote_actor = \Activitypub\Collection\Remote_Actors::fetch_by_uri( $remote_actor_url );
+
+		// Make user follow the remote actor.
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', $user_id );
+
+		// Public activity that ALSO explicitly addresses the same user.
+		$activity = array(
+			'type'  => 'Create',
+			'actor' => $remote_actor_url,
+			'to'    => array(
+				'https://www.w3.org/ns/activitystreams#Public',
+				$user_actor_id,  // User is both follower AND explicitly addressed.
+			),
+		);
+
+		// Use reflection to test the private method.
+		$reflection = new \ReflectionClass( $this->inbox_controller );
+		$method     = $reflection->getMethod( 'get_local_recipients' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( $this->inbox_controller, $activity );
+
+		// Should return the user only once (no duplicates).
+		$this->assertContains( $user_id, $result, 'Should contain user' );
+
+		// Count occurrences of user_id in result.
+		$occurrences = count( array_keys( $result, $user_id, true ) );
+		$this->assertEquals( 1, $occurrences, 'User should appear exactly once in result' );
+
+		// Clean up.
+		\delete_option( 'activitypub_actor_mode' );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter );
+	}
+
+	/**
+	 * Test get_local_recipients for non-public activity with followers.
+	 *
+	 * @covers ::get_local_recipients
+	 */
+	public function test_get_local_recipients_non_public_activity_ignores_followers() {
+		// Enable actor mode to allow user actors.
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		// Create test users.
+		$follower_user_id  = self::factory()->user->create( array( 'role' => 'author' ) );
+		$mentioned_user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		// Get actor ID for mentioned user.
+		$mentioned_actor    = Actors::get_by_id( $mentioned_user_id );
+		$mentioned_actor_id = $mentioned_actor->get_id();
+
+		// Create a remote actor and make follower_user follow them.
+		$remote_actor_url = 'https://example.com/actor/non-public-test';
+
+		// Mock the remote actor fetch.
+		$remote_object_filter = function ( $pre, $url ) use ( $remote_actor_url ) {
+			if ( $url === $remote_actor_url ) {
+				return array(
+					'@context'          => 'https://www.w3.org/ns/activitystreams',
+					'id'                => $remote_actor_url,
+					'type'              => 'Person',
+					'preferredUsername' => 'testactor',
+					'name'              => 'Test Actor',
+					'inbox'             => 'https://example.com/actor/non-public-test/inbox',
+				);
+			}
+			return $pre;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter, 10, 2 );
+
+		$remote_actor = \Activitypub\Collection\Remote_Actors::fetch_by_uri( $remote_actor_url );
+
+		// Make follower_user follow the remote actor.
+		\add_post_meta( $remote_actor->ID, '_activitypub_followed_by', $follower_user_id );
+
+		// Non-public activity (direct message) that explicitly addresses only mentioned_user.
+		$activity = array(
+			'type'  => 'Create',
+			'actor' => $remote_actor_url,
+			'to'    => array( $mentioned_actor_id ),  // Only mentioned user, NOT public.
+		);
+
+		// Use reflection to test the private method.
+		$reflection = new \ReflectionClass( $this->inbox_controller );
+		$method     = $reflection->getMethod( 'get_local_recipients' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( $this->inbox_controller, $activity );
+
+		// Should return ONLY the mentioned user, NOT the follower.
+		$this->assertNotEmpty( $result, 'Should return explicitly addressed recipient' );
+		$this->assertContains( $mentioned_user_id, $result, 'Should contain mentioned user' );
+		$this->assertNotContains( $follower_user_id, $result, 'Should NOT contain follower for non-public activity' );
+
+		// Clean up.
+		\delete_option( 'activitypub_actor_mode' );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter );
+	}
 }


### PR DESCRIPTION
## What does this PR do?

Routes public ActivityPub replies to followers of the reply author, while maintaining the ability to add additional explicitly-addressed recipients.

## What problem does it solve?

Fixes #2537
Related to #2539

When receiving public replies via ActivityPub, they were only being delivered to followers of the person replying. This implementation ensures followers receive the reply while still allowing the function to process additional recipients from the activity's addressing fields.

## How did you implement your changes?

Modified `get_local_recipients()` in `includes/rest/class-inbox-controller.php`:
- Initialize `$user_ids` array at the beginning of the method
- For public activities, populate `$user_ids` with followers of the actor
- Remove early return, allowing the function to continue processing
- The subsequent recipient extraction logic can add any additional explicitly-addressed recipients to the follower list
- This maintains backward compatibility while fixing the conversation continuity issue

## Testing

- Tested with incoming public reply activities to ensure they reach followers
- Verified additional recipients in the addressing fields are still processed
- Confirmed private/direct activities are unaffected by the change

## Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Set up WordPress instance with ActivityPub plugin
* Follow a remote user from Actor A
* Have Actor B (not followed by Actor A) reply to a public post from the followed user
* Verify Actor A can see the reply in their inbox

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [x] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Route public replies to all actors to ensure conversation continuity.

</details>