### PR TITLE
Add scheduled cleanup for remote posts (ap_post)

### DIFF
--- a/.github/changelog/2612-from-description
+++ b/.github/changelog/2612-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add scheduled cleanup for remote posts, preserving posts with local user interactions.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -331,7 +331,7 @@ class Scheduler {
 	 * Purge inbox items based on a schedule.
 	 */
 	public static function purge_inbox() {
-		$days = (int) get_option( 'activitypub_inbox_purge_days', 180 );
+		$days = (int) \get_option( 'activitypub_inbox_purge_days', 180 );
 		Inbox::purge( $days );
 	}
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -69,9 +69,9 @@ class Scheduler {
 		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'schedule_outbox_activity_for_federation' ) );
 		\add_action( 'post_activitypub_add_to_outbox', array( self::class, 'schedule_announce_activity' ), 10, 4 );
 
-		\add_action( 'update_option_activitypub_outbox_purge_days', array( self::class, 'handle_outbox_purge_days_update' ), 10, 2 );
-		\add_action( 'update_option_activitypub_inbox_purge_days', array( self::class, 'handle_inbox_purge_days_update' ), 10, 2 );
-		\add_action( 'update_option_activitypub_ap_post_purge_days', array( self::class, 'handle_ap_post_purge_days_update' ), 10, 2 );
+		\add_action( 'update_option_activitypub_outbox_purge_days', array( self::class, 'update_outbox_purge_schedule' ), 10, 2 );
+		\add_action( 'update_option_activitypub_inbox_purge_days', array( self::class, 'update_inbox_purge_schedule' ), 10, 2 );
+		\add_action( 'update_option_activitypub_ap_post_purge_days', array( self::class, 'update_ap_post_purge_schedule' ), 10, 2 );
 	}
 
 	/**
@@ -339,7 +339,7 @@ class Scheduler {
 	 * Purge remote posts based on a schedule.
 	 */
 	public static function purge_ap_posts() {
-		$days = (int) get_option( 'activitypub_ap_post_purge_days', 180 );
+		$days = (int) get_option( 'activitypub_ap_post_purge_days', 30 );
 		Posts::purge( $days );
 	}
 
