### PR TITLE
Improve IFTAS DNI list description

### DIFF
--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -599,7 +599,7 @@ class Settings_Fields {
 				<button type="button" class="button add-blocklist-subscription-btn" data-url="<?php echo \esc_attr( Blocklist_Subscriptions::IFTAS_DNI_URL ); ?>">
 					<?php \esc_html_e( 'Subscribe to IFTAS DNI List', 'activitypub' ); ?>
 				</button>
-				<?php \esc_html_e( 'A curated list of the worst actors on the fediverse.', 'activitypub' ); ?>
+				<?php echo \wp_kses_post( \__( 'Domains <a href="https://about.iftas.org/" target="_blank" rel="noopener">IFTAS</a> recommends not federating with.', 'activitypub' ) ); ?>
 			</p>
 			<?php endif; ?>
 		</div>


### PR DESCRIPTION
## Description

Replaces the description "A curated list of the worst actors on the fediverse" with clearer wording that focuses on the action (blocking) rather than characterizing the actors.

**Before:** "A curated list of the worst actors on the fediverse."
**After:** "Domains IFTAS recommends not federating with." (with IFTAS linked to their website)

## Testing Instructions

1. Go to Settings → ActivityPub → Moderation
2. Look at the IFTAS DNI List subscription section
3. Verify the new description appears with IFTAS as a link to https://about.iftas.org/

## Follow-up to

#2590