### PR TITLE
Fix error when receiving replies to non-existent posts

### DIFF
--- a/.github/changelog/fix-interactions-missing-post-id
+++ b/.github/changelog/fix-interactions-missing-post-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix error when receiving replies to non-existent posts.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -82,6 +82,11 @@ class Interactions {
 			$comment_post_id = $parent_comment->comment_post_ID;
 		}
 
+		if ( ! $comment_post_id ) {
+			// Not a reply to a post or comment.
+			return false;
+		}
+
 		$comment_data['comment_post_ID'] = $comment_post_id;
 		$comment_data['comment_parent']  = $parent_comment_id ? $parent_comment_id : 0;
 

--- a/tests/phpunit/tests/includes/collection/class-test-interactions.php
+++ b/tests/phpunit/tests/includes/collection/class-test-interactions.php
@@ -1065,6 +1065,74 @@ class Test_Interactions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test add_comment returns false when post ID cannot be determined.
+	 *
+	 * This tests the guard against missing post ID when the inReplyTo
+	 * doesn't resolve to any known post or comment.
+	 *
+	 * @covers ::add_comment
+	 */
+	public function test_add_comment_returns_false_when_no_post_id() {
+		$activity = array(
+			'actor'  => 'https://example.com/users/someone',
+			'id'     => 'https://example.com/activities/orphan',
+			'object' => array(
+				'id'        => 'https://example.com/notes/orphan',
+				'content'   => 'This is a reply to nothing',
+				'inReplyTo' => 'https://nonexistent.example.com/post/does-not-exist',
+			),
+		);
+
+		// Mock actor metadata.
+		$metadata_filter = static function () {
+			return array(
+				'name'              => 'Someone',
+				'preferredUsername' => 'someone',
+				'id'                => 'https://example.com/users/someone',
+				'url'               => 'https://example.com/@someone',
+			);
+		};
+		\add_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter );
+
+		$result = Interactions::add_comment( $activity );
+
+		$this->assertFalse( $result, 'Should return false when inReplyTo does not resolve to a post or comment' );
+
+		\remove_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter );
+	}
+
+	/**
+	 * Test add_reaction returns false when post ID cannot be determined.
+	 *
+	 * @covers ::add_reaction
+	 */
+	public function test_add_reaction_returns_false_when_no_post_id() {
+		$activity = array(
+			'type'   => 'Like',
+			'actor'  => 'https://example.com/users/liker',
+			'object' => 'https://nonexistent.example.com/post/does-not-exist',
+			'id'     => 'https://example.com/activities/orphan-like',
+		);
+
+		// Mock actor metadata.
+		$metadata_filter = static function () {
+			return array(
+				'name'              => 'Liker',
+				'preferredUsername' => 'liker',
+				'id'                => 'https://example.com/users/liker',
+				'url'               => 'https://example.com/@liker',
+			);
+		};
+		\add_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter );
+
+		$result = Interactions::add_reaction( $activity );
+
+		$this->assertFalse( $result, 'Should return false when object does not resolve to a post' );
+
+		\remove_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter );
+	}
+
+	/**
 	 * Test that nested replies work with ap_post.
 	 *
 	 * @covers ::add_comment

--- a/tests/phpunit/tests/includes/handler/class-test-create.php
+++ b/tests/phpunit/tests/includes/handler/class-test-create.php
@@ -542,4 +542,48 @@ class Test_Create extends \WP_UnitTestCase {
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_callback );
 		\delete_option( 'activitypub_create_posts' );
 	}
+
+	/**
+	 * Test that replies to non-existent posts return false.
+	 *
+	 * @covers \Activitypub\Collection\Interactions::add_comment
+	 */
+	public function test_reply_to_non_existent_post_returns_false() {
+		$object = array(
+			'actor'  => $this->user_url,
+			'type'   => 'Create',
+			'id'     => 'https://example.com/id/' . microtime( true ),
+			'to'     => array( $this->user_url ),
+			'cc'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'object' => array(
+				'id'        => 'https://example.com/reply/123',
+				'url'       => 'https://example.com/reply/123',
+				'inReplyTo' => 'https://non-existent-site.example/post/999',
+				'content'   => 'Reply to non-existent post',
+			),
+		);
+
+		$result = Create::handle_create( $object, $this->user_id );
+
+		$this->assertNull( $result );
+
+		// Verify no comment was created.
+		$args = array(
+			'type'   => 'comment',
+			'status' => 'any',
+		);
+
+		$query    = new \WP_Comment_Query( $args );
+		$comments = $query->comments;
+
+		// Filter to check for our specific comment.
+		$found = array_filter(
+			$comments,
+			function ( $comment ) {
+				return 'Reply to non-existent post' === $comment->comment_content;
+			}
+		);
+
+		$this->assertEmpty( $found );
+	}
 }


### PR DESCRIPTION
## Proposed changes:

* Add guard to return false when `comment_post_id` is not set in `Interactions::add_comment()`, preventing errors when processing replies that don't reference a valid post or comment.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Receive a reply activity that references a non-existent post
* Verify no error is thrown and the comment is gracefully skipped

### Changelog entry

Changelog entry already added manually.