### PR TITLE
Add HTTP signatures to WebFinger requests

### DIFF
--- a/.github/changelog/2594-from-description
+++ b/.github/changelog/2594-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Mentions now work with GoToSocial and other platforms that require signed requests.

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -215,14 +215,16 @@ class Webfinger {
 			\rawurlencode( $identifier )
 		);
 
-		$response = \wp_safe_remote_get(
-			$webfinger_url,
-			array(
-				'headers' => array( 'Accept' => 'application/jrd+json' ),
-			)
-		);
+		$set_accept_header = function ( $args ) {
+			$args['headers']['Accept'] = 'application/jrd+json';
+			return $args;
+		};
 
-		if ( \is_wp_error( $response ) || \wp_remote_retrieve_response_code( $response ) >= 400 ) {
+		\add_filter( 'http_request_args', $set_accept_header );
+		$response = Http::get( $webfinger_url );
+		\remove_filter( 'http_request_args', $set_accept_header );
+
+		if ( \is_wp_error( $response ) ) {
 			return new \WP_Error(
 				'webfinger_url_not_accessible',
 				__( 'The WebFinger Resource is not accessible.', 'activitypub' ),


### PR DESCRIPTION
Fixes #2593

## Proposed changes:
* Updates `Webfinger::get_data()` to use `Http::get()` for signed HTTP requests.
* Uses `http_request_args` filter to override the Accept header to `application/jrd+json`.

Some ActivityPub implementations like GoToSocial require HTTP signatures for all requests, including WebFinger lookups. Previously, WebFinger requests were made without signatures, causing 401 Unauthorized errors when trying to resolve mentions for users on these platforms.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Verify WebFinger lookups work against standard Mastodon instances.
* Verify WebFinger lookups work against GoToSocial instances (requires a GoToSocial account to test mentions).
* Run existing WebFinger unit tests with `npm run env-test -- --filter=Webfinger`.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Mentions now work with GoToSocial and other platforms that require signed requests.

</details>