### PR TITLE
Include build directory in block.json version updates

### DIFF
--- a/bin/__tests__/release.test.js
+++ b/bin/__tests__/release.test.js
@@ -239,7 +239,7 @@ function old_function() {}`;
 		} );
 	} );
 
-	describe( 'Block.json file patterns (src/**/block.json)', () => {
+	describe( 'Block.json file patterns (src/**/block.json and build/**/block.json)', () => {
 		const patterns = [
 			{
 				search: /"version": "\d+\.\d+\.\d+"/,

--- a/bin/release.js
+++ b/bin/release.js
@@ -280,8 +280,8 @@ async function createRelease() {
 		] );
 	} );
 
-	// Update version in block.json files
-	const blockJsonFiles = execWithOutput( 'find src -name "block.json"' ).split( '\n' );
+	// Update version in block.json files (src and build directories)
+	const blockJsonFiles = execWithOutput( 'find src build -name "block.json"' ).split( '\n' );
 
 	blockJsonFiles.forEach( ( filePath ) => {
 		if ( filePath ) {


### PR DESCRIPTION
While #2670 caught block versions in src, it didn't update the ones in build, which actually get distributed.

## Proposed changes:

* Extend the release script to update block.json files in `build/` directory in addition to `src/`
* Update test description to reflect both directories

Both directories contain block metadata that needs version updates for proper cache invalidation.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Review the one-line change in `bin/release.js`
* Run `npm run test:unit -- bin/__tests__/release.test.js` to verify all tests pass