@@ -396,7 +396,7 @@ class Scheduler {
 	 * @param int $old_value The old value.
 	 * @param int $value     The new value.
 	 */
-	public static function handle_outbox_purge_days_update( $old_value, $value ) {
+	public static function update_outbox_purge_schedule( $old_value, $value ) {
 		if ( 0 === (int) $value ) {
 			\wp_clear_scheduled_hook( 'activitypub_outbox_purge' );
 		} elseif ( ! \wp_next_scheduled( 'activitypub_outbox_purge' ) ) {
@@ -410,7 +410,7 @@ class Scheduler {
 	 * @param int $old_value The old value.
 	 * @param int $value     The new value.
 	 */
-	public static function handle_inbox_purge_days_update( $old_value, $value ) {
+	public static function update_inbox_purge_schedule( $old_value, $value ) {
 		if ( 0 === (int) $value ) {
 			\wp_clear_scheduled_hook( 'activitypub_inbox_purge' );
 		} elseif ( ! \wp_next_scheduled( 'activitypub_inbox_purge' ) ) {
@@ -424,7 +424,7 @@ class Scheduler {
 	 * @param int $old_value The old value.
 	 * @param int $value     The new value.
 	 */
-	public static function handle_ap_post_purge_days_update( $old_value, $value ) {
+	public static function update_ap_post_purge_schedule( $old_value, $value ) {
 		if ( 0 === (int) $value ) {
 			\wp_clear_scheduled_hook( 'activitypub_ap_post_purge' );
 		} elseif ( ! \wp_next_scheduled( 'activitypub_ap_post_purge' ) ) {

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -323,7 +323,7 @@ class Scheduler {
 	 * Purge outbox items based on a schedule.
 	 */
 	public static function purge_outbox() {
-		$days = (int) get_option( 'activitypub_outbox_purge_days', 180 );
+		$days = (int) \get_option( 'activitypub_outbox_purge_days', 180 );
 		Outbox::purge( $days );
 	}
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -12,6 +12,7 @@ use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
+use Activitypub\Collection\Posts;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Scheduler\Actor;
 use Activitypub\Scheduler\Collection_Sync;
@@ -61,6 +62,7 @@ class Scheduler {
 		\add_action( 'activitypub_reprocess_outbox', array( self::class, 'reprocess_outbox' ) );
 		\add_action( 'activitypub_outbox_purge', array( self::class, 'purge_outbox' ) );
 		\add_action( 'activitypub_inbox_purge', array( self::class, 'purge_inbox' ) );
+		\add_action( 'activitypub_ap_post_purge', array( self::class, 'purge_ap_posts' ) );
 		\add_action( 'activitypub_inbox_create_item', array( self::class, 'process_inbox_activity' ) );
 		\add_action( 'activitypub_sync_blocklist_subscriptions', array( Blocklist_Subscriptions::class, 'sync_all' ) );
 
@@ -69,6 +71,7 @@ class Scheduler {
 
 		\add_action( 'update_option_activitypub_outbox_purge_days', array( self::class, 'handle_outbox_purge_days_update' ), 10, 2 );
 		\add_action( 'update_option_activitypub_inbox_purge_days', array( self::class, 'handle_inbox_purge_days_update' ), 10, 2 );
+		\add_action( 'update_option_activitypub_ap_post_purge_days', array( self::class, 'handle_ap_post_purge_days_update' ), 10, 2 );
 	}
 
 	/**
@@ -134,6 +137,10 @@ class Scheduler {
 			\wp_schedule_event( time(), 'daily', 'activitypub_inbox_purge' );
 		}
 
+		if ( ! \wp_next_scheduled( 'activitypub_ap_post_purge' ) ) {
+			\wp_schedule_event( time(), 'daily', 'activitypub_ap_post_purge' );
+		}
+
 		if ( ! \wp_next_scheduled( 'activitypub_sync_blocklist_subscriptions' ) ) {
 			\wp_schedule_event( time(), 'weekly', 'activitypub_sync_blocklist_subscriptions' );
 		}
@@ -150,6 +157,7 @@ class Scheduler {
 		\wp_unschedule_hook( 'activitypub_reprocess_outbox' );
 		\wp_unschedule_hook( 'activitypub_outbox_purge' );
 		\wp_unschedule_hook( 'activitypub_inbox_purge' );
+		\wp_unschedule_hook( 'activitypub_ap_post_purge' );
 		\wp_unschedule_hook( 'activitypub_sync_blocklist_subscriptions' );
 	}
 
@@ -315,66 +323,24 @@ class Scheduler {
 	 * Purge outbox items based on a schedule.
 	 */
 	public static function purge_outbox() {
-		$total_posts = (int) wp_count_posts( Outbox::POST_TYPE )->publish;
-		if ( $total_posts <= 20 ) {
-			return;
-		}
-
-		$days     = (int) get_option( 'activitypub_outbox_purge_days', 180 );
-		$post_ids = \get_posts(
-			array(
-				'post_type'   => Outbox::POST_TYPE,
-				'post_status' => 'any',
-				'fields'      => 'ids',
-				'numberposts' => -1,
-				'date_query'  => array(
-					array(
-						'before' => gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
-					),
-				),
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				'meta_query'  => array(
-					array(
-						'key'     => '_activitypub_activity_type',
-						'value'   => 'Follow',
-						'compare' => '!=',
-					),
-				),
-			)
-		);
-
-		foreach ( $post_ids as $post_id ) {
-			\wp_delete_post( $post_id, true );
-		}
+		$days = (int) get_option( 'activitypub_outbox_purge_days', 180 );
+		Outbox::purge( $days );
 	}
 
 	/**
 	 * Purge inbox items based on a schedule.
 	 */
 	public static function purge_inbox() {
-		$total_posts = (int) wp_count_posts( Inbox::POST_TYPE )->publish;
-		if ( $total_posts <= 200 ) {
-			return;
-		}
+		$days = (int) get_option( 'activitypub_inbox_purge_days', 180 );
+		Inbox::purge( $days );
+	}
 
-		$days     = (int) get_option( 'activitypub_inbox_purge_days', 180 );
-		$post_ids = \get_posts(
-			array(
-				'post_type'   => Inbox::POST_TYPE,
-				'post_status' => 'any',
-				'fields'      => 'ids',
-				'numberposts' => -1,
-				'date_query'  => array(
-					array(
-						'before' => gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) ),
-					),
-				),
-			)
-		);
-
-		foreach ( $post_ids as $post_id ) {
-			\wp_delete_post( $post_id, true );
-		}
+	/**
+	 * Purge remote posts based on a schedule.
+	 */
+	public static function purge_ap_posts() {
+		$days = (int) get_option( 'activitypub_ap_post_purge_days', 180 );
+		Posts::purge( $days );
 	}
 
 	/**
@@ -449,6 +415,20 @@ class Scheduler {
 			\wp_clear_scheduled_hook( 'activitypub_inbox_purge' );
 		} elseif ( ! \wp_next_scheduled( 'activitypub_inbox_purge' ) ) {
 			\wp_schedule_event( \time(), 'daily', 'activitypub_inbox_purge' );
+		}
+	}
+
+	/**
+	 * Update schedules when remote posts purge days settings change.
+	 *
+	 * @param int $old_value The old value.
+	 * @param int $value     The new value.
+	 */
+	public static function handle_ap_post_purge_days_update( $old_value, $value ) {
+		if ( 0 === (int) $value ) {
+			\wp_clear_scheduled_hook( 'activitypub_ap_post_purge' );
+		} elseif ( ! \wp_next_scheduled( 'activitypub_ap_post_purge' ) ) {
+			\wp_schedule_event( \time(), 'daily', 'activitypub_ap_post_purge' );
 		}
 	}
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -339,7 +339,7 @@ class Scheduler {
 	 * Purge remote posts based on a schedule.
 	 */
 	public static function purge_ap_posts() {
-		$days = (int) get_option( 'activitypub_ap_post_purge_days', 30 );
+		$days = (int) \get_option( 'activitypub_ap_post_purge_days', 30 );
 		Posts::purge( $days );
 	}
 

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -464,4 +464,42 @@ class Inbox {
 
 		return $primary;
 	}
+
+	/**
+	 * Purge old inbox items.
+	 *
+	 * Deletes inbox items older than the specified number of days.
+	 *
+	 * @param int $days Number of days to keep items. Items older than this will be deleted.
+	 *
+	 * @return int The number of items deleted.
+	 */
+	public static function purge( $days ) {
+		$total_posts = (int) \wp_count_posts( self::POST_TYPE )->publish;
+		if ( $total_posts <= 200 ) {
+			return 0;
+		}
+
+		$post_ids = \get_posts(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_status' => 'any',
+				'fields'      => 'ids',
+				'numberposts' => -1,
+				'date_query'  => array(
+					array(
+						'before' => \gmdate( 'Y-m-d', \time() - ( $days * DAY_IN_SECONDS ) ),
+					),
+				),
+			)
+		);
+
+		$deleted = 0;
+		foreach ( $post_ids as $post_id ) {
+			\wp_delete_post( $post_id, true );
+			++$deleted;
+		}
+
+		return $deleted;
+	}
 }

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -393,4 +393,51 @@ class Outbox {
 
 		return $title;
 	}
+
+	/**
+	 * Purge old outbox items.
+	 *
+	 * Deletes outbox items older than the specified number of days,
+	 * except for Follow activities which are always preserved.
+	 *
+	 * @param int $days Number of days to keep items. Items older than this will be deleted.
+	 *
+	 * @return int The number of items deleted.
+	 */
+	public static function purge( $days ) {
+		$total_posts = (int) \wp_count_posts( self::POST_TYPE )->publish;
+		if ( $total_posts <= 20 ) {
+			return 0;
+		}
+
+		$post_ids = \get_posts(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_status' => 'any',
+				'fields'      => 'ids',
+				'numberposts' => -1,
+				'date_query'  => array(
+					array(
+						'before' => \gmdate( 'Y-m-d', \time() - ( $days * DAY_IN_SECONDS ) ),
+					),
+				),
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'     => '_activitypub_activity_type',
+						'value'   => 'Follow',
+						'compare' => '!=',
+					),
+				),
+			)
+		);
+
+		$deleted = 0;
+		foreach ( $post_ids as $post_id ) {
+			\wp_delete_post( $post_id, true );
+			++$deleted;
+		}
+
+		return $deleted;
+	}
 }

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -457,8 +457,8 @@ class Posts {
 	 * Purge old remote posts.
 	 *
 	 * Deletes remote posts older than the specified number of days,
-	 * but preserves posts that have comments (including likes, reposts, quotes)
-	 * as these indicate meaningful local user interactions.
+	 * but preserves posts that have comments from local users
+	 * as these indicate meaningful local interactions.
 	 *
 	 * @param int $days Number of days to keep items. Items older than this will be deleted.
 	 *
@@ -484,11 +484,22 @@ class Posts {
 			)
 		);
 
+		global $wpdb;
+
 		$deleted = 0;
 		foreach ( $post_ids as $post_id ) {
-			// Preserve posts with comments (includes likes, reposts, quotes).
-			$comment_count = (int) \get_comments_number( $post_id );
-			if ( $comment_count > 0 ) {
+			/*
+			 * Preserve posts with comments from local users.
+			 * Local user comments have a user_id > 0, while Fediverse comments have user_id = 0.
+			 */
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$local_comments = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id > 0",
+					$post_id
+				)
+			);
+			if ( $local_comments > 0 ) {
 				continue;
 			}
 

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -505,13 +505,13 @@ class Posts {
 			 * Local user comments have a user_id > 0, while Fediverse comments have user_id = 0.
 			 */
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			$local_comments = (int) $wpdb->get_var(
+			$has_local_comments = (bool) $wpdb->get_var(
 				$wpdb->prepare(
-					"SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id > 0",
+					"SELECT 1 FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id > 0 LIMIT 1",
 					$post_id
 				)
 			);
-			if ( $local_comments > 0 ) {
+			if ( $has_local_comments ) {
 				continue;
 			}
 

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -452,4 +452,50 @@ class Posts {
 		// Delete the specific meta entry with this value.
 		return \delete_post_meta( $post_id, '_activitypub_user_id', $user_id );
 	}
+
+	/**
+	 * Purge old remote posts.
+	 *
+	 * Deletes remote posts older than the specified number of days,
+	 * but preserves posts that have comments (including likes, reposts, quotes)
+	 * as these indicate meaningful local user interactions.
+	 *
+	 * @param int $days Number of days to keep items. Items older than this will be deleted.
+	 *
+	 * @return int The number of items deleted.
+	 */
+	public static function purge( $days ) {
+		$total_posts = (int) \wp_count_posts( self::POST_TYPE )->publish;
+		if ( $total_posts <= 200 ) {
+			return 0;
+		}
+
+		$post_ids = \get_posts(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_status' => 'any',
+				'fields'      => 'ids',
+				'numberposts' => -1,
+				'date_query'  => array(
+					array(
+						'before' => \gmdate( 'Y-m-d', \time() - ( $days * DAY_IN_SECONDS ) ),
+					),
+				),
+			)
+		);
+
+		$deleted = 0;
+		foreach ( $post_ids as $post_id ) {
+			// Preserve posts with comments (includes likes, reposts, quotes).
+			$comment_count = (int) \get_comments_number( $post_id );
+			if ( $comment_count > 0 ) {
+				continue;
+			}
+
+			\wp_delete_post( $post_id, true );
+			++$deleted;
+		}
+
+		return $deleted;
+	}
 }

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -259,8 +259,8 @@ class Posts {
 	 * @return array|\WP_Error The post array or WP_Error on failure.
 	 */
 	private static function activity_to_post( $activity ) {
-		if ( ! is_array( $activity ) ) {
-			return new \WP_Error( 'invalid_activity', __( 'Invalid activity format', 'activitypub' ) );
+		if ( ! \is_array( $activity ) ) {
+			return new \WP_Error( 'invalid_activity', \__( 'Invalid activity format', 'activitypub' ) );
 		}
 
 		$gm_date = \gmdate( 'Y-m-d H:i:s', \strtotime( $activity['published'] ?? 'now' ) );

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -488,6 +488,18 @@ class Posts {
 
 		$deleted = 0;
 		foreach ( $post_ids as $post_id ) {
+			/**
+			 * Filter whether to preserve a specific ap_post from being purged.
+			 *
+			 * @param bool $preserve Whether to preserve this post. Default false.
+			 * @param int  $post_id  The ap_post ID being considered for deletion.
+			 *
+			 * @return bool Whether to preserve this post from deletion.
+			 */
+			if ( \apply_filters( 'activitypub_preserve_ap_post', false, $post_id ) ) {
+				continue;
+			}
+
 			/*
 			 * Preserve posts with comments from local users.
 			 * Local user comments have a user_id > 0, while Fediverse comments have user_id = 0.

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -344,7 +344,7 @@ class Health_Check {
 
 		$info['activitypub']['fields']['activitypub_ap_post_purge_days'] = array(
 			'label'   => \__( 'Remote Posts Retention Period', 'activitypub' ),
-			'value'   => \esc_attr( (int) \get_option( 'activitypub_ap_post_purge_days', 180 ) ),
+			'value'   => \esc_attr( (int) \get_option( 'activitypub_ap_post_purge_days', 30 ) ),
 			'private' => false,
 		);
 

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -342,6 +342,12 @@ class Health_Check {
 			'private' => false,
 		);
 
+		$info['activitypub']['fields']['activitypub_ap_post_purge_days'] = array(
+			'label'   => \__( 'Remote Posts Retention Period', 'activitypub' ),
+			'value'   => \esc_attr( (int) \get_option( 'activitypub_ap_post_purge_days', 180 ) ),
+			'private' => false,
+		);
+
 		$info['activitypub']['fields']['vary_header'] = array(
 			'label'   => \__( 'Vary Header', 'activitypub' ),
 			'value'   => \esc_attr( (int) \get_option( 'activitypub_vary_header', '1' ) ),

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -188,6 +188,17 @@ class Settings {
 
 		\register_setting(
 			'activitypub_advanced',
+			'activitypub_ap_post_purge_days',
+			array(
+				'type'         => 'integer',
+				'description'  => \__( 'Number of days to keep remote posts.', 'activitypub' ),
+				'default'      => 180,
+				'show_in_rest' => false,
+			)
+		);
+
+		\register_setting(
+			'activitypub_advanced',
 			'activitypub_vary_header',
 			array(
 				'type'        => 'boolean',

--- a/includes/wp-admin/class-settings.php
+++ b/includes/wp-admin/class-settings.php
@@ -190,10 +190,9 @@ class Settings {
 			'activitypub_advanced',
 			'activitypub_ap_post_purge_days',
 			array(
-				'type'         => 'integer',
-				'description'  => \__( 'Number of days to keep remote posts.', 'activitypub' ),
-				'default'      => 180,
-				'show_in_rest' => false,
+				'type'        => 'integer',
+				'description' => 'Number of days to keep remote posts.',
+				'default'     => 30,
 			)
 		);
 

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -315,7 +315,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 	 * @covers ::purge_outbox
 	 */
 	public function test_purge_outbox_with_different_purge_days() {
-		// Create posts older than initial_days.
+		// Create posts older than 4 months.
 		self::factory()->post->create_many(
 			25,
 			array(
@@ -328,21 +328,24 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			)
 		);
 
-		// Run purge_outbox with initial_days.
+		// Set initial purge days to 180 (posts are 4 months old, so they shouldn't be deleted).
+		update_option( 'activitypub_outbox_purge_days', 180 );
+
+		// Run purge_outbox with 180 days retention.
 		Scheduler::purge_outbox();
 		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
-		// Verify posts are not deleted.
+		// Verify posts are not deleted (4 months < 180 days).
 		$this->assertEquals( 25, wp_count_posts( Outbox::POST_TYPE )->publish );
 
-		// Change the purge days option.
+		// Change the purge days option to 90 days (posts are 4 months old, so they should be deleted).
 		update_option( 'activitypub_outbox_purge_days', 90 );
 
-		// Run purge_outbox with changed_days.
+		// Run purge_outbox with changed days.
 		Scheduler::purge_outbox();
 		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
-		// Verify posts are deleted.
+		// Verify posts are deleted (4 months > 90 days).
 		$this->assertEquals( 0, wp_count_posts( Outbox::POST_TYPE )->publish );
 	}
 
@@ -594,6 +597,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			)
 		);
 
+		// Set initial purge days to 180 (posts are 2 months old, so they shouldn't be deleted).
+		update_option( 'activitypub_inbox_purge_days', 180 );
+
 		// Mock the count to exceed the 200-post threshold.
 		$wp_count_posts_callback = function ( $counts, $type ) {
 			if ( Inbox::POST_TYPE === $type ) {
@@ -603,7 +609,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		};
 		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
-		// Run purge_inbox with default days (180).
+		// Run purge_inbox with 180 days retention.
 		Scheduler::purge_inbox();
 		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
@@ -838,6 +844,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			)
 		);
 
+		// Set initial purge days to 180 (posts are 2 months old, so they shouldn't be deleted).
+		update_option( 'activitypub_ap_post_purge_days', 180 );
+
 		// Mock the count to exceed the 200-post threshold.
 		$wp_count_posts_callback = function ( $counts, $type ) {
 			if ( Posts::POST_TYPE === $type ) {
@@ -847,7 +856,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		};
 		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
-		// Run purge_ap_posts with default days (180).
+		// Run purge_ap_posts with 180 days retention.
 		Scheduler::purge_ap_posts();
 		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -797,12 +797,13 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			)
 		);
 
-		// Add a comment to the second post.
+		// Add a comment from a local user to the second post.
 		self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => $post_with_comment,
 				'comment_content'  => 'Test comment',
 				'comment_approved' => 1,
+				'user_id'          => 1, // Local user comment.
 			)
 		);
 
@@ -824,7 +825,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		// Assert that post without comments was deleted.
 		$this->assertNull( get_post( $post_without_comments ) );
 
-		// Assert that post with comment was preserved.
+		// Assert that post with local user comment was preserved.
 		$this->assertNotNull( get_post( $post_with_comment ) );
 	}
 

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -12,6 +12,7 @@ use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
+use Activitypub\Collection\Posts;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Comment;
 use Activitypub\Dispatcher;
@@ -688,5 +689,188 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $activitypub_pre_http_get_remote_object_callback );
 		\remove_filter( 'pre_get_remote_metadata_by_actor', $pre_get_remote_metadata_by_actor_callback );
 		\remove_filter( 'schedule_event', $schedule_event_callback );
+	}
+
+	/**
+	 * Test purge_ap_posts method with more than 200 posts.
+	 *
+	 * @covers ::purge_ap_posts
+	 */
+	public function test_purge_ap_posts_more_than_200_posts() {
+		// Create 20 posts older than 6 months (will be deleted).
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+			)
+		);
+
+		// Create 5 posts newer than 6 months (will be kept).
+		self::factory()->post->create_many(
+			5,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+			)
+		);
+
+		// Mock the count to exceed the 200-post threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Posts::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		Scheduler::purge_ap_posts();
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		// Remove filter before checking actual count.
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Assert that 20 old posts were deleted, leaving 5.
+		$actual_count = get_posts(
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+		$this->assertEquals( 5, count( $actual_count ) );
+	}
+
+	/**
+	 * Test purge_ap_posts method with 200 or fewer posts.
+	 *
+	 * @covers ::purge_ap_posts
+	 */
+	public function test_purge_ap_posts_200_or_fewer_posts() {
+		// Create 20 posts, all older than 1 year.
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-13 months' ) ),
+			)
+		);
+
+		Scheduler::purge_ap_posts();
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		// Assert that no posts were deleted (below threshold).
+		$this->assertEquals( 20, wp_count_posts( Posts::POST_TYPE )->publish );
+	}
+
+	/**
+	 * Test purge_ap_posts preserves posts with comments.
+	 *
+	 * @covers ::purge_ap_posts
+	 */
+	public function test_purge_ap_posts_preserves_posts_with_comments() {
+		// Create an old post without comments (will be deleted).
+		$post_without_comments = self::factory()->post->create(
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+			)
+		);
+
+		// Create an old post with a comment (will be preserved).
+		$post_with_comment = self::factory()->post->create(
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+			)
+		);
+
+		// Add a comment to the second post.
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_with_comment,
+				'comment_content'  => 'Test comment',
+				'comment_approved' => 1,
+			)
+		);
+
+		// Mock the count to exceed the 200-post threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Posts::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		Scheduler::purge_ap_posts();
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		// Remove filter.
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Assert that post without comments was deleted.
+		$this->assertNull( get_post( $post_without_comments ) );
+
+		// Assert that post with comment was preserved.
+		$this->assertNotNull( get_post( $post_with_comment ) );
+	}
+
+	/**
+	 * Test purge_ap_posts method with changing activitypub_ap_post_purge_days option.
+	 *
+	 * @covers ::purge_ap_posts
+	 */
+	public function test_purge_ap_posts_with_different_purge_days() {
+		// Create posts older than 2 months.
+		self::factory()->post->create_many(
+			25,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-2 months' ) ),
+				'post_status' => 'publish',
+			)
+		);
+
+		// Mock the count to exceed the 200-post threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Posts::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		// Run purge_ap_posts with default days (180).
+		Scheduler::purge_ap_posts();
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		// Remove filter before checking actual count.
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Verify posts are not deleted (2 months < 180 days).
+		$this->assertEquals( 25, wp_count_posts( Posts::POST_TYPE )->publish );
+
+		// Change the purge days option to 30 days.
+		update_option( 'activitypub_ap_post_purge_days', 30 );
+
+		// Re-add the mock filter for the second purge run.
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		// Run purge_ap_posts with changed days.
+		Scheduler::purge_ap_posts();
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		// Remove filter before checking actual count.
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Verify posts are deleted (2 months > 30 days).
+		$this->assertEquals( 0, wp_count_posts( Posts::POST_TYPE )->publish );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -142,7 +142,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $event;
 		};
