### PR TITLE
Fix Follow requests from Pixelfed not being processed

### DIFF
--- a/.github/changelog/2755-from-description
+++ b/.github/changelog/2755-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Follow requests from Pixelfed and other implementations that don't set audience fields.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -771,7 +771,7 @@ function url_to_commentid( $url ) {
  *
  * @param array|string $data The ActivityPub object.
  *
- * @return string The URI of the ActivityPub object.
+ * @return string|null The URI of the ActivityPub object.
  */
 function object_to_uri( $data ) {
 	// Check whether it is already simple.

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -19,6 +19,7 @@ use function Activitypub\extract_recipients_from_activity;
 use function Activitypub\is_activity_public;
 use function Activitypub\is_collection;
 use function Activitypub\is_same_domain;
+use function Activitypub\object_to_uri;
 use function Activitypub\user_can_activitypub;
 
 /**
@@ -404,6 +405,19 @@ class Inbox_Controller extends \WP_REST_Controller {
 			}
 
 			$user_ids[] = $user_id;
+		}
+
+		// Check for an Actor in the Object field.
+		if ( empty( $user_ids ) ) {
+			$object = object_to_uri( $activity['object'] );
+
+			if ( \is_string( $object ) ) {
+				$user_id = Actors::get_id_by_resource( $object );
+
+				if ( ! \is_wp_error( $user_id ) && user_can_activitypub( $user_id ) ) {
+					$user_ids[] = $user_id;
+				}
+			}
 		}
 
 		return array_unique( array_map( 'intval', $user_ids ) );

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -19,7 +19,6 @@ use function Activitypub\extract_recipients_from_activity;
 use function Activitypub\is_activity_public;
 use function Activitypub\is_collection;
 use function Activitypub\is_same_domain;
-use function Activitypub\object_to_uri;
 use function Activitypub\user_can_activitypub;
 
 /**
@@ -409,14 +408,10 @@ class Inbox_Controller extends \WP_REST_Controller {
 
 		// Check for an Actor in the Object field.
 		if ( empty( $user_ids ) ) {
-			$object = object_to_uri( $activity['object'] );
+			$user_id = Actors::get_id_by_resource( $activity['object'] );
 
-			if ( \is_string( $object ) ) {
-				$user_id = Actors::get_id_by_resource( $object );
-
-				if ( ! \is_wp_error( $user_id ) && user_can_activitypub( $user_id ) ) {
-					$user_ids[] = $user_id;
-				}
+			if ( ! \is_wp_error( $user_id ) && user_can_activitypub( $user_id ) ) {
+				$user_ids[] = $user_id;
 			}
 		}
 

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -514,9 +514,10 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 	 */
 	public function test_get_local_recipients_external_only() {
 		$activity = array(
-			'type' => 'Create',
-			'to'   => array( 'https://external.example.com/user/123' ),
-			'cc'   => array( 'https://another.example.com/user/456' ),
+			'type'   => 'Create',
+			'object' => 'https://external.example.com/post/123',
+			'to'     => array( 'https://external.example.com/user/123' ),
+			'cc'     => array( 'https://another.example.com/user/456' ),
 		);
 
 		// Use reflection to test the private method.
@@ -565,12 +566,13 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 	 */
 	public function test_get_local_recipients_with_malformed_urls() {
 		$activity = array(
-			'type' => 'Create',
-			'to'   => array(
+			'type'   => 'Create',
+			'object' => 'https://external.example.com/post/123',
+			'to'     => array(
 				'not-a-valid-url',
 				get_home_url() . '/invalid-actor-path',
 			),
-			'cc'   => array(),
+			'cc'     => array(),
 		);
 
 		// Use reflection to test the private method.

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -1146,4 +1146,92 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		\delete_option( 'activitypub_actor_mode' );
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $remote_object_filter );
 	}
+
+	/**
+	 * Test get_local_recipients for Follow activity without audience fields.
+	 *
+	 * Some ActivityPub implementations like Pixelfed do not set audience fields
+	 * (to/cc/bcc) for Follow activities, even when sent to the shared inbox.
+	 * The recipient should be determined from the object field instead.
+	 *
+	 * @covers ::get_local_recipients
+	 */
+	public function test_get_local_recipients_follow_without_audience() {
+		// Enable actor mode to allow user actors.
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		// Get actor ID for the test user.
+		$user_actor    = Actors::get_by_id( self::$user_id );
+		$user_actor_id = $user_actor->get_id();
+
+		// Follow activity without any audience fields (to/cc/bcc).
+		// The object field contains the actor being followed.
+		$activity = array(
+			'id'     => 'https://pixelfed.example/follow/123',
+			'type'   => 'Follow',
+			'actor'  => 'https://pixelfed.example/users/remoteuser',
+			'object' => $user_actor_id,
+		);
+
+		// Use reflection to test the private method.
+		$reflection = new \ReflectionClass( $this->inbox_controller );
+		$method     = $reflection->getMethod( 'get_local_recipients' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( $this->inbox_controller, $activity );
+
+		// Should return the user from the object field.
+		$this->assertNotEmpty( $result, 'Should return recipient from object field when no audience' );
+		$this->assertContains( self::$user_id, $result, 'Should contain user referenced in object field' );
+
+		// Clean up.
+		\delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * Test Follow request without audience fields via REST endpoint.
+	 *
+	 * This simulates how Pixelfed sends Follow activities to the shared inbox
+	 * without setting audience fields.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_follow_request_without_audience_via_rest() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		// Get actor ID for the test user.
+		$user_actor    = Actors::get_by_id( self::$user_id );
+		$user_actor_id = $user_actor->get_id();
+
+		// Set up mock action.
+		$inbox_action = new \MockAction();
+		\add_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+
+		// Follow activity without any audience fields - simulating Pixelfed behavior.
+		$json = array(
+			'@context' => 'https://www.w3.org/ns/activitystreams',
+			'id'       => 'https://pixelfed.example/follow/456',
+			'type'     => 'Follow',
+			'actor'    => 'https://pixelfed.example/users/remoteuser',
+			'object'   => $user_actor_id,
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+		$this->assertEquals( 202, $response->get_status() );
+
+		// Verify the action was triggered for the user.
+		$this->assertGreaterThanOrEqual( 1, $inbox_action->get_call_count(), 'activitypub_inbox hook should be called' );
+
+		// Clean up.
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\remove_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+		\delete_option( 'activitypub_actor_mode' );
+	}
 }


### PR DESCRIPTION
Fixes #2756

## Proposed changes:
* Add fallback to check the activity's `object` field when determining recipients for the shared inbox
* When no recipients are found through audience fields (`to`/`cc`/`bcc`), extract the actor URI from the `object` field and resolve it to a local user

### Other information:

Pixelfed does not set an audience (`to`/`cc`/`bcc`) for Follow activities, even when sent to the shared inbox. This caused Follow requests to be silently ignored because the recipient could not be determined.

For Follow activities, the `object` field contains the actor being followed, which can be used to identify the local recipient.

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Have a Pixelfed user send a Follow request to a WordPress user via the shared inbox
2. Verify the Follow request is processed and the follower appears in the followers list

Or run the new tests:
```bash
npm run env-test -- --filter "test_get_local_recipients_follow_without_audience"
npm run env-test -- --filter "test_follow_request_without_audience_via_rest"
```

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix Follow requests from Pixelfed and other implementations that don't set audience fields.

</details>