### PR TITLE
Fix ActivityPub comments being marked as spam by Akismet

### DIFF
--- a/.github/changelog/fix-akismet-spam-override
+++ b/.github/changelog/fix-akismet-spam-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed ActivityPub comments being marked as spam by Akismet.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -29,7 +29,7 @@ class Comment {
 		\add_filter( 'comment_feed_where', array( static::class, 'comment_feed_where' ) );
 		\add_filter( 'get_comment_link', array( self::class, 'remote_comment_link' ), 11, 2 );
 		\add_action( 'pre_get_comments', array( static::class, 'comment_query' ) );
-		\add_filter( 'pre_comment_approved', array( static::class, 'pre_comment_approved' ), 10, 2 );
+		\add_filter( 'pre_comment_approved', array( static::class, 'pre_comment_approved' ), 11, 2 );
 		\add_filter( 'get_avatar_comment_types', array( static::class, 'get_avatar_comment_types' ), 99 );
 		\add_action( 'update_option_activitypub_allow_likes', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_action( 'update_option_activitypub_allow_reposts', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
@@ -731,7 +731,11 @@ class Comment {
 	 * @return int|string|\WP_Error The approval status. 1, 0, 'spam', 'trash', or WP_Error.
 	 */
 	public static function pre_comment_approved( $approved, $comment_data ) {
-		if ( $approved || \is_wp_error( $approved ) ) {
+		/*
+		 * Only return early for already-approved comments or errors.
+		 * Don't short-circuit on 'spam' or 'trash' - we may want to override those.
+		 */
+		if ( 1 === $approved || '1' === $approved || \is_wp_error( $approved ) ) {
 			return $approved;
 		}
 

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -732,10 +732,11 @@ class Comment {
 	 */
 	public static function pre_comment_approved( $approved, $comment_data ) {
 		/*
-		 * Only return early for already-approved comments or errors.
-		 * Don't short-circuit on 'spam' or 'trash' - we may want to override those.
+		 * Only return early for already-approved comments, trash, or errors.
+		 * Don't short-circuit on 'spam' - we may want to override Akismet.
+		 * Respect 'trash' since it comes from the WordPress disallowed list.
 		 */
-		if ( 1 === $approved || '1' === $approved || \is_wp_error( $approved ) ) {
+		if ( 1 === $approved || '1' === $approved || 'trash' === $approved || \is_wp_error( $approved ) ) {
 			return $approved;
 		}
 

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -173,7 +173,7 @@ class Test_Comment extends \WP_UnitTestCase {
 		$comment_autoapproved = \get_comment( $comment_id_autoapproved );
 		$this->assertEquals( '1', $comment_autoapproved->comment_approved );
 
-		\remove_filter( 'pre_comment_approved', array( 'Activitypub\Comment', 'pre_comment_approved' ) );
+		\remove_filter( 'pre_comment_approved', array( 'Activitypub\Comment', 'pre_comment_approved' ), 11 );
 
 		$comment_id_unapproved = \wp_new_comment(
 			array(


### PR DESCRIPTION
Fixes #2735

## Proposed changes:

* Run `pre_comment_approved` filter at priority 11 (after Akismet's priority 10) so we can override Akismet's spam verdict for authenticated ActivityPub comments
* Fix early return logic to only short-circuit for actually approved comments (`1` or `'1'`), not for `'spam'` or `'trash'` status - previously any truthy value caused an early return

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install and activate Akismet with an API key
* Receive an ActivityPub comment (like, reply, or announce) from a federated server
* Verify the comment is auto-approved according to your settings, not marked as spam

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fixed ActivityPub comments being marked as spam by Akismet.

</details>