### PR TITLE
Remove invalid activitypub from NodeInfo services arrays

### DIFF
--- a/.github/changelog/2603-from-description
+++ b/.github/changelog/2603-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix NodeInfo documents to comply with schema specification.

--- a/includes/rest/class-nodeinfo-controller.php
+++ b/includes/rest/class-nodeinfo-controller.php
@@ -52,7 +52,7 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<version>\d\.\d)',
 			array(
-				'args' => array(
+				'args'   => array(
 					'version' => array(
 						'description' => 'The version of the NodeInfo schema.',
 						'type'        => 'string',
@@ -64,6 +64,7 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => '__return_true',
 				),
+				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
 	}
@@ -175,5 +176,175 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 		 * @param string $version  The NodeInfo version.
 		 */
 		return \apply_filters( 'nodeinfo_data', $nodeinfo, $version );
+	}
+
+	/**
+	 * Retrieves the NodeInfo schema, conforming to JSON Schema.
+	 *
+	 * @return array NodeInfo schema data.
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'nodeinfo',
+			'type'       => 'object',
+			'properties' => array(
+				'version'           => array(
+					'description' => 'The version of the NodeInfo schema.',
+					'type'        => 'string',
+					'enum'        => array( '2.0', '2.1' ),
+				),
+				'software'          => array(
+					'description' => 'Information about the software.',
+					'type'        => 'object',
+					'properties'  => array(
+						'name'       => array(
+							'description' => 'The canonical name of this server software.',
+							'type'        => 'string',
+						),
+						'version'    => array(
+							'description' => 'The version of this server software.',
+							'type'        => 'string',
+						),
+						'homepage'   => array(
+							'description' => 'The url of the homepage of this server software.',
+							'type'        => 'string',
+							'format'      => 'uri',
+						),
+						'repository' => array(
+							'description' => 'The url of the source code repository of this server software.',
+							'type'        => 'string',
+							'format'      => 'uri',
+						),
+					),
+				),
+				'protocols'         => array(
+					'description' => 'The protocols supported on this server.',
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'string',
+						'enum' => array(
+							'activitypub',
+							'buddycloud',
+							'dfrn',
+							'diaspora',
+							'libertree',
+							'ostatus',
+							'pumpio',
+							'tent',
+							'xmpp',
+							'zot',
+						),
+					),
+				),
+				'services'          => array(
+					'description' => 'The third party sites this server can connect to via their application API.',
+					'type'        => 'object',
+					'properties'  => array(
+						'inbound'  => array(
+							'description' => 'The third party sites this server can retrieve messages from for combined display with regular traffic.',
+							'type'        => 'array',
+							'items'       => array(
+								'type' => 'string',
+								'enum' => array(
+									'atom1.0',
+									'gnusocial',
+									'imap',
+									'pnut',
+									'pop3',
+									'pumpio',
+									'rss2.0',
+									'twitter',
+								),
+							),
+						),
+						'outbound' => array(
+							'description' => 'The third party sites this server can publish messages to on the behalf of a user.',
+							'type'        => 'array',
+							'items'       => array(
+								'type' => 'string',
+								'enum' => array(
+									'atom1.0',
+									'blogger',
+									'buddycloud',
+									'diaspora',
+									'dreamwidth',
+									'drupal',
+									'facebook',
+									'friendica',
+									'gnusocial',
+									'google',
+									'insanejournal',
+									'libertree',
+									'linkedin',
+									'livejournal',
+									'mediagoblin',
+									'myspace',
+									'pinterest',
+									'pnut',
+									'posterous',
+									'pumpio',
+									'redmatrix',
+									'rss2.0',
+									'smtp',
+									'tent',
+									'tumblr',
+									'twitter',
+									'wordpress',
+									'xmpp',
+								),
+							),
+						),
+					),
+				),
+				'openRegistrations' => array(
+					'description' => 'Whether this server allows open self-registration.',
+					'type'        => 'boolean',
+				),
+				'usage'             => array(
+					'description' => 'Usage statistics for this server.',
+					'type'        => 'object',
+					'properties'  => array(
+						'users'         => array(
+							'description' => 'Statistics about the users of this server.',
+							'type'        => 'object',
+							'properties'  => array(
+								'total'          => array(
+									'description' => 'The total amount of on this server registered users.',
+									'type'        => 'integer',
+									'minimum'     => 0,
+								),
+								'activeMonth'    => array(
+									'description' => 'The amount of users that signed in at least once in the last 30 days.',
+									'type'        => 'integer',
+									'minimum'     => 0,
+								),
+								'activeHalfyear' => array(
+									'description' => 'The amount of users that signed in at least once in the last 180 days.',
+									'type'        => 'integer',
+									'minimum'     => 0,
+								),
+							),
+						),
+						'localPosts'    => array(
+							'description' => 'The amount of posts that were made by users that are registered on this server.',
+							'type'        => 'integer',
+							'minimum'     => 0,
+						),
+						'localComments' => array(
+							'description' => 'The amount of comments that were made by users that are registered on this server.',
+							'type'        => 'integer',
+							'minimum'     => 0,
+						),
+					),
+				),
+				'metadata'          => array(
+					'description' => 'Free form key value pairs for software specific values.',
+					'type'        => 'object',
+				),
+			),
+		);
+
+		return $schema;
 	}
 }

--- a/includes/rest/class-nodeinfo-controller.php
+++ b/includes/rest/class-nodeinfo-controller.php
@@ -184,7 +184,7 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 	 * @return array NodeInfo schema data.
 	 */
 	public function get_item_schema() {
-		$schema = array(
+		return array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'nodeinfo',
 			'type'       => 'object',
@@ -344,7 +344,5 @@ class Nodeinfo_Controller extends \WP_REST_Controller {
 				),
 			),
 		);
-
-		return $schema;
 	}
 }

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -75,9 +75,6 @@ class Nodeinfo {
 		$nodeinfo['metadata']['federation']    = array( 'enabled' => true );
 		$nodeinfo['metadata']['staffAccounts'] = self::get_staff();
 
-		$nodeinfo['services']['inbound'][]  = 'activitypub';
-		$nodeinfo['services']['outbound'][] = 'activitypub';
-
 		return $nodeinfo;
 	}
 

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -66,6 +66,15 @@ class Nodeinfo {
 
 		$nodeinfo['protocols'][] = 'activitypub';
 
+		$nodeinfo['services']['inbound']  = array_merge(
+			$nodeinfo['services']['inbound'],
+			array( 'gnusocial' )
+		);
+		$nodeinfo['services']['outbound'] = array_merge(
+			$nodeinfo['services']['outbound'],
+			array( 'friendica', 'gnusocial', 'mediagoblin', 'wordpress' )
+		);
+
 		$nodeinfo['usage']['users'] = array(
 			'total'          => get_total_users(),
 			'activeMonth'    => get_active_users(),


### PR DESCRIPTION
Fixes #2600

## Proposed changes:

Removes `activitypub` from the NodeInfo `services.inbound` and `services.outbound` arrays, as it is not a valid service value according to the NodeInfo 2.0 and 2.1 schemas.

ActivityPub is correctly listed in the `protocols` array, which is the appropriate place for it. The `services` arrays should only contain platform names like 'twitter', 'facebook', 'diaspora', etc., according to the schema specification.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Existing tests continue to pass. No new tests needed as this is removing invalid data.

## Testing instructions:

* Visit `/.well-known/nodeinfo` on a site with the plugin active
* Follow the `href` links for NodeInfo 2.0 and 2.1 documents  
* Validate the returned JSON against the schemas at https://github.com/jhass/nodeinfo/tree/main/schemas
* Verify the documents now pass schema validation
* Confirm `activitypub` is present in the `protocols` array but not in `services.inbound` or `services.outbound`

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [x] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Fix NodeInfo documents to comply with schema specification.

</details>