### PR TITLE
Fix inconsistent default for hashtag setting

### DIFF
--- a/.github/changelog/fix-hashtag-default-consistency
+++ b/.github/changelog/fix-hashtag-default-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed inconsistent default value for the hashtag setting on new installations.

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -17,7 +17,7 @@ class Hashtag {
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
-		if ( '1' === \get_option( 'activitypub_use_hashtags', '1' ) ) {
+		if ( '1' === \get_option( 'activitypub_use_hashtags', '0' ) ) {
 			\add_action( 'wp_insert_post', array( self::class, 'insert_post' ), 10, 2 );
 			\add_filter( 'the_content', array( self::class, 'the_content' ) );
 			\add_filter( 'activitypub_activity_object_array', array( self::class, 'filter_activity_object' ), 99 );

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -356,7 +356,7 @@ class Settings_Fields {
 	 * Render use hashtags field.
 	 */
 	public static function render_use_hashtags_field() {
-		$value = get_option( 'activitypub_use_hashtags', '1' );
+		$value = get_option( 'activitypub_use_hashtags', '0' );
 		?>
 		<p>
 			<label>

--- a/tests/phpunit/tests/includes/class-test-hashtag.php
+++ b/tests/phpunit/tests/includes/class-test-hashtag.php
@@ -249,10 +249,11 @@ ENDPRE;
 	}
 
 	/**
-	 * Test that hashtag filters work with boolean-like option values.
+	 * Test that hashtag filters are enabled when the option is the string '1'.
 	 *
-	 * WordPress checkboxes can store '1', 1, true, or '0', 0, false, ''.
-	 * This test ensures the setting works correctly with string '1'.
+	 * WordPress checkboxes can store values like '1', 1, true, or '0', 0, false, ''.
+	 * The current implementation treats only the string '1' as enabling hashtags,
+	 * and this test verifies that behavior.
 	 *
 	 * @covers ::init
 	 */
@@ -272,7 +273,9 @@ ENDPRE;
 		);
 
 		// Clean up.
+		\remove_action( 'wp_insert_post', array( \Activitypub\Hashtag::class, 'insert_post' ) );
 		\remove_filter( 'the_content', array( \Activitypub\Hashtag::class, 'the_content' ) );
+		\remove_filter( 'activitypub_activity_object_array', array( \Activitypub\Hashtag::class, 'filter_activity_object' ), 99 );
 		\delete_option( 'activitypub_use_hashtags' );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-hashtag.php
+++ b/tests/phpunit/tests/includes/class-test-hashtag.php
@@ -177,4 +177,102 @@ ENDPRE;
 			),
 		);
 	}
+
+	/**
+	 * Test that hashtag filters are added when the setting is enabled.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_adds_filters_when_enabled() {
+		// Remove any existing filters first.
+		\remove_action( 'wp_insert_post', array( \Activitypub\Hashtag::class, 'insert_post' ) );
+		\remove_filter( 'the_content', array( \Activitypub\Hashtag::class, 'the_content' ) );
+		\remove_filter( 'activitypub_activity_object_array', array( \Activitypub\Hashtag::class, 'filter_activity_object' ), 99 );
+
+		// Enable the hashtag setting.
+		\update_option( 'activitypub_use_hashtags', '1' );
+
+		// Call init.
+		\Activitypub\Hashtag::init();
+
+		// Verify filters were added.
+		$this->assertNotFalse(
+			\has_action( 'wp_insert_post', array( \Activitypub\Hashtag::class, 'insert_post' ) ),
+			'insert_post action should be added when hashtags are enabled'
+		);
+		$this->assertNotFalse(
+			\has_filter( 'the_content', array( \Activitypub\Hashtag::class, 'the_content' ) ),
+			'the_content filter should be added when hashtags are enabled'
+		);
+		$this->assertNotFalse(
+			\has_filter( 'activitypub_activity_object_array', array( \Activitypub\Hashtag::class, 'filter_activity_object' ) ),
+			'filter_activity_object filter should be added when hashtags are enabled'
+		);
+
+		// Clean up.
+		\delete_option( 'activitypub_use_hashtags' );
+	}
+
+	/**
+	 * Test that hashtag filters are not added when the setting is disabled.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_does_not_add_filters_when_disabled() {
+		// Remove any existing filters first.
+		\remove_action( 'wp_insert_post', array( \Activitypub\Hashtag::class, 'insert_post' ) );
+		\remove_filter( 'the_content', array( \Activitypub\Hashtag::class, 'the_content' ) );
+		\remove_filter( 'activitypub_activity_object_array', array( \Activitypub\Hashtag::class, 'filter_activity_object' ), 99 );
+
+		// Disable the hashtag setting (default).
+		\update_option( 'activitypub_use_hashtags', '0' );
+
+		// Call init.
+		\Activitypub\Hashtag::init();
+
+		// Verify filters were NOT added.
+		$this->assertFalse(
+			\has_action( 'wp_insert_post', array( \Activitypub\Hashtag::class, 'insert_post' ) ),
+			'insert_post action should not be added when hashtags are disabled'
+		);
+		$this->assertFalse(
+			\has_filter( 'the_content', array( \Activitypub\Hashtag::class, 'the_content' ) ),
+			'the_content filter should not be added when hashtags are disabled'
+		);
+		$this->assertFalse(
+			\has_filter( 'activitypub_activity_object_array', array( \Activitypub\Hashtag::class, 'filter_activity_object' ) ),
+			'filter_activity_object filter should not be added when hashtags are disabled'
+		);
+
+		// Clean up.
+		\delete_option( 'activitypub_use_hashtags' );
+	}
+
+	/**
+	 * Test that hashtag filters work with boolean-like option values.
+	 *
+	 * WordPress checkboxes can store '1', 1, true, or '0', 0, false, ''.
+	 * This test ensures the setting works correctly with string '1'.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_with_string_option_value() {
+		// Remove any existing filters first.
+		\remove_action( 'wp_insert_post', array( \Activitypub\Hashtag::class, 'insert_post' ) );
+		\remove_filter( 'the_content', array( \Activitypub\Hashtag::class, 'the_content' ) );
+		\remove_filter( 'activitypub_activity_object_array', array( \Activitypub\Hashtag::class, 'filter_activity_object' ), 99 );
+
+		// Test with string '1' (typical checkbox value).
+		\update_option( 'activitypub_use_hashtags', '1' );
+		\Activitypub\Hashtag::init();
+
+		$this->assertNotFalse(
+			\has_filter( 'the_content', array( \Activitypub\Hashtag::class, 'the_content' ) ),
+			'Hashtag feature should be enabled with string "1"'
+		);
+
+		// Clean up.
+		\remove_filter( 'the_content', array( \Activitypub\Hashtag::class, 'the_content' ) );
+		\delete_option( 'activitypub_use_hashtags' );
+	}
 }


### PR DESCRIPTION
Partial fix for #2715

## Proposed changes:
* Fix inconsistent default value for the `activitypub_use_hashtags` setting
* The registered default in `class-options.php` was `'0'` but the fallback values in `get_option()` calls were `'1'`
* This caused the hashtag feature to be unintentionally enabled by default on new installations
* Add tests for `Hashtag::init()` to verify filters are correctly added/removed based on the setting

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* On a fresh installation (or after deleting the `activitypub_use_hashtags` option), verify the hashtag setting is disabled by default
* Enable the setting and verify hashtags in content are converted to tag links
* Disable the setting and verify hashtags are no longer converted

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fixed inconsistent default value for the hashtag setting on new installations.

</details>