### PR TITLE
Refactor mention detection to use Remote_Actors

### DIFF
--- a/.github/changelog/2602-from-description
+++ b/.github/changelog/2602-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve performance and reliability of @-mention detection.

--- a/includes/class-http.php
+++ b/includes/class-http.php
@@ -235,19 +235,8 @@ class Http {
 			);
 		}
 
-		if ( is_wp_error( $url ) ) {
+		if ( \is_wp_error( $url ) ) {
 			return $url;
-		}
-
-		$transient_key = self::generate_cache_key( $url );
-
-		// Only check the cache if needed.
-		if ( $cached ) {
-			$data = \get_transient( $transient_key );
-
-			if ( $data ) {
-				return $data;
-			}
 		}
 
 		if ( ! \wp_http_validate_url( $url ) ) {
@@ -261,7 +250,7 @@ class Http {
 			);
 		}
 
-		$response = self::get( $url );
+		$response = self::get( $url, $cached );
 
 		if ( \is_wp_error( $response ) ) {
 			return $response;
@@ -280,8 +269,6 @@ class Http {
 				)
 			);
 		}
-
-		\set_transient( $transient_key, $data, WEEK_IN_SECONDS );
 
 		return $data;
 	}

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -7,7 +7,7 @@
 
 namespace Activitypub;
 
-use WP_Error;
+use Activitypub\Collection\Remote_Actors;
 
 /**
  * ActivityPub Mention Class.
@@ -65,27 +65,17 @@ class Mention {
 	 * @return string The final string.
 	 */
 	public static function replace_with_links( $result ) {
-		$metadata = get_remote_metadata_by_actor( $result[0] );
+		$post = Remote_Actors::fetch_by_acct( $result[0] );
 
-		if (
-			! empty( $metadata ) &&
-			! is_wp_error( $metadata ) &&
-			( ! empty( $metadata['id'] ) || ! empty( $metadata['url'] ) )
-		) {
-			$username = ltrim( $result[0], '@' );
-			if ( ! empty( $metadata['name'] ) ) {
-				$username = $metadata['name'];
-			}
-			if ( ! empty( $metadata['preferredUsername'] ) ) {
-				$username = $metadata['preferredUsername'];
-			}
-
-			$url = isset( $metadata['url'] ) ? object_to_uri( $metadata['url'] ) : object_to_uri( $metadata['id'] );
-
-			return \sprintf( '<a rel="mention" class="u-url mention" href="%1$s">@%2$s</a>', esc_url( $url ), esc_html( $username ) );
+		if ( is_wp_error( $post ) ) {
+			return $result[0];
 		}
 
-		return $result[0];
+		$actor    = Remote_Actors::get_actor( $post );
+		$username = $actor->get_preferred_username() ?: $actor->get_name() ?: ltrim( $result[0], '@' );
+		$url      = object_to_uri( $actor->get_url() ?: $actor->get_id() );
+
+		return \sprintf( '<a rel="mention" class="u-url mention" href="%1$s">@%2$s</a>', esc_url( $url ), esc_html( $username ) );
 	}
 
 	/**
@@ -114,7 +104,7 @@ class Mention {
 	 *
 	 * @param string $actor The Actor URL.
 	 *
-	 * @return string|WP_Error The Inbox-URL or WP_Error if not found.
+	 * @return string|\WP_Error The Inbox-URL or WP_Error if not found.
 	 */
 	public static function get_inbox_by_mentioned_actor( $actor ) {
 		$metadata = get_remote_metadata_by_actor( $actor );
@@ -131,7 +121,7 @@ class Mention {
 			return $metadata['inbox'];
 		}
 
-		return new WP_Error( 'activitypub_no_inbox', \__( 'No "Inbox" found', 'activitypub' ), $metadata );
+		return new \WP_Error( 'activitypub_no_inbox', \__( 'No "Inbox" found', 'activitypub' ), $metadata );
 	}
 
 	/**

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -67,11 +67,16 @@ class Mention {
 	public static function replace_with_links( $result ) {
 		$post = Remote_Actors::fetch_by_acct( $result[0] );
 
-		if ( is_wp_error( $post ) ) {
+		if ( \is_wp_error( $post ) ) {
 			return $result[0];
 		}
 
-		$actor    = Remote_Actors::get_actor( $post );
+		$actor = Remote_Actors::get_actor( $post );
+
+		if ( \is_wp_error( $actor ) ) {
+			return $result[0];
+		}
+
 		$username = $actor->get_preferred_username() ?: $actor->get_name() ?: ltrim( $result[0], '@' );
 		$url      = object_to_uri( $actor->get_url() ?: $actor->get_id() );
 

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -77,7 +77,7 @@ class Mention {
 			return $result[0];
 		}
 
-		$username = $actor->get_preferred_username() ?: $actor->get_name() ?: ltrim( $result[0], '@' );
+		$username = $actor->get_preferred_username() ?: $actor->get_name() ?: Sanitize::webfinger( $result[0] );
 		$url      = object_to_uri( $actor->get_url() ?: $actor->get_id() );
 
 		return \sprintf( '<a rel="mention" class="u-url mention" href="%1$s">@%2$s</a>', esc_url( $url ), esc_html( $username ) );

--- a/tests/phpunit/tests/includes/class-test-mention.php
+++ b/tests/phpunit/tests/includes/class-test-mention.php
@@ -25,9 +25,13 @@ class Test_Mention extends \WP_UnitTestCase {
 	 */
 	public static $actors = array(
 		'username@example.org' => array(
-			'id'   => 'https://example.org/users/username',
-			'url'  => 'https://example.org/users/username',
-			'name' => 'username',
+			'@context'          => 'https://www.w3.org/ns/activitystreams',
+			'id'                => 'https://example.org/users/username',
+			'type'              => 'Person',
+			'url'               => 'https://example.org/users/username',
+			'name'              => 'username',
+			'preferredUsername' => 'username',
+			'inbox'             => 'https://example.org/users/username/inbox',
 		),
 	);
 
@@ -36,7 +40,6 @@ class Test_Mention extends \WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		add_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'pre_get_remote_metadata_by_actor' ), 10, 2 );
 		add_filter( 'pre_http_request', array( $this, 'pre_http_request' ), 10, 3 );
 		add_filter( 'activitypub_pre_http_get_remote_object', array( $this, 'activitypub_pre_http_get_remote_object' ), 10, 2 );
 	}
