### PR TITLE
Update block.json versions during releases

### DIFF
--- a/bin/__tests__/fixtures/block.json
+++ b/bin/__tests__/fixtures/block.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"name": "activitypub/test-block",
+	"apiVersion": 3,
+	"version": "2.0.0",
+	"title": "Test Block",
+	"category": "widgets",
+	"description": "A test block for version replacement testing.",
+	"textdomain": "activitypub"
+}

--- a/bin/__tests__/release.test.js
+++ b/bin/__tests__/release.test.js
@@ -239,6 +239,65 @@ function old_function() {}`;
 		} );
 	} );
 
+	describe( 'Block.json file patterns (src/**/block.json)', () => {
+		const patterns = [
+			{
+				search: /"version": "\d+\.\d+\.\d+"/,
+				replace: `"version": "${ testVersion }"`,
+			},
+		];
+
+		test( 'replaces version field in block.json', () => {
+			const content = `{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"name": "activitypub/follow-me",
+	"version": "2.0.0",
+	"title": "Follow me"
+}`;
+
+			const result = applyVersionReplacements( content, testVersion, patterns );
+			expect( result ).toContain( `"version": "${ testVersion }"` );
+			expect( result ).not.toContain( '"version": "2.0.0"' );
+		} );
+
+		test( 'replaces version in block.json fixture file', () => {
+			const fixturePath = path.join( __dirname, 'fixtures', 'block.json' );
+			const content = fs.readFileSync( fixturePath, 'utf8' );
+
+			const result = applyVersionReplacements( content, testVersion, patterns );
+			expect( result ).toContain( `"version": "${ testVersion }"` );
+			expect( result ).not.toContain( '"version": "2.0.0"' );
+		} );
+
+		test( 'preserves other JSON structure', () => {
+			const content = `{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"name": "activitypub/test-block",
+	"apiVersion": 3,
+	"version": "1.5.0",
+	"title": "Test Block",
+	"category": "widgets"
+}`;
+
+			const result = applyVersionReplacements( content, testVersion, patterns );
+			expect( result ).toContain( '"name": "activitypub/test-block"' );
+			expect( result ).toContain( '"apiVersion": 3' );
+			expect( result ).toContain( '"title": "Test Block"' );
+			expect( result ).toContain( `"version": "${ testVersion }"` );
+		} );
+
+		test( 'handles version field regardless of position', () => {
+			const content = `{
+	"version": "0.9.0",
+	"name": "activitypub/early-version"
+}`;
+
+			const result = applyVersionReplacements( content, testVersion, patterns );
+			expect( result ).toContain( `"version": "${ testVersion }"` );
+			expect( result ).not.toContain( '"version": "0.9.0"' );
+		} );
+	} );
+
 	describe( 'Edge cases and complex scenarios', () => {
 		test( 'handles multiple replacements in single file', () => {
 			const content = `/**

--- a/bin/release.js
+++ b/bin/release.js
@@ -280,6 +280,20 @@ async function createRelease() {
 		] );
 	} );
 
+	// Update version in block.json files
+	const blockJsonFiles = execWithOutput( 'find src -name "block.json"' ).split( '\n' );
+
+	blockJsonFiles.forEach( ( filePath ) => {
+		if ( filePath ) {
+			updateVersionInFile( filePath, version, [
+				{
+					search: /"version": "\d+\.\d+\.\d+"/,
+					replace: `"version": "${ version }"`,
+				},
+			] );
+		}
+	} );
+
 	// Stage and commit changes
 	exec( 'git add .' );
 	exec( `git commit -m "Release ${ version }"` );


### PR DESCRIPTION
This ensures proper cache invalidation for block assets. The `version` field in block.json flows through to `wp_register_script()` and `wp_register_style()` as the `ver` parameter, which WordPress appends to asset URLs as `?ver=X.X.X`.

## Proposed changes:

* Update release script to sync all `block.json` version fields with the plugin version during releases
* Add tests for the new version replacement patterns with a fixture file

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Review the changes to `bin/release.js`
* Run `npm run test:unit -- bin/__tests__/release.test.js` to verify all tests pass