### PR TITLE
Remove unnecessary scripts and styles from App page

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -121,13 +121,13 @@ function plugin_init() {
  */
 function plugin_admin_init() {
 	// Screen Options and Menus are set before `admin_init`.
-	\add_action( 'init', array( __NAMESPACE__ . '\WP_Admin\App', 'hide_admin_bar' ), 0 ); // Before admin bar init.
 	\add_action( 'init', array( __NAMESPACE__ . '\WP_Admin\Heartbeat', 'init' ), 9 ); // Before script loader.
 	\add_filter( 'init', array( __NAMESPACE__ . '\WP_Admin\Screen_Options', 'init' ) );
 	\add_action( 'admin_menu', array( __NAMESPACE__ . '\WP_Admin\Menu', 'admin_menu' ) );
 
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Admin', 'init' ) );
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Advanced_Settings_Fields', 'init' ) );
+	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\App', 'init' ), 0 ); // Before admin bar init.
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Blog_Settings_Fields', 'init' ) );
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Health_Check', 'init' ) );
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Settings', 'init' ) );

--- a/activitypub.php
+++ b/activitypub.php
@@ -121,6 +121,7 @@ function plugin_init() {
  */
 function plugin_admin_init() {
 	// Screen Options and Menus are set before `admin_init`.
+	\add_action( 'init', array( __NAMESPACE__ . '\WP_Admin\App', 'hide_admin_bar' ), 0 ); // Before admin bar init.
 	\add_action( 'init', array( __NAMESPACE__ . '\WP_Admin\Heartbeat', 'init' ), 9 ); // Before script loader.
 	\add_filter( 'init', array( __NAMESPACE__ . '\WP_Admin\Screen_Options', 'init' ) );
 	\add_action( 'admin_menu', array( __NAMESPACE__ . '\WP_Admin\Menu', 'admin_menu' ) );

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -297,7 +297,7 @@ class Admin {
 			);
 		}
 
-		if ( false !== strpos( $hook_suffix, 'activitypub' ) ) {
+		if ( false !== strpos( $hook_suffix, 'activitypub' ) && 'dashboard_page_activitypub-social-web' !== $hook_suffix ) {
 			wp_enqueue_style(
 				'activitypub-admin-styles',
 				plugins_url(

--- a/includes/wp-admin/class-app.php
+++ b/includes/wp-admin/class-app.php
@@ -13,6 +13,18 @@ namespace Activitypub\WP_Admin;
 class App {
 
 	/**
+	 * Hide the admin bar on the App page.
+	 *
+	 * Must run early (on init) before the admin bar is initialized.
+	 */
+	public static function hide_admin_bar() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( \is_admin() && isset( $_GET['page'] ) && 'activitypub-social-web' === $_GET['page'] ) {
+			\add_filter( 'wp_admin_bar_class', '__return_false' );
+		}
+	}
+
+	/**
 	 * Remove admin notices from the App page.
 	 */
 	public static function remove_admin_notices() {
@@ -32,6 +44,10 @@ class App {
 	 * Enqueue scripts and styles for the App page.
 	 */
 	public static function enqueue_scripts() {
+		\wp_dequeue_style( 'colors' );
+		\wp_dequeue_script( 'common' );
+		\wp_dequeue_script( 'svg-painter' );
+
 		// Define paths to preload - must match exact fields from entities.js.
 		$preload_paths = array(
 			'/?_fields=description,gmt_offset,home,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',

--- a/includes/wp-admin/class-app.php
+++ b/includes/wp-admin/class-app.php
@@ -13,13 +13,13 @@ namespace Activitypub\WP_Admin;
 class App {
 
 	/**
-	 * Hide the admin bar on the App page.
+	 * Initialize the App page.
 	 *
-	 * Must run early (on init) before the admin bar is initialized.
+	 * Must run early (on admin_init) before the admin bar is initialized.
 	 */
-	public static function hide_admin_bar() {
+	public static function init() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( \is_admin() && isset( $_GET['page'] ) && 'activitypub-social-web' === $_GET['page'] ) {
+		if ( isset( $_GET['page'] ) && 'activitypub-social-web' === $_GET['page'] ) {
 			\add_filter( 'wp_admin_bar_class', '__return_false' );
 		}
 	}


### PR DESCRIPTION
## Proposed changes:
* Hide admin bar by filtering `wp_admin_bar_class` early on `init`
* Exclude App page from `Admin::enqueue_scripts` to prevent loading admin styles/scripts
* Dequeue `colors`, `common`, and `svg-painter` assets that aren't needed for the React app

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Go to Dashboard → Social Web
* Verify the admin bar is not shown
* Verify the admin menu styles are not loaded (check Network tab)
* Verify the app still functions correctly

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>