### PR TITLE
Fix test_prevent_empty_post_meta to work in isolation

### DIFF
--- a/tests/phpunit/tests/includes/class-test-post-types.php
+++ b/tests/phpunit/tests/includes/class-test-post-types.php
@@ -7,7 +7,6 @@
 
 namespace Activitypub\Tests;
 
-use Activitypub\Activitypub;
 use Activitypub\Post_Types;
 
 /**
@@ -20,9 +19,9 @@ class Test_Post_Types extends \WP_UnitTestCase {
 	/**
 	 * Set up test environment.
 	 */
-	public function setUp(): void {
-		parent::setUp();
-		Activitypub::init();
+	public function set_up(): void {
+		parent::set_up();
+		Post_Types::init();
 	}
 
 	/**
@@ -33,12 +32,15 @@ class Test_Post_Types extends \WP_UnitTestCase {
 	public function test_prevent_empty_post_meta() {
 		$post_id = self::factory()->post->create( array( 'post_author' => 1 ) );
 
+		// Storing the default value should be prevented.
 		\update_post_meta( $post_id, 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS );
-		$this->assertEmpty( \get_post_meta( $post_id, 'activitypub_max_image_attachments', true ) );
-		\delete_post_meta( $post_id, 'activitypub_max_image_attachments' );
+		$this->assertFalse( \metadata_exists( 'post', $post_id, 'activitypub_max_image_attachments' ) );
 
+		// Storing a non-default value should work.
 		\update_post_meta( $post_id, 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS + 3 );
+		$this->assertTrue( \metadata_exists( 'post', $post_id, 'activitypub_max_image_attachments' ) );
 		$this->assertEquals( ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS + 3, \get_post_meta( $post_id, 'activitypub_max_image_attachments', true ) );
+
 		\delete_post_meta( $post_id, 'activitypub_max_image_attachments' );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

* Fix `test_prevent_empty_post_meta` test that was passing in the full test suite but failing when run in isolation

### Root Cause Analysis

The test was failing in isolation due to a subtle interaction between WordPress's test framework and how post meta registration works:

**During full test suite:**
1. Bootstrap runs → Plugin loads → `init` hook fires → `Post_Types::init()` runs → meta gets registered with defaults via `register_post_meta()`
2. First test runs → hooks backed up (with the `init` hooks)
3. After each test: `WP_UnitTestCase::tear_down()` calls `unregister_all_meta_keys()` which clears `$wp_meta_keys`, then `_restore_hooks()` restores hooks
4. **But the `init` hook already fired during bootstrap** — it won't fire again!
5. So subsequent tests have the hooks restored, but `register_activitypub_post_meta()` never runs again because it's scheduled on `init` hook which already fired
6. By the time `Test_Post_Types` runs (20th test file alphabetically), meta has been unregistered and never re-registered
7. `get_post_meta()` returns empty string → test passes **accidentally**

**During isolated test:**
1. Bootstrap runs → Plugin loads → `init` hook fires → meta gets registered with default value of 4
2. Test runs with meta registered
3. `prevent_empty_post_meta` filter correctly prevents storage in database
4. But `get_post_meta()` returns the registered default (4), not empty
5. `assertEmpty()` fails because 4 is not empty

### The Fix

1. Call `Post_Types::init()` directly in `set_up()` to ensure the `prevent_empty_post_meta` filter is active for each test
2. Use `metadata_exists()` instead of `assertEmpty(get_post_meta())` — this correctly tests whether the filter prevented storage, because `get_post_meta()` returns registered defaults even when no actual meta exists in the database
3. Also fixed method name from `setUp()` to `set_up()` per WordPress test conventions

### Other information:

- [x] Have you written new tests for your changes, if applicable?

This PR fixes existing tests rather than adding new functionality.

## Testing instructions:

* Run the test in isolation: `npm run env-test -- --filter=test_prevent_empty_post_meta`
* Run the full test suite: `npm run env-test`
* Both should pass