### PR TITLE
Add image optimization for imported attachments

### DIFF
--- a/.github/changelog/2609-from-description
+++ b/.github/changelog/2609-from-description
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: added
 
 Add image optimization for imported attachments (resize to 1200px max, convert to WebP).

--- a/.github/changelog/2609-from-description
+++ b/.github/changelog/2609-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add image optimization for imported attachments (resize to 1200px max, convert to WebP).

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -643,13 +643,21 @@ class Attachments {
 		// Check if WebP is supported.
 		$can_webp = $editor->supports_mime_type( 'image/webp' );
 
-		// Determine output format.
+		// Determine output format and save.
 		if ( $can_webp ) {
+			// Convert to WebP.
 			$new_path = \preg_replace( '/\.[^.]+$/', '.webp', $file_path );
 			$result   = $editor->save( $new_path, 'image/webp' );
 		} elseif ( \in_array( $mime_type, array( 'image/png', 'image/webp' ), true ) ) {
 			// Keep original format for potentially transparent images when WebP not available.
-			$result = $needs_resize ? $editor->save( $file_path ) : true;
+			if ( ! $needs_resize ) {
+				// No changes needed.
+				return array(
+					'path'    => $file_path,
+					'changed' => false,
+				);
+			}
+			$result = $editor->save( $file_path );
 		} else {
 			// Convert to JPEG when WebP not available.
 			$new_path = \preg_replace( '/\.[^.]+$/', '.jpg', $file_path );
@@ -663,18 +671,17 @@ class Attachments {
 			);
 		}
 
-		// If format changed, delete the original.
-		if ( is_array( $result ) && isset( $result['path'] ) && $result['path'] !== $file_path ) {
+		// Handle result - $result is always an array from $editor->save().
+		$result_path = $result['path'] ?? $file_path;
+
+		// If path changed (format conversion), delete the original file.
+		if ( $result_path !== $file_path ) {
 			\wp_delete_file( $file_path );
-			return array(
-				'path'    => $result['path'],
-				'changed' => true,
-			);
 		}
 
 		return array(
-			'path'    => $file_path,
-			'changed' => $needs_resize,
+			'path'    => $result_path,
+			'changed' => true,
 		);
 	}
 

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -452,7 +452,7 @@ class Attachments {
 		}
 
 		// Optimize images before sideloading (resize and convert to WebP).
-		$optimized = self::optimize_image( $tmp_file );
+		$optimized = self::optimize_image( $tmp_file, self::MAX_IMAGE_DIMENSION );
 		if ( $optimized['changed'] ) {
 			$tmp_file = $optimized['path'];
 		}
@@ -578,7 +578,7 @@ class Attachments {
 		}
 
 		// Optimize images (resize and convert to WebP).
-		$optimized = self::optimize_image( $file_path );
+		$optimized = self::optimize_image( $file_path, self::MAX_IMAGE_DIMENSION );
 		if ( $optimized['changed'] ) {
 			$file_path = $optimized['path'];
 			$file_name = \basename( $file_path );
@@ -601,11 +601,12 @@ class Attachments {
 	 * Uses WordPress image editor to resize large images and convert them
 	 * to WebP format for better compression while maintaining quality.
 	 *
-	 * @param string $file_path Path to the image file.
+	 * @param string $file_path     Path to the image file.
+	 * @param int    $max_dimension Maximum width/height in pixels.
 	 *
 	 * @return array{path: string, changed: bool}|\WP_Error The optimized file path and whether it changed, or WP_Error.
 	 */
-	private static function optimize_image( $file_path ) {
+	private static function optimize_image( $file_path, $max_dimension ) {
 		// Check if it's an image.
 		$mime_type = \wp_check_filetype( $file_path )['type'] ?? '';
 		if ( ! $mime_type || ! \str_starts_with( $mime_type, 'image/' ) ) {
@@ -631,9 +632,8 @@ class Attachments {
 			);
 		}
 
-		$size          = $editor->get_size();
-		$max_dimension = self::MAX_IMAGE_DIMENSION;
-		$needs_resize  = $size['width'] > $max_dimension || $size['height'] > $max_dimension;
+		$size         = $editor->get_size();
+		$needs_resize = $size['width'] > $max_dimension || $size['height'] > $max_dimension;
 
 		// Resize if needed.
 		if ( $needs_resize ) {

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -427,13 +427,14 @@ class Attachments {
 			require_once ABSPATH . 'wp-admin/includes/image.php';
 		}
 
+		// Initialize filesystem.
+		\WP_Filesystem();
+		global $wp_filesystem;
+
 		$is_local = ! preg_match( '#^https?://#i', $attachment_data['url'] );
 
 		if ( $is_local ) {
 			// Read local file from disk.
-			\WP_Filesystem();
-			global $wp_filesystem;
-
 			if ( ! $wp_filesystem->exists( $attachment_data['url'] ) ) {
 				/* translators: %s: file path */
 				return new \WP_Error( 'file_not_found', sprintf( \__( 'File not found: %s', 'activitypub' ), $attachment_data['url'] ) );
@@ -451,18 +452,24 @@ class Attachments {
 			}
 		}
 
-		// Optimize images before sideloading (resize and convert to WebP).
-		$optimized = self::optimize_image( $tmp_file, self::MAX_IMAGE_DIMENSION );
-		if ( $optimized['changed'] ) {
-			$tmp_file = $optimized['path'];
-		}
-
-		// Prepare file array for WordPress.
+		// Get original filename from URL.
 		$original_name = \basename( \wp_parse_url( $attachment_data['url'], PHP_URL_PATH ) );
 
-		// Update filename extension if format changed.
-		if ( $optimized['changed'] ) {
-			$new_ext       = \pathinfo( $tmp_file, PATHINFO_EXTENSION );
+		// Rename temp file to have proper extension for optimize_image to detect mime type.
+		$original_ext = \pathinfo( $original_name, PATHINFO_EXTENSION );
+		if ( $original_ext ) {
+			$renamed_tmp = $tmp_file . '.' . $original_ext;
+			if ( $wp_filesystem->move( $tmp_file, $renamed_tmp, true ) ) {
+				$tmp_file = $renamed_tmp;
+			}
+		}
+
+		// Optimize images before sideloading (resize and convert to WebP).
+		$tmp_file = self::optimize_image( $tmp_file, self::MAX_IMAGE_DIMENSION );
+
+		// Update filename extension to match optimized file.
+		$new_ext = \pathinfo( $tmp_file, PATHINFO_EXTENSION );
+		if ( $new_ext ) {
 			$original_name = \preg_replace( '/\.[^.]+$/', '.' . $new_ext, $original_name );
 		}
 
@@ -472,14 +479,12 @@ class Attachments {
 		);
 
 		// Prepare attachment post data.
-		// Clear mime type if format changed so WordPress auto-detects it.
-		$mime_type = $optimized['changed'] ? '' : ( $attachment_data['mediaType'] ?? '' );
+		// Let WordPress auto-detect the mime type from the file.
 		$post_data = array(
-			'post_mime_type' => $mime_type,
-			'post_title'     => $attachment_data['name'] ?? '',
-			'post_content'   => $attachment_data['name'] ?? '',
-			'post_author'    => $author_id,
-			'meta_input'     => array(
+			'post_title'   => $attachment_data['name'] ?? '',
+			'post_content' => $attachment_data['name'] ?? '',
+			'post_author'  => $author_id,
+			'meta_input'   => array(
 				'_source_url' => $attachment_data['url'],
 			),
 		);
@@ -579,11 +584,8 @@ class Attachments {
 		}
 
 		// Optimize images (resize and convert to WebP).
-		$optimized = self::optimize_image( $file_path, $max_dimension );
-		if ( $optimized['changed'] ) {
-			$file_path = $optimized['path'];
-			$file_name = \basename( $file_path );
-		}
+		$file_path = self::optimize_image( $file_path, $max_dimension );
+		$file_name = \basename( $file_path );
 
 		// Get mime type and validate file.
 		$file_info = \wp_check_filetype_and_ext( $file_path, $file_name );
@@ -597,6 +599,32 @@ class Attachments {
 	}
 
 	/**
+	 * Get a unique file path by appending a counter if the file already exists.
+	 *
+	 * @param string $file_path The desired file path.
+	 *
+	 * @return string A unique file path that doesn't exist.
+	 */
+	private static function get_unique_path( $file_path ) {
+		if ( ! \file_exists( $file_path ) ) {
+			return $file_path;
+		}
+
+		$path_info = \pathinfo( $file_path );
+		$dir       = $path_info['dirname'];
+		$base_name = $path_info['filename'];
+		$extension = isset( $path_info['extension'] ) ? '.' . $path_info['extension'] : '';
+		$counter   = 1;
+
+		do {
+			$new_path = $dir . '/' . $base_name . '-' . $counter . $extension;
+			++$counter;
+		} while ( \file_exists( $new_path ) );
+
+		return $new_path;
+	}
+
+	/**
 	 * Optimize an image file by resizing and converting to WebP.
 	 *
 	 * Uses WordPress image editor to resize large images and convert them
@@ -605,32 +633,23 @@ class Attachments {
 	 * @param string $file_path     Path to the image file.
 	 * @param int    $max_dimension Maximum width/height in pixels.
 	 *
-	 * @return array{path: string, changed: bool}|\WP_Error The optimized file path and whether it changed, or WP_Error.
+	 * @return string The optimized file path.
 	 */
 	private static function optimize_image( $file_path, $max_dimension ) {
 		// Check if it's an image.
 		$mime_type = \wp_check_filetype( $file_path )['type'] ?? '';
 		if ( ! $mime_type || ! \str_starts_with( $mime_type, 'image/' ) ) {
-			return array(
-				'path'    => $file_path,
-				'changed' => false,
-			);
+			return $file_path;
 		}
 
 		// Skip SVG and GIF files (GIFs may be animated).
 		if ( \in_array( $mime_type, array( 'image/svg+xml', 'image/gif' ), true ) ) {
-			return array(
-				'path'    => $file_path,
-				'changed' => false,
-			);
+			return $file_path;
 		}
 
 		$editor = \wp_get_image_editor( $file_path );
 		if ( \is_wp_error( $editor ) ) {
-			return array(
-				'path'    => $file_path,
-				'changed' => false,
-			);
+			return $file_path;
 		}
 
 		$size         = $editor->get_size();
@@ -647,29 +666,23 @@ class Attachments {
 		// Determine output format and save.
 		if ( $can_webp ) {
 			// Convert to WebP.
-			$new_path = \preg_replace( '/\.[^.]+$/', '.webp', $file_path );
+			$new_path = self::get_unique_path( \preg_replace( '/\.[^.]+$/', '.webp', $file_path ) );
 			$result   = $editor->save( $new_path, 'image/webp' );
 		} elseif ( \in_array( $mime_type, array( 'image/png', 'image/webp' ), true ) ) {
 			// Keep original format for potentially transparent images when WebP not available.
 			if ( ! $needs_resize ) {
 				// No changes needed.
-				return array(
-					'path'    => $file_path,
-					'changed' => false,
-				);
+				return $file_path;
 			}
 			$result = $editor->save( $file_path );
 		} else {
 			// Convert to JPEG when WebP not available.
-			$new_path = \preg_replace( '/\.[^.]+$/', '.jpg', $file_path );
+			$new_path = self::get_unique_path( \preg_replace( '/\.[^.]+$/', '.jpg', $file_path ) );
 			$result   = $editor->save( $new_path, 'image/jpeg' );
 		}
 
 		if ( \is_wp_error( $result ) ) {
-			return array(
-				'path'    => $file_path,
-				'changed' => false,
-			);
+			return $file_path;
 		}
 
 		// Handle result - $result is always an array from $editor->save().
@@ -680,10 +693,7 @@ class Attachments {
 			\wp_delete_file( $file_path );
 		}
 
-		return array(
-			'path'    => $result_path,
-			'changed' => true,
-		);
+		return $result_path;
 	}
 
 	/**

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -28,6 +28,13 @@ class Attachments {
 	public static $comments_dir = '/activitypub/comments/';
 
 	/**
+	 * Maximum width for imported images.
+	 *
+	 * @var int
+	 */
+	const MAX_IMAGE_DIMENSION = 1200;
+
+	/**
 	 * Initialize the class and set up filters.
 	 */
 	public static function init() {
@@ -444,15 +451,31 @@ class Attachments {
 			}
 		}
 
+		// Optimize images before sideloading (resize and convert to WebP).
+		$optimized = self::optimize_image( $tmp_file );
+		if ( $optimized['changed'] ) {
+			$tmp_file = $optimized['path'];
+		}
+
 		// Prepare file array for WordPress.
+		$original_name = \basename( \wp_parse_url( $attachment_data['url'], PHP_URL_PATH ) );
+
+		// Update filename extension if format changed.
+		if ( $optimized['changed'] ) {
+			$new_ext       = \pathinfo( $tmp_file, PATHINFO_EXTENSION );
+			$original_name = \preg_replace( '/\.[^.]+$/', '.' . $new_ext, $original_name );
+		}
+
 		$file_array = array(
-			'name'     => \basename( \wp_parse_url( $attachment_data['url'], PHP_URL_PATH ) ),
+			'name'     => $original_name,
 			'tmp_name' => $tmp_file,
 		);
 
 		// Prepare attachment post data.
+		// Clear mime type if format changed so WordPress auto-detects it.
+		$mime_type = $optimized['changed'] ? '' : ( $attachment_data['mediaType'] ?? '' );
 		$post_data = array(
-			'post_mime_type' => $attachment_data['mediaType'] ?? '',
+			'post_mime_type' => $mime_type,
 			'post_title'     => $attachment_data['name'] ?? '',
 			'post_content'   => $attachment_data['name'] ?? '',
 			'post_author'    => $author_id,
@@ -463,8 +486,8 @@ class Attachments {
 
 		// Add alt text for images.
 		if ( ! empty( $attachment_data['name'] ) ) {
-			$mime_type = $attachment_data['mediaType'] ?? '';
-			if ( 'image' === strtok( $mime_type, '/' ) ) {
+			$original_mime = $attachment_data['mediaType'] ?? '';
+			if ( 'image' === strtok( $original_mime, '/' ) ) {
 				$post_data['meta_input']['_wp_attachment_image_alt'] = $attachment_data['name'];
 			}
 		}
@@ -554,6 +577,13 @@ class Attachments {
 			return new \WP_Error( 'file_move_failed', \__( 'Failed to move file to destination.', 'activitypub' ) );
 		}
 
+		// Optimize images (resize and convert to WebP).
+		$optimized = self::optimize_image( $file_path );
+		if ( $optimized['changed'] ) {
+			$file_path = $optimized['path'];
+			$file_name = \basename( $file_path );
+		}
+
 		// Get mime type and validate file.
 		$file_info = \wp_check_filetype_and_ext( $file_path, $file_name );
 		$mime_type = $file_info['type'] ?? $attachment_data['mediaType'] ?? '';
@@ -562,6 +592,89 @@ class Attachments {
 			'url'       => $paths['baseurl'] . '/' . $file_name,
 			'mime_type' => $mime_type,
 			'alt'       => $attachment_data['name'] ?? '',
+		);
+	}
+
+	/**
+	 * Optimize an image file by resizing and converting to WebP.
+	 *
+	 * Uses WordPress image editor to resize large images and convert them
+	 * to WebP format for better compression while maintaining quality.
+	 *
+	 * @param string $file_path Path to the image file.
+	 *
+	 * @return array{path: string, changed: bool}|\WP_Error The optimized file path and whether it changed, or WP_Error.
+	 */
+	private static function optimize_image( $file_path ) {
+		// Check if it's an image.
+		$mime_type = \wp_check_filetype( $file_path )['type'] ?? '';
+		if ( ! $mime_type || ! \str_starts_with( $mime_type, 'image/' ) ) {
+			return array(
+				'path'    => $file_path,
+				'changed' => false,
+			);
+		}
+
+		// Skip SVG and GIF files (GIFs may be animated).
+		if ( \in_array( $mime_type, array( 'image/svg+xml', 'image/gif' ), true ) ) {
+			return array(
+				'path'    => $file_path,
+				'changed' => false,
+			);
+		}
+
+		$editor = \wp_get_image_editor( $file_path );
+		if ( \is_wp_error( $editor ) ) {
+			return array(
+				'path'    => $file_path,
+				'changed' => false,
+			);
+		}
+
+		$size          = $editor->get_size();
+		$max_dimension = self::MAX_IMAGE_DIMENSION;
+		$needs_resize  = $size['width'] > $max_dimension || $size['height'] > $max_dimension;
+
+		// Resize if needed.
+		if ( $needs_resize ) {
+			$editor->resize( $max_dimension, $max_dimension, false );
+		}
+
+		// Check if WebP is supported.
+		$can_webp = $editor->supports_mime_type( 'image/webp' );
+
+		// Determine output format.
+		if ( $can_webp ) {
+			$new_path = \preg_replace( '/\.[^.]+$/', '.webp', $file_path );
+			$result   = $editor->save( $new_path, 'image/webp' );
+		} elseif ( \in_array( $mime_type, array( 'image/png', 'image/webp' ), true ) ) {
+			// Keep original format for potentially transparent images when WebP not available.
+			$result = $needs_resize ? $editor->save( $file_path ) : true;
+		} else {
+			// Convert to JPEG when WebP not available.
+			$new_path = \preg_replace( '/\.[^.]+$/', '.jpg', $file_path );
+			$result   = $editor->save( $new_path, 'image/jpeg' );
+		}
+
+		if ( \is_wp_error( $result ) ) {
+			return array(
+				'path'    => $file_path,
+				'changed' => false,
+			);
+		}
+
+		// If format changed, delete the original.
+		if ( is_array( $result ) && isset( $result['path'] ) && $result['path'] !== $file_path ) {
+			\wp_delete_file( $file_path );
+			return array(
+				'path'    => $result['path'],
+				'changed' => true,
+			);
+		}
+
+		return array(
+			'path'    => $file_path,
+			'changed' => $needs_resize,
 		);
 	}
 

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -512,6 +512,7 @@ class Attachments {
 	 * @param array  $attachment_data The normalized attachment data.
 	 * @param int    $object_id       The post or comment ID to attach to.
 	 * @param string $object_type     The object type ('post' or 'comment').
+	 * @param int    $max_dimension   Optional. Maximum image dimension in pixels. Default MAX_IMAGE_DIMENSION.
 	 *
 	 * @return array|\WP_Error {
 	 *     Array of file data on success, WP_Error on failure.
@@ -521,7 +522,7 @@ class Attachments {
 	 *     @type string $alt       Alt text from attachment name field.
 	 * }
 	 */
-	private static function save_file( $attachment_data, $object_id, $object_type ) {
+	private static function save_file( $attachment_data, $object_id, $object_type, $max_dimension = self::MAX_IMAGE_DIMENSION ) {
 		$mime_type = $attachment_data['mediaType'] ?? '';
 
 		// Skip download for video and audio files - use remote URL directly.
@@ -578,7 +579,7 @@ class Attachments {
 		}
 
 		// Optimize images (resize and convert to WebP).
-		$optimized = self::optimize_image( $file_path, self::MAX_IMAGE_DIMENSION );
+		$optimized = self::optimize_image( $file_path, $max_dimension );
 		if ( $optimized['changed'] ) {
 			$file_path = $optimized['path'];
 			$file_name = \basename( $file_path );

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -801,4 +801,245 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$this->assertEquals( 'https://example.com/audio.mp3', $result[2]['url'] );
 		$this->assertEquals( 'audio/mpeg', $result[2]['mime_type'] );
 	}
+
+	/**
+	 * Test optimize_image returns original path for non-image files.
+	 *
+	 * @covers ::optimize_image
+	 */
+	public function test_optimize_image_skips_non_images() {
+		$method = new \ReflectionMethod( Attachments::class, 'optimize_image' );
+		$method->setAccessible( true );
+
+		// Test with audio file.
+		$audio_file = AP_TESTS_DIR . '/data/assets/sample-audio.mp3';
+		$result     = $method->invoke( null, $audio_file, 1200 );
+		$this->assertEquals( $audio_file, $result );
+
+		// Test with video file.
+		$video_file = AP_TESTS_DIR . '/data/assets/sample-video.mp4';
+		$result     = $method->invoke( null, $video_file, 1200 );
+		$this->assertEquals( $video_file, $result );
+	}
+
+	/**
+	 * Test optimize_image skips GIF files (may be animated).
+	 *
+	 * @covers ::optimize_image
+	 */
+	public function test_optimize_image_skips_gif() {
+		$method = new \ReflectionMethod( Attachments::class, 'optimize_image' );
+		$method->setAccessible( true );
+
+		// Create a simple GIF file.
+		$gif_file = wp_tempnam( 'test.gif' ) . '.gif';
+		// Minimal valid GIF89a header.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Test data, not obfuscation.
+		$gif_data = base64_decode( 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test file creation.
+		file_put_contents( $gif_file, $gif_data );
+
+		$result = $method->invoke( null, $gif_file, 1200 );
+		$this->assertEquals( $gif_file, $result );
+
+		// Clean up.
+		wp_delete_file( $gif_file );
+	}
+
+	/**
+	 * Test optimize_image converts JPEG to WebP when supported.
+	 *
+	 * @covers ::optimize_image
+	 */
+	public function test_optimize_image_converts_to_webp() {
+		$method = new \ReflectionMethod( Attachments::class, 'optimize_image' );
+		$method->setAccessible( true );
+
+		// Copy test image to temp location with proper extension.
+		$source    = AP_TESTS_DIR . '/data/assets/test.jpg';
+		$temp_dir  = sys_get_temp_dir();
+		$temp_file = $temp_dir . '/test-webp-' . uniqid() . '.jpg';
+		copy( $source, $temp_file );
+
+		$result = $method->invoke( null, $temp_file, 1200 );
+
+		// Check if WebP is supported in this environment.
+		$editor = wp_get_image_editor( $source );
+		if ( ! is_wp_error( $editor ) && $editor->supports_mime_type( 'image/webp' ) ) {
+			// Should be converted to WebP.
+			$this->assertStringEndsWith( '.webp', $result );
+			$this->assertFileExists( $result );
+			// Clean up result file.
+			wp_delete_file( $result );
+			// Clean up original if it still exists (shouldn't, but be safe).
+			if ( file_exists( $temp_file ) ) {
+				wp_delete_file( $temp_file );
+			}
+		} else {
+			// WebP not supported, should convert to JPEG or keep original.
+			$this->assertFileExists( $result );
+			wp_delete_file( $result );
+			if ( file_exists( $temp_file ) ) {
+				wp_delete_file( $temp_file );
+			}
+		}
+	}
+
+	/**
+	 * Test optimize_image resizes large images.
+	 *
+	 * @covers ::optimize_image
+	 */
+	public function test_optimize_image_resizes_large_images() {
+		$method = new \ReflectionMethod( Attachments::class, 'optimize_image' );
+		$method->setAccessible( true );
+
+		// Create a large test image (2000x2000).
+		$large_image = wp_tempnam( 'large.jpg' ) . '.jpg';
+		$image       = imagecreatetruecolor( 2000, 2000 );
+		$white       = imagecolorallocate( $image, 255, 255, 255 );
+		imagefill( $image, 0, 0, $white );
+		imagejpeg( $image, $large_image, 90 );
+		imagedestroy( $image );
+
+		// Optimize with max dimension of 500.
+		$result = $method->invoke( null, $large_image, 500 );
+
+		$this->assertFileExists( $result );
+
+		// Check the dimensions of the result.
+		$editor = wp_get_image_editor( $result );
+		if ( ! is_wp_error( $editor ) ) {
+			$size = $editor->get_size();
+			$this->assertLessThanOrEqual( 500, $size['width'] );
+			$this->assertLessThanOrEqual( 500, $size['height'] );
+		}
+
+		// Clean up.
+		wp_delete_file( $result );
+		if ( file_exists( $large_image ) ) {
+			wp_delete_file( $large_image );
+		}
+	}
+
+	/**
+	 * Test optimize_image preserves small images dimensions.
+	 *
+	 * @covers ::optimize_image
+	 */
+	public function test_optimize_image_preserves_small_images() {
+		$method = new \ReflectionMethod( Attachments::class, 'optimize_image' );
+		$method->setAccessible( true );
+
+		// Copy small test image (100x100) to temp location.
+		$source    = AP_TESTS_DIR . '/data/assets/test.jpg';
+		$temp_file = wp_tempnam( 'small.jpg' ) . '.jpg';
+		copy( $source, $temp_file );
+
+		// Get original dimensions.
+		$original_editor = wp_get_image_editor( $temp_file );
+		$this->assertNotWPError( $original_editor );
+		$original_size = $original_editor->get_size();
+
+		// Optimize with max dimension larger than image.
+		$result = $method->invoke( null, $temp_file, 1200 );
+
+		$this->assertFileExists( $result );
+
+		// Check dimensions are preserved.
+		$result_editor = wp_get_image_editor( $result );
+		if ( ! is_wp_error( $result_editor ) ) {
+			$result_size = $result_editor->get_size();
+			$this->assertEquals( $original_size['width'], $result_size['width'] );
+			$this->assertEquals( $original_size['height'], $result_size['height'] );
+		}
+
+		// Clean up.
+		wp_delete_file( $result );
+		if ( file_exists( $temp_file ) ) {
+			wp_delete_file( $temp_file );
+		}
+	}
+
+	/**
+	 * Test optimize_image returns original for non-existent file.
+	 *
+	 * @covers ::optimize_image
+	 */
+	public function test_optimize_image_handles_nonexistent_file() {
+		$method = new \ReflectionMethod( Attachments::class, 'optimize_image' );
+		$method->setAccessible( true );
+
+		$fake_path = '/tmp/nonexistent-image-12345.jpg';
+		$result    = $method->invoke( null, $fake_path, 1200 );
+
+		// Should return original path when file doesn't exist or can't be processed.
+		$this->assertEquals( $fake_path, $result );
+	}
+
+	/**
+	 * Test optimize_image handles PNG files correctly.
+	 *
+	 * @covers ::optimize_image
+	 */
+	public function test_optimize_image_handles_png() {
+		$method = new \ReflectionMethod( Attachments::class, 'optimize_image' );
+		$method->setAccessible( true );
+
+		// Create a test PNG image.
+		$png_file = wp_tempnam( 'test.png' ) . '.png';
+		$image    = imagecreatetruecolor( 100, 100 );
+		// Enable alpha channel for transparency.
+		imagesavealpha( $image, true );
+		$transparent = imagecolorallocatealpha( $image, 0, 0, 0, 127 );
+		imagefill( $image, 0, 0, $transparent );
+		imagepng( $image, $png_file );
+		imagedestroy( $image );
+
+		$result = $method->invoke( null, $png_file, 1200 );
+
+		$this->assertFileExists( $result );
+
+		// Check if WebP is supported.
+		$editor = wp_get_image_editor( $png_file );
+		if ( ! is_wp_error( $editor ) && $editor->supports_mime_type( 'image/webp' ) ) {
+			// Should be converted to WebP.
+			$this->assertStringEndsWith( '.webp', $result );
+		}
+
+		// Clean up.
+		wp_delete_file( $result );
+		if ( file_exists( $png_file ) ) {
+			wp_delete_file( $png_file );
+		}
+	}
+
+	/**
+	 * Test get_unique_path generates unique filenames.
+	 *
+	 * @covers ::get_unique_path
+	 */
+	public function test_get_unique_path() {
+		$method = new \ReflectionMethod( Attachments::class, 'get_unique_path' );
+		$method->setAccessible( true );
+
+		$temp_dir = sys_get_temp_dir();
+
+		// Test with non-existent file - should return same path.
+		$non_existent = $temp_dir . '/unique-test-' . uniqid() . '.jpg';
+		$result       = $method->invoke( null, $non_existent );
+		$this->assertEquals( $non_existent, $result );
+
+		// Test with existing file - should return path with counter.
+		$existing_file = wp_tempnam( 'existing.jpg' ) . '.jpg';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test file creation.
+		file_put_contents( $existing_file, 'test' );
+
+		$result = $method->invoke( null, $existing_file );
+		$this->assertNotEquals( $existing_file, $result );
+		$this->assertStringContainsString( '-1.jpg', $result );
+
+		// Clean up.
+		wp_delete_file( $existing_file );
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -481,8 +481,11 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$attachments = \get_attached_media( '', $post_id );
 		$this->assertCount( 3, $attachments ); // shared.jpg, inline-only.jpg, attachment-only.jpg.
 
-		// Verify image block was added for attachment-only.jpg (single images use standalone blocks).
-		$this->assertStringContainsString( '<!-- wp:image', $post->post_content );
+		// Verify image block or gallery was added for attachment-only.jpg.
+		$this->assertTrue(
+			str_contains( $post->post_content, '<!-- wp:image' ) || str_contains( $post->post_content, '<!-- wp:gallery' ),
+			'Expected image or gallery block in post content'
+		);
 	}
 
 	/**
@@ -624,8 +627,9 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$this->assertIsInt( $result[0] );
 
 		// Verify the attachment filename is clean without query parameters.
+		// Note: Image may be converted to WebP during optimization.
 		$attachment_file = get_attached_file( $result[0] );
-		$this->assertStringEndsWith( '.jpg', $attachment_file );
+		$this->assertMatchesRegularExpression( '/\.(jpg|webp)$/', $attachment_file );
 		$this->assertStringNotContainsString( '?', $attachment_file );
 		$this->assertStringNotContainsString( 'stp=', $attachment_file );
 		$this->assertStringNotContainsString( 'nc_cat=', $attachment_file );
@@ -660,7 +664,8 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$this->assertCount( 1, $result );
 
 		// Verify the URL doesn't contain query parameters.
-		$this->assertStringEndsWith( '.png', $result[0]['url'] );
+		// Note: Image may be converted to WebP during optimization.
+		$this->assertMatchesRegularExpression( '/\.(png|webp)$/', $result[0]['url'] );
 		$this->assertStringNotContainsString( '?', $result[0]['url'] );
 		$this->assertStringNotContainsString( 'size=', $result[0]['url'] );
 	}

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -789,9 +789,9 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertCount( 3, $result );
 
-		// Image should be downloaded to local storage.
+		// Image should be downloaded to local storage (may be converted to WebP).
 		$this->assertStringContainsString( 'activitypub/ap_posts', $result[0]['url'] );
-		$this->assertEquals( 'image/jpeg', $result[0]['mime_type'] );
+		$this->assertContains( $result[0]['mime_type'], array( 'image/jpeg', 'image/webp' ) );
 
 		// Video should use remote URL.
 		$this->assertEquals( 'https://example.com/video.mp4', $result[1]['url'] );


### PR DESCRIPTION
## Proposed changes:

* Add automatic image optimization for imported ActivityPub attachments to reduce file sizes
* Resize large images to max 1200px dimension while maintaining aspect ratio
* Convert images to WebP format when supported by the server (falls back to JPEG when not)
* Skip GIFs (may be animated) and SVGs (vector graphics) to preserve their special properties

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Existing tests were updated to handle the new WebP conversion behavior.

## Testing instructions:

* Set up a local WordPress environment with wp-env
* Have another ActivityPub-enabled instance (like Mastodon) post an image larger than 1200px
* Follow that account and receive the post
* Check the imported image in `wp-content/uploads/activitypub/` - it should be:
  * Resized to max 1200px on the longest edge
  * Converted to WebP format (or JPEG if WebP not supported)
  * Significantly smaller file size than the original

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add image optimization for imported attachments (resize to 1200px max, convert to WebP).

</details>