### PR TITLE
Fix old posts being federated when edited

### DIFF
--- a/.github/changelog/2703-from-description
+++ b/.github/changelog/2703-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix old posts being federated when edited despite "Do not federate" default.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -330,7 +330,8 @@ function is_post_disabled( $post ) {
 		return true;
 	}
 
-	$visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
+	// Use effective visibility (saved or calculated default).
+	$visibility = get_content_visibility( $post );
 
 	if (
 		ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL === $visibility ||
@@ -1422,7 +1423,11 @@ function is_same_domain( $url ) {
 /**
  * Get the visibility of a post.
  *
- * @param int $post_id The post ID.
+ * Returns the saved visibility value or calculates a default based on
+ * post age and federation status. This ensures consistent behavior between
+ * the UI (which shows defaults) and the actual federation logic.
+ *
+ * @param int|\WP_Post $post_id The post ID or post object.
  *
  * @return string|false The visibility of the post or false if not found.
  */
@@ -1441,7 +1446,25 @@ function get_content_visibility( $post_id ) {
 	);
 
 	if ( in_array( $visibility, $options, true ) ) {
+		// Visibility is explicitly set, use it.
 		$_visibility = $visibility;
+	} else {
+		// No explicit visibility set, calculate default.
+		$status = \get_post_meta( $post->ID, 'activitypub_status', true );
+
+		if ( 'federated' === $status ) {
+			// Post is already federated, default to public.
+			$_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
+		} else {
+			// Check if post is older than 30 days.
+			$post_timestamp = \strtotime( $post->post_date );
+			$one_month_ago  = \strtotime( '-30 days' );
+
+			if ( $post_timestamp < $one_month_ago ) {
+				// Old post, default to local (do not federate).
+				$_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL;
+			}
+		}
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1446,10 +1446,14 @@ function get_content_visibility( $post_id ) {
 	);
 
 	if ( in_array( $visibility, $options, true ) ) {
-		// Visibility is explicitly set, use it.
+		// Visibility is explicitly set to a non-public value, use it.
 		$_visibility = $visibility;
+	} elseif ( \metadata_exists( 'post', $post->ID, 'activitypub_content_visibility' ) ) {
+		// Meta exists but is not in options - treat as explicit public.
+		// This handles both '' (Block Editor) and 'public' (Classic Editor).
+		$_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
 	} else {
-		// No explicit visibility set, calculate default.
+		// No visibility meta exists, calculate default based on age/status.
 		$status = \get_post_meta( $post->ID, 'activitypub_status', true );
 
 		if ( 'federated' === $status ) {

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -241,7 +241,36 @@ class Classic_Editor {
 		// Save content visibility.
 		if ( isset( $_POST['activitypub_content_visibility'] ) ) {
 			$visibility = \sanitize_text_field( \wp_unslash( $_POST['activitypub_content_visibility'] ) );
-			\update_post_meta( $post_id, 'activitypub_content_visibility', $visibility );
+
+			// Normalize 'public' to empty string to match REST API behavior.
+			if ( 'public' === $visibility ) {
+				$visibility = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
+			}
+
+			// Calculate the natural default (what it would be without saved meta).
+			$post           = \get_post( $post_id );
+			$status         = \get_post_meta( $post_id, 'activitypub_status', true );
+			$post_timestamp = \strtotime( $post->post_date );
+			$one_month_ago  = \strtotime( '-30 days' );
+			$is_old_post    = $post_timestamp < $one_month_ago;
+
+			// Determine what the natural default would be.
+			if ( 'federated' === $status ) {
+				$natural_default = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
+			} elseif ( $is_old_post ) {
+				$natural_default = ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL;
+			} else {
+				$natural_default = ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
+			}
+
+			// Only save if different from natural default (to avoid flooding DB).
+			// For old posts, we need to save public explicitly to override the age-based default.
+			if ( $visibility !== $natural_default ) {
+				\update_post_meta( $post_id, 'activitypub_content_visibility', $visibility );
+			} else {
+				// Value matches natural default, remove any saved meta.
+				\delete_post_meta( $post_id, 'activitypub_content_visibility' );
+			}
 		}
 
 		// Save quote interaction policy.

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -189,28 +189,7 @@ class Classic_Editor {
 	 * @return string The default visibility value.
 	 */
 	private static function get_default_visibility( $post ) {
-		// If already set, use that value.
-		$saved_visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
-		if ( $saved_visibility ) {
-			return $saved_visibility;
-		}
-
-		// If post is federated, use public.
-		$status = \get_post_meta( $post->ID, 'activitypub_status', true );
-		if ( 'federated' === $status ) {
-			return ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
-		}
-
-		// If post is older than 1 month, default to local.
-		$post_timestamp = \strtotime( $post->post_date );
-		$one_month_ago  = \strtotime( '-30 days' );
-
-		if ( $post_timestamp < $one_month_ago ) {
-			return ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL;
-		}
-
-		// Default to public for new posts.
-		return ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
+		return \Activitypub\get_content_visibility( $post );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Fix old posts (>30 days) being federated when edited, even when "Do not federate" is shown as default in the editor
* Use `metadata_exists()` to distinguish between "never set" (calculate age-based default) and "explicitly set to public" (respect user choice)
* Update Classic Editor to only save visibility when it differs from the natural default, avoiding DB flooding with default values
* Normalize 'public' to empty string in Classic Editor to match REST API behavior

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

**Scenario 1: Old post without explicit visibility**
1. Create a post dated >30 days ago (or manually set `post_date` in database)
2. Edit the post without touching the visibility setting
3. Save → post should NOT be federated (default is now "local" for old posts)

**Scenario 2: Old post with explicit public visibility**
1. Create a post dated >30 days ago
2. Edit the post and explicitly select "Public" visibility
3. Save → post SHOULD be federated (user choice is respected)
4. Edit again → visibility should still show "Public" (not reset to "local")

**Scenario 3: New post keeps default**
1. Create a new post, keep visibility as default "Public"
2. Save → post is federated
3. Check database → `activitypub_content_visibility` meta should NOT exist (no DB flooding)

**Scenario 4: Any post set to local**
1. Create/edit any post and set visibility to "Do not federate"
2. Save → post is NOT federated
3. Edit again → visibility is still "Do not federate"

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix old posts being federated when edited despite "Do not federate" default.

</details>