### PR TITLE
Fix PHP 8.4+ deprecation warning for str_getcsv()

### DIFF
--- a/includes/class-blocklist-subscriptions.php
+++ b/includes/class-blocklist-subscriptions.php
@@ -169,7 +169,7 @@ class Blocklist_Subscriptions {
 		}
 
 		// Parse first line to detect format.
-		$first_line = \str_getcsv( $lines[0] );
+		$first_line = \str_getcsv( $lines[0], ',', '"', '\\' );
 		$first_cell = \trim( $first_line[0] ?? '' );
 		$has_header = \str_starts_with( $first_cell, '#' ) || 'domain' === \strtolower( $first_cell );
 
@@ -189,7 +189,7 @@ class Blocklist_Subscriptions {
 
 		// Process each line.
 		foreach ( $lines as $line ) {
-			$row    = \str_getcsv( $line );
+			$row    = \str_getcsv( $line, ',', '"', '\\' );
 			$domain = \trim( $row[ $domain_index ] ?? '' );
 
 			// Skip empty lines and comments.


### PR DESCRIPTION
## Summary

Follow-up to #2590.

Fixes PHP 8.4+ deprecation warnings for `str_getcsv()` in the Blocklist Subscriptions class.

In PHP 8.4+, the `$escape` parameter must be explicitly provided as its default value is changing from `"\\"` to `""`. This PR explicitly passes all parameters to maintain the current behavior while avoiding the deprecation notice.

## Changes

- Explicitly pass separator, enclosure, and escape parameters to `str_getcsv()` calls in `Blocklist_Subscriptions::parse_csv_string()`

## Testing

- Verified no deprecation warnings in PHP 8.4+
- Maintains compatibility with PHP 7.2+