### PR TITLE
Cache expensive operations in Post transformer

### DIFF
--- a/.github/changelog/2604-from-description
+++ b/.github/changelog/2604-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cache expensive operations in Post transformer to improve performance.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -364,7 +364,9 @@ class Post extends Base {
 		$max_media = (int) \apply_filters( 'activitypub_max_image_attachments', $max_media );
 
 		if ( 0 === $max_media ) {
-			return array();
+			$this->attachment = array();
+
+			return $this->attachment;
 		}
 
 		$media = array(

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -42,6 +42,48 @@ class Post extends Base {
 	private $actor_object = null;
 
 	/**
+	 * The content.
+	 *
+	 * @var string|false False indicates not yet computed.
+	 */
+	private $content = false;
+
+	/**
+	 * The summary.
+	 *
+	 * @var string|null|false False indicates not yet computed.
+	 */
+	private $summary = false;
+
+	/**
+	 * The tags.
+	 *
+	 * @var array|false False indicates not yet computed.
+	 */
+	private $tags = false;
+
+	/**
+	 * The attachment.
+	 *
+	 * @var array|false False indicates not yet computed.
+	 */
+	private $attachment = false;
+
+	/**
+	 * The mentions.
+	 *
+	 * @var array|false False indicates not yet computed.
+	 */
+	private $mentions = false;
+
+	/**
+	 * The in_reply_to.
+	 *
+	 * @var string|array|null|false False indicates not yet computed.
+	 */
+	private $in_reply_to = false;
+
+	/**
 	 * Transforms the WP_Post object to an ActivityPub Object
 	 *
 	 * @return \Activitypub\Activity\Base_Object The ActivityPub Object
@@ -290,12 +332,18 @@ class Post extends Base {
 	 * @return array The Attachments.
 	 */
 	protected function get_attachment() {
+		if ( false !== $this->attachment ) {
+			return $this->attachment;
+		}
+
 		/*
 		 * Remove attachments from the Fediverse if a post was federated and then set back to draft.
 		 * Except in preview mode, where we want to show attachments.
 		 */
 		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
-			return array();
+			$this->attachment = array();
+
+			return $this->attachment;
 		}
 
 		$max_media = \get_post_meta( $this->item->ID, 'activitypub_max_image_attachments', true );
@@ -363,7 +411,9 @@ class Post extends Base {
 		 *
 		 * @return array The filtered attachments.
 		 */
-		return \apply_filters( 'activitypub_attachments', $attachments, $this->item );
+		$this->attachment = \apply_filters( 'activitypub_attachments', $attachments, $this->item );
+
+		return $this->attachment;
 	}
 
 	/**
@@ -381,14 +431,10 @@ class Post extends Base {
 			return \ucfirst( $post_format_setting );
 		}
 
-		$has_title = \post_type_supports( $this->item->post_type, 'title' );
-		$content   = \wp_strip_all_tags( $this->item->post_content );
-
 		// Check if the post has a title.
 		if (
-			! $has_title ||
-			! $this->item->post_title ||
-			\strlen( $content ) <= ACTIVITYPUB_NOTE_LENGTH
+			! \post_type_supports( $this->item->post_type, 'title' ) ||
+			! $this->item->post_title
 		) {
 			return 'Note';
 		}
@@ -430,6 +476,10 @@ class Post extends Base {
 	 * @return array The list of Tags.
 	 */
 	protected function get_tag() {
+		if ( false !== $this->tags ) {
+			return $this->tags;
+		}
+
 		$tags = parent::get_tag();
 
 		$post_tags = \get_the_tags( $this->item->ID );
@@ -448,7 +498,9 @@ class Post extends Base {
 			}
 		}
 
-		return \array_unique( $tags, SORT_REGULAR );
+		$this->tags = \array_unique( $tags, SORT_REGULAR );
+
+		return $this->tags;
 	}
 
 	/**
@@ -464,12 +516,20 @@ class Post extends Base {
 			return null;
 		}
 
-		// Remove Teaser from drafts.
-		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
-			return \__( '(This post is being modified)', 'activitypub' );
+		if ( false !== $this->summary ) {
+			return $this->summary;
 		}
 
-		return generate_post_summary( $this->item );
+		// Remove Teaser from drafts.
+		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
+			$this->summary = \__( '(This post is being modified)', 'activitypub' );
+
+			return $this->summary;
+		}
+
+		$this->summary = generate_post_summary( $this->item );
+
+		return $this->summary;
 	}
 
 	/**
@@ -509,6 +569,10 @@ class Post extends Base {
 		// Remove Content from drafts.
 		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
 			return \__( '(This post is being modified)', 'activitypub' );
+		}
+
+		if ( false !== $this->content ) {
+			return $this->content;
 		}
 
 		global $post;
@@ -551,7 +615,9 @@ class Post extends Base {
 		 * @param string   $content The transformed post content.
 		 * @param \WP_Post $post    The post object being transformed.
 		 */
-		return \apply_filters( 'activitypub_the_content', $content, $post );
+		$this->content = \apply_filters( 'activitypub_the_content', $content, $post );
+
+		return $this->content;
 	}
 
 	/**
@@ -578,8 +644,13 @@ class Post extends Base {
 	 * @return string|array|null The in-reply-to URL of the post.
 	 */
 	protected function get_in_reply_to() {
+		if ( false !== $this->in_reply_to ) {
+			return $this->in_reply_to;
+		}
+
 		if ( ! site_supports_blocks() ) {
-			return null;
+			$this->in_reply_to = null;
+			return $this->in_reply_to;
 		}
 
 		$reply_urls = array();
@@ -596,14 +667,17 @@ class Post extends Base {
 		}
 
 		if ( empty( $reply_urls ) ) {
-			return null;
+			$this->in_reply_to = null;
+			return $this->in_reply_to;
 		}
 
 		if ( 1 === count( $reply_urls ) ) {
-			return \current( $reply_urls );
+			$this->in_reply_to = \current( $reply_urls );
+			return $this->in_reply_to;
 		}
 
-		return \array_values( \array_unique( $reply_urls ) );
+		$this->in_reply_to = \array_values( \array_unique( $reply_urls ) );
+		return $this->in_reply_to;
 	}
 
 	/**
@@ -639,6 +713,10 @@ class Post extends Base {
 	 * @return array The list of @-Mentions.
 	 */
 	protected function get_mentions() {
+		if ( false !== $this->mentions ) {
+			return $this->mentions;
+		}
+
 		/**
 		 * Filter the mentions in the post content.
 		 *
@@ -648,12 +726,14 @@ class Post extends Base {
 		 *
 		 * @return array The filtered mentions.
 		 */
-		return apply_filters(
+		$this->mentions = apply_filters(
 			'activitypub_extract_mentions',
 			array(),
 			$this->item->post_content . ' ' . $this->item->post_excerpt,
 			$this->item
 		);
+
+		return $this->mentions;
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -432,10 +432,7 @@ class Post extends Base {
 		}
 
 		// Check if the post has a title.
-		if (
-			! \post_type_supports( $this->item->post_type, 'title' ) ||
-			! $this->item->post_title
-		) {
+		if ( ! \post_type_supports( $this->item->post_type, 'title' ) || ! $this->item->post_title ) {
 			return 'Note';
 		}
 
@@ -566,12 +563,14 @@ class Post extends Base {
 	 * @return string The content.
 	 */
 	protected function get_content() {
-		// Remove Content from drafts.
-		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
-			return \__( '(This post is being modified)', 'activitypub' );
+		if ( false !== $this->content ) {
+			return $this->content;
 		}
 
-		if ( false !== $this->content ) {
+		// Remove Content from drafts.
+		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
+			$this->content = \__( '(This post is being modified)', 'activitypub' );
+
 			return $this->content;
 		}
 
@@ -668,15 +667,18 @@ class Post extends Base {
 
 		if ( empty( $reply_urls ) ) {
 			$this->in_reply_to = null;
+
 			return $this->in_reply_to;
 		}
 
 		if ( 1 === count( $reply_urls ) ) {
 			$this->in_reply_to = \current( $reply_urls );
+
 			return $this->in_reply_to;
 		}
 
 		$this->in_reply_to = \array_values( \array_unique( $reply_urls ) );
+
 		return $this->in_reply_to;
 	}
 

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -112,8 +112,8 @@ class Test_Post extends \WP_UnitTestCase {
 					'post_content' => 'Short content',
 				),
 				null,
-				'Note',
-				'Should return Note for short content',
+				'Article',
+				'Should return Article for short content with title',
 			),
 			'no_title'             => array(
 				array(

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -426,7 +426,9 @@ class Test_Post extends \WP_UnitTestCase {
 
 		\delete_post_meta( $post_id, 'activitypub_max_image_attachments' );
 
-		$result = $method->invoke( $transformer );
+		// Create a new transformer instance to avoid cached attachment result.
+		$transformer = new Post( $post );
+		$result      = $method->invoke( $transformer );
 		$this->assertTrue( (bool) \did_filter( 'activitypub_attachment_ids' ) );
 	}
 


### PR DESCRIPTION
## Proposed changes:

This PR adds caching for expensive operations in the Post transformer to improve performance by avoiding redundant computation during object serialization.

**Cached properties:**
* content: Processed ActivityPub content with shortcodes and filters
* summary: Post summary/excerpt
* tags: Post tags including hashtags
* attachment: Post attachments
* mentions: Extracted mentions from content
* in_reply_to: Reply-to URLs from reply blocks

All cached properties use `false` as a sentinel value to indicate "not yet computed", providing a consistent pattern across all properties and correctly handling nullable return values.

**Content length check removed:**
The content length check in `get_type()` has been removed due to inconsistent usage. Previously, the type determination would sometimes use raw content and sometimes use processed content depending on call order, leading to unpredictable behavior. The type is now determined solely based on post format, title support, and post type.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Checkout the branch
2. Run the test suite: `npx wp-env run tests-cli -- /var/www/html/wp-content/plugins/activitypub/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/activitypub/phpunit.xml.dist`
3. Verify all 1443 tests pass
4. Test creating ActivityPub posts to ensure content, tags, and attachments are correctly generated
5. Verify performance improvement when accessing Post transformer properties multiple times
6. Confirm that short posts with titles are now correctly identified as Articles (not Notes based on length)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Cache expensive operations in Post transformer to improve performance.

</details>