### PR TITLE
feat: make following table columns filterable

### DIFF
--- a/includes/wp-admin/table/class-blocked-actors.php
+++ b/includes/wp-admin/table/class-blocked-actors.php
@@ -160,34 +160,6 @@ class Blocked_Actors extends \WP_List_Table {
 	}
 
 	/**
-	 * Get columns.
-	 *
-	 * @return array
-	 */
-	public function get_columns() {
-		return array(
-			'cb'         => '<input type="checkbox" />',
-			'username'   => \__( 'Username', 'activitypub' ),
-			'post_title' => \__( 'Name', 'activitypub' ),
-			'webfinger'  => \__( 'Profile', 'activitypub' ),
-			'modified'   => \__( 'Blocked date', 'activitypub' ),
-		);
-	}
-
-	/**
-	 * Returns sortable columns.
-	 *
-	 * @return array
-	 */
-	public function get_sortable_columns() {
-		return array(
-			'username'   => array( 'username', true ),
-			'post_title' => array( 'post_title', true ),
-			'modified'   => array( 'modified', false ),
-		);
-	}
-
-	/**
 	 * Prepare items.
 	 */
 	public function prepare_items() {
@@ -250,20 +222,6 @@ class Blocked_Actors extends \WP_List_Table {
 		return array(
 			'delete' => \__( 'Unblock', 'activitypub' ),
 		);
-	}
-
-	/**
-	 * Column default.
-	 *
-	 * @param array  $item        Item.
-	 * @param string $column_name Column name.
-	 * @return string
-	 */
-	public function column_default( $item, $column_name ) {
-		if ( ! \array_key_exists( $column_name, $item ) ) {
-			return \esc_html__( 'None', 'activitypub' );
-		}
-		return \esc_html( $item[ $column_name ] );
 	}
 
 	/**

--- a/includes/wp-admin/table/class-followers.php
+++ b/includes/wp-admin/table/class-followers.php
@@ -213,34 +213,6 @@ class Followers extends \WP_List_Table {
 	}
 
 	/**
-	 * Get columns.
-	 *
-	 * @return array
-	 */
-	public function get_columns() {
-		return array(
-			'cb'         => '<input type="checkbox" />',
-			'username'   => \esc_html__( 'Username', 'activitypub' ),
-			'post_title' => \esc_html__( 'Name', 'activitypub' ),
-			'webfinger'  => \esc_html__( 'Profile', 'activitypub' ),
-			'modified'   => \esc_html__( 'Last updated', 'activitypub' ),
-		);
-	}
-
-	/**
-	 * Returns sortable columns.
-	 *
-	 * @return array
-	 */
-	public function get_sortable_columns() {
-		return array(
-			'username'   => array( 'username', true ),
-			'post_title' => array( 'post_title', true ),
-			'modified'   => array( 'modified', false ),
-		);
-	}
-
-	/**
 	 * Prepare items.
 	 */
 	public function prepare_items() {
@@ -337,21 +309,6 @@ class Followers extends \WP_List_Table {
 			'delete' => \__( 'Delete', 'activitypub' ),
 			'block'  => \__( 'Block', 'activitypub' ),
 		);
-	}
-
-	/**
-	 * Column default.
-	 *
-	 * @param array  $item        Item.
-	 * @param string $column_name Column name.
-	 * @return string
-	 */
-	public function column_default( $item, $column_name ) {
-		if ( ! array_key_exists( $column_name, $item ) ) {
-			return \esc_html__( 'None', 'activitypub' );
-		}
-
-		return \esc_html( $item[ $column_name ] );
 	}
 
 	/**

--- a/includes/wp-admin/table/class-following.php
+++ b/includes/wp-admin/table/class-following.php
@@ -174,13 +174,26 @@ class Following extends \WP_List_Table {
 	 * @return array
 	 */
 	public function get_columns() {
-		return array(
+		$columns = array(
 			'cb'         => '<input type="checkbox" />',
 			'username'   => \__( 'Username', 'activitypub' ),
 			'post_title' => \__( 'Name', 'activitypub' ),
 			'webfinger'  => \__( 'Profile', 'activitypub' ),
 			'modified'   => \__( 'Last updated', 'activitypub' ),
 		);
+
+		/**
+		 * Filters the columns displayed in the ActivityPub Following list table.
+		 *
+		 * Allows plugins to add, remove, or reorder columns shown in the
+		 * Following list table on the ActivityPub admin screen.
+		 *
+		 * @since 7.9.0
+		 *
+		 * @param string[]                              $columns Array of columns.
+		 * @param \Activitypub\WP_Admin\Table\Following $table   The current Following list table instance.
+		 */
+		return \apply_filters( 'activitypub_following_columns', $columns, $this );
 	}
 
 	/**
@@ -189,11 +202,24 @@ class Following extends \WP_List_Table {
 	 * @return array
 	 */
 	public function get_sortable_columns() {
-		return array(
+		$columns = array(
 			'username'   => array( 'username', true ),
 			'post_title' => array( 'post_title', true ),
 			'modified'   => array( 'modified', false ),
 		);
+
+		/**
+		 * Filters the sortable columns in the ActivityPub Following list table.
+		 *
+		 * Allows plugins to register additional sortable columns or modify the default sortable behavior.
+		 *
+		 * @since 7.9.0
+		 *
+		 * @param array<string, array>                  $columns Sortable columns in the format
+		 *                                                       `column_id => array( orderby, is_sortable_default )`.
+		 * @param \Activitypub\WP_Admin\Table\Following $table   The current Following list table instance.
+		 */
+		return apply_filters( 'activitypub_following_sortable_columns', $columns, $this );
 	}
 
 	/**
@@ -350,6 +376,26 @@ class Following extends \WP_List_Table {
 	 * @return string
 	 */
 	public function column_default( $item, $column_name ) {
+		/**
+		 * Filters the displayed value for a column in the ActivityPub Following list table.
+		 *
+		 * Allows plugins to provide custom output for individual columns.
+		 * If a non-null value is returned, it will be used instead of the
+		 * default column rendering logic.
+		 *
+		 * @since 7.9.0
+		 *
+		 * @param string|null                           $value       The column value. Default null.
+		 * @param string                                $column_name The name of the current column.
+		 * @param array                                 $item        The current following item data.
+		 * @param \Activitypub\WP_Admin\Table\Following $table       The current Following list table instance.
+		 */
+		$value = \apply_filters( 'activitypub_following_column_value', null, $column_name, $item, $this );
+
+		if ( null !== $value ) {
+			return $value;
+		}
+
 		if ( ! array_key_exists( $column_name, $item ) ) {
 			return \esc_html__( 'None', 'activitypub' );
 		}

--- a/includes/wp-admin/table/class-following.php
+++ b/includes/wp-admin/table/class-following.php
@@ -169,60 +169,6 @@ class Following extends \WP_List_Table {
 	}
 
 	/**
-	 * Get columns.
-	 *
-	 * @return array
-	 */
-	public function get_columns() {
-		$columns = array(
-			'cb'         => '<input type="checkbox" />',
-			'username'   => \__( 'Username', 'activitypub' ),
-			'post_title' => \__( 'Name', 'activitypub' ),
-			'webfinger'  => \__( 'Profile', 'activitypub' ),
-			'modified'   => \__( 'Last updated', 'activitypub' ),
-		);
-
-		/**
-		 * Filters the columns displayed in the ActivityPub Following list table.
-		 *
-		 * Allows plugins to add, remove, or reorder columns shown in the
-		 * Following list table on the ActivityPub admin screen.
-		 *
-		 * @since 7.9.0
-		 *
-		 * @param string[]                              $columns Array of columns.
-		 * @param \Activitypub\WP_Admin\Table\Following $table   The current Following list table instance.
-		 */
-		return \apply_filters( 'activitypub_following_columns', $columns, $this );
-	}
-
-	/**
-	 * Returns sortable columns.
-	 *
-	 * @return array
-	 */
-	public function get_sortable_columns() {
-		$columns = array(
-			'username'   => array( 'username', true ),
-			'post_title' => array( 'post_title', true ),
-			'modified'   => array( 'modified', false ),
-		);
-
-		/**
-		 * Filters the sortable columns in the ActivityPub Following list table.
-		 *
-		 * Allows plugins to register additional sortable columns or modify the default sortable behavior.
-		 *
-		 * @since 7.9.0
-		 *
-		 * @param array<string, array>                  $columns Sortable columns in the format
-		 *                                                       `column_id => array( orderby, is_sortable_default )`.
-		 * @param \Activitypub\WP_Admin\Table\Following $table   The current Following list table instance.
-		 */
-		return apply_filters( 'activitypub_following_sortable_columns', $columns, $this );
-	}
-
-	/**
 	 * Prepare items.
 	 */
 	public function prepare_items() {
@@ -366,40 +312,6 @@ class Following extends \WP_List_Table {
 		return array(
 			'delete' => \__( 'Unfollow', 'activitypub' ),
 		);
-	}
-
-	/**
-	 * Column default.
-	 *
-	 * @param array  $item        Item.
-	 * @param string $column_name Column name.
-	 * @return string
-	 */
-	public function column_default( $item, $column_name ) {
-		/**
-		 * Filters the displayed value for a column in the ActivityPub Following list table.
-		 *
-		 * Allows plugins to provide custom output for individual columns.
-		 * If a non-null value is returned, it will be used instead of the
-		 * default column rendering logic.
-		 *
-		 * @since 7.9.0
-		 *
-		 * @param string|null                           $value       The column value. Default null.
-		 * @param string                                $column_name The name of the current column.
-		 * @param array                                 $item        The current following item data.
-		 * @param \Activitypub\WP_Admin\Table\Following $table       The current Following list table instance.
-		 */
-		$value = \apply_filters( 'activitypub_following_column_value', null, $column_name, $item, $this );
-
-		if ( null !== $value ) {
-			return $value;
-		}
-
-		if ( ! array_key_exists( $column_name, $item ) ) {
-			return \esc_html__( 'None', 'activitypub' );
-		}
-		return \esc_html( $item[ $column_name ] );
 	}
 
 	/**

--- a/includes/wp-admin/table/trait-actor-list-table.php
+++ b/includes/wp-admin/table/trait-actor-list-table.php
@@ -11,6 +11,108 @@ namespace Activitypub\WP_Admin\Table;
  * Actor Table Trait.
  */
 trait Actor_List_Table {
+	/**
+	 * Returns the lowercase short classname which is used as keys for filtering.
+	 *
+	 * @return string
+	 */
+	protected static function actor_list_table_key() {
+		return strtolower( ( new \ReflectionClass( static::class) )->getShortName() );
+	}
+
+	/**
+	 * Column default.
+	 *
+	 * @param array  $item        Item.
+	 * @param string $column_name Column name.
+	 * @return string
+	 */
+	public function column_default( $item, $column_name ) {
+		/**
+		 * Filters the displayed value for a column in the ActivityPub Following list table.
+		 *
+		 * Allows plugins to provide custom output for individual columns.
+		 * If a non-null value is returned, it will be used instead of the
+		 * default column rendering logic.
+		 *
+		 * @since 7.9.0
+		 *
+		 * @param string|null                           $value       The column value. Default null.
+		 * @param string                                $column_name The name of the current column.
+		 * @param array                                 $item        The current following item data.
+		 * @param \Activitypub\WP_Admin\Table\Following $table       The current Following list table instance.
+		 */
+		$value = \apply_filters(
+			'activitypub_' . $this->actor_list_table_key() . '_column_value',
+			null,
+			$column_name,
+			$item,
+			$this
+		);
+
+		if ( null !== $value ) {
+			return $value;
+		}
+
+		if ( ! \array_key_exists( $column_name, $item ) ) {
+			return \esc_html__( 'None', 'activitypub' );
+		}
+		return \esc_html( $item[ $column_name ] );
+	}
+
+	/**
+	 * Returns sortable columns.
+	 *
+	 * @return array
+	 */
+	public function get_sortable_columns() {
+		$columns = array(
+			'username'   => array( 'username', true ),
+			'post_title' => array( 'post_title', true ),
+			'modified'   => array( 'modified', false ),
+		);
+
+		/**
+		 * Filters the sortable columns in the ActivityPub Following list table.
+		 *
+		 * Allows plugins to register additional sortable columns or modify the default sortable behavior.
+		 *
+		 * @since 7.9.0
+		 *
+		 * @param array<string, array>                  $columns Sortable columns in the format
+		 *                                                       `column_id => array( orderby, is_sortable_default )`.
+		 * @param \Activitypub\WP_Admin\Table\Following $table   The current Following list table instance.
+		 */
+		return apply_filters( 'activitypub_' . $this->actor_list_table_key() . '_sortable_columns', $columns, $this );
+	}
+
+	/**
+	 * Get columns.
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		$columns = array(
+			'cb'         => '<input type="checkbox" />',
+			'username'   => \__( 'Username', 'activitypub' ),
+			'post_title' => \__( 'Name', 'activitypub' ),
+			'webfinger'  => \__( 'Profile', 'activitypub' ),
+			'modified'   => \__( 'Last updated', 'activitypub' ),
+		);
+
+		/**
+		 * Filters the columns displayed in the ActivityPub Following list table.
+		 *
+		 * Allows plugins to add, remove, or reorder columns shown in the
+		 * Following list table on the ActivityPub admin screen.
+		 *
+		 * @since 7.9.0
+		 *
+		 * @param string[]                              $columns Array of columns.
+		 * @param \Activitypub\WP_Admin\Table\Following $table   The current Following list table instance.
+		 */
+		return \apply_filters( 'activitypub_' . $this->actor_list_table_key() . '_columns', $columns, $this );
+	}
 
 	/**
 	 * Sanitizes and normalizes an actor search term.


### PR DESCRIPTION
The Following table is not filterable by the default WordPress filters like `"manage_{$post_type}_posts_columns"`. Thats why this PR introduces custom filters. I wonder whether passing the whole table instance as a filter parameter is too much, maybe just `$this->user_id` is sufficient.

### Other information:

I offer to write tests and will provide changelog entries etc., after initial review about this feature idea.

### Background:

The idea came up while porting the "Event Sources" feature of the "Event Bridge For ActivityPub" to the new following structure. I wanted to add a boolean switch to import remote events to the sites calendar, to not do so from all followings but the selected ones. My intuition was to avoid having to manage this feature on two pages (one for adding the following, and a second one for activating existing followings).

- [x] Automatically create a changelog entry
