### PR TITLE
Use static closures where possible

### DIFF
--- a/build/followers/render.php
+++ b/build/followers/render.php
@@ -58,7 +58,7 @@ $followers = array_map(
 	 *
 	 * @return array
 	 */
-	function ( $follower ) {
+	static function ( $follower ) {
 		$actor    = Remote_Actors::get_actor( $follower );
 		$username = $actor->get_preferred_username();
 

--- a/build/reactions/render.php
+++ b/build/reactions/render.php
@@ -97,7 +97,7 @@ foreach ( Comment::get_comment_types() as $_type => $type_object ) {
 		'label' => $label,
 		'count' => $count,
 		'items' => array_map(
-			function ( $comment ) {
+			static function ( $comment ) {
 				return array(
 					'name'   => html_entity_decode( $comment->comment_author ),
 					'url'    => $comment->comment_author_url,
@@ -128,7 +128,7 @@ wp_interactivity_state( 'activitypub/reactions', array( 'reactions' => array( $_
 
 // Render a subset of the most recent reactions for facepile.
 $reactions = array_map(
-	function ( $reaction ) use ( $attributes ) {
+	static function ( $reaction ) use ( $attributes ) {
 		$count = 20;
 		if ( 'wide' === $attributes['align'] ) {
 			$count = 40;

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -225,7 +225,7 @@ class Activitypub {
 				'description'       => 'The user description.',
 				'single'            => true,
 				'default'           => '',
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					return wp_kses( $value, 'user_description' );
 				},
 			)
@@ -336,7 +336,7 @@ class Activitypub {
 				'description'       => 'User-specific blocked ActivityPub domains.',
 				'single'            => true,
 				'default'           => array(),
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					return \array_unique( \array_map( array( Sanitize::class, 'host_list' ), $value ) );
 				},
 			)
@@ -350,7 +350,7 @@ class Activitypub {
 				'description'       => 'User-specific blocked ActivityPub keywords.',
 				'single'            => true,
 				'default'           => array(),
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					return \array_map( 'sanitize_text_field', $value );
 				},
 			)

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -116,7 +116,7 @@ class Blocks {
 				 * @param \WP_REST_Request $request    The request object.
 				 * @return int The number of published posts.
 				 */
-				'get_callback' => function ( $response, $field_name, $request ) {
+				'get_callback' => static function ( $response, $field_name, $request ) {
 					return (int) count_user_posts( $request->get_param( 'id' ), 'post', true );
 				},
 				'schema'       => array(
@@ -300,7 +300,7 @@ class Blocks {
 		// Convert paragraphs to blocks.
 		\preg_match_all( '#<p>.*?</p>#is', $data['post_content'], $matches );
 		$blocks = \array_map(
-			function ( $paragraph ) {
+			static function ( $paragraph ) {
 				return '<!-- wp:paragraph -->' . PHP_EOL . $paragraph . PHP_EOL . '<!-- /wp:paragraph -->' . PHP_EOL;
 			},
 			$matches[0] ?? array()

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -207,7 +207,7 @@ class Mailer {
 		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/emails/new-follower.php', false, $template_args );
 		$html_message = \ob_get_clean();
 
-		$alt_function = function ( $mailer ) use ( $actor, $admin_url ) {
+		$alt_function = static function ( $mailer ) use ( $actor, $admin_url ) {
 			/* translators: 1: Follower name */
 			$message = \sprintf( \__( 'New Follower: %1$s.', 'activitypub' ), $actor['name'] ) . "\r\n\r\n";
 			/* translators: Follower URL */
@@ -295,7 +295,7 @@ class Mailer {
 			\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/emails/new-dm.php', false, $template_args );
 			$html_message = \ob_get_clean();
 
-			$alt_function = function ( $mailer ) use ( $actor, $activity ) {
+			$alt_function = static function ( $mailer ) use ( $actor, $activity ) {
 				$content = \html_entity_decode(
 					\wp_strip_all_tags(
 						str_replace( '</p>', PHP_EOL . PHP_EOL, $activity['object']['content'] )
@@ -395,7 +395,7 @@ class Mailer {
 			\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/emails/new-mention.php', false, $template_args );
 			$html_message = \ob_get_clean();
 
-			$alt_function = function ( $mailer ) use ( $actor, $activity ) {
+			$alt_function = static function ( $mailer ) use ( $actor, $activity ) {
 				$content = \html_entity_decode(
 					\wp_strip_all_tags(
 						str_replace( '</p>', PHP_EOL . PHP_EOL, $activity['object']['content'] )

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -76,7 +76,7 @@ class Options {
 				'type'              => 'integer',
 				'description'       => 'Number of images to attach to posts.',
 				'default'           => ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS,
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					return \is_numeric( $value ) ? \absint( $value ) : ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS;
 				},
 			)

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -143,7 +143,7 @@ class Post_Types {
 				'description'       => 'The type of the activity',
 				'single'            => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					$schema = array(
 						'type'    => 'string',
 						'enum'    => Activity::TYPES,
@@ -177,7 +177,7 @@ class Post_Types {
 				'type'              => 'string',
 				'single'            => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					$schema = array(
 						'type'    => 'string',
 						'enum'    => array( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL ),
@@ -246,7 +246,7 @@ class Post_Types {
 				'description'       => 'The type of the activity',
 				'single'            => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					$schema = array(
 						'type'    => 'string',
 						'enum'    => Activity::TYPES,
@@ -269,7 +269,7 @@ class Post_Types {
 				'type'              => 'string',
 				'single'            => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					$schema = array(
 						'type'    => 'string',
 						'enum'    => array( 'application', 'blog', 'user' ),
@@ -315,7 +315,7 @@ class Post_Types {
 				'type'              => 'string',
 				'single'            => true,
 				'show_in_rest'      => true,
-				'sanitize_callback' => function ( $value ) {
+				'sanitize_callback' => static function ( $value ) {
 					$schema = array(
 						'type'    => 'string',
 						'enum'    => array( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL ),
@@ -470,7 +470,7 @@ class Post_Types {
 					'type'              => 'string',
 					'single'            => true,
 					'show_in_rest'      => true,
-					'sanitize_callback' => function ( $value ) {
+					'sanitize_callback' => static function ( $value ) {
 						$schema = array(
 							'type'    => 'string',
 							'enum'    => array( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL ),
@@ -505,7 +505,7 @@ class Post_Types {
 					'type'              => 'string',
 					'single'            => true,
 					'show_in_rest'      => true,
-					'sanitize_callback' => function ( $value ) {
+					'sanitize_callback' => static function ( $value ) {
 						$schema = array(
 							'type'    => 'string',
 							'enum'    => array( ACTIVITYPUB_INTERACTION_POLICY_ANYONE, ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS, ACTIVITYPUB_INTERACTION_POLICY_ME ),
@@ -528,7 +528,7 @@ class Post_Types {
 					'type'              => 'string',
 					'single'            => true,
 					'show_in_rest'      => true,
-					'sanitize_callback' => function ( $value ) {
+					'sanitize_callback' => static function ( $value ) {
 						$schema = array(
 							'type'    => 'string',
 							'enum'    => array( 'pending', 'federated', 'failed' ),
@@ -560,7 +560,7 @@ class Post_Types {
 				 * @param array $response Prepared response array.
 				 * @return string The raw post content.
 				 */
-				'get_callback' => function ( $response ) {
+				'get_callback' => static function ( $response ) {
 					return \get_post_field( 'post_content', $response['id'] );
 				},
 				'schema'       => array(

--- a/includes/class-router.php
+++ b/includes/class-router.php
@@ -158,7 +158,7 @@ class Router {
 
 		add_action(
 			'wp_head',
-			function () use ( $id ) {
+			static function () use ( $id ) {
 				echo PHP_EOL . '<link rel="alternate" title="ActivityPub (JSON)" type="application/activity+json" href="' . esc_url( $id ) . '" />' . PHP_EOL;
 			}
 		);

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -86,7 +86,7 @@ class Sanitize {
 	public static function host_list( $value ) {
 		$value = \explode( PHP_EOL, (string) $value );
 		$value = \array_map(
-			function ( $host ) {
+			static function ( $host ) {
 				$host = \trim( $host );
 				$host = \strtolower( $host );
 				$host = \set_url_scheme( $host );

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -405,7 +405,7 @@ class Actors {
 		// Filter out any WP_Error instances.
 		return array_filter(
 			$actors,
-			function ( $actor ) {
+			static function ( $actor ) {
 				return ! \is_wp_error( $actor );
 			}
 		);

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -217,7 +217,7 @@ class Extra_Fields {
 
 		\add_filter(
 			'activitypub_link_rel',
-			function ( $rel ) {
+			static function ( $rel ) {
 				$rel .= ' me';
 
 				return $rel;

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -412,7 +412,7 @@ class Interactions {
 		// No nonce possible for this submission route.
 		\add_filter(
 			'akismet_comment_nonce',
-			function () {
+			static function () {
 				return 'inactive';
 			}
 		);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -273,7 +273,7 @@ function esc_hashtag( $input ) {
 	// Capitalize every letter that is preceded by a hyphen.
 	$hashtag = preg_replace_callback(
 		'/-+(.)/',
-		function ( $matches ) {
+		static function ( $matches ) {
 			return strtoupper( $matches[1] );
 		},
 		$hashtag
@@ -993,7 +993,7 @@ function get_enclosures( $post_id ) {
 	}
 
 	$enclosures = array_map(
-		function ( $enclosure ) {
+		static function ( $enclosure ) {
 			// Check if the enclosure is a string.
 			if ( ! $enclosure || ! is_string( $enclosure ) ) {
 				return false;

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -87,7 +87,7 @@ class Actors_Inbox_Controller extends Actors_Controller {
 						'object' => array(
 							'description'       => 'The object of the activity.',
 							'required'          => true,
-							'validate_callback' => function ( $param, $request, $key ) {
+							'validate_callback' => static function ( $param, $request, $key ) {
 								/**
 								 * Filter the ActivityPub object validation.
 								 *

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -161,7 +161,7 @@ class Followers_Controller extends Actors_Controller {
 		if ( Actors::show_social_graph( $user_id ) ) {
 			$response['orderedItems'] = \array_filter(
 				\array_map(
-					function ( $item ) use ( $context ) {
+					static function ( $item ) use ( $context ) {
 						if ( 'full' === $context ) {
 							$actor = Remote_Actors::get_actor( $item );
 							if ( \is_wp_error( $actor ) ) {

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -118,7 +118,7 @@ class Following_Controller extends Actors_Controller {
 		if ( Actors::show_social_graph( $user_id ) ) {
 			$response['orderedItems'] = \array_filter(
 				\array_map(
-					function ( $item ) use ( $context ) {
+					static function ( $item ) use ( $context ) {
 						if ( 'full' === $context ) {
 							$actor = Remote_Actors::get_actor( $item );
 							if ( \is_wp_error( $actor ) ) {

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -76,7 +76,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 						'object' => array(
 							'description'       => 'The object of the activity.',
 							'required'          => true,
-							'validate_callback' => function ( $param, $request, $key ) {
+							'validate_callback' => static function ( $param, $request, $key ) {
 								/**
 								 * Filter the ActivityPub object validation.
 								 *
@@ -92,7 +92,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 							'description'       => 'The primary recipients of the activity.',
 							'type'              => array( 'string', 'array' ),
 							'required'          => false,
-							'sanitize_callback' => function ( $param ) {
+							'sanitize_callback' => static function ( $param ) {
 								if ( \is_string( $param ) ) {
 									$param = array( $param );
 								}
@@ -103,7 +103,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 						'cc'     => array(
 							'description'       => 'The secondary recipients of the activity.',
 							'type'              => array( 'string', 'array' ),
-							'sanitize_callback' => function ( $param ) {
+							'sanitize_callback' => static function ( $param ) {
 								if ( \is_string( $param ) ) {
 									$param = array( $param );
 								}
@@ -114,7 +114,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 						'bcc'    => array(
 							'description'       => 'The private recipients of the activity.',
 							'type'              => array( 'string', 'array' ),
-							'sanitize_callback' => function ( $param ) {
+							'sanitize_callback' => static function ( $param ) {
 								if ( \is_string( $param ) ) {
 									$param = array( $param );
 								}

--- a/includes/rest/class-post-controller.php
+++ b/includes/rest/class-post-controller.php
@@ -122,7 +122,7 @@ class Post_Controller extends \WP_REST_Controller {
 			$reactions[ $type_object['collection'] ] = array(
 				'label' => $label,
 				'items' => \array_map(
-					function ( $comment ) {
+					static function ( $comment ) {
 						return array(
 							'name'   => html_entity_decode( $comment->comment_author ),
 							'url'    => $comment->comment_author_url,

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -603,7 +603,7 @@ abstract class Base {
 
 		return \array_filter(
 			$attachments,
-			function ( $attachment ) use ( &$seen_ids ) {
+			static function ( $attachment ) use ( &$seen_ids ) {
 				if ( isset( $attachment['id'] ) && ! in_array( $attachment['id'], $seen_ids, true ) ) {
 					$seen_ids[] = $attachment['id'];
 					return true;

--- a/includes/transformer/class-comment.php
+++ b/includes/transformer/class-comment.php
@@ -253,7 +253,7 @@ class Comment extends Base {
 		// Now that we have the full tree of ancestors, only return the ones received from the fediverse.
 		return array_filter(
 			$ancestors,
-			function ( $comment_id ) {
+			static function ( $comment_id ) {
 				return \get_comment_meta( $comment_id, 'protocol', true ) === 'activitypub';
 			}
 		);

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -889,7 +889,7 @@ class Post extends Base {
 						$media['image'] = array_merge(
 							$media['image'],
 							array_map(
-								function ( $id ) {
+								static function ( $id ) {
 									return array( 'id' => $id );
 								},
 								$block['attrs']['ids']

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -405,7 +405,7 @@ class Admin {
 		// Disable the edit_post capability for federated posts.
 		\add_filter(
 			'user_has_cap',
-			function ( $all_caps, $caps, $arg ) {
+			static function ( $all_caps, $caps, $arg ) {
 				if ( 'edit_post' !== $arg[0] ) {
 					return $all_caps;
 				}
@@ -436,7 +436,7 @@ class Admin {
 
 		add_filter(
 			"views_{$screen_id}",
-			function ( $views ) {
+			static function ( $views ) {
 				if ( Extra_Fields::is_extra_fields_post_type( get_current_screen()->post_type ) ) {
 					return array();
 				}
@@ -915,7 +915,7 @@ class Admin {
 		$tabs = \get_current_screen()->get_help_tabs();
 		$ids  = \array_values( \wp_list_pluck( $tabs, 'id' ) );
 		$ids  = \array_map(
-			function ( $id ) {
+			static function ( $id ) {
 				return '#tab-link-' . $id;
 			},
 			$ids

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -506,7 +506,7 @@ class Health_Check {
 		// search for the word 'captcha' in the list of active plugins.
 		$captcha_plugins = array_filter(
 			$active_plugins,
-			function ( $plugin ) {
+			static function ( $plugin ) {
 				return \str_contains( strtolower( $plugin ), 'captcha' );
 			}
 		);
@@ -518,7 +518,7 @@ class Health_Check {
 		// Get nice plugin names instead of file paths using WordPress built-in functions.
 		$all_plugins          = \get_plugins();
 		$captcha_plugin_names = array_map(
-			function ( $plugin_file ) use ( $all_plugins ) {
+			static function ( $plugin_file ) use ( $all_plugins ) {
 				if ( isset( $all_plugins[ $plugin_file ]['Name'] ) ) {
 					return $all_plugins[ $plugin_file ]['Name'];
 				}

--- a/includes/wp-admin/import/class-mastodon.php
+++ b/includes/wp-admin/import/class-mastodon.php
@@ -412,7 +412,7 @@ class Mastodon {
 			'post_type'    => 'post',
 			'meta_input'   => array( '_source_id' => $post['object']['id'] ),
 			'tags_input'   => \array_map(
-				function ( $tag ) {
+				static function ( $tag ) {
 					if ( 'Hashtag' === $tag['type'] ) {
 						return \ltrim( $tag['name'], '#' );
 					}

--- a/includes/wp-admin/import/class-starter-kit.php
+++ b/includes/wp-admin/import/class-starter-kit.php
@@ -99,7 +99,7 @@ class Starter_Kit {
 				self::$actor_list = \array_values(
 					array_filter(
 						array_map(
-							function ( $actor ) {
+							static function ( $actor ) {
 								$actor = \sanitize_text_field( $actor );
 								$actor = \wp_unslash( $actor );
 								return self::is_valid_actor( $actor ) ? $actor : null;
@@ -308,7 +308,7 @@ class Starter_Kit {
 			return;
 		}
 
-		self::$blog_user_filter_callback = function ( $users ) {
+		self::$blog_user_filter_callback = static function ( $users ) {
 			return \preg_replace(
 				'/<\/select>/',
 				'<option value="0">' . \__( 'Blog User', 'activitypub' ) . '</option></select>',

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -88,7 +88,7 @@ class Classic_Editor {
 
 		// Transform IDs into associative arrays.
 		$media_ids = \array_map(
-			function ( $id ) {
+			static function ( $id ) {
 				return array( 'id' => $id );
 			},
 			$query->get_posts()

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -310,7 +310,7 @@ class Enable_Mastodon_Apps {
 		$account->fields = self::get_extra_fields( $user_id_to_use );
 		// Now do it in source['fields'] with stripped tags.
 		$account->source['fields'] = \array_map(
-			function ( $field ) {
+			static function ( $field ) {
 				$field['value'] = \wp_strip_all_tags( $field['value'], true );
 				return $field;
 			},
@@ -588,7 +588,7 @@ class Enable_Mastodon_Apps {
 
 		if ( ! empty( $object['attachment'] ) ) {
 			$status->media_attachments = array_map(
-				function ( $attachment ) {
+				static function ( $attachment ) {
 					$default_attachment = array(
 						'url'       => null,
 						'mediaType' => null,
@@ -676,7 +676,7 @@ class Enable_Mastodon_Apps {
 			}
 
 			$new_statuses         = array_map(
-				function ( $item ) use ( $account, $args ) {
+				static function ( $item ) use ( $account, $args ) {
 					if ( $args['exclude_replies'] ) {
 						if ( isset( $item['object']['inReplyTo'] ) && $item['object']['inReplyTo'] ) {
 							return null;
@@ -844,7 +844,7 @@ class Enable_Mastodon_Apps {
 		// Sort by date descending.
 		\usort(
 			$notifications,
-			function ( $a, $b ) {
+			static function ( $a, $b ) {
 				$a_date = \is_array( $a ) ? $a['created_at'] : $a->created_at;
 				$b_date = \is_array( $b ) ? $b['created_at'] : $b->created_at;
 				return \strcmp( $b_date, $a_date );

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -140,7 +140,7 @@ class Nodeinfo {
 		);
 
 		return array_map(
-			function ( $user ) {
+			static function ( $user ) {
 				return Webfinger::get_user_resource( $user->ID );
 			},
 			$admins

--- a/integration/load.php
+++ b/integration/load.php
@@ -111,7 +111,7 @@ function plugin_init() {
 	if ( \defined( 'SSP_VERSION' ) ) {
 		add_filter(
 			'activitypub_transformer',
-			function ( $transformer, $data, $object_class ) {
+			static function ( $transformer, $data, $object_class ) {
 				if (
 					'WP_Post' === $object_class &&
 					\get_post_meta( $data->ID, 'audio_file', true )

--- a/src/followers/render.php
+++ b/src/followers/render.php
@@ -58,7 +58,7 @@ $followers = array_map(
 	 *
 	 * @return array
 	 */
-	function ( $follower ) {
+	static function ( $follower ) {
 		$actor    = Remote_Actors::get_actor( $follower );
 		$username = $actor->get_preferred_username();
 

--- a/src/reactions/render.php
+++ b/src/reactions/render.php
@@ -97,7 +97,7 @@ foreach ( Comment::get_comment_types() as $_type => $type_object ) {
 		'label' => $label,
 		'count' => $count,
 		'items' => array_map(
-			function ( $comment ) {
+			static function ( $comment ) {
 				return array(
 					'name'   => html_entity_decode( $comment->comment_author ),
 					'url'    => $comment->comment_author_url,
@@ -128,7 +128,7 @@ wp_interactivity_state( 'activitypub/reactions', array( 'reactions' => array( $_
 
 // Render a subset of the most recent reactions for facepile.
 $reactions = array_map(
-	function ( $reaction ) use ( $attributes ) {
+	static function ( $reaction ) use ( $attributes ) {
 		$count = 20;
 		if ( 'wide' === $attributes['align'] ) {
 			$count = 40;


### PR DESCRIPTION
## Proposed changes:
* Convert 57 non-static closures to static closures across 31 files
* Static closures improve code clarity by explicitly indicating they don't reference `$this`
* Provides minor performance benefits by not binding `$this` unnecessarily

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Not applicable - this is a code style improvement with no functional change.

## Testing instructions:

* Run `composer lint` - should pass ✅
* Run tests to verify no regressions
* All closures that could be static are now marked as such

### Changelog entry

- [x] Skip Changelog - Not a functional change