@@ -45,7 +48,6 @@ class Test_Mention extends \WP_UnitTestCase {
 	 * Tear down the test case.
 	 */
 	public function tear_down() {
-		remove_filter( 'pre_get_remote_metadata_by_actor', array( get_called_class(), 'pre_get_remote_metadata_by_actor' ) );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request' ) );
 		remove_filter( 'activitypub_pre_http_get_remote_object', array( $this, 'activitypub_pre_http_get_remote_object' ) );
 		parent::tear_down();
@@ -103,6 +105,26 @@ ENDPRE;
 	 * @return array|false|\WP_Error
 	 */
 	public function pre_http_request( $response, $parsed_args, $url ) {
+		// Mock webfinger for test actors.
+		if ( 'https://example.org/.well-known/webfinger?resource=acct%3Ausername%40example.org' === $url ) {
+			return array(
+				'headers'  => array( 'content-type' => 'application/jrd+json' ),
+				'body'     => wp_json_encode(
+					array(
+						'subject' => 'acct:username@example.org',
+						'links'   => array(
+							array(
+								'rel'  => 'self',
+								'type' => 'application/activity+json',
+								'href' => 'https://example.org/users/username',
+							),
+						),
+					)
+				),
+				'response' => array( 'code' => 200 ),
+			);
+		}
+
 		// Mock responses for remote users.
 		if ( 'https://notiz.blog/.well-known/webfinger?resource=acct%3Apfefferle%40notiz.blog' === $url ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
@@ -137,6 +159,16 @@ ENDPRE;
 	public function activitypub_pre_http_get_remote_object( $pre, $url_or_object ) {
 		$url = object_to_uri( $url_or_object );
 
+		// Check if this is a URL from our test actors.
+		foreach ( self::$actors as $actor_data ) {
+			if ( isset( $actor_data['id'] ) && $actor_data['id'] === $url ) {
+				return $actor_data;
+			}
+			if ( isset( $actor_data['url'] ) && $actor_data['url'] === $url ) {
+				return $actor_data;
+			}
+		}
+
 		// Return parsed object data for ActivityPub actors.
 		if ( 'https://notiz.blog/author/matthias-pfefferle/' === $url ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
@@ -148,23 +180,6 @@ ENDPRE;
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			$fixture = json_decode( file_get_contents( AP_TESTS_DIR . '/data/fixtures/lemmy-ml-u-pfefferle.json' ), true );
 			return json_decode( $fixture['body'], true );
-		}
-
-		return $pre;
-	}
-
-	/**
-	 * Filters remote metadata by actor.
-	 *
-	 * @param array|string $pre   The pre-filtered value.
-	 * @param string       $actor The actor.
-	 * @return array|string
-	 */
-	public static function pre_get_remote_metadata_by_actor( $pre, $actor ) {
-		$actor = ltrim( $actor, '@' );
-
-		if ( isset( self::$actors[ $actor ] ) ) {
-			return self::$actors[ $actor ];
 		}
 
 		return $pre;


### PR DESCRIPTION
## Proposed changes:

Refactors the Mention class to use the newer `Remote_Actors` collection instead of the deprecated `get_remote_metadata_by_actor()` function.

This change:
- Modernizes the mention detection code to use `Remote_Actors::fetch_by_acct()`
- Uses the Actor object API for accessing actor properties
- Removes duplicate caching logic from `Http::get_remote_object()` (now handled in `Http::get()`)
- Updates tests to use the new `activitypub_pre_http_get_remote_object` filter

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* All existing mention tests pass (18 tests, 26 assertions)
* Run `npm run env-test -- --filter=Test_Mention` to verify mention detection works correctly
* Verify PHPCS standards check passes with `composer lint`
* Test @-mentions in posts to ensure they are properly converted to links

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [x] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [ ] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Improve performance and reliability of @-mention detection.

</details>