### PR TITLE
Add local caching for remote actor avatars

### DIFF
--- a/.github/changelog/2609-from-description
+++ b/.github/changelog/2609-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add image optimization for imported attachments (resize to 1200px max, convert to WebP).

--- a/.github/changelog/2609-from-description
+++ b/.github/changelog/2609-from-description
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add image optimization for imported attachments (resize to 1200px max, convert to WebP).

--- a/.github/changelog/2610-from-description
+++ b/.github/changelog/2610-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add local caching for remote actor avatars.

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -670,13 +670,21 @@ class Attachments {
 		// Check if WebP is supported.
 		$can_webp = $editor->supports_mime_type( 'image/webp' );
 
-		// Determine output format.
+		// Determine output format and save.
 		if ( $can_webp ) {
+			// Convert to WebP.
 			$new_path = \preg_replace( '/\.[^.]+$/', '.webp', $file_path );
 			$result   = $editor->save( $new_path, 'image/webp' );
 		} elseif ( \in_array( $mime_type, array( 'image/png', 'image/webp' ), true ) ) {
 			// Keep original format for potentially transparent images when WebP not available.
-			$result = $needs_resize ? $editor->save( $file_path ) : true;
+			if ( ! $needs_resize ) {
+				// No changes needed.
+				return array(
+					'path'    => $file_path,
+					'changed' => false,
+				);
+			}
+			$result = $editor->save( $file_path );
 		} else {
 			// Convert to JPEG when WebP not available.
 			$new_path = \preg_replace( '/\.[^.]+$/', '.jpg', $file_path );
@@ -690,18 +698,17 @@ class Attachments {
 			);
 		}
 
-		// If format changed, delete the original.
-		if ( is_array( $result ) && isset( $result['path'] ) && $result['path'] !== $file_path ) {
+		// Handle result - $result is always an array from $editor->save().
+		$result_path = $result['path'] ?? $file_path;
+
+		// If path changed (format conversion), delete the original file.
+		if ( $result_path !== $file_path ) {
 			\wp_delete_file( $file_path );
-			return array(
-				'path'    => $result['path'],
-				'changed' => true,
-			);
 		}
 
 		return array(
-			'path'    => $file_path,
-			'changed' => $needs_resize,
+			'path'    => $result_path,
+			'changed' => true,
 		);
 	}
 

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -454,13 +454,14 @@ class Attachments {
 			require_once ABSPATH . 'wp-admin/includes/image.php';
 		}
 
+		// Initialize filesystem.
+		\WP_Filesystem();
+		global $wp_filesystem;
+
 		$is_local = ! preg_match( '#^https?://#i', $attachment_data['url'] );
 
 		if ( $is_local ) {
 			// Read local file from disk.
-			\WP_Filesystem();
-			global $wp_filesystem;
-
 			if ( ! $wp_filesystem->exists( $attachment_data['url'] ) ) {
 				/* translators: %s: file path */
 				return new \WP_Error( 'file_not_found', sprintf( \__( 'File not found: %s', 'activitypub' ), $attachment_data['url'] ) );
@@ -478,18 +479,24 @@ class Attachments {
 			}
 		}
 
-		// Optimize images before sideloading (resize and convert to WebP).
-		$optimized = self::optimize_image( $tmp_file, self::MAX_IMAGE_DIMENSION );
-		if ( $optimized['changed'] ) {
-			$tmp_file = $optimized['path'];
-		}
-
-		// Prepare file array for WordPress.
+		// Get original filename from URL.
 		$original_name = \basename( \wp_parse_url( $attachment_data['url'], PHP_URL_PATH ) );
 
-		// Update filename extension if format changed.
-		if ( $optimized['changed'] ) {
-			$new_ext       = \pathinfo( $tmp_file, PATHINFO_EXTENSION );
+		// Rename temp file to have proper extension for optimize_image to detect mime type.
+		$original_ext = \pathinfo( $original_name, PATHINFO_EXTENSION );
+		if ( $original_ext ) {
+			$renamed_tmp = $tmp_file . '.' . $original_ext;
+			if ( $wp_filesystem->move( $tmp_file, $renamed_tmp, true ) ) {
+				$tmp_file = $renamed_tmp;
+			}
+		}
+
+		// Optimize images before sideloading (resize and convert to WebP).
+		$tmp_file = self::optimize_image( $tmp_file, self::MAX_IMAGE_DIMENSION );
+
+		// Update filename extension to match optimized file.
+		$new_ext = \pathinfo( $tmp_file, PATHINFO_EXTENSION );
+		if ( $new_ext ) {
 			$original_name = \preg_replace( '/\.[^.]+$/', '.' . $new_ext, $original_name );
 		}
 
@@ -499,14 +506,12 @@ class Attachments {
 		);
 
 		// Prepare attachment post data.
-		// Clear mime type if format changed so WordPress auto-detects it.
-		$mime_type = $optimized['changed'] ? '' : ( $attachment_data['mediaType'] ?? '' );
+		// Let WordPress auto-detect the mime type from the file.
 		$post_data = array(
-			'post_mime_type' => $mime_type,
-			'post_title'     => $attachment_data['name'] ?? '',
-			'post_content'   => $attachment_data['name'] ?? '',
-			'post_author'    => $author_id,
-			'meta_input'     => array(
+			'post_title'   => $attachment_data['name'] ?? '',
+			'post_content' => $attachment_data['name'] ?? '',
+			'post_author'  => $author_id,
+			'meta_input'   => array(
 				'_source_url' => $attachment_data['url'],
 			),
 		);
@@ -606,11 +611,8 @@ class Attachments {
 		}
 
 		// Optimize images (resize and convert to WebP).
-		$optimized = self::optimize_image( $file_path, $max_dimension );
-		if ( $optimized['changed'] ) {
-			$file_path = $optimized['path'];
-			$file_name = \basename( $file_path );
-		}
+		$file_path = self::optimize_image( $file_path, $max_dimension );
+		$file_name = \basename( $file_path );
 
 		// Get mime type and validate file.
 		$file_info = \wp_check_filetype_and_ext( $file_path, $file_name );
@@ -624,6 +626,32 @@ class Attachments {
 	}
 
 	/**
+	 * Get a unique file path by appending a counter if the file already exists.
+	 *
+	 * @param string $file_path The desired file path.
+	 *
+	 * @return string A unique file path that doesn't exist.
+	 */
+	private static function get_unique_path( $file_path ) {
+		if ( ! \file_exists( $file_path ) ) {
+			return $file_path;
+		}
+
+		$path_info = \pathinfo( $file_path );
+		$dir       = $path_info['dirname'];
+		$base_name = $path_info['filename'];
+		$extension = isset( $path_info['extension'] ) ? '.' . $path_info['extension'] : '';
+		$counter   = 1;
+
+		do {
+			$new_path = $dir . '/' . $base_name . '-' . $counter . $extension;
+			++$counter;
+		} while ( \file_exists( $new_path ) );
+
+		return $new_path;
+	}
+
+	/**
 	 * Optimize an image file by resizing and converting to WebP.
 	 *
 	 * Uses WordPress image editor to resize large images and convert them
@@ -632,32 +660,23 @@ class Attachments {
 	 * @param string $file_path     Path to the image file.
 	 * @param int    $max_dimension Maximum width/height in pixels.
 	 *
-	 * @return array{path: string, changed: bool}|\WP_Error The optimized file path and whether it changed, or WP_Error.
+	 * @return string The optimized file path.
 	 */
 	private static function optimize_image( $file_path, $max_dimension ) {
 		// Check if it's an image.
 		$mime_type = \wp_check_filetype( $file_path )['type'] ?? '';
 		if ( ! $mime_type || ! \str_starts_with( $mime_type, 'image/' ) ) {
-			return array(
-				'path'    => $file_path,
-				'changed' => false,
-			);
+			return $file_path;
 		}
 
 		// Skip SVG and GIF files (GIFs may be animated).
 		if ( \in_array( $mime_type, array( 'image/svg+xml', 'image/gif' ), true ) ) {
-			return array(
-				'path'    => $file_path,
-				'changed' => false,
-			);
+			return $file_path;
 		}
 
 		$editor = \wp_get_image_editor( $file_path );
 		if ( \is_wp_error( $editor ) ) {
-			return array(
-				'path'    => $file_path,
-				'changed' => false,
-			);
+			return $file_path;
 		}
 
 		$size         = $editor->get_size();
@@ -674,29 +693,23 @@ class Attachments {
 		// Determine output format and save.
 		if ( $can_webp ) {
 			// Convert to WebP.
-			$new_path = \preg_replace( '/\.[^.]+$/', '.webp', $file_path );
+			$new_path = self::get_unique_path( \preg_replace( '/\.[^.]+$/', '.webp', $file_path ) );
 			$result   = $editor->save( $new_path, 'image/webp' );
 		} elseif ( \in_array( $mime_type, array( 'image/png', 'image/webp' ), true ) ) {
 			// Keep original format for potentially transparent images when WebP not available.
 			if ( ! $needs_resize ) {
 				// No changes needed.
-				return array(
-					'path'    => $file_path,
-					'changed' => false,
-				);
+				return $file_path;
 			}
 			$result = $editor->save( $file_path );
 		} else {
 			// Convert to JPEG when WebP not available.
-			$new_path = \preg_replace( '/\.[^.]+$/', '.jpg', $file_path );
+			$new_path = self::get_unique_path( \preg_replace( '/\.[^.]+$/', '.jpg', $file_path ) );
 			$result   = $editor->save( $new_path, 'image/jpeg' );
 		}
 
 		if ( \is_wp_error( $result ) ) {
-			return array(
-				'path'    => $file_path,
-				'changed' => false,
-			);
+			return $file_path;
 		}
 
 		// Handle result - $result is always an array from $editor->save().
@@ -707,10 +720,7 @@ class Attachments {
 			\wp_delete_file( $file_path );
 		}
 
-		return array(
-			'path'    => $result_path,
-			'changed' => true,
-		);
+		return $result_path;
 	}
 
 	/**

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -479,7 +479,7 @@ class Attachments {
 		}
 
 		// Optimize images before sideloading (resize and convert to WebP).
-		$optimized = self::optimize_image( $tmp_file );
+		$optimized = self::optimize_image( $tmp_file, self::MAX_IMAGE_DIMENSION );
 		if ( $optimized['changed'] ) {
 			$tmp_file = $optimized['path'];
 		}
@@ -605,7 +605,7 @@ class Attachments {
 		}
 
 		// Optimize images (resize and convert to WebP).
-		$optimized = self::optimize_image( $file_path );
+		$optimized = self::optimize_image( $file_path, self::MAX_IMAGE_DIMENSION );
 		if ( $optimized['changed'] ) {
 			$file_path = $optimized['path'];
 			$file_name = \basename( $file_path );
@@ -628,11 +628,12 @@ class Attachments {
 	 * Uses WordPress image editor to resize large images and convert them
 	 * to WebP format for better compression while maintaining quality.
 	 *
-	 * @param string $file_path Path to the image file.
+	 * @param string $file_path     Path to the image file.
+	 * @param int    $max_dimension Maximum width/height in pixels.
 	 *
 	 * @return array{path: string, changed: bool}|\WP_Error The optimized file path and whether it changed, or WP_Error.
 	 */
-	private static function optimize_image( $file_path ) {
+	private static function optimize_image( $file_path, $max_dimension ) {
 		// Check if it's an image.
 		$mime_type = \wp_check_filetype( $file_path )['type'] ?? '';
 		if ( ! $mime_type || ! \str_starts_with( $mime_type, 'image/' ) ) {
@@ -658,9 +659,8 @@ class Attachments {
 			);
 		}
 
-		$size          = $editor->get_size();
-		$max_dimension = self::MAX_IMAGE_DIMENSION;
-		$needs_resize  = $size['width'] > $max_dimension || $size['height'] > $max_dimension;
+		$size         = $editor->get_size();
+		$needs_resize = $size['width'] > $max_dimension || $size['height'] > $max_dimension;
 
 		// Resize if needed.
 		if ( $needs_resize ) {

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -8,6 +8,7 @@
 namespace Activitypub;
 
 use Activitypub\Collection\Posts;
+use Activitypub\Collection\Remote_Actors;
 
 /**
  * Attachments processor class.
@@ -28,6 +29,13 @@ class Attachments {
 	public static $comments_dir = '/activitypub/comments/';
 
 	/**
+	 * Directory for storing actor avatar files.
+	 *
+	 * @var string
+	 */
+	public static $actors_dir = '/activitypub/actors/';
+
+	/**
 	 * Maximum width for imported images.
 	 *
 	 * @var int
@@ -35,10 +43,18 @@ class Attachments {
 	const MAX_IMAGE_DIMENSION = 1200;
 
 	/**
+	 * Maximum width for actor avatars.
+	 *
+	 * @var int
+	 */
+	const MAX_AVATAR_DIMENSION = 512;
+
+	/**
 	 * Initialize the class and set up filters.
 	 */
 	public static function init() {
 		\add_action( 'before_delete_post', array( self::class, 'delete_ap_posts_directory' ) );
+		\add_action( 'before_delete_post', array( self::class, 'delete_actors_directory' ) );
 	}
 
 	/**
@@ -207,7 +223,18 @@ class Attachments {
 	 */
 	private static function get_storage_paths( $object_id, $object_type ) {
 		$upload_dir = \wp_upload_dir();
-		$sub_dir    = 'comment' === $object_type ? self::$comments_dir : self::$ap_posts_dir;
+
+		switch ( $object_type ) {
+			case 'comment':
+				$sub_dir = self::$comments_dir;
+				break;
+			case 'actor':
+				$sub_dir = self::$actors_dir;
+				break;
+			default:
+				$sub_dir = self::$ap_posts_dir;
+				break;
+		}
 
 		return array(
 			'basedir' => $upload_dir['basedir'] . $sub_dir . $object_id,
@@ -427,14 +454,13 @@ class Attachments {
 			require_once ABSPATH . 'wp-admin/includes/image.php';
 		}
 
-		// Initialize filesystem.
-		\WP_Filesystem();
-		global $wp_filesystem;
-
 		$is_local = ! preg_match( '#^https?://#i', $attachment_data['url'] );
 
 		if ( $is_local ) {
 			// Read local file from disk.
+			\WP_Filesystem();
+			global $wp_filesystem;
+
 			if ( ! $wp_filesystem->exists( $attachment_data['url'] ) ) {
 				/* translators: %s: file path */
 				return new \WP_Error( 'file_not_found', sprintf( \__( 'File not found: %s', 'activitypub' ), $attachment_data['url'] ) );
@@ -452,24 +478,18 @@ class Attachments {
 			}
 		}
 
-		// Get original filename from URL.
-		$original_name = \basename( \wp_parse_url( $attachment_data['url'], PHP_URL_PATH ) );
-
-		// Rename temp file to have proper extension for optimize_image to detect mime type.
-		$original_ext = \pathinfo( $original_name, PATHINFO_EXTENSION );
-		if ( $original_ext ) {
-			$renamed_tmp = $tmp_file . '.' . $original_ext;
-			if ( $wp_filesystem->move( $tmp_file, $renamed_tmp, true ) ) {
-				$tmp_file = $renamed_tmp;
-			}
+		// Optimize images before sideloading (resize and convert to WebP).
+		$optimized = self::optimize_image( $tmp_file );
+		if ( $optimized['changed'] ) {
+			$tmp_file = $optimized['path'];
 		}
 
-		// Optimize images before sideloading (resize and convert to WebP).
-		$tmp_file = self::optimize_image( $tmp_file, self::MAX_IMAGE_DIMENSION );
+		// Prepare file array for WordPress.
+		$original_name = \basename( \wp_parse_url( $attachment_data['url'], PHP_URL_PATH ) );
 
-		// Update filename extension to match optimized file.
-		$new_ext = \pathinfo( $tmp_file, PATHINFO_EXTENSION );
-		if ( $new_ext ) {
+		// Update filename extension if format changed.
+		if ( $optimized['changed'] ) {
+			$new_ext       = \pathinfo( $tmp_file, PATHINFO_EXTENSION );
 			$original_name = \preg_replace( '/\.[^.]+$/', '.' . $new_ext, $original_name );
 		}
 
@@ -479,12 +499,14 @@ class Attachments {
 		);
 
 		// Prepare attachment post data.
-		// Let WordPress auto-detect the mime type from the file.
+		// Clear mime type if format changed so WordPress auto-detects it.
+		$mime_type = $optimized['changed'] ? '' : ( $attachment_data['mediaType'] ?? '' );
 		$post_data = array(
-			'post_title'   => $attachment_data['name'] ?? '',
-			'post_content' => $attachment_data['name'] ?? '',
-			'post_author'  => $author_id,
-			'meta_input'   => array(
+			'post_mime_type' => $mime_type,
+			'post_title'     => $attachment_data['name'] ?? '',
+			'post_content'   => $attachment_data['name'] ?? '',
+			'post_author'    => $author_id,
+			'meta_input'     => array(
 				'_source_url' => $attachment_data['url'],
 			),
 		);
@@ -517,7 +539,6 @@ class Attachments {
 	 * @param array  $attachment_data The normalized attachment data.
 	 * @param int    $object_id       The post or comment ID to attach to.
 	 * @param string $object_type     The object type ('post' or 'comment').
-	 * @param int    $max_dimension   Optional. Maximum image dimension in pixels. Default MAX_IMAGE_DIMENSION.
 	 *
 	 * @return array|\WP_Error {
 	 *     Array of file data on success, WP_Error on failure.
@@ -527,7 +548,7 @@ class Attachments {
 	 *     @type string $alt       Alt text from attachment name field.
 	 * }
 	 */
-	private static function save_file( $attachment_data, $object_id, $object_type, $max_dimension = self::MAX_IMAGE_DIMENSION ) {
+	private static function save_file( $attachment_data, $object_id, $object_type ) {
 		$mime_type = $attachment_data['mediaType'] ?? '';
 
 		// Skip download for video and audio files - use remote URL directly.
@@ -584,8 +605,11 @@ class Attachments {
 		}
 
 		// Optimize images (resize and convert to WebP).
-		$file_path = self::optimize_image( $file_path, $max_dimension );
-		$file_name = \basename( $file_path );
+		$optimized = self::optimize_image( $file_path );
+		if ( $optimized['changed'] ) {
+			$file_path = $optimized['path'];
+			$file_name = \basename( $file_path );
+		}
 
 		// Get mime type and validate file.
 		$file_info = \wp_check_filetype_and_ext( $file_path, $file_name );
@@ -599,61 +623,44 @@ class Attachments {
 	}
 
 	/**
-	 * Get a unique file path by appending a counter if the file already exists.
-	 *
-	 * @param string $file_path The desired file path.
-	 *
-	 * @return string A unique file path that doesn't exist.
-	 */
-	private static function get_unique_path( $file_path ) {
-		if ( ! \file_exists( $file_path ) ) {
-			return $file_path;
-		}
-
-		$path_info = \pathinfo( $file_path );
-		$dir       = $path_info['dirname'];
-		$base_name = $path_info['filename'];
-		$extension = isset( $path_info['extension'] ) ? '.' . $path_info['extension'] : '';
-		$counter   = 1;
-
-		do {
-			$new_path = $dir . '/' . $base_name . '-' . $counter . $extension;
-			++$counter;
-		} while ( \file_exists( $new_path ) );
-
-		return $new_path;
-	}
-
-	/**
 	 * Optimize an image file by resizing and converting to WebP.
 	 *
 	 * Uses WordPress image editor to resize large images and convert them
 	 * to WebP format for better compression while maintaining quality.
 	 *
-	 * @param string $file_path     Path to the image file.
-	 * @param int    $max_dimension Maximum width/height in pixels.
+	 * @param string $file_path Path to the image file.
 	 *
-	 * @return string The optimized file path.
+	 * @return array{path: string, changed: bool}|\WP_Error The optimized file path and whether it changed, or WP_Error.
 	 */
-	private static function optimize_image( $file_path, $max_dimension ) {
+	private static function optimize_image( $file_path ) {
 		// Check if it's an image.
 		$mime_type = \wp_check_filetype( $file_path )['type'] ?? '';
 		if ( ! $mime_type || ! \str_starts_with( $mime_type, 'image/' ) ) {
-			return $file_path;
+			return array(
+				'path'    => $file_path,
+				'changed' => false,
+			);
 		}
 
 		// Skip SVG and GIF files (GIFs may be animated).
 		if ( \in_array( $mime_type, array( 'image/svg+xml', 'image/gif' ), true ) ) {
-			return $file_path;
+			return array(
+				'path'    => $file_path,
+				'changed' => false,
+			);
 		}
 
 		$editor = \wp_get_image_editor( $file_path );
 		if ( \is_wp_error( $editor ) ) {
-			return $file_path;
+			return array(
+				'path'    => $file_path,
+				'changed' => false,
+			);
 		}
 
-		$size         = $editor->get_size();
-		$needs_resize = $size['width'] > $max_dimension || $size['height'] > $max_dimension;
+		$size          = $editor->get_size();
+		$max_dimension = self::MAX_IMAGE_DIMENSION;
+		$needs_resize  = $size['width'] > $max_dimension || $size['height'] > $max_dimension;
 
 		// Resize if needed.
 		if ( $needs_resize ) {
@@ -663,37 +670,39 @@ class Attachments {
 		// Check if WebP is supported.
 		$can_webp = $editor->supports_mime_type( 'image/webp' );
 
-		// Determine output format and save.
+		// Determine output format.
 		if ( $can_webp ) {
-			// Convert to WebP.
-			$new_path = self::get_unique_path( \preg_replace( '/\.[^.]+$/', '.webp', $file_path ) );
+			$new_path = \preg_replace( '/\.[^.]+$/', '.webp', $file_path );
 			$result   = $editor->save( $new_path, 'image/webp' );
 		} elseif ( \in_array( $mime_type, array( 'image/png', 'image/webp' ), true ) ) {
 			// Keep original format for potentially transparent images when WebP not available.
-			if ( ! $needs_resize ) {
-				// No changes needed.
-				return $file_path;
-			}
-			$result = $editor->save( $file_path );
+			$result = $needs_resize ? $editor->save( $file_path ) : true;
 		} else {
 			// Convert to JPEG when WebP not available.
-			$new_path = self::get_unique_path( \preg_replace( '/\.[^.]+$/', '.jpg', $file_path ) );
+			$new_path = \preg_replace( '/\.[^.]+$/', '.jpg', $file_path );
 			$result   = $editor->save( $new_path, 'image/jpeg' );
 		}
 
 		if ( \is_wp_error( $result ) ) {
-			return $file_path;
+			return array(
+				'path'    => $file_path,
+				'changed' => false,
+			);
 		}
 
-		// Handle result - $result is always an array from $editor->save().
-		$result_path = $result['path'] ?? $file_path;
-
-		// If path changed (format conversion), delete the original file.
-		if ( $result_path !== $file_path ) {
+		// If format changed, delete the original.
+		if ( is_array( $result ) && isset( $result['path'] ) && $result['path'] !== $file_path ) {
 			\wp_delete_file( $file_path );
+			return array(
+				'path'    => $result['path'],
+				'changed' => true,
+			);
 		}
 
-		return $result_path;
+		return array(
+			'path'    => $file_path,
+			'changed' => $needs_resize,
+		);
 	}
 
 	/**
@@ -957,5 +966,63 @@ class Attachments {
 		$gallery .= '<!-- /wp:gallery -->';
 
 		return $gallery;
+	}
+
+	/**
+	 * Save a remote actor's avatar locally.
+	 *
+	 * Downloads the avatar image, optimizes it, and stores it in the actors directory.
+	 * Returns the local URL for the saved avatar.
+	 *
+	 * @param int    $actor_id   The local actor post ID.
+	 * @param string $avatar_url The remote avatar URL.
+	 *
+	 * @return string|false The local avatar URL on success, false on failure.
+	 */
+	public static function save_actor_avatar( $actor_id, $avatar_url ) {
+		// Validate actor_id is a positive integer to prevent path traversal.
+		$actor_id = (int) $actor_id;
+		if ( $actor_id <= 0 ) {
+			return false;
+		}
+
+		if ( empty( $avatar_url ) || ! \filter_var( $avatar_url, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
+
+		// Delete existing avatar files before saving new one.
+		// This prevents accumulating old avatar files since save_file creates unique filenames.
+		self::delete_actors_directory( $actor_id );
+
+		$attachment_data = array( 'url' => $avatar_url );
+		$result          = self::save_file( $attachment_data, $actor_id, 'actor', self::MAX_AVATAR_DIMENSION );
+
+		if ( \is_wp_error( $result ) || ! isset( $result['url'] ) ) {
+			return false;
+		}
+
+		return $result['url'];
+	}
+
+	/**
+	 * Delete the activitypub files directory for an actor.
+	 *
+	 * @param int $actor_id The actor post ID.
+	 */
+	public static function delete_actors_directory( $actor_id ) {
+		if ( Remote_Actors::POST_TYPE !== \get_post_type( $actor_id ) ) {
+			return;
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		\WP_Filesystem();
+		global $wp_filesystem;
+
+		$activitypub_dir = self::get_storage_paths( $actor_id, 'actor' )['basedir'];
+
+		if ( $wp_filesystem->is_dir( $activitypub_dir ) ) {
+			$wp_filesystem->rmdir( $activitypub_dir, true );
+		}
 	}
 }

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -539,6 +539,7 @@ class Attachments {
 	 * @param array  $attachment_data The normalized attachment data.
 	 * @param int    $object_id       The post or comment ID to attach to.
 	 * @param string $object_type     The object type ('post' or 'comment').
+	 * @param int    $max_dimension   Optional. Maximum image dimension in pixels. Default MAX_IMAGE_DIMENSION.
 	 *
 	 * @return array|\WP_Error {
 	 *     Array of file data on success, WP_Error on failure.
@@ -548,7 +549,7 @@ class Attachments {
 	 *     @type string $alt       Alt text from attachment name field.
 	 * }
 	 */
-	private static function save_file( $attachment_data, $object_id, $object_type ) {
+	private static function save_file( $attachment_data, $object_id, $object_type, $max_dimension = self::MAX_IMAGE_DIMENSION ) {
 		$mime_type = $attachment_data['mediaType'] ?? '';
 
 		// Skip download for video and audio files - use remote URL directly.
@@ -605,7 +606,7 @@ class Attachments {
 		}
 
 		// Optimize images (resize and convert to WebP).
-		$optimized = self::optimize_image( $file_path, self::MAX_IMAGE_DIMENSION );
+		$optimized = self::optimize_image( $file_path, $max_dimension );
 		if ( $optimized['changed'] ) {
 			$file_path = $optimized['path'];
 			$file_name = \basename( $file_path );

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -699,11 +699,8 @@ class Remote_Actors {
 	 * @return string|null The cached avatar URL, or null if no avatar.
 	 */
 	private static function cache_avatar( $post_id, $actor ) {
-		if ( \is_array( $actor ) || ( \is_object( $actor ) && ! $actor instanceof Actor ) ) {
-			$remote_avatar_url = object_to_uri( $actor['icon'] ?? ( $actor->icon ?? null ) );
-		} else {
-			$remote_avatar_url = object_to_uri( $actor->get_icon() );
-		}
+		$data              = $actor instanceof Actor ? $actor->to_array() : (array) $actor;
+		$remote_avatar_url = object_to_uri( $data['icon'] ?? null );
 
 		if ( empty( $remote_avatar_url ) ) {
 			// No avatar to save, clean up any existing avatar.

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Collection;
 
 use Activitypub\Activity\Actor;
+use Activitypub\Attachments;
 use Activitypub\Http;
 use Activitypub\Sanitize;
 use Activitypub\Webfinger;
@@ -111,6 +112,11 @@ class Remote_Actors {
 			\kses_init_filters();
 		}
 
+		// Cache the actor's avatar locally.
+		if ( ! \is_wp_error( $post_id ) ) {
+			self::cache_avatar( $post_id, $actor );
+		}
+
 		return $post_id;
 	}
 
@@ -156,6 +162,11 @@ class Remote_Actors {
 		if ( $has_kses ) {
 			// Restore KSES filters.
 			\kses_init_filters();
+		}
+
+		// Re-cache the actor's avatar if it has changed.
+		if ( ! \is_wp_error( $post_id ) ) {
+			self::cache_avatar( $post_id, $actor );
 		}
 
 		return $post_id;
@@ -531,12 +542,6 @@ class Remote_Actors {
 			'_activitypub_acct'  => $webfinger,
 		);
 
-		// Store avatar URL if available.
-		$icon = object_to_uri( $actor->get_icon() );
-		if ( $icon ) {
-			$meta_input['_activitypub_avatar_url'] = $icon;
-		}
-
 		return array(
 			'guid'         => \esc_url_raw( $actor->get_id() ),
 			'post_title'   => \wp_strip_all_tags( \wp_slash( $actor->get_name() ?: $actor->get_preferred_username() ) ),
@@ -653,6 +658,9 @@ class Remote_Actors {
 	/**
 	 * Get the avatar URL for a remote actor.
 	 *
+	 * Returns the locally cached avatar URL if available, otherwise falls back
+	 * to the default avatar.
+	 *
 	 * @param int $id The ID of the remote actor post.
 	 *
 	 * @return string The avatar URL or empty string if not found.
@@ -663,7 +671,7 @@ class Remote_Actors {
 			return $avatar_url;
 		}
 
-		// If not found in meta, try to extract from post_content JSON.
+		// If not found in meta, try to extract from post_content JSON and cache it.
 		$post = \get_post( $id );
 		if ( ! $post || empty( $post->post_content ) ) {
 			return '';
@@ -677,10 +685,39 @@ class Remote_Actors {
 			return $default_avatar_url;
 		}
 
-		$avatar_url = object_to_uri( $actor_data['icon'] );
-		// Cache it in meta for next time.
+		// Try to cache the avatar locally.
+		$remote_avatar_url = object_to_uri( $actor_data['icon'] );
+		$local_url         = Attachments::cache_actor_avatar( $remote_avatar_url, $id );
+
+		$avatar_url = $local_url ? $local_url : $remote_avatar_url;
 		\update_post_meta( $id, '_activitypub_avatar_url', \esc_url_raw( $avatar_url ) );
 
 		return $avatar_url;
+	}
+
+	/**
+	 * Cache a remote actor's avatar locally.
+	 *
+	 * Downloads the avatar image, optimizes it (resize/WebP), and stores it locally.
+	 *
+	 * @param int   $post_id The actor post ID.
+	 * @param Actor $actor   The actor object.
+	 */
+	private static function cache_avatar( $post_id, $actor ) {
+		$remote_avatar_url = object_to_uri( $actor->get_icon() );
+
+		if ( empty( $remote_avatar_url ) ) {
+			// No avatar to cache, clean up any existing cached avatar.
+			Attachments::delete_actor_avatar_files( $post_id );
+			\delete_post_meta( $post_id, '_activitypub_avatar_url' );
+			return;
+		}
+
+		// Download and cache the avatar locally.
+		$local_url = Attachments::cache_actor_avatar( $remote_avatar_url, $post_id );
+
+		// Store the local URL if caching succeeded, otherwise store the remote URL.
+		$avatar_url = $local_url ? $local_url : $remote_avatar_url;
+		\update_post_meta( $post_id, '_activitypub_avatar_url', \esc_url_raw( $avatar_url ) );
 	}
 }

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -717,7 +717,7 @@ class Remote_Actors {
 		$local_url = Attachments::save_actor_avatar( $remote_avatar_url, $post_id );
 
 		// Store the local URL if caching succeeded, otherwise store the remote URL.
-		$avatar_url = $local_url ? $local_url : $remote_avatar_url;
+		$avatar_url = $local_url ?: $remote_avatar_url;
 		\update_post_meta( $post_id, '_activitypub_avatar_url', \esc_url_raw( $avatar_url ) );
 	}
 }

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -685,14 +685,7 @@ class Remote_Actors {
 			return $default_avatar_url;
 		}
 
-		// Try to cache the avatar locally.
-		$remote_avatar_url = object_to_uri( $actor_data['icon'] );
-		$local_url         = Attachments::save_actor_avatar( $remote_avatar_url, $id );
-
-		$avatar_url = $local_url ? $local_url : $remote_avatar_url;
-		\update_post_meta( $id, '_activitypub_avatar_url', \esc_url_raw( $avatar_url ) );
-
-		return $avatar_url;
+		return self::cache_avatar( $id, $actor_data );
 	}
 
 	/**
@@ -700,24 +693,32 @@ class Remote_Actors {
 	 *
 	 * Downloads the avatar image, optimizes it (resize/WebP), and stores it locally.
 	 *
-	 * @param int   $post_id The actor post ID.
-	 * @param Actor $actor   The actor object.
+	 * @param int                $post_id The actor post ID.
+	 * @param Actor|array|object $actor   The actor object or data array.
+	 *
+	 * @return string|null The cached avatar URL, or null if no avatar.
 	 */
 	private static function cache_avatar( $post_id, $actor ) {
-		$remote_avatar_url = object_to_uri( $actor->get_icon() );
+		if ( \is_array( $actor ) || ( \is_object( $actor ) && ! $actor instanceof Actor ) ) {
+			$remote_avatar_url = object_to_uri( $actor['icon'] ?? ( $actor->icon ?? null ) );
+		} else {
+			$remote_avatar_url = object_to_uri( $actor->get_icon() );
+		}
 
 		if ( empty( $remote_avatar_url ) ) {
 			// No avatar to save, clean up any existing avatar.
 			Attachments::delete_actors_directory( $post_id );
 			\delete_post_meta( $post_id, '_activitypub_avatar_url' );
-			return;
+			return null;
 		}
 
 		// Download and save the avatar locally.
-		$local_url = Attachments::save_actor_avatar( $remote_avatar_url, $post_id );
+		$local_url = Attachments::save_actor_avatar( $post_id, $remote_avatar_url );
 
 		// Store the local URL if caching succeeded, otherwise store the remote URL.
 		$avatar_url = $local_url ?: $remote_avatar_url;
 		\update_post_meta( $post_id, '_activitypub_avatar_url', \esc_url_raw( $avatar_url ) );
+
+		return $avatar_url;
 	}
 }

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -687,7 +687,7 @@ class Remote_Actors {
 
 		// Try to cache the avatar locally.
 		$remote_avatar_url = object_to_uri( $actor_data['icon'] );
-		$local_url         = Attachments::cache_actor_avatar( $remote_avatar_url, $id );
+		$local_url         = Attachments::save_actor_avatar( $remote_avatar_url, $id );
 
 		$avatar_url = $local_url ? $local_url : $remote_avatar_url;
 		\update_post_meta( $id, '_activitypub_avatar_url', \esc_url_raw( $avatar_url ) );
@@ -707,14 +707,14 @@ class Remote_Actors {
 		$remote_avatar_url = object_to_uri( $actor->get_icon() );
 
 		if ( empty( $remote_avatar_url ) ) {
-			// No avatar to cache, clean up any existing cached avatar.
-			Attachments::delete_actor_avatar_files( $post_id );
+			// No avatar to save, clean up any existing avatar.
+			Attachments::delete_actors_directory( $post_id );
 			\delete_post_meta( $post_id, '_activitypub_avatar_url' );
 			return;
 		}
 
-		// Download and cache the avatar locally.
-		$local_url = Attachments::cache_actor_avatar( $remote_avatar_url, $post_id );
+		// Download and save the avatar locally.
+		$local_url = Attachments::save_actor_avatar( $remote_avatar_url, $post_id );
 
 		// Store the local URL if caching succeeded, otherwise store the remote URL.
 		$avatar_url = $local_url ? $local_url : $remote_avatar_url;

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -1057,7 +1057,7 @@ class Test_Attachments extends \WP_UnitTestCase {
 		);
 
 		$avatar_url = 'https://example.com/avatar.jpg';
-		$result     = Attachments::save_actor_avatar( $avatar_url, $actor_id );
+		$result     = Attachments::save_actor_avatar( $actor_id, $avatar_url );
 
 		$this->assertIsString( $result );
 		$this->assertStringContainsString( 'wp-content/uploads/activitypub/actors/' . $actor_id, $result );
@@ -1077,7 +1077,7 @@ class Test_Attachments extends \WP_UnitTestCase {
 			)
 		);
 
-		$result = Attachments::save_actor_avatar( '', $actor_id );
+		$result = Attachments::save_actor_avatar( $actor_id, '' );
 
 		$this->assertFalse( $result );
 	}
@@ -1094,7 +1094,7 @@ class Test_Attachments extends \WP_UnitTestCase {
 			)
 		);
 
-		$result = Attachments::save_actor_avatar( 'not-a-valid-url', $actor_id );
+		$result = Attachments::save_actor_avatar( $actor_id, 'not-a-valid-url' );
 
 		$this->assertFalse( $result );
 	}
@@ -1112,7 +1112,7 @@ class Test_Attachments extends \WP_UnitTestCase {
 		);
 
 		// Use the missing.jpg URL that our mock returns as an error.
-		$result = Attachments::save_actor_avatar( 'https://example.com/missing.jpg', $actor_id );
+		$result = Attachments::save_actor_avatar( $actor_id, 'https://example.com/missing.jpg' );
 
 		$this->assertFalse( $result );
 	}
@@ -1131,11 +1131,11 @@ class Test_Attachments extends \WP_UnitTestCase {
 		);
 
 		// Save first avatar.
-		$first_result = Attachments::save_actor_avatar( 'https://example.com/avatar1.jpg', $actor_id );
+		$first_result = Attachments::save_actor_avatar( $actor_id, 'https://example.com/avatar1.jpg' );
 		$this->assertIsString( $first_result );
 
 		// Save second avatar (should replace the first).
-		$second_result = Attachments::save_actor_avatar( 'https://example.com/avatar2.jpg', $actor_id );
+		$second_result = Attachments::save_actor_avatar( $actor_id, 'https://example.com/avatar2.jpg' );
 		$this->assertIsString( $second_result );
 
 		// URLs should be different (different source filenames).
@@ -1155,7 +1155,7 @@ class Test_Attachments extends \WP_UnitTestCase {
 		);
 
 		// Save an avatar first.
-		$avatar_url = Attachments::save_actor_avatar( 'https://example.com/avatar.jpg', $actor_id );
+		$avatar_url = Attachments::save_actor_avatar( $actor_id, 'https://example.com/avatar.jpg' );
 		$this->assertIsString( $avatar_url );
 
 		// Get the directory path.

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -1042,4 +1042,164 @@ class Test_Attachments extends \WP_UnitTestCase {
 		// Clean up.
 		wp_delete_file( $existing_file );
 	}
+
+	/**
+	 * Test save_actor_avatar with valid URL.
+	 *
+	 * @covers ::save_actor_avatar
+	 */
+	public function test_save_actor_avatar_success() {
+		// Create a test actor post.
+		$actor_id = self::factory()->post->create(
+			array(
+				'post_type' => 'ap_actor',
+			)
+		);
+
+		$avatar_url = 'https://example.com/avatar.jpg';
+		$result     = Attachments::save_actor_avatar( $avatar_url, $actor_id );
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'wp-content/uploads/activitypub/actors/' . $actor_id, $result );
+		// Note: Image may be converted to WebP during optimization.
+		$this->assertMatchesRegularExpression( '/\.(jpg|webp)$/', $result );
+	}
+
+	/**
+	 * Test save_actor_avatar with empty URL.
+	 *
+	 * @covers ::save_actor_avatar
+	 */
+	public function test_save_actor_avatar_empty_url() {
+		$actor_id = self::factory()->post->create(
+			array(
+				'post_type' => 'ap_actor',
+			)
+		);
+
+		$result = Attachments::save_actor_avatar( '', $actor_id );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test save_actor_avatar with invalid URL.
+	 *
+	 * @covers ::save_actor_avatar
+	 */
+	public function test_save_actor_avatar_invalid_url() {
+		$actor_id = self::factory()->post->create(
+			array(
+				'post_type' => 'ap_actor',
+			)
+		);
+
+		$result = Attachments::save_actor_avatar( 'not-a-valid-url', $actor_id );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test save_actor_avatar with download error.
+	 *
+	 * @covers ::save_actor_avatar
+	 */
+	public function test_save_actor_avatar_download_error() {
+		$actor_id = self::factory()->post->create(
+			array(
+				'post_type' => 'ap_actor',
+			)
+		);
+
+		// Use the missing.jpg URL that our mock returns as an error.
+		$result = Attachments::save_actor_avatar( 'https://example.com/missing.jpg', $actor_id );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test save_actor_avatar replaces existing avatar.
+	 *
+	 * @covers ::save_actor_avatar
+	 * @covers ::delete_actors_directory
+	 */
+	public function test_save_actor_avatar_replaces_existing() {
+		$actor_id = self::factory()->post->create(
+			array(
+				'post_type' => 'ap_actor',
+			)
+		);
+
+		// Save first avatar.
+		$first_result = Attachments::save_actor_avatar( 'https://example.com/avatar1.jpg', $actor_id );
+		$this->assertIsString( $first_result );
+
+		// Save second avatar (should replace the first).
+		$second_result = Attachments::save_actor_avatar( 'https://example.com/avatar2.jpg', $actor_id );
+		$this->assertIsString( $second_result );
+
+		// URLs should be different (different source filenames).
+		$this->assertNotEquals( $first_result, $second_result );
+	}
+
+	/**
+	 * Test delete_actors_directory removes actor files.
+	 *
+	 * @covers ::delete_actors_directory
+	 */
+	public function test_delete_actors_directory() {
+		$actor_id = self::factory()->post->create(
+			array(
+				'post_type' => 'ap_actor',
+			)
+		);
+
+		// Save an avatar first.
+		$avatar_url = Attachments::save_actor_avatar( 'https://example.com/avatar.jpg', $actor_id );
+		$this->assertIsString( $avatar_url );
+
+		// Get the directory path.
+		$upload_dir = \wp_upload_dir();
+		$actor_dir  = $upload_dir['basedir'] . '/activitypub/actors/' . $actor_id;
+
+		// Verify directory exists.
+		$this->assertTrue( \is_dir( $actor_dir ) );
+
+		// Delete the directory.
+		Attachments::delete_actors_directory( $actor_id );
+
+		// Verify directory is gone.
+		$this->assertFalse( \is_dir( $actor_dir ) );
+	}
+
+	/**
+	 * Test delete_actors_directory ignores non-actor post types.
+	 *
+	 * @covers ::delete_actors_directory
+	 */
+	public function test_delete_actors_directory_ignores_non_actors() {
+		// Create a regular post (not an actor).
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		// Create a directory that would match the path pattern.
+		$upload_dir = \wp_upload_dir();
+		$fake_dir   = $upload_dir['basedir'] . '/activitypub/actors/' . $post_id;
+		\wp_mkdir_p( $fake_dir );
+
+		// Verify directory exists.
+		$this->assertTrue( \is_dir( $fake_dir ) );
+
+		// Try to delete - should be ignored because it's not an actor post type.
+		Attachments::delete_actors_directory( $post_id );
+
+		// Directory should still exist.
+		$this->assertTrue( \is_dir( $fake_dir ) );
+
+		// Clean up.
+		\rmdir( $fake_dir );
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-attachments.php
+++ b/tests/phpunit/tests/includes/class-test-attachments.php
@@ -1200,6 +1200,8 @@ class Test_Attachments extends \WP_UnitTestCase {
 		$this->assertTrue( \is_dir( $fake_dir ) );
 
 		// Clean up.
-		\rmdir( $fake_dir );
+		global $wp_filesystem;
+		\WP_Filesystem();
+		$wp_filesystem->rmdir( $fake_dir );
 	}
 }


### PR DESCRIPTION
fixes #926

## Proposed changes:

* Cache remote actor avatars locally to reduce external dependencies and improve load times
* Download and optimize avatars when actors are created or updated
* Reuse the image optimization from #2609 (resize to 1200px, convert to WebP)
* Track remote avatar URL separately to detect changes and avoid unnecessary re-downloads
* Clean up cached avatar files when actor is deleted
* Gracefully fall back to remote URL if local caching fails

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Uses existing test coverage - the avatar caching gracefully handles test environments where HTTP downloads aren't mocked.

**Note:** This PR depends on #2609 (image optimization) - set as base branch.

## Testing instructions:

* Set up a local WordPress environment with wp-env
* Follow a remote ActivityPub actor (e.g., from Mastodon)
* Check `wp-content/uploads/activitypub/actors/{actor_id}/` for the cached avatar
* The avatar should be resized and converted to WebP format
* Verify the avatar displays correctly in followers/following lists
* Update the remote actor's avatar on their server
* Wait for the scheduled update (or manually trigger `activitypub_update_remote_actors`)
* Verify the new avatar is downloaded and cached

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add local caching for remote actor avatars.

</details>