### PR TITLE
Add hide_for method to Comment class

### DIFF
--- a/.github/changelog/add-get-non-public-post-types
+++ b/.github/changelog/add-get-non-public-post-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Hide comments from non-public post types in the WordPress admin comments list.

--- a/.github/changelog/add-get-non-public-post-types
+++ b/.github/changelog/add-get-non-public-post-types
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Hide comments from non-public post types in the WordPress admin comments list.
+Hide comments from specific post types in the WordPress admin comments list.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -8,7 +8,6 @@
 namespace Activitypub;
 
 use Activitypub\Collection\Actors;
-use Activitypub\Collection\Posts;
 
 /**
  * ActivityPub Comment Class.
@@ -704,9 +703,7 @@ class Comment {
 
 		// Do only exclude interactions of `ap_post` post type.
 		if ( \is_admin() ) {
-			if ( \get_option( 'activitypub_create_posts', false ) ) {
-				$query->query_vars['post_type'] = array_diff( \get_post_types_by_support( 'comments' ), array( Posts::POST_TYPE ) );
-			}
+			$query->query_vars['post_type'] = array_diff( \get_post_types_by_support( 'comments' ), self::get_post_types_to_hide_comments_for() );
 			return;
 		}
 
@@ -767,14 +764,11 @@ class Comment {
 			return 1;
 		}
 
-		// Auto approve reactions to an `ap_post`.
-		if ( \get_option( 'activitypub_create_posts', false ) ) {
-			$post_id = $comment_data['comment_post_ID'];
-			$post    = \get_post( $post_id );
+		$post_id = $comment_data['comment_post_ID'];
+		$post    = \get_post( $post_id );
 
-			if ( $post && Posts::POST_TYPE === $post->post_type ) {
-				return 1;
-			}
+		if ( $post && in_array( $post->post_type, self::get_post_types_to_hide_comments_for(), true ) ) {
+			return 1;
 		}
 
 		return $approved;
@@ -826,5 +820,24 @@ class Comment {
 	 */
 	public static function is_comment_type_enabled( $comment_type ) {
 		return '1' === get_option( "activitypub_allow_{$comment_type}s", '1' );
+	}
+
+	/**
+	 * Get post types to hide comments for in admin.
+	 *
+	 * These are non-public post types whose comments should not appear
+	 * in the main comments list in the WordPress admin.
+	 *
+	 * @return string[] Array of post type names to hide comments for.
+	 */
+	public static function get_post_types_to_hide_comments_for() {
+		$post_types = \get_post_types( array( 'public' => false ), 'names' );
+
+		/**
+		 * Filters the list of post types to hide comments for.
+		 *
+		 * @param string[] $post_types Array of post type names to hide comments for.
+		 */
+		return \apply_filters( 'activitypub_post_types_to_hide_comments_for', $post_types );
 	}
 }

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -8,6 +8,7 @@
 namespace Activitypub;
 
 use Activitypub\Collection\Actors;
+use Activitypub\Collection\Posts;
 
 /**
  * ActivityPub Comment Class.
@@ -703,7 +704,7 @@ class Comment {
 
 		// Do only exclude interactions of `ap_post` post type.
 		if ( \is_admin() ) {
-			$query->query_vars['post_type'] = array_diff( \get_post_types_by_support( 'comments' ), self::get_post_types_to_hide_comments_for() );
+			$query->query_vars['post_type'] = array_diff( \get_post_types_by_support( 'comments' ), self::hide_for() );
 			return;
 		}
 
@@ -767,7 +768,7 @@ class Comment {
 		$post_id = $comment_data['comment_post_ID'];
 		$post    = \get_post( $post_id );
 
-		if ( $post && in_array( $post->post_type, self::get_post_types_to_hide_comments_for(), true ) ) {
+		if ( $post && in_array( $post->post_type, self::hide_for(), true ) ) {
 			return 1;
 		}
 
@@ -830,14 +831,14 @@ class Comment {
 	 *
 	 * @return string[] Array of post type names to hide comments for.
 	 */
-	public static function get_post_types_to_hide_comments_for() {
-		$post_types = \get_post_types( array( 'public' => false ), 'names' );
+	public static function hide_for() {
+		$post_types = array( Posts::POST_TYPE );
 
 		/**
 		 * Filters the list of post types to hide comments for.
 		 *
 		 * @param string[] $post_types Array of post type names to hide comments for.
 		 */
-		return \apply_filters( 'activitypub_post_types_to_hide_comments_for', $post_types );
+		return \apply_filters( 'activitypub_hide_comments_for', $post_types );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -773,11 +773,11 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that ap_post comments are shown when querying for specific post.
+	 * Test that ap_post comments are hidden even when querying for specific post.
 	 *
 	 * @covers ::comment_query
 	 */
-	public function test_ap_post_comments_shown_when_querying_specific_post() {
+	public function test_ap_post_comments_hidden_when_querying_specific_post() {
 		// Create an ap_post.
 		$ap_post_id = wp_insert_post(
 			array(
@@ -800,7 +800,7 @@ class Test_Comment extends \WP_UnitTestCase {
 		// Simulate admin context.
 		\set_current_screen( 'edit-comments' );
 
-		// Query comments for specific post - should include ap_post comments.
+		// Query comments for specific post - should NOT include ap_post comments.
 		$query    = new \WP_Comment_Query();
 		$comments = $query->query(
 			array(
@@ -809,7 +809,7 @@ class Test_Comment extends \WP_UnitTestCase {
 		);
 
 		$comment_ids = wp_list_pluck( $comments, 'comment_ID' );
-		$this->assertContains( (string) $ap_comment_id, $comment_ids, 'AP post comment should be shown when querying specific post' );
+		$this->assertNotContains( (string) $ap_comment_id, $comment_ids, 'AP post comment should be hidden even when querying specific post' );
 
 		// Clean up.
 		\set_current_screen( 'front' );
@@ -860,11 +860,11 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test not auto-approving comments on ap_post when option is disabled.
+	 * Test auto-approving comments on ap_post regardless of option.
 	 *
 	 * @covers ::pre_comment_approved
 	 */
-	public function test_no_auto_approve_comments_on_ap_post_when_disabled() {
+	public function test_auto_approve_comments_on_ap_post_always() {
 		// Disable flood control.
 		\remove_action( 'check_comment_flood', 'check_comment_flood_db', 10 );
 
@@ -894,9 +894,9 @@ class Test_Comment extends \WP_UnitTestCase {
 			)
 		);
 
-		// The comment should NOT be auto-approved.
+		// The comment should be auto-approved on ap_post regardless of option.
 		$comment = \get_comment( $comment_id );
-		$this->assertEquals( '0', $comment->comment_approved, 'Comment on ap_post should not be auto-approved when option is disabled' );
+		$this->assertEquals( '1', $comment->comment_approved, 'Comment on ap_post should be auto-approved regardless of option' );
 
 		// Clean up.
 		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
@@ -994,17 +994,192 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_post_types_to_hide_comments_for.
+	 * Test hide_for returns ap_post by default.
 	 *
-	 * @covers ::get_post_types_to_hide_comments_for
+	 * @covers ::hide_for
 	 */
-	public function test_get_post_types_to_hide_comments_for() {
-		$post_types = Comment::get_post_types_to_hide_comments_for();
+	public function test_hide_for() {
+		$post_types = Comment::hide_for();
 
 		$this->assertIsArray( $post_types );
 		$this->assertContains( Posts::POST_TYPE, $post_types, 'ap_post should be in the list of post types to hide comments for' );
-		$this->assertNotContains( 'post', $post_types, 'post should not be in the list of post types to hide comments for' );
-		$this->assertNotContains( 'page', $post_types, 'page should not be in the list of post types to hide comments for' );
+		$this->assertCount( 1, $post_types, 'Only ap_post should be in the default list' );
+	}
+
+	/**
+	 * Test hide_for filter can add post types.
+	 *
+	 * @covers ::hide_for
+	 */
+	public function test_hide_for_filter_can_add_post_types() {
+		$filter = function ( $post_types ) {
+			$post_types[] = 'custom_post_type';
+			return $post_types;
+		};
+
+		\add_filter( 'activitypub_hide_comments_for', $filter );
+
+		$post_types = Comment::hide_for();
+
+		$this->assertContains( 'custom_post_type', $post_types, 'Filter should be able to add custom post types' );
+		$this->assertContains( Posts::POST_TYPE, $post_types, 'ap_post should still be in the list' );
+
+		\remove_filter( 'activitypub_hide_comments_for', $filter );
+	}
+
+	/**
+	 * Test hide_for filter can remove post types.
+	 *
+	 * @covers ::hide_for
+	 */
+	public function test_hide_for_filter_can_remove_post_types() {
+		$filter = function ( $post_types ) {
+			return array_diff( $post_types, array( Posts::POST_TYPE ) );
+		};
+
+		\add_filter( 'activitypub_hide_comments_for', $filter );
+
+		$post_types = Comment::hide_for();
+
+		$this->assertNotContains( Posts::POST_TYPE, $post_types, 'Filter should be able to remove ap_post from the list' );
+
+		\remove_filter( 'activitypub_hide_comments_for', $filter );
+	}
+
+	/**
+	 * Test hide_for filter affects comment_query behavior.
+	 *
+	 * @covers ::hide_for
+	 * @covers ::comment_query
+	 */
+	public function test_hide_for_filter_affects_comment_query() {
+		// Register a custom post type for testing.
+		\register_post_type(
+			'custom_hidden',
+			array(
+				'public'   => true,
+				'supports' => array( 'comments' ),
+			)
+		);
+
+		// Create a custom post.
+		$custom_post_id = wp_insert_post(
+			array(
+				'post_type'   => 'custom_hidden',
+				'post_title'  => 'Custom Post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create a comment on the custom post.
+		$custom_comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID' => $custom_post_id,
+				'comment_content' => 'Comment on custom post',
+				'comment_author'  => 'Test User',
+			)
+		);
+
+		// Simulate admin context.
+		\set_current_screen( 'edit-comments' );
+
+		// Without filter, comment should be visible.
+		$query       = new \WP_Comment_Query();
+		$comments    = $query->query( array() );
+		$comment_ids = wp_list_pluck( $comments, 'comment_ID' );
+		$this->assertContains( (string) $custom_comment_id, $comment_ids, 'Custom post comment should be visible without filter' );
+
+		// Add filter to hide custom_hidden post type.
+		$filter = function ( $post_types ) {
+			$post_types[] = 'custom_hidden';
+			return $post_types;
+		};
+		\add_filter( 'activitypub_hide_comments_for', $filter );
+
+		// With filter, comment should be hidden.
+		$query       = new \WP_Comment_Query();
+		$comments    = $query->query( array() );
+		$comment_ids = wp_list_pluck( $comments, 'comment_ID' );
+		$this->assertNotContains( (string) $custom_comment_id, $comment_ids, 'Custom post comment should be hidden with filter' );
+
+		// Clean up.
+		\remove_filter( 'activitypub_hide_comments_for', $filter );
+		\set_current_screen( 'front' );
+		\unregister_post_type( 'custom_hidden' );
+	}
+
+	/**
+	 * Test hide_for filter affects pre_comment_approved behavior.
+	 *
+	 * @covers ::hide_for
+	 * @covers ::pre_comment_approved
+	 */
+	public function test_hide_for_filter_affects_auto_approval() {
+		// Disable flood control.
+		\remove_action( 'check_comment_flood', 'check_comment_flood_db', 10 );
+
+		// Register a custom post type for testing.
+		\register_post_type(
+			'custom_hidden',
+			array(
+				'public'   => true,
+				'supports' => array( 'comments' ),
+			)
+		);
+
+		// Create a custom post.
+		$custom_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'custom_hidden',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Without filter, comment should NOT be auto-approved.
+		$comment_id = \wp_new_comment(
+			array(
+				'comment_type'         => 'comment',
+				'comment_content'      => 'Comment without filter.',
+				'comment_author'       => 'Test User',
+				'comment_author_url'   => 'https://example.com/@testuser',
+				'comment_post_ID'      => $custom_post_id,
+				'comment_author_email' => '',
+				'comment_meta'         => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+		$comment    = \get_comment( $comment_id );
+		$this->assertEquals( '0', $comment->comment_approved, 'Comment should not be auto-approved without filter' );
+
+		// Add filter to include custom_hidden in hide_for list.
+		$filter = function ( $post_types ) {
+			$post_types[] = 'custom_hidden';
+			return $post_types;
+		};
+		\add_filter( 'activitypub_hide_comments_for', $filter );
+
+		// With filter, comment should be auto-approved.
+		$comment_id_2 = \wp_new_comment(
+			array(
+				'comment_type'         => 'comment',
+				'comment_content'      => 'Comment with filter.',
+				'comment_author'       => 'Test User 2',
+				'comment_author_url'   => 'https://example.com/@testuser2',
+				'comment_post_ID'      => $custom_post_id,
+				'comment_author_email' => '',
+				'comment_meta'         => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+		$comment_2    = \get_comment( $comment_id_2 );
+		$this->assertEquals( '1', $comment_2->comment_approved, 'Comment should be auto-approved with filter' );
+
+		// Clean up.
+		\remove_filter( 'activitypub_hide_comments_for', $filter );
+		\unregister_post_type( 'custom_hidden' );
+		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Collection\Posts;
 use Activitypub\Comment;
 
 /**
@@ -990,6 +991,20 @@ class Test_Comment extends \WP_UnitTestCase {
 		// Clean up.
 		\delete_option( 'activitypub_create_posts' );
 		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
+	}
+
+	/**
+	 * Test get_post_types_to_hide_comments_for.
+	 *
+	 * @covers ::get_post_types_to_hide_comments_for
+	 */
+	public function test_get_post_types_to_hide_comments_for() {
+		$post_types = Comment::get_post_types_to_hide_comments_for();
+
+		$this->assertIsArray( $post_types );
+		$this->assertContains( Posts::POST_TYPE, $post_types, 'ap_post should be in the list of post types to hide comments for' );
+		$this->assertNotContains( 'post', $post_types, 'post should not be in the list of post types to hide comments for' );
+		$this->assertNotContains( 'page', $post_types, 'page should not be in the list of post types to hide comments for' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* Add new `hide_for()` method to the `Comment` class that returns post types whose comments should be hidden in the WordPress admin.
* Refactor `comment_query()` and `pre_comment_approved()` methods to use the new helper method.
* Add `activitypub_hide_comments_for` filter to customize which post types have hidden comments.
* Add comprehensive unit tests for the new functionality and filter behavior.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run the test suite: `npm run env-test -- --filter=test_hide_for`
* Verify the tests pass and confirm:
  * `ap_post` is the only post type in the default list
  * The filter can add/remove post types
  * The filter affects both comment visibility and auto-approval

### Changelog entry

Changelog entry added manually via `composer changelog:add`.