-		add_filter( 'schedule_event', $schedule_event_callback );
+		\add_filter( 'schedule_event', $schedule_event_callback );
 
 		// Run reprocess_outbox.
 		Scheduler::reprocess_outbox();
@@ -154,7 +154,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 
 		// Test with published activities (should not be scheduled).
 		$published_id = Outbox::add( $activity, self::$user_id );
-		wp_update_post(
+		\wp_update_post(
 			array(
 				'ID'          => $published_id,
 				'post_status' => 'publish',
@@ -171,7 +171,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		$this->assertNotContains( $published_id, $scheduled_events, 'Published activity should not be scheduled' );
 
 		// Clean up.
-		remove_filter( 'schedule_event', $schedule_event_callback );
+		\remove_filter( 'schedule_event', $schedule_event_callback );
 	}
 
 	/**
@@ -187,7 +187,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $event;
 		};
-		add_filter( 'schedule_event', $schedule_event_callback );
+		\add_filter( 'schedule_event', $schedule_event_callback );
 
 		// Run reprocess_outbox with no pending activities.
 		Scheduler::reprocess_outbox();
@@ -195,7 +195,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		// Verify no events were scheduled.
 		$this->assertEmpty( $scheduled_events, 'No events should be scheduled when there are no pending activities' );
 
-		remove_filter( 'schedule_event', $schedule_event_callback );
+		\remove_filter( 'schedule_event', $schedule_event_callback );
 	}
 
 	/**
@@ -226,16 +226,16 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $event;
 		};
-		add_filter( 'schedule_event', $schedule_event_callback );
+		\add_filter( 'schedule_event', $schedule_event_callback );
 
 		// Run reprocess_outbox.
 		Scheduler::reprocess_outbox();
 
 		// Verify scheduling time.
-		$this->assertSame( $scheduled_time, wp_next_scheduled( 'activitypub_process_outbox', array( $pending_id ) ) );
+		$this->assertSame( $scheduled_time, \wp_next_scheduled( 'activitypub_process_outbox', array( $pending_id ) ) );
 
 		// Clean up.
-		remove_filter( 'schedule_event', $schedule_event_callback );
+		\remove_filter( 'schedule_event', $schedule_event_callback );
 	}
 
 	/**
@@ -250,9 +250,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 month' ) ),
 				'meta_input'  => array(
-					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Update',
+					'_activitypub_activity_type' => \wp_rand( 0, 1 ) ? 'Create' : 'Update',
 				),
 			)
 		);
@@ -261,9 +261,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 				'meta_input'  => array(
-					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Update',
+					'_activitypub_activity_type' => \wp_rand( 0, 1 ) ? 'Create' : 'Update',
 				),
 			)
 		);
@@ -271,7 +271,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			5,
 			array(
 				'post_type'   => Outbox::POST_TYPE,
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 				'post_status' => 'publish',
 				'meta_input'  => array(
 					'_activitypub_activity_type' => 'Follow',
@@ -280,10 +280,10 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		);
 
 		Scheduler::purge_outbox();
-		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
 		// Assert that 5 posts were deleted, leaving 25.
-		$this->assertEquals( 30, wp_count_posts( Outbox::POST_TYPE )->publish );
+		$this->assertEquals( 30, \wp_count_posts( Outbox::POST_TYPE )->publish );
 	}
 
 	/**
@@ -298,15 +298,15 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 			)
 		);
 
 		Scheduler::purge_outbox();
-		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
 		// Assert that no posts were deleted.
-		$this->assertEquals( 20, wp_count_posts( Outbox::POST_TYPE )->publish );
+		$this->assertEquals( 20, \wp_count_posts( Outbox::POST_TYPE )->publish );
 	}
 
 	/**
@@ -320,33 +320,33 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			25,
 			array(
 				'post_type'   => Outbox::POST_TYPE,
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-4 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-4 months' ) ),
 				'post_status' => 'publish',
 				'meta_input'  => array(
-					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Update',
+					'_activitypub_activity_type' => \wp_rand( 0, 1 ) ? 'Create' : 'Update',
 				),
 			)
 		);
 
 		// Set initial purge days to 180 (posts are 4 months old, so they shouldn't be deleted).
-		update_option( 'activitypub_outbox_purge_days', 180 );
+		\update_option( 'activitypub_outbox_purge_days', 180 );
 
 		// Run purge_outbox with 180 days retention.
 		Scheduler::purge_outbox();
-		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
 		// Verify posts are not deleted (4 months < 180 days).
-		$this->assertEquals( 25, wp_count_posts( Outbox::POST_TYPE )->publish );
+		$this->assertEquals( 25, \wp_count_posts( Outbox::POST_TYPE )->publish );
 
 		// Change the purge days option to 90 days (posts are 4 months old, so they should be deleted).
-		update_option( 'activitypub_outbox_purge_days', 90 );
+		\update_option( 'activitypub_outbox_purge_days', 90 );
 
 		// Run purge_outbox with changed days.
 		Scheduler::purge_outbox();
-		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
 		// Verify posts are deleted (4 months > 90 days).
-		$this->assertEquals( 0, wp_count_posts( Outbox::POST_TYPE )->publish );
+		$this->assertEquals( 0, \wp_count_posts( Outbox::POST_TYPE )->publish );
 	}
 
 	/**
@@ -368,12 +368,12 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		\do_action( 'activitypub_update_comment_counts', 10, 0 );
 
 		// Verify a scheduled event was created.
-		$next_scheduled = wp_next_scheduled( 'activitypub_update_comment_counts', array( 10, 0 ) );
+		$next_scheduled = \wp_next_scheduled( 'activitypub_update_comment_counts', array( 10, 0 ) );
 		$this->assertNotFalse( $next_scheduled );
 
 		// Clean up.
-		delete_option( 'activitypub_migration_lock' );
-		wp_clear_scheduled_hook( 'activitypub_update_comment_counts', array( 10, 0 ) );
+		\delete_option( 'activitypub_migration_lock' );
+		\wp_clear_scheduled_hook( 'activitypub_update_comment_counts', array( 10, 0 ) );
 	}
 
 	/**
@@ -462,12 +462,12 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $event;
 		};
-		add_filter( 'schedule_event', $schedule_event_callback );
+		\add_filter( 'schedule_event', $schedule_event_callback );
 
 		Scheduler::schedule_announce_activity( $outbox_activity_id, $activity, self::$user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
 
 		// Get the most recent outbox item for the blog actor.
-		$announce_outbox_items = get_posts(
+		$announce_outbox_items = \get_posts(
 			array(
 				'post_type'      => Outbox::POST_TYPE,
 				'post_author'    => Actors::BLOG_USER_ID,
@@ -485,8 +485,8 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		$this->assertContains( $announce_outbox_id, $scheduled_events, 'Should schedule the announce outbox activity' );
 
 		// Check for Announce activity in the outbox.
-		$announce_post     = get_post( $announce_outbox_id );
-		$announce_activity = json_decode( $announce_post->post_content, true );
+		$announce_post     = \get_post( $announce_outbox_id );
+		$announce_activity = \json_decode( $announce_post->post_content, true );
 		$this->assertEquals( 'Announce', $announce_activity['type'] );
 
 		// Verify the original author is in the CC field.
@@ -495,7 +495,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		$this->assertContains( $original_author_url, $announce_activity['cc'], 'Original author should be in cc field' );
 
 		// Clean up.
-		remove_filter( 'schedule_event', $schedule_event_callback );
+		\remove_filter( 'schedule_event', $schedule_event_callback );
 	}
 
 	/**
@@ -510,9 +510,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 month' ) ),
 				'meta_input'  => array(
-					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Follow',
+					'_activitypub_activity_type' => \wp_rand( 0, 1 ) ? 'Create' : 'Follow',
 				),
 			)
 		);
@@ -521,9 +521,9 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-13 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-13 months' ) ),
 				'meta_input'  => array(
-					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Follow',
+					'_activitypub_activity_type' => \wp_rand( 0, 1 ) ? 'Create' : 'Follow',
 				),
 			)
 		);
@@ -535,13 +535,13 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		Scheduler::purge_inbox();
-		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
 		// Assert that 5 posts were deleted, leaving 20.
-		$actual_count = get_posts(
+		$actual_count = \get_posts(
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
@@ -549,10 +549,10 @@ class Test_Scheduler extends \WP_UnitTestCase {
 				'fields'      => 'ids',
 			)
 		);
-		$this->assertEquals( 20, count( $actual_count ) );
+		$this->assertEquals( 20, \count( $actual_count ) );
 
 		// Clean up filter.
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 	}
 
 	/**
@@ -567,15 +567,15 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-13 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-13 months' ) ),
 			)
 		);
 
 		Scheduler::purge_inbox();
-		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
 		// Assert that no posts were deleted.
-		$this->assertEquals( 20, wp_count_posts( Inbox::POST_TYPE )->publish );
+		$this->assertEquals( 20, \wp_count_posts( Inbox::POST_TYPE )->publish );
 	}
 
 	/**
@@ -589,16 +589,16 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			25,
 			array(
 				'post_type'   => Inbox::POST_TYPE,
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-2 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-2 months' ) ),
 				'post_status' => 'publish',
 				'meta_input'  => array(
-					'_activitypub_activity_type' => wp_rand( 0, 1 ) ? 'Create' : 'Follow',
+					'_activitypub_activity_type' => \wp_rand( 0, 1 ) ? 'Create' : 'Follow',
 				),
 			)
 		);
 
 		// Set initial purge days to 180 (posts are 2 months old, so they shouldn't be deleted).
-		update_option( 'activitypub_inbox_purge_days', 180 );
+		\update_option( 'activitypub_inbox_purge_days', 180 );
 
 		// Mock the count to exceed the 200-post threshold.
 		$wp_count_posts_callback = function ( $counts, $type ) {
@@ -607,33 +607,33 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		// Run purge_inbox with 180 days retention.
 		Scheduler::purge_inbox();
-		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
 		// Remove filter before checking actual count.
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Verify posts are not deleted (2 months < 180 days).
-		$this->assertEquals( 25, wp_count_posts( Inbox::POST_TYPE )->publish );
+		$this->assertEquals( 25, \wp_count_posts( Inbox::POST_TYPE )->publish );
 
 		// Change the purge days option to 30 days.
-		update_option( 'activitypub_inbox_purge_days', 30 );
+		\update_option( 'activitypub_inbox_purge_days', 30 );
 
 		// Re-add the mock filter for the second purge run.
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		// Run purge_inbox with changed days.
 		Scheduler::purge_inbox();
-		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
 		// Remove filter before checking actual count.
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Verify posts are deleted (2 months > 30 days).
-		$this->assertEquals( 0, wp_count_posts( Inbox::POST_TYPE )->publish );
+		$this->assertEquals( 0, \wp_count_posts( Inbox::POST_TYPE )->publish );
 	}
 
 	/**
@@ -709,7 +709,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 			)
 		);
 
@@ -719,7 +719,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 month' ) ),
 			)
 		);
 
@@ -730,16 +730,16 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		Scheduler::purge_ap_posts();
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
 		// Remove filter before checking actual count.
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Assert that 20 old posts were deleted, leaving 5.
-		$actual_count = get_posts(
+		$actual_count = \get_posts(
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
@@ -747,7 +747,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 				'fields'      => 'ids',
 			)
 		);
-		$this->assertEquals( 5, count( $actual_count ) );
+		$this->assertEquals( 5, \count( $actual_count ) );
 	}
 
 	/**
@@ -762,15 +762,15 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-13 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-13 months' ) ),
 			)
 		);
 
 		Scheduler::purge_ap_posts();
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
 		// Assert that no posts were deleted (below threshold).
-		$this->assertEquals( 20, wp_count_posts( Posts::POST_TYPE )->publish );
+		$this->assertEquals( 20, \wp_count_posts( Posts::POST_TYPE )->publish );
 	}
 
 	/**
@@ -784,7 +784,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 			)
 		);
 
@@ -793,7 +793,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 			)
 		);
 
@@ -814,19 +814,19 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		Scheduler::purge_ap_posts();
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
 		// Remove filter.
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Assert that post without comments was deleted.
-		$this->assertNull( get_post( $post_without_comments ) );
+		$this->assertNull( \get_post( $post_without_comments ) );
 
 		// Assert that post with local user comment was preserved.
-		$this->assertNotNull( get_post( $post_with_comment ) );
+		$this->assertNotNull( \get_post( $post_with_comment ) );
 	}
 
 	/**
@@ -840,13 +840,13 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			25,
 			array(
 				'post_type'   => Posts::POST_TYPE,
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-2 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-2 months' ) ),
 				'post_status' => 'publish',
 			)
 		);
 
 		// Set initial purge days to 180 (posts are 2 months old, so they shouldn't be deleted).
-		update_option( 'activitypub_ap_post_purge_days', 180 );
+		\update_option( 'activitypub_ap_post_purge_days', 180 );
 
 		// Mock the count to exceed the 200-post threshold.
 		$wp_count_posts_callback = function ( $counts, $type ) {
@@ -855,32 +855,32 @@ class Test_Scheduler extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		// Run purge_ap_posts with 180 days retention.
 		Scheduler::purge_ap_posts();
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
 		// Remove filter before checking actual count.
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Verify posts are not deleted (2 months < 180 days).
-		$this->assertEquals( 25, wp_count_posts( Posts::POST_TYPE )->publish );
+		$this->assertEquals( 25, \wp_count_posts( Posts::POST_TYPE )->publish );
 
 		// Change the purge days option to 30 days.
-		update_option( 'activitypub_ap_post_purge_days', 30 );
+		\update_option( 'activitypub_ap_post_purge_days', 30 );
 
 		// Re-add the mock filter for the second purge run.
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		// Run purge_ap_posts with changed days.
 		Scheduler::purge_ap_posts();
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
 		// Remove filter before checking actual count.
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Verify posts are deleted (2 months > 30 days).
-		$this->assertEquals( 0, wp_count_posts( Posts::POST_TYPE )->publish );
+		$this->assertEquals( 0, \wp_count_posts( Posts::POST_TYPE )->publish );
 	}
 }

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -1115,7 +1115,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 			)
 		);
 
@@ -1125,7 +1125,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 month' ) ),
 			)
 		);
 
@@ -1136,18 +1136,18 @@ class Test_Inbox extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		$deleted = Inbox::purge( 180 );
-		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Assert that 20 old posts were deleted.
 		$this->assertEquals( 20, $deleted );
 
 		// Verify 5 new posts remain.
-		$remaining = get_posts(
+		$remaining = \get_posts(
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
@@ -1170,16 +1170,16 @@ class Test_Inbox extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
 		$deleted = Inbox::purge( 180 );
-		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
 		// Assert no posts were deleted (below threshold).
 		$this->assertEquals( 0, $deleted );
-		$this->assertEquals( 20, wp_count_posts( Inbox::POST_TYPE )->publish );
+		$this->assertEquals( 20, \wp_count_posts( Inbox::POST_TYPE )->publish );
 	}
 
 	/**
@@ -1194,7 +1194,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-45 days' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-45 days' ) ),
 			)
 		);
 
@@ -1205,7 +1205,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		// Purge with 60 days retention - should not delete.
 		$deleted = Inbox::purge( 60 );
@@ -1213,9 +1213,9 @@ class Test_Inbox extends \WP_UnitTestCase {
 
 		// Purge with 30 days retention - should delete all.
 		$deleted = Inbox::purge( 30 );
-		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		$this->assertEquals( 10, $deleted );
 	}
@@ -1232,7 +1232,7 @@ class Test_Inbox extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Inbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
@@ -1243,11 +1243,11 @@ class Test_Inbox extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		$deleted = Inbox::purge( 180 );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Should return exact count of deleted posts.
 		$this->assertEquals( 15, $deleted );

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -1102,4 +1102,154 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$remote_actor_meta = \get_post_meta( $inbox_id, '_activitypub_activity_remote_actor', true );
 		$this->assertEquals( 'https://pixelfed.social/users/pfefferle', $remote_actor_meta );
 	}
+
+	/**
+	 * Test purge method with more than 200 posts.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_more_than_200_posts() {
+		// Create 20 old posts (will be deleted).
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+			)
+		);
+
+		// Create 5 new posts (will be kept).
+		self::factory()->post->create_many(
+			5,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+			)
+		);
+
+		// Mock the count to exceed the 200-post threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Inbox::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		$deleted = Inbox::purge( 180 );
+		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Assert that 20 old posts were deleted.
+		$this->assertEquals( 20, $deleted );
+
+		// Verify 5 new posts remain.
+		$remaining = get_posts(
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+		$this->assertCount( 5, $remaining );
+	}
+
+	/**
+	 * Test purge method with 200 or fewer posts.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_200_or_fewer_posts() {
+		// Create 20 old posts.
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		$deleted = Inbox::purge( 180 );
+		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+
+		// Assert no posts were deleted (below threshold).
+		$this->assertEquals( 0, $deleted );
+		$this->assertEquals( 20, wp_count_posts( Inbox::POST_TYPE )->publish );
+	}
+
+	/**
+	 * Test purge method with different retention days.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_with_different_days() {
+		// Create posts older than 60 days but newer than 30 days.
+		self::factory()->post->create_many(
+			10,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-45 days' ) ),
+			)
+		);
+
+		// Mock the count to exceed threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Inbox::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		// Purge with 60 days retention - should not delete.
+		$deleted = Inbox::purge( 60 );
+		$this->assertEquals( 0, $deleted );
+
+		// Purge with 30 days retention - should delete all.
+		$deleted = Inbox::purge( 30 );
+		wp_cache_delete( _count_posts_cache_key( Inbox::POST_TYPE ), 'counts' );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		$this->assertEquals( 10, $deleted );
+	}
+
+	/**
+	 * Test purge returns count of deleted items.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_returns_deleted_count() {
+		// Create 15 old posts.
+		self::factory()->post->create_many(
+			15,
+			array(
+				'post_type'   => Inbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		// Mock the count to exceed threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Inbox::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		$deleted = Inbox::purge( 180 );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Should return exact count of deleted posts.
+		$this->assertEquals( 15, $deleted );
+	}
 }

--- a/tests/phpunit/tests/includes/collection/class-test-outbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-outbox.php
@@ -222,16 +222,16 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Create first outbox item.
 		$first_id = \Activitypub\add_to_outbox( $object, $activity_type, 1 );
 		$this->assertNotFalse( $first_id );
-		$this->assertEquals( 'pending', get_post_status( $first_id ) );
+		$this->assertEquals( 'pending', \get_post_status( $first_id ) );
 
 		// Create second outbox item with same object_id and activity_type.
 		$second_id = \Activitypub\add_to_outbox( $object, $activity_type, 1 );
 		$this->assertNotFalse( $second_id );
 
 		// First item should now be published (invalidated).
-		$this->assertEquals( 'publish', get_post_status( $first_id ) );
+		$this->assertEquals( 'publish', \get_post_status( $first_id ) );
 		// New item should still be pending.
-		$this->assertEquals( 'pending', get_post_status( $second_id ) );
+		$this->assertEquals( 'pending', \get_post_status( $second_id ) );
 	}
 
 	/**
@@ -252,10 +252,10 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Add new item that should trigger invalidation of item1.
 		$new_item = \Activitypub\add_to_outbox( $object1, 'Create', 1 );
 
-		$this->assertEquals( 'publish', get_post_status( $item1 ) );
-		$this->assertEquals( 'pending', get_post_status( $item2 ) );
-		$this->assertEquals( 'pending', get_post_status( $item3 ) );
-		$this->assertEquals( 'pending', get_post_status( $new_item ) );
+		$this->assertEquals( 'publish', \get_post_status( $item1 ) );
+		$this->assertEquals( 'pending', \get_post_status( $item2 ) );
+		$this->assertEquals( 'pending', \get_post_status( $item3 ) );
+		$this->assertEquals( 'pending', \get_post_status( $new_item ) );
 	}
 
 	/**
@@ -271,19 +271,19 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$update_id = \Activitypub\add_to_outbox( $object, 'Update', 1 );
 		$like_id   = \Activitypub\add_to_outbox( $object, 'Like', 1 );
 
-		$this->assertEquals( 'pending', get_post_status( $create_id ) );
-		$this->assertEquals( 'pending', get_post_status( $update_id ) );
-		$this->assertEquals( 'pending', get_post_status( $like_id ) );
+		$this->assertEquals( 'pending', \get_post_status( $create_id ) );
+		$this->assertEquals( 'pending', \get_post_status( $update_id ) );
+		$this->assertEquals( 'pending', \get_post_status( $like_id ) );
 
 		// Add Delete activity.
 		$delete_id = \Activitypub\add_to_outbox( $object, 'Delete', 1 );
 
 		// All previous activities should be published (invalidated).
-		$this->assertEquals( 'publish', get_post_status( $create_id ) );
-		$this->assertEquals( 'publish', get_post_status( $update_id ) );
-		$this->assertEquals( 'publish', get_post_status( $like_id ) );
+		$this->assertEquals( 'publish', \get_post_status( $create_id ) );
+		$this->assertEquals( 'publish', \get_post_status( $update_id ) );
+		$this->assertEquals( 'publish', \get_post_status( $like_id ) );
 		// Delete activity should still be pending.
-		$this->assertEquals( 'pending', get_post_status( $delete_id ) );
+		$this->assertEquals( 'pending', \get_post_status( $delete_id ) );
 	}
 
 	/**
@@ -404,9 +404,9 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Only ID for Deletes.
 		if ( 'Delete' === $expected ) {
-			$this->assertSame( get_permalink( $id ), $activity->get_object() );
+			$this->assertSame( \get_permalink( $id ), $activity->get_object() );
 		} else {
-			$outbox_activity = json_decode( get_post( $undo_id )->post_content, true );
+			$outbox_activity = \json_decode( \get_post( $undo_id )->post_content, true );
 			$this->assertEquals( $outbox_activity['object'], $activity->get_object()->to_array( false ) );
 		}
 
@@ -458,8 +458,8 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$this->assertNotInstanceOf( \WP_Error::class, $activity );
 
 		// Verify the updated attribute is set and matches the post's modified date.
-		$post             = get_post( $id );
-		$expected_updated = gmdate( 'Y-m-d\TH:i:s\Z', strtotime( $post->post_modified ) );
+		$post             = \get_post( $id );
+		$expected_updated = \gmdate( 'Y-m-d\TH:i:s\Z', \strtotime( $post->post_modified ) );
 		$this->assertEquals( $expected_updated, $activity->get_updated() );
 	}
 
@@ -475,7 +475,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 				'meta_input'  => array(
 					'_activitypub_activity_type' => 'Create',
 				),
@@ -488,7 +488,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 month' ) ),
 				'meta_input'  => array(
 					'_activitypub_activity_type' => 'Create',
 				),
@@ -502,18 +502,18 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		$deleted = Outbox::purge( 180 );
-		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Assert that 20 old posts were deleted.
 		$this->assertEquals( 20, $deleted );
 
 		// Verify 5 new posts remain.
-		$remaining = get_posts(
+		$remaining = \get_posts(
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
@@ -536,16 +536,16 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
 		$deleted = Outbox::purge( 180 );
-		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
 		// Assert no posts were deleted (below threshold).
 		$this->assertEquals( 0, $deleted );
-		$this->assertEquals( 15, wp_count_posts( Outbox::POST_TYPE )->publish );
+		$this->assertEquals( 15, \wp_count_posts( Outbox::POST_TYPE )->publish );
 	}
 
 	/**
@@ -559,20 +559,20 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
-		update_post_meta( $follow_post_id, '_activitypub_activity_type', 'Follow' );
+		\update_post_meta( $follow_post_id, '_activitypub_activity_type', 'Follow' );
 
 		// Create old Create activity (should be deleted).
 		$create_post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
-		update_post_meta( $create_post_id, '_activitypub_activity_type', 'Create' );
+		\update_post_meta( $create_post_id, '_activitypub_activity_type', 'Create' );
 
 		// Mock the count to exceed the 20-post threshold.
 		$wp_count_posts_callback = function ( $counts, $type ) {
@@ -581,21 +581,21 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		$deleted = Outbox::purge( 180 );
-		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Assert only 1 post was deleted (Create, not Follow).
 		$this->assertEquals( 1, $deleted );
 
 		// Follow activity should still exist.
-		$this->assertNotNull( get_post( $follow_post_id ) );
+		$this->assertNotNull( \get_post( $follow_post_id ) );
 
 		// Create activity should be deleted.
-		$this->assertNull( get_post( $create_post_id ) );
+		$this->assertNull( \get_post( $create_post_id ) );
 	}
 
 	/**
@@ -610,7 +610,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			array(
 				'post_type'   => Outbox::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-45 days' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-45 days' ) ),
 				'meta_input'  => array(
 					'_activitypub_activity_type' => 'Create',
 				),
@@ -624,7 +624,7 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		// Purge with 60 days retention - should not delete.
 		$deleted = Outbox::purge( 60 );
@@ -632,9 +632,9 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		// Purge with 30 days retention - should delete all.
 		$deleted = Outbox::purge( 30 );
-		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		$this->assertEquals( 10, $deleted );
 	}

--- a/tests/phpunit/tests/includes/collection/class-test-outbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-outbox.php
@@ -462,4 +462,180 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$expected_updated = gmdate( 'Y-m-d\TH:i:s\Z', strtotime( $post->post_modified ) );
 		$this->assertEquals( $expected_updated, $activity->get_updated() );
 	}
+
+	/**
+	 * Test purge method with more than 20 posts.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_more_than_20_posts() {
+		// Create 20 old posts with activity type (will be deleted).
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'meta_input'  => array(
+					'_activitypub_activity_type' => 'Create',
+				),
+			)
+		);
+
+		// Create 5 new posts (will be kept).
+		self::factory()->post->create_many(
+			5,
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'meta_input'  => array(
+					'_activitypub_activity_type' => 'Create',
+				),
+			)
+		);
+
+		// Mock the count to exceed the 20-post threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Outbox::POST_TYPE === $type ) {
+				$counts->publish = 25;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		$deleted = Outbox::purge( 180 );
+		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Assert that 20 old posts were deleted.
+		$this->assertEquals( 20, $deleted );
+
+		// Verify 5 new posts remain.
+		$remaining = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+		$this->assertCount( 5, $remaining );
+	}
+
+	/**
+	 * Test purge method with 20 or fewer posts.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_20_or_fewer_posts() {
+		// Create 15 old posts.
+		self::factory()->post->create_many(
+			15,
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		$deleted = Outbox::purge( 180 );
+		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+
+		// Assert no posts were deleted (below threshold).
+		$this->assertEquals( 0, $deleted );
+		$this->assertEquals( 15, wp_count_posts( Outbox::POST_TYPE )->publish );
+	}
+
+	/**
+	 * Test purge method preserves Follow activities.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_preserves_follow_activities() {
+		// Create old Follow activity (should be preserved).
+		$follow_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+		update_post_meta( $follow_post_id, '_activitypub_activity_type', 'Follow' );
+
+		// Create old Create activity (should be deleted).
+		$create_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+		update_post_meta( $create_post_id, '_activitypub_activity_type', 'Create' );
+
+		// Mock the count to exceed the 20-post threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Outbox::POST_TYPE === $type ) {
+				$counts->publish = 25;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		$deleted = Outbox::purge( 180 );
+		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Assert only 1 post was deleted (Create, not Follow).
+		$this->assertEquals( 1, $deleted );
+
+		// Follow activity should still exist.
+		$this->assertNotNull( get_post( $follow_post_id ) );
+
+		// Create activity should be deleted.
+		$this->assertNull( get_post( $create_post_id ) );
+	}
+
+	/**
+	 * Test purge method with different retention days.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_with_different_days() {
+		// Create posts older than 60 days but newer than 30 days.
+		self::factory()->post->create_many(
+			10,
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-45 days' ) ),
+				'meta_input'  => array(
+					'_activitypub_activity_type' => 'Create',
+				),
+			)
+		);
+
+		// Mock the count to exceed threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Outbox::POST_TYPE === $type ) {
+				$counts->publish = 25;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		// Purge with 60 days retention - should not delete.
+		$deleted = Outbox::purge( 60 );
+		$this->assertEquals( 0, $deleted );
+
+		// Purge with 30 days retention - should delete all.
+		$deleted = Outbox::purge( 30 );
+		wp_cache_delete( _count_posts_cache_key( Outbox::POST_TYPE ), 'counts' );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		$this->assertEquals( 10, $deleted );
+	}
 }

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -1342,4 +1342,270 @@ class Test_Posts extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( '#test', $result );
 		$this->assertStringNotContainsString( '#php', $result );
 	}
+
+	/**
+	 * Test purge method with more than 200 posts.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_more_than_200_posts() {
+		// Create 20 old posts (will be deleted).
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+			)
+		);
+
+		// Create 5 new posts (will be kept).
+		self::factory()->post->create_many(
+			5,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+			)
+		);
+
+		// Mock the count to exceed the 200-post threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Posts::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		$deleted = Posts::purge( 180 );
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Assert that 20 old posts were deleted.
+		$this->assertEquals( 20, $deleted );
+
+		// Verify 5 new posts remain.
+		$remaining = get_posts(
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+		$this->assertCount( 5, $remaining );
+	}
+
+	/**
+	 * Test purge method with 200 or fewer posts.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_200_or_fewer_posts() {
+		// Create 20 old posts.
+		self::factory()->post->create_many(
+			20,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		$deleted = Posts::purge( 180 );
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		// Assert no posts were deleted (below threshold).
+		$this->assertEquals( 0, $deleted );
+		$this->assertEquals( 20, wp_count_posts( Posts::POST_TYPE )->publish );
+	}
+
+	/**
+	 * Test purge method preserves posts with comments.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_preserves_posts_with_comments() {
+		// Create old post without comments (should be deleted).
+		$post_without_comments = self::factory()->post->create(
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		// Create old post with a comment (should be preserved).
+		$post_with_comment = self::factory()->post->create(
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		// Add a comment to the second post.
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_with_comment,
+				'comment_content'  => 'Test comment',
+				'comment_approved' => 1,
+			)
+		);
+
+		// Mock the count to exceed the 200-post threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Posts::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		$deleted = Posts::purge( 180 );
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Assert only 1 post was deleted.
+		$this->assertEquals( 1, $deleted );
+
+		// Post without comments should be deleted.
+		$this->assertNull( get_post( $post_without_comments ) );
+
+		// Post with comment should still exist.
+		$this->assertNotNull( get_post( $post_with_comment ) );
+	}
+
+	/**
+	 * Test purge preserves posts with multiple comments.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_preserves_posts_with_multiple_comments() {
+		// Create old post with multiple comments (should be preserved).
+		$post_with_comments = self::factory()->post->create(
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		// Add multiple comments.
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_with_comments,
+				'comment_content'  => 'First comment',
+				'comment_approved' => 1,
+			)
+		);
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_with_comments,
+				'comment_content'  => 'Second comment',
+				'comment_approved' => 1,
+			)
+		);
+
+		// Create old post without any interactions (should be deleted).
+		$post_without_interactions = self::factory()->post->create(
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		// Mock the count to exceed threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Posts::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		$deleted = Posts::purge( 180 );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Only post without interactions should be deleted.
+		$this->assertEquals( 1, $deleted );
+		$this->assertNotNull( get_post( $post_with_comments ) );
+		$this->assertNull( get_post( $post_without_interactions ) );
+	}
+
+	/**
+	 * Test purge method with different retention days.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_with_different_days() {
+		// Create posts older than 60 days but newer than 30 days.
+		self::factory()->post->create_many(
+			10,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-45 days' ) ),
+			)
+		);
+
+		// Mock the count to exceed threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Posts::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		// Purge with 60 days retention - should not delete.
+		$deleted = Posts::purge( 60 );
+		$this->assertEquals( 0, $deleted );
+
+		// Purge with 30 days retention - should delete all.
+		$deleted = Posts::purge( 30 );
+		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		$this->assertEquals( 10, $deleted );
+	}
+
+	/**
+	 * Test purge returns count of deleted items.
+	 *
+	 * @covers ::purge
+	 */
+	public function test_purge_returns_deleted_count() {
+		// Create 15 old posts.
+		self::factory()->post->create_many(
+			15,
+			array(
+				'post_type'   => Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			)
+		);
+
+		// Mock the count to exceed threshold.
+		$wp_count_posts_callback = function ( $counts, $type ) {
+			if ( Posts::POST_TYPE === $type ) {
+				$counts->publish = 225;
+			}
+			return $counts;
+		};
+		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+
+		$deleted = Posts::purge( 180 );
+
+		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+
+		// Should return exact count of deleted posts.
+		$this->assertEquals( 15, $deleted );
+	}
 }

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -1423,7 +1423,7 @@ class Test_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test purge method preserves posts with comments.
+	 * Test purge method preserves posts with local user comments.
 	 *
 	 * @covers ::purge
 	 */
@@ -1437,7 +1437,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			)
 		);
 
