### PR TITLE
Preserve whitespace inside pre elements when federating content

### DIFF
--- a/.github/changelog/2595-from-description
+++ b/.github/changelog/2595-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Preserve newlines inside pre elements when federating content.

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -201,4 +201,25 @@ class Sanitize {
 
 		return $content;
 	}
+
+	/**
+	 * Strip newlines, carriage returns, and tabs from content while preserving them inside pre elements.
+	 *
+	 * Code blocks require whitespace to be preserved for proper formatting.
+	 *
+	 * @param string $content The content to process.
+	 *
+	 * @return string The trimmed content with whitespace stripped except inside pre elements.
+	 */
+	public static function strip_whitespace( $content ) {
+		return \trim(
+			\preg_replace_callback(
+				'/(<pre[^>]*>.*?<\/pre>)|[\n\r\t]+/is',
+				static function ( $matches ) {
+					return $matches[1] ?? '';
+				},
+				$content
+			)
+		);
+	}
 }

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -191,7 +191,7 @@ class Shortcodes {
 		// Replace script and style elements.
 		$content = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $content );
 		$content = \strip_shortcodes( $content );
-		$content = \trim( \preg_replace( '/[\n\r\t]/', '', $content ) );
+		$content = Sanitize::strip_whitespace( $content );
 
 		add_shortcode( 'ap_content', array( 'Activitypub\Shortcodes', 'content' ) );
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -12,6 +12,7 @@ use Activitypub\Collection\Actors;
 use Activitypub\Collection\Interactions;
 use Activitypub\Collection\Replies;
 use Activitypub\Model\Blog;
+use Activitypub\Sanitize;
 use Activitypub\Shortcodes;
 
 use function Activitypub\esc_hashtag;
@@ -539,8 +540,7 @@ class Post extends Base {
 		\wp_reset_postdata();
 
 		$content = \wpautop( $content );
-		$content = \preg_replace( '/[\n\r\t]/', '', $content );
-		$content = \trim( $content );
+		$content = Sanitize::strip_whitespace( $content );
 
 		// Don't need these anymore, should never appear in a post.
 		Shortcodes::unregister();

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -1107,6 +1107,54 @@ class Test_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that code blocks preserve newlines when content is transformed.
+	 *
+	 * @covers ::get_content
+	 */
+	public function test_code_blocks_preserve_newlines() {
+		$code_content = "function test() {\n\treturn true;\n}";
+		$post         = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Code Example',
+				'post_content' => '<pre>' . $code_content . '</pre>',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$object  = Post::transform( $post )->to_object();
+		$content = $object->get_content();
+
+		// The pre block content should preserve newlines and tabs.
+		$this->assertStringContainsString( '<pre>', $content, 'Content should contain pre tag' );
+		$this->assertStringContainsString( "\n", $content, 'Content should preserve newlines inside pre blocks' );
+		$this->assertStringContainsString( "\t", $content, 'Content should preserve tabs inside pre blocks' );
+	}
+
+	/**
+	 * Test that regular content has whitespace stripped while code blocks are preserved.
+	 *
+	 * @covers ::get_content
+	 */
+	public function test_mixed_content_preserves_code_blocks() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Mixed Content',
+				'post_content' => "<p>Regular paragraph</p>\n\n<pre class=\"code\">line1\nline2\nline3</pre>\n\n<p>Another paragraph</p>",
+				'post_status'  => 'publish',
+			)
+		);
+
+		$object  = Post::transform( $post )->to_object();
+		$content = $object->get_content();
+
+		// Pre block should preserve newlines.
+		$this->assertStringContainsString( "line1\nline2\nline3", $content, 'Pre block should preserve newlines' );
+
+		// Regular paragraphs should be joined without extra newlines.
+		$this->assertStringNotContainsString( "</p>\n\n<p>", $content, 'Paragraphs should not have newlines between them' );
+	}
+
+	/**
 	 * Data provider for get_post_content_template tests with various scenarios.
 	 *
 	 * @return array Each test case contains:


### PR DESCRIPTION
Fixes #2592

## Proposed changes:
* Add `Sanitize::strip_whitespace()` method that strips newlines, carriage returns, and tabs from content while preserving them inside `<pre>` elements.
* Update `Shortcodes::content()` and `Post::get_content()` to use the new sanitization method.

Code blocks in federated posts were losing their newline characters, making them unreadable. The fix uses a regex with `preg_replace_callback` to preserve whitespace inside `<pre>` tags while stripping it from the rest of the content.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create a post with a code block containing multiple lines
2. Publish the post
3. View the federated content on a remote instance (or inspect the ActivityPub JSON at `/wp-json/activitypub/1.0/posts/{id}`)
4. Verify the code block preserves newlines and formatting

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Preserve newlines inside pre elements when federating content.

</details>