### PR TITLE
Skip downloading video and audio attachments

### DIFF
--- a/.github/changelog/fix-skip-video-audio-sideload
+++ b/.github/changelog/fix-skip-video-audio-sideload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Skip downloading video and audio attachments, embedding remote URLs directly to avoid storage limits.

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -483,6 +483,9 @@ class Attachments {
 	/**
 	 * Save a file directly to uploads/activitypub/{type}/{id}/.
 	 *
+	 * For video and audio files, returns the remote URL directly without downloading
+	 * to avoid storage overhead for large media files.
+	 *
 	 * @param array  $attachment_data The normalized attachment data.
 	 * @param int    $object_id       The post or comment ID to attach to.
 	 * @param string $object_type     The object type ('post' or 'comment').
@@ -490,12 +493,23 @@ class Attachments {
 	 * @return array|\WP_Error {
 	 *     Array of file data on success, WP_Error on failure.
 	 *
-	 *     @type string $url       Full URL to the saved file.
+	 *     @type string $url       Full URL to the saved file (or remote URL for video/audio).
 	 *     @type string $mime_type MIME type of the file.
 	 *     @type string $alt       Alt text from attachment name field.
 	 * }
 	 */
 	private static function save_file( $attachment_data, $object_id, $object_type ) {
+		$mime_type = $attachment_data['mediaType'] ?? '';
+
+		// Skip download for video and audio files - use remote URL directly.
+		if ( str_starts_with( $mime_type, 'video/' ) || str_starts_with( $mime_type, 'audio/' ) ) {
+			return array(
+				'url'       => $attachment_data['url'],
+				'mime_type' => $attachment_data['mediaType'],
+				'alt'       => $attachment_data['name'] ?? '',
+			);
+		}
+
 		if ( ! \function_exists( 'download_url' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -664,4 +664,136 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( '?', $result[0]['url'] );
 		$this->assertStringNotContainsString( 'size=', $result[0]['url'] );
 	}
+
+	/**
+	 * Test that video attachments use remote URL directly without downloading.
+	 *
+	 * @covers ::save_file
+	 */
+	public function test_video_uses_remote_url() {
+		// Create a test post.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'ap_post',
+				'post_content' => 'Test video content',
+			)
+		);
+
+		$attachments = array(
+			array(
+				'url'       => 'https://example.com/video.mp4',
+				'mediaType' => 'video/mp4',
+				'name'      => 'Test Video',
+				'type'      => 'Video',
+			),
+		);
+
+		$result = Attachments::import_post_files( $attachments, $post_id );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+
+		// Verify the URL is the original remote URL (not downloaded).
+		$this->assertEquals( 'https://example.com/video.mp4', $result[0]['url'] );
+		$this->assertEquals( 'video/mp4', $result[0]['mime_type'] );
+		$this->assertEquals( 'Test Video', $result[0]['alt'] );
+
+		// Verify content was updated with video block.
+		$post = get_post( $post_id );
+		$this->assertStringContainsString( '<!-- wp:video', $post->post_content );
+		$this->assertStringContainsString( 'https://example.com/video.mp4', $post->post_content );
+	}
+
+	/**
+	 * Test that audio attachments use remote URL directly without downloading.
+	 *
+	 * @covers ::save_file
+	 */
+	public function test_audio_uses_remote_url() {
+		// Create a test post.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'ap_post',
+				'post_content' => 'Test audio content',
+			)
+		);
+
+		$attachments = array(
+			array(
+				'url'       => 'https://example.com/podcast.mp3',
+				'mediaType' => 'audio/mpeg',
+				'name'      => 'Test Audio',
+				'type'      => 'Audio',
+			),
+		);
+
+		$result = Attachments::import_post_files( $attachments, $post_id );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+
+		// Verify the URL is the original remote URL (not downloaded).
+		$this->assertEquals( 'https://example.com/podcast.mp3', $result[0]['url'] );
+		$this->assertEquals( 'audio/mpeg', $result[0]['mime_type'] );
+		$this->assertEquals( 'Test Audio', $result[0]['alt'] );
+
+		// Verify content was updated with audio block.
+		$post = get_post( $post_id );
+		$this->assertStringContainsString( '<!-- wp:audio', $post->post_content );
+		$this->assertStringContainsString( 'https://example.com/podcast.mp3', $post->post_content );
+	}
+
+	/**
+	 * Test mixed attachments with images, video, and audio.
+	 *
+	 * @covers ::import_post_files
+	 * @covers ::save_file
+	 */
+	public function test_mixed_attachments_images_video_audio() {
+		// Create a test post.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'ap_post',
+				'post_content' => 'Mixed media content',
+			)
+		);
+
+		$attachments = array(
+			array(
+				'url'       => 'https://example.com/image.jpg',
+				'mediaType' => 'image/jpeg',
+				'name'      => 'Test Image',
+				'type'      => 'Image',
+			),
+			array(
+				'url'       => 'https://example.com/video.mp4',
+				'mediaType' => 'video/mp4',
+				'name'      => 'Test Video',
+				'type'      => 'Video',
+			),
+			array(
+				'url'       => 'https://example.com/audio.mp3',
+				'mediaType' => 'audio/mpeg',
+				'name'      => 'Test Audio',
+				'type'      => 'Audio',
+			),
+		);
+
+		$result = Attachments::import_post_files( $attachments, $post_id );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 3, $result );
+
+		// Image should be downloaded to local storage.
+		$this->assertStringContainsString( 'activitypub/ap_posts', $result[0]['url'] );
+		$this->assertEquals( 'image/jpeg', $result[0]['mime_type'] );
+
+		// Video should use remote URL.
+		$this->assertEquals( 'https://example.com/video.mp4', $result[1]['url'] );
+		$this->assertEquals( 'video/mp4', $result[1]['mime_type'] );
+
+		// Audio should use remote URL.
+		$this->assertEquals( 'https://example.com/audio.mp3', $result[2]['url'] );
+		$this->assertEquals( 'audio/mpeg', $result[2]['mime_type'] );
+	}
 }


### PR DESCRIPTION
## Proposed changes:
* When processing incoming ActivityPub attachments, skip downloading video and audio files and instead embed the remote URLs directly.
* This avoids downloading large media files that could exceed storage limits on the server.
* Images continue to be downloaded and stored locally as before.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Receive a federated post that includes a video or audio attachment.
2. Verify the video/audio block in the post content uses the original remote URL instead of a local copy.
3. Verify images in federated posts are still downloaded and stored locally.

### Changelog entry

Changelog entry added via `.github/changelog/fix-skip-video-audio-sideload`.