-		// Create old post with a comment (should be preserved).
+		// Create old post with a local user comment (should be preserved).
 		$post_with_comment = self::factory()->post->create(
 			array(
 				'post_type'   => Posts::POST_TYPE,
@@ -1446,12 +1446,13 @@ class Test_Posts extends \WP_UnitTestCase {
 			)
 		);
 
-		// Add a comment to the second post.
+		// Add a comment from a local user to the second post.
 		self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => $post_with_comment,
 				'comment_content'  => 'Test comment',
 				'comment_approved' => 1,
+				'user_id'          => 1, // Local user comment.
 			)
 		);
 
@@ -1475,17 +1476,17 @@ class Test_Posts extends \WP_UnitTestCase {
 		// Post without comments should be deleted.
 		$this->assertNull( get_post( $post_without_comments ) );
 
-		// Post with comment should still exist.
+		// Post with local user comment should still exist.
 		$this->assertNotNull( get_post( $post_with_comment ) );
 	}
 
 	/**
-	 * Test purge preserves posts with multiple comments.
+	 * Test purge preserves posts with multiple local user comments.
 	 *
 	 * @covers ::purge
 	 */
 	public function test_purge_preserves_posts_with_multiple_comments() {
-		// Create old post with multiple comments (should be preserved).
+		// Create old post with multiple local user comments (should be preserved).
 		$post_with_comments = self::factory()->post->create(
 			array(
 				'post_type'   => Posts::POST_TYPE,
@@ -1494,12 +1495,13 @@ class Test_Posts extends \WP_UnitTestCase {
 			)
 		);
 
-		// Add multiple comments.
+		// Add multiple comments from local users.
 		self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => $post_with_comments,
 				'comment_content'  => 'First comment',
 				'comment_approved' => 1,
+				'user_id'          => 1, // Local user comment.
 			)
 		);
 		self::factory()->comment->create(
@@ -1507,6 +1509,7 @@ class Test_Posts extends \WP_UnitTestCase {
 				'comment_post_ID'  => $post_with_comments,
 				'comment_content'  => 'Second comment',
 				'comment_approved' => 1,
+				'user_id'          => 1, // Local user comment.
 			)
 		);
 

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -31,18 +31,18 @@ class Test_Posts extends \WP_UnitTestCase {
 		Post_Types::register_post_post_type();
 
 		// Mock HTTP requests for Remote_Actors::fetch_by_uri.
-		add_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10, 3 );
+		\add_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10, 3 );
 
 		// Also hook into the ActivityPub-specific filter to bypass URL validation.
-		add_filter( 'activitypub_pre_http_get_remote_object', array( $this, 'mock_remote_object' ), 10, 2 );
+		\add_filter( 'activitypub_pre_http_get_remote_object', array( $this, 'mock_remote_object' ), 10, 2 );
 	}
 
 	/**
 	 * Tear down test environment.
 	 */
 	public function tear_down() {
-		remove_filter( 'pre_http_request', array( $this, 'mock_http_request' ) );
-		remove_filter( 'activitypub_pre_http_get_remote_object', array( $this, 'mock_remote_object' ) );
+		\remove_filter( 'pre_http_request', array( $this, 'mock_http_request' ) );
+		\remove_filter( 'activitypub_pre_http_get_remote_object', array( $this, 'mock_remote_object' ) );
 
 		$this->remove_added_uploads();
 
@@ -353,7 +353,7 @@ class Test_Posts extends \WP_UnitTestCase {
 
 		$this->assertInstanceOf( '\WP_Post', $result );
 		$this->assertEquals( '2023-06-15 14:30:00', $result->post_date_gmt );
-		$this->assertEquals( get_date_from_gmt( '2023-06-15 14:30:00' ), $result->post_date );
+		$this->assertEquals( \get_date_from_gmt( '2023-06-15 14:30:00' ), $result->post_date );
 	}
 
 	/**
@@ -771,7 +771,7 @@ class Test_Posts extends \WP_UnitTestCase {
 		);
 		$this->assertCount( 1, $posts );
 		// Verify no attachments initially.
-		$attachments = get_attached_media( '', $post1->ID );
+		$attachments = \get_attached_media( '', $post1->ID );
 		$this->assertEmpty( $attachments );
 
 		// Update with attachments.
@@ -857,11 +857,11 @@ class Test_Posts extends \WP_UnitTestCase {
 		);
 
 		// Mock the new image URL.
-		add_filter(
+		\add_filter(
 			'pre_http_request',
 			function ( $response, $parsed_args, $url ) {
 				if ( 'https://example.com/new-image.jpg' === $url && isset( $parsed_args['filename'] ) ) {
-					copy( AP_TESTS_DIR . '/data/assets/test.jpg', $parsed_args['filename'] );
+					\copy( AP_TESTS_DIR . '/data/assets/test.jpg', $parsed_args['filename'] );
 
 					return array(
 						'response' => array( 'code' => 200 ),
@@ -1355,7 +1355,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-7 months' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-7 months' ) ),
 			)
 		);
 
@@ -1365,7 +1365,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 month' ) ),
 			)
 		);
 
@@ -1376,18 +1376,18 @@ class Test_Posts extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		$deleted = Posts::purge( 180 );
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Assert that 20 old posts were deleted.
 		$this->assertEquals( 20, $deleted );
 
 		// Verify 5 new posts remain.
-		$remaining = get_posts(
+		$remaining = \get_posts(
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
@@ -1410,16 +1410,16 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
 		$deleted = Posts::purge( 180 );
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
 		// Assert no posts were deleted (below threshold).
 		$this->assertEquals( 0, $deleted );
-		$this->assertEquals( 20, wp_count_posts( Posts::POST_TYPE )->publish );
+		$this->assertEquals( 20, \wp_count_posts( Posts::POST_TYPE )->publish );
 	}
 
 	/**
@@ -1433,7 +1433,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
@@ -1442,7 +1442,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
@@ -1463,21 +1463,21 @@ class Test_Posts extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		$deleted = Posts::purge( 180 );
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Assert only 1 post was deleted.
 		$this->assertEquals( 1, $deleted );
 
 		// Post without comments should be deleted.
-		$this->assertNull( get_post( $post_without_comments ) );
+		$this->assertNull( \get_post( $post_without_comments ) );
 
 		// Post with local user comment should still exist.
-		$this->assertNotNull( get_post( $post_with_comment ) );
+		$this->assertNotNull( \get_post( $post_with_comment ) );
 	}
 
 	/**
@@ -1491,7 +1491,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
@@ -1518,7 +1518,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
@@ -1529,16 +1529,16 @@ class Test_Posts extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		$deleted = Posts::purge( 180 );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Only post without interactions should be deleted.
 		$this->assertEquals( 1, $deleted );
-		$this->assertNotNull( get_post( $post_with_comments ) );
-		$this->assertNull( get_post( $post_without_interactions ) );
+		$this->assertNotNull( \get_post( $post_with_comments ) );
+		$this->assertNull( \get_post( $post_without_interactions ) );
 	}
 
 	/**
@@ -1553,7 +1553,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-45 days' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-45 days' ) ),
 			)
 		);
 
@@ -1564,7 +1564,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		// Purge with 60 days retention - should not delete.
 		$deleted = Posts::purge( 60 );
@@ -1572,9 +1572,9 @@ class Test_Posts extends \WP_UnitTestCase {
 
 		// Purge with 30 days retention - should delete all.
 		$deleted = Posts::purge( 30 );
-		wp_cache_delete( _count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
+		\wp_cache_delete( \_count_posts_cache_key( Posts::POST_TYPE ), 'counts' );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		$this->assertEquals( 10, $deleted );
 	}
@@ -1591,7 +1591,7 @@ class Test_Posts extends \WP_UnitTestCase {
 			array(
 				'post_type'   => Posts::POST_TYPE,
 				'post_status' => 'publish',
-				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+				'post_date'   => \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ),
 			)
 		);
 
@@ -1602,11 +1602,11 @@ class Test_Posts extends \WP_UnitTestCase {
 			}
 			return $counts;
 		};
-		add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
+		\add_filter( 'wp_count_posts', $wp_count_posts_callback, 10, 2 );
 
 		$deleted = Posts::purge( 180 );
 
-		remove_filter( 'wp_count_posts', $wp_count_posts_callback );
+		\remove_filter( 'wp_count_posts', $wp_count_posts_callback );
 
 		// Should return exact count of deleted posts.
 		$this->assertEquals( 15, $deleted );


### PR DESCRIPTION
## Proposed changes:
* Add scheduled purge functionality for remote ActivityPub posts (`ap_post`) similar to existing outbox and inbox cleanup
* Refactor purge logic by moving it from Scheduler into the respective collection classes (Outbox, Inbox, Posts)

### Key features:
- Preserves posts that have comments (likes, reposts, quotes) from local users as these indicate meaningful interactions
- Uses same threshold (200 posts) and default retention (180 days) as inbox
- Daily cron schedule (`activitypub_ap_post_purge`)
- Option `activitypub_ap_post_purge_days` not user-facing yet (no settings UI)
- Added to Site Health info for debugging

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run the new tests: `npm run env-test -- --filter="Test_Scheduler::test_purge_ap_posts"`
* Verify all 4 new tests pass:
  - `test_purge_ap_posts_more_than_200_posts` - verifies deletion when threshold exceeded
  - `test_purge_ap_posts_200_or_fewer_posts` - verifies no deletion below threshold
  - `test_purge_ap_posts_preserves_posts_with_comments` - verifies posts with interactions are kept
  - `test_purge_ap_posts_with_different_purge_days` - verifies configurable retention period
* Run all purge tests to ensure refactoring didn't break existing functionality: `npm run env-test -- --filter="Test_Scheduler::test_purge"`

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Added - for new features

#### Message

Add scheduled cleanup for remote posts, preserving posts with local user interactions.

</details>