### PR TITLE
Prevent comment email notifications for ap_post

### DIFF
--- a/.github/changelog/fix-prevent-ap-post-notifications
+++ b/.github/changelog/fix-prevent-ap-post-notifications
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent comment email notifications for ap_post.

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -8,7 +8,6 @@
 namespace Activitypub;
 
 use Activitypub\Collection\Actors;
-use Activitypub\Collection\Posts;
 
 /**
  * Mailer Class.
@@ -463,11 +462,6 @@ class Mailer {
 			return $maybe_notify;
 		}
 
-		// Only prevent if the create_posts option is enabled.
-		if ( '1' !== \get_option( 'activitypub_create_posts', false ) ) {
-			return $maybe_notify;
-		}
-
 		$comment = \get_comment( $comment_id );
 		if ( ! $comment ) {
 			return $maybe_notify;
@@ -479,7 +473,7 @@ class Mailer {
 		}
 
 		// Prevent notifications for comments on ap_post.
-		if ( Posts::POST_TYPE === $post->post_type ) {
+		if ( is_ap_post( $post ) ) {
 			return false;
 		}
 

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -993,9 +993,6 @@ class Test_Mailer extends WP_UnitTestCase {
 	 * @covers ::maybe_prevent_comment_notification
 	 */
 	public function test_prevent_email_notifications_for_ap_post_comments() {
-		// Enable the create_posts option.
-		\update_option( 'activitypub_create_posts', '1' );
-
 		// Create an ap_post.
 		$ap_post_id = self::factory()->post->create(
 			array(
@@ -1019,9 +1016,6 @@ class Test_Mailer extends WP_UnitTestCase {
 		// Test notify_moderator filter.
 		$notify_moderator = \apply_filters( 'notify_moderator', true, $comment_id );
 		$this->assertFalse( $notify_moderator, 'Email notifications to moderator should be prevented for ap_post comments' );
-
-		// Clean up.
-		\delete_option( 'activitypub_create_posts' );
 	}
 
 	/**
@@ -1030,9 +1024,6 @@ class Test_Mailer extends WP_UnitTestCase {
 	 * @covers ::maybe_prevent_comment_notification
 	 */
 	public function test_allow_email_notifications_for_regular_post_comments() {
-		// Enable the create_posts option.
-		\update_option( 'activitypub_create_posts', '1' );
-
 		// Create a regular post.
 		$post_id = self::factory()->post->create(
 			array(
@@ -1055,43 +1046,6 @@ class Test_Mailer extends WP_UnitTestCase {
 		// Test notify_moderator filter.
 		$notify_moderator = \apply_filters( 'notify_moderator', true, $comment_id );
 		$this->assertTrue( $notify_moderator, 'Email notifications to moderator should be allowed for regular post comments' );
-
-		// Clean up.
-		\delete_option( 'activitypub_create_posts' );
-	}
-
-	/**
-	 * Test that email notifications are allowed for ap_post when option is disabled.
-	 *
-	 * @covers ::maybe_prevent_comment_notification
-	 */
-	public function test_allow_email_notifications_when_option_disabled() {
-		// Ensure the create_posts option is disabled.
-		\delete_option( 'activitypub_create_posts' );
-
-		// Create an ap_post.
-		$ap_post_id = self::factory()->post->create(
-			array(
-				'post_type'   => 'ap_post',
-				'post_status' => 'publish',
-			)
-		);
-
-		// Create a comment on the ap_post.
-		$comment_id = self::factory()->comment->create(
-			array(
-				'comment_post_ID'  => $ap_post_id,
-				'comment_approved' => '1',
-			)
-		);
-
-		// Test notify_post_author filter.
-		$notify_author = \apply_filters( 'notify_post_author', true, $comment_id );
-		$this->assertTrue( $notify_author, 'Email notifications should be allowed when option is disabled' );
-
-		// Test notify_moderator filter.
-		$notify_moderator = \apply_filters( 'notify_moderator', true, $comment_id );
-		$this->assertTrue( $notify_moderator, 'Email notifications should be allowed when option is disabled' );
 	}
 
 	/**
@@ -1100,9 +1054,6 @@ class Test_Mailer extends WP_UnitTestCase {
 	 * @covers ::maybe_prevent_comment_notification
 	 */
 	public function test_respect_existing_notification_settings() {
-		// Enable the create_posts option.
-		\update_option( 'activitypub_create_posts', '1' );
-
 		// Create an ap_post.
 		$ap_post_id = self::factory()->post->create(
 			array(
@@ -1125,9 +1076,6 @@ class Test_Mailer extends WP_UnitTestCase {
 
 		$notify_moderator = \apply_filters( 'notify_moderator', false, $comment_id );
 		$this->assertFalse( $notify_moderator, 'Should respect already disabled notifications' );
-
-		// Clean up.
-		\delete_option( 'activitypub_create_posts' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
* Prevent all comment email notifications for `ap_post` posts.
* Uses `is_ap_post()` helper function.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create or have an existing `ap_post` 
2. Add a comment to the `ap_post`
3. Verify that no email notification is sent

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Prevent comment email notifications for ap_post.

</details>