### PR TITLE
Filter empty strings from NodeInfo staffAccounts

### DIFF
--- a/.github/changelog/fix-nodeinfo-empty-staff-accounts
+++ b/.github/changelog/fix-nodeinfo-empty-staff-accounts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure NodeInfo accurately represents site administrators to the Fediverse.

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -135,15 +135,11 @@ class Nodeinfo {
 				'orderby' => 'ID',
 				'order'   => 'ASC',
 				'cap'     => 'activitypub',
-				'fields'  => array( 'ID' ),
+				'fields'  => 'ID',
 			)
 		);
+		$admins = array_map( array( Webfinger::class, 'get_user_resource' ), $admins );
 
-		return array_map(
-			function ( $user ) {
-				return Webfinger::get_user_resource( $user->ID );
-			},
-			$admins
-		);
+		return array_values( array_filter( $admins ) );
 	}
 }

--- a/tests/phpunit/tests/integration/class-test-nodeinfo.php
+++ b/tests/phpunit/tests/integration/class-test-nodeinfo.php
@@ -383,7 +383,7 @@ class Test_Nodeinfo extends \WP_UnitTestCase {
 
 		// Check that staffAccounts is an array with no empty strings.
 		$this->assertIsArray( $result['metadata']['staffAccounts'] );
-		$this->assertEmpty( $result['metadata']['staffAccounts'], 'Staff accounts should not contain empty strings' );
+		$this->assertEmpty( $result['metadata']['staffAccounts'], 'Staff accounts should be empty in blog-only mode' );
 
 		\delete_option( 'activitypub_actor_mode' );
 	}

--- a/tests/phpunit/tests/integration/class-test-nodeinfo.php
+++ b/tests/phpunit/tests/integration/class-test-nodeinfo.php
@@ -364,6 +364,31 @@ class Test_Nodeinfo extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test staff accounts do not contain empty strings when user type is disabled.
+	 *
+	 * @covers ::add_nodeinfo_data
+	 * @covers ::get_staff
+	 */
+	public function test_nodeinfo_staff_accounts_filters_empty_strings() {
+		$original_nodeinfo = array(
+			'protocols' => array(),
+			'usage'     => array(),
+			'metadata'  => array(),
+		);
+
+		// Set blog-only mode, which disables user accounts.
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+
+		$result = Nodeinfo::add_nodeinfo_data( $original_nodeinfo, '2.0' );
+
+		// Check that staffAccounts is an array with no empty strings.
+		$this->assertIsArray( $result['metadata']['staffAccounts'] );
+		$this->assertEmpty( $result['metadata']['staffAccounts'], 'Staff accounts should not contain empty strings' );
+
+		\delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
 	 * Test integration with actual WordPress hooks.
 	 *
 	 * @covers ::init


### PR DESCRIPTION
## Proposed changes:
* Filter out empty strings from the `staffAccounts` array in NodeInfo metadata
* Simplify `get_staff()` by using `'fields' => 'ID'` to get user IDs directly

When user accounts are disabled (blog-only mode), admin users with the `activitypub` capability would still be queried but `Webfinger::get_user_resource()` returns empty strings for them. This resulted in empty strings appearing in the `staffAccounts` array in NodeInfo output:

```json
"staffAccounts": [
  "",
  ""
]
```

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Enable blog-only mode in ActivityPub settings (disable user accounts)
2. Ensure you have admin users with the `activitypub` capability
3. Visit `/.well-known/nodeinfo` and follow the link to the NodeInfo endpoint
4. Verify `staffAccounts` is an empty array `[]` rather than containing empty strings

### Changelog entry

Changelog entry already included in this PR.