### PR TITLE
Use stable term_id-based IDs for Term transformer

### DIFF
--- a/.github/changelog/2605-from-description
+++ b/.github/changelog/2605-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use stable term_id-based IDs for Term transformer to ensure federation consistency.

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -198,6 +198,14 @@ class Query {
 			}
 		}
 
+		// Check Term by ID.
+		if ( ! $queried_object ) {
+			$term_id = \get_query_var( 'term_id' );
+			if ( $term_id ) {
+				$queried_object = \get_term( $term_id );
+			}
+		}
+
 		// Try to get Author by ID.
 		if ( ! $queried_object ) {
 			$url       = $this->get_request_url();

--- a/includes/class-router.php
+++ b/includes/class-router.php
@@ -262,6 +262,28 @@ class Router {
 			\wp_safe_redirect( $actor->get_url(), 301 );
 			exit;
 		}
+
+		$term_id = \get_query_var( 'term_id', null );
+		if ( $term_id ) {
+			$term = \get_term( $term_id );
+
+			// Load a 404-page if `term_id` is set but not valid.
+			if ( ! $term || \is_wp_error( $term ) ) {
+				$wp_query->set_404();
+				return;
+			}
+
+			// Don't redirect for ActivityPub requests.
+			if ( is_activitypub_request() ) {
+				return;
+			}
+
+			$term_link = \get_term_link( $term );
+			if ( ! \is_wp_error( $term_link ) ) {
+				\wp_safe_redirect( $term_link, 301 );
+				exit;
+			}
+		}
 	}
 
 	/**
@@ -280,6 +302,7 @@ class Router {
 		$vars[] = 'type';
 		$vars[] = 'c';
 		$vars[] = 'p';
+		$vars[] = 'term_id';
 
 		return $vars;
 	}

--- a/includes/transformer/class-term.php
+++ b/includes/transformer/class-term.php
@@ -22,17 +22,45 @@ class Term extends Base {
 		$base_object               = new \Activitypub\Activity\Base_Object();
 		$base_object->{'@context'} = 'https://www.w3.org/ns/activitystreams';
 		$base_object->set_type( 'OrderedCollection' );
-		$base_object->set_id( \get_term_link( $this->item ) );
+		$base_object->set_id( $this->get_id() );
+		$base_object->set_url( $this->get_url() );
 
 		return $base_object;
 	}
 
 	/**
-	 * Get the OrderedCollection ID (term link).
+	 * Get the OrderedCollection ID.
 	 *
-	 * @return string The OrderedCollection ID (term link).
+	 * @return string The OrderedCollection ID.
 	 */
 	public function to_id() {
-		return \get_term_link( $this->item );
+		return $this->get_id();
+	}
+
+	/**
+	 * Returns the stable ID of the Term.
+	 *
+	 * Uses term_id query parameter to ensure the ID remains stable
+	 * even if the term slug is changed.
+	 *
+	 * @return string The Term's stable ID.
+	 */
+	public function get_id() {
+		return \add_query_arg( 'term_id', $this->item->term_id, \home_url( '/' ) );
+	}
+
+	/**
+	 * Returns the URL of the Term.
+	 *
+	 * @return string The Term's URL (term link).
+	 */
+	public function get_url() {
+		$term_link = \get_term_link( $this->item );
+
+		if ( \is_wp_error( $term_link ) ) {
+			return '';
+		}
+
+		return \esc_url( $term_link );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-query.php
+++ b/tests/phpunit/tests/includes/class-test-query.php
@@ -170,6 +170,32 @@ class Test_Query extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_queried_object with term_id query var.
+	 *
+	 * @covers ::get_queried_object
+	 */
+	public function test_get_queried_object_with_term_id() {
+		// Create a test term.
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'post_tag',
+				'name'     => 'Test Tag',
+				'slug'     => 'test-tag',
+			)
+		);
+
+		// Test with term_id query var.
+		Query::get_instance()->__destruct();
+		$this->go_to( \add_query_arg( 'term_id', $term->term_id, \home_url( '/' ) ) );
+		\set_query_var( 'term_id', $term->term_id );
+		$query  = Query::get_instance();
+		$object = $query->get_queried_object();
+
+		$this->assertInstanceOf( 'WP_Term', $object );
+		$this->assertEquals( $term->term_id, $object->term_id );
+	}
+
+	/**
 	 * Test is_activitypub_request method.
 	 *
 	 * @covers ::is_activitypub_request

--- a/tests/phpunit/tests/includes/transformer/class-test-term.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-term.php
@@ -71,9 +71,13 @@ class Test_Term extends \WP_UnitTestCase {
 		// Check type is OrderedCollection.
 		$this->assertEquals( 'OrderedCollection', $object->get_type() );
 
-		// Check ID is the term link.
+		// Check ID uses stable term_id-based URL.
+		$expected_id = \add_query_arg( 'term_id', $term->term_id, \home_url( '/' ) );
+		$this->assertEquals( $expected_id, $object->get_id() );
+
+		// Check URL is the term link.
 		$expected_url = get_term_link( $term );
-		$this->assertEquals( $expected_url, $object->get_id() );
+		$this->assertEquals( $expected_url, $object->get_url() );
 	}
 
 	/**
@@ -86,13 +90,43 @@ class Test_Term extends \WP_UnitTestCase {
 		$transformer = new Term( $term );
 		$id          = $transformer->to_id();
 
-		// Should return the term link.
+		// Should return stable term_id-based URL.
+		$expected_id = \add_query_arg( 'term_id', $term->term_id, \home_url( '/' ) );
+		$this->assertEquals( $expected_id, $id );
+	}
+
+	/**
+	 * Test get_id returns stable ID.
+	 *
+	 * @covers ::get_id
+	 */
+	public function test_get_id() {
+		$term        = get_term( self::$term_id );
+		$transformer = new Term( $term );
+
+		$expected_id = \add_query_arg( 'term_id', $term->term_id, \home_url( '/' ) );
+		$this->assertEquals( $expected_id, $transformer->get_id() );
+	}
+
+	/**
+	 * Test get_url returns term link.
+	 *
+	 * @covers ::get_url
+	 */
+	public function test_get_url() {
+		$term        = get_term( self::$term_id );
+		$transformer = new Term( $term );
+
 		$expected_url = get_term_link( $term );
-		$this->assertEquals( $expected_url, $id );
+		$this->assertEquals( $expected_url, $transformer->get_url() );
 	}
 
 	/**
 	 * Test with category taxonomy.
+	 *
+	 * @covers ::to_object
+	 * @covers ::get_id
+	 * @covers ::get_url
 	 */
 	public function test_category_term() {
 		$category = self::factory()->term->create_and_get(
@@ -107,6 +141,12 @@ class Test_Term extends \WP_UnitTestCase {
 		$object      = $transformer->to_object();
 
 		$this->assertEquals( 'OrderedCollection', $object->get_type() );
-		$this->assertEquals( get_term_link( $category ), $object->get_id() );
+
+		// ID should use stable term_id-based URL.
+		$expected_id = \add_query_arg( 'term_id', $category->term_id, \home_url( '/' ) );
+		$this->assertEquals( $expected_id, $object->get_id() );
+
+		// URL should be the term link.
+		$this->assertEquals( get_term_link( $category ), $object->get_url() );
 	}
 }


### PR DESCRIPTION
Fixes #2598

## Summary

This PR implements stable ActivityPub IDs for terms by using `?term_id=X` URLs instead of slug-based term links. This ensures that changing a term's slug doesn't break federation, as the ActivityPub ID remains constant.

## Proposed changes:

* Add `get_id()` method to Term transformer returning stable `?term_id=X` URL
* Add `get_url()` method returning human-readable term link (e.g., `/tag/my-tag/`)
* Update `to_object()` to set both `id` (stable) and `url` (human-readable) properties
* Add `term_id` query variable resolution in Query class
* Add redirect logic in Router for non-ActivityPub requests to term archive URL
* Register `term_id` as query variable

This ensures term IDs remain stable even when term slugs are changed, which is critical for federation consistency. Similar to how posts use `?p=123` for stable IDs.

### Behavior:
- **ActivityPub requests** to `?term_id=123` → Returns ActivityPub OrderedCollection object
- **Browser requests** to `?term_id=123` → 301 redirect to `/tag/my-tag/` (canonical term URL)
- **Invalid term_id** → 404 page

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create a tag (e.g., "Test Tag" with slug `test-tag`)
2. Note the term_id from the database or URL
3. Visit `/?term_id={id}` in browser → should redirect to `/tag/test-tag/`
4. Request `/?term_id={id}` with ActivityPub Accept header → should return OrderedCollection JSON
5. Change the tag slug to something else (e.g., `renamed-tag`)
6. The ActivityPub ID (`/?term_id={id}`) remains the same, preserving federation

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Use stable term_id-based IDs for Term transformer to ensure federation consistency.

</details>