### PR TITLE
Add location support using WordPress Geodata

### DIFF
--- a/.github/changelog/2760-from-description
+++ b/.github/changelog/2760-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add location support for posts using WordPress Geodata post meta fields.

--- a/includes/activity/class-base-object.php
+++ b/includes/activity/class-base-object.php
@@ -9,6 +9,8 @@
 
 namespace Activitypub\Activity;
 
+use Activitypub\Activity\Extended_Object\Place;
+
 /**
  * Base_Object is an implementation of one of the
  * Activity Streams Core Types.
@@ -21,47 +23,47 @@ namespace Activitypub\Activity;
  *
  * @see https://www.w3.org/TR/activitystreams-core/#object
  *
- * @method array|string|null    get_attachment()         Gets the attachment property of the object.
- * @method array|string|null    get_attributed_to()      Gets the entity attributed as the original author.
- * @method string|null          get_audience()           Gets the total population of entities for which the object can be considered relevant.
- * @method string[]|string|null get_bcc()                Gets the private secondary audience of the object.
- * @method string[]|string|null get_bto()                Gets the private primary audience of the object.
- * @method string[]|string|null get_cc()                 Gets the secondary recipients of the object.
- * @method string|null          get_content()            Gets the content property of the object.
- * @method string[]|null        get_content_map()        Gets the content map property of the object.
- * @method string|null          get_context()            Gets the context within which the object exists.
- * @method array|null           get_dcterms()            Gets the Dublin Core terms property of the object.
- * @method string|null          get_duration()           Gets the duration property of time-bound resources.
- * @method string|null          get_end_time()           Gets the date and time describing the ending time of the object.
- * @method string|null          get_generator()          Gets the entity that generated the object.
- * @method string[]|null        get_icon()               Gets the icon property of the object.
- * @method string|null          get_id()                 Gets the object's unique global identifier.
- * @method string[]|null        get_image()              Gets the image property of the object.
- * @method string[]|string|null get_in_reply_to()        Gets the objects this object is in reply to.
- * @method array|null           get_interaction_policy() Gets the interaction policy property of the object.
- * @method array|null           get_likes()              Gets the collection of likes for this object.
- * @method array|string|null    get_location()           Gets the physical or logical locations associated with the object.
- * @method string|null          get_media_type()         Gets the MIME media type of the content property.
- * @method string|null          get_name()               Gets the natural language name of the object.
- * @method string[]|null        get_name_map()           Gets the name map property of the object.
- * @method string|null          get_preview()            Gets the entity that provides a preview of this object.
- * @method string|null          get_published()          Gets the date and time the object was published in ISO 8601 format.
- * @method string|null          get_quote()              Gets the quote property of the object (FEP-044f).
- * @method string|null          get_quote_url()          Gets the quoteUrl property of the object.
- * @method string|null          get_quote_uri()          Gets the quoteUri property of the object.
- * @method string|null          get__misskey_quote()     Gets the _misskey_quote property of the object.
- * @method string|array|null    get_replies()            Gets the collection of responses to this object.
- * @method bool|null            get_sensitive()          Gets the sensitive property of the object.
- * @method array|null           get_shares()             Gets the collection of shares for this object.
- * @method array|null           get_source()             Gets the source property indicating content markup derivation.
- * @method string|null          get_start_time()         Gets the date and time describing the starting time of the object.
- * @method string|null          get_summary()            Gets the natural language summary of the object.
- * @method string[]|null        get_summary_map()        Gets the summary map property of the object.
- * @method array[]|null         get_tag()                Gets the tag property of the object.
- * @method string[]|string|null get_to()                 Gets the primary recipients of the object.
- * @method string               get_type()               Gets the type of the object.
- * @method string|null          get_updated()            Gets the date and time the object was updated in ISO 8601 format.
- * @method string|null          get_url()                Gets the URL of the object.
+ * @method array|string|null       get_attachment()         Gets the attachment property of the object.
+ * @method array|string|null       get_attributed_to()      Gets the entity attributed as the original author.
+ * @method string|null             get_audience()           Gets the total population of entities for which the object can be considered relevant.
+ * @method string[]|string|null    get_bcc()                Gets the private secondary audience of the object.
+ * @method string[]|string|null    get_bto()                Gets the private primary audience of the object.
+ * @method string[]|string|null    get_cc()                 Gets the secondary recipients of the object.
+ * @method string|null             get_content()            Gets the content property of the object.
+ * @method string[]|null           get_content_map()        Gets the content map property of the object.
+ * @method string|null             get_context()            Gets the context within which the object exists.
+ * @method array|null              get_dcterms()            Gets the Dublin Core terms property of the object.
+ * @method string|null             get_duration()           Gets the duration property of time-bound resources.
+ * @method string|null             get_end_time()           Gets the date and time describing the ending time of the object.
+ * @method string|null             get_generator()          Gets the entity that generated the object.
+ * @method string[]|null           get_icon()               Gets the icon property of the object.
+ * @method string|null             get_id()                 Gets the object's unique global identifier.
+ * @method string[]|null           get_image()              Gets the image property of the object.
+ * @method string[]|string|null    get_in_reply_to()        Gets the objects this object is in reply to.
+ * @method array|null              get_interaction_policy() Gets the interaction policy property of the object.
+ * @method array|null              get_likes()              Gets the collection of likes for this object.
+ * @method array|string|null|Place get_location()           Gets the physical or logical locations associated with the object.
+ * @method string|null             get_media_type()         Gets the MIME media type of the content property.
+ * @method string|null             get_name()               Gets the natural language name of the object.
+ * @method string[]|null           get_name_map()           Gets the name map property of the object.
+ * @method string|null             get_preview()            Gets the entity that provides a preview of this object.
+ * @method string|null             get_published()          Gets the date and time the object was published in ISO 8601 format.
+ * @method string|null             get_quote()              Gets the quote property of the object (FEP-044f).
+ * @method string|null             get_quote_url()          Gets the quoteUrl property of the object.
+ * @method string|null             get_quote_uri()          Gets the quoteUri property of the object.
+ * @method string|null             get__misskey_quote()     Gets the _misskey_quote property of the object.
+ * @method string|array|null       get_replies()            Gets the collection of responses to this object.
+ * @method bool|null               get_sensitive()          Gets the sensitive property of the object.
+ * @method array|null              get_shares()             Gets the collection of shares for this object.
+ * @method array|null              get_source()             Gets the source property indicating content markup derivation.
+ * @method string|null             get_start_time()         Gets the date and time describing the starting time of the object.
+ * @method string|null             get_summary()            Gets the natural language summary of the object.
+ * @method string[]|null           get_summary_map()        Gets the summary map property of the object.
+ * @method array[]|null            get_tag()                Gets the tag property of the object.
+ * @method string[]|string|null    get_to()                 Gets the primary recipients of the object.
+ * @method string                  get_type()               Gets the type of the object.
+ * @method string|null             get_updated()            Gets the date and time the object was updated in ISO 8601 format.
+ * @method string|null             get_url()                Gets the URL of the object.
  *
  * @method string|string[] add_cc( string|array $cc ) Adds one or more entities to the secondary audience of the object.
  * @method string|string[] add_to( string|array $to ) Adds one or more entities to the primary audience of the object.
@@ -85,7 +87,7 @@ namespace Activitypub\Activity;
  * @method Base_Object set_in_reply_to( string|string[] $in_reply_to ) Sets the is in reply to property of the object.
  * @method Base_Object set_interaction_policy( array|null $policy )    Sets the interaction policy property of the object.
  * @method Base_Object set_likes( array $likes )                       Sets the collection of likes for this object.
- * @method Base_Object set_location( array|string $location )          Sets the physical or logical locations associated with the object.
+ * @method Base_Object set_location( array|string|Place $location )    Sets the physical or logical locations associated with the object.
  * @method Base_Object set_media_type( string $media_type )            Sets the MIME media type of the content property.
  * @method Base_Object set_name( string $name )                        Sets the natural language name of the object.
  * @method Base_Object set_name_map( array|null $name_map )            Sets the name map property of the object.
@@ -336,7 +338,7 @@ class Base_Object extends Generic_Object {
 	 *
 	 * @see https://www.w3.org/TR/activitystreams-vocabulary/#dfn-location
 	 *
-	 * @var string|null
+	 * @var string|null|Place
 	 */
 	protected $location;
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -727,7 +727,11 @@ class Post extends Base {
 		}
 
 		// Both latitude and longitude are required for a valid location.
-		if ( empty( $meta['geo_latitude'][0] ) || empty( $meta['geo_longitude'][0] ) ) {
+		// Use is_numeric() instead of empty() since 0 is a valid coordinate (Equator/Prime Meridian).
+		$has_latitude  = isset( $meta['geo_latitude'][0] ) && is_numeric( $meta['geo_latitude'][0] );
+		$has_longitude = isset( $meta['geo_longitude'][0] ) && is_numeric( $meta['geo_longitude'][0] );
+
+		if ( ! $has_latitude || ! $has_longitude ) {
 			return null;
 		}
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -708,6 +708,53 @@ class Post extends Base {
 	}
 
 	/**
+	 * Returns the location of the post as a Place object.
+	 *
+	 * Uses WordPress Geodata post meta fields to build the location.
+	 *
+	 * @see https://codex.wordpress.org/Geodata
+	 * @see https://www.w3.org/TR/activitystreams-vocabulary/#dfn-location
+	 *
+	 * @return array|null The Place object or null if no public geodata is available.
+	 */
+	protected function get_location() {
+		$post_id = $this->item->ID;
+		$meta    = \get_post_meta( $post_id );
+
+		// If geo_public exists and is explicitly set to 0, don't share location.
+		if ( isset( $meta['geo_public'] ) && '0' === $meta['geo_public'][0] ) {
+			return null;
+		}
+
+		// Both latitude and longitude are required for a valid location.
+		if ( empty( $meta['geo_latitude'][0] ) || empty( $meta['geo_longitude'][0] ) ) {
+			return null;
+		}
+
+		$place = array(
+			'type'      => 'Place',
+			'latitude'  => (float) $meta['geo_latitude'][0],
+			'longitude' => (float) $meta['geo_longitude'][0],
+		);
+
+		// Add the address/name if available.
+		if ( ! empty( $meta['geo_address'][0] ) ) {
+			$place['name'] = \sanitize_text_field( $meta['geo_address'][0] );
+		}
+
+		/**
+		 * Filter the location Place object for a post.
+		 *
+		 * @param array    $place   The Place object.
+		 * @param \WP_Post $post    The post object.
+		 * @param int      $post_id The post ID.
+		 *
+		 * @return array|null The filtered Place object or null to disable location.
+		 */
+		return \apply_filters( 'activitypub_post_location', $place, $this->item, $post_id );
+	}
+
+	/**
 	 * Helper function to extract the @-Mentions from the post content.
 	 *
 	 * @return array The list of @-Mentions.

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -1204,4 +1204,245 @@ class Test_Post extends \WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test get_location method with public geodata.
+	 *
+	 * @covers ::get_location
+	 */
+	public function test_get_location_with_public_geodata() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post with Location',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Set geodata.
+		\update_post_meta( $post_id, 'geo_latitude', '52.5200' );
+		\update_post_meta( $post_id, 'geo_longitude', '13.4050' );
+		\update_post_meta( $post_id, 'geo_address', 'Berlin, Germany' );
+		\update_post_meta( $post_id, 'geo_public', '1' );
+
+		$post        = get_post( $post_id );
+		$transformer = new Post( $post );
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_location' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$location = $method->invoke( $transformer );
+
+		$this->assertIsArray( $location );
+		$this->assertSame( 'Place', $location['type'] );
+		$this->assertSame( 52.52, $location['latitude'] );
+		$this->assertSame( 13.405, $location['longitude'] );
+		$this->assertSame( 'Berlin, Germany', $location['name'] );
+	}
+
+	/**
+	 * Test get_location method without geo_public set (defaults to public).
+	 *
+	 * @covers ::get_location
+	 */
+	public function test_get_location_without_geo_public_defaults_public() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post with Location',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Set geodata without geo_public.
+		\update_post_meta( $post_id, 'geo_latitude', '48.8566' );
+		\update_post_meta( $post_id, 'geo_longitude', '2.3522' );
+
+		$post        = get_post( $post_id );
+		$transformer = new Post( $post );
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_location' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$location = $method->invoke( $transformer );
+
+		$this->assertIsArray( $location );
+		$this->assertSame( 'Place', $location['type'] );
+		$this->assertSame( 48.8566, $location['latitude'] );
+		$this->assertSame( 2.3522, $location['longitude'] );
+		$this->assertArrayNotHasKey( 'name', $location );
+	}
+
+	/**
+	 * Test get_location method with private geodata (geo_public = 0).
+	 *
+	 * @covers ::get_location
+	 */
+	public function test_get_location_with_private_geodata() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post with Private Location',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Set geodata as private.
+		\update_post_meta( $post_id, 'geo_latitude', '40.7128' );
+		\update_post_meta( $post_id, 'geo_longitude', '-74.0060' );
+		\update_post_meta( $post_id, 'geo_public', '0' );
+
+		$post        = get_post( $post_id );
+		$transformer = new Post( $post );
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_location' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$location = $method->invoke( $transformer );
+
+		$this->assertNull( $location, 'Location should be null when geo_public is 0.' );
+	}
+
+	/**
+	 * Test get_location method without geodata.
+	 *
+	 * @covers ::get_location
+	 */
+	public function test_get_location_without_geodata() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post without Location',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$post        = get_post( $post_id );
+		$transformer = new Post( $post );
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_location' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$location = $method->invoke( $transformer );
+
+		$this->assertNull( $location, 'Location should be null when no geodata is present.' );
+	}
+
+	/**
+	 * Test get_location method with only latitude (missing longitude).
+	 *
+	 * @covers ::get_location
+	 */
+	public function test_get_location_with_incomplete_geodata() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post with Incomplete Location',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Set only latitude.
+		\update_post_meta( $post_id, 'geo_latitude', '51.5074' );
+
+		$post        = get_post( $post_id );
+		$transformer = new Post( $post );
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_location' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$location = $method->invoke( $transformer );
+
+		$this->assertNull( $location, 'Location should be null when longitude is missing.' );
+	}
+
+	/**
+	 * Test get_location filter.
+	 *
+	 * @covers ::get_location
+	 */
+	public function test_get_location_filter() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post with Location Filter',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Set geodata.
+		\update_post_meta( $post_id, 'geo_latitude', '35.6762' );
+		\update_post_meta( $post_id, 'geo_longitude', '139.6503' );
+
+		// Add a filter to modify the location.
+		$filter = function ( $place ) {
+			$place['name']     = 'Tokyo, Japan';
+			$place['altitude'] = 40;
+			return $place;
+		};
+		\add_filter( 'activitypub_post_location', $filter, 10, 3 );
+
+		$post        = get_post( $post_id );
+		$transformer = new Post( $post );
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_location' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$location = $method->invoke( $transformer );
+
+		$this->assertIsArray( $location );
+		$this->assertSame( 'Tokyo, Japan', $location['name'] );
+		$this->assertSame( 40, $location['altitude'] );
+
+		\remove_filter( 'activitypub_post_location', $filter );
+	}
+
+	/**
+	 * Test that location is included in to_object output.
+	 *
+	 * @covers ::to_object
+	 */
+	public function test_location_in_to_object() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post with Location',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Set geodata.
+		\update_post_meta( $post_id, 'geo_latitude', '51.5074' );
+		\update_post_meta( $post_id, 'geo_longitude', '-0.1278' );
+		\update_post_meta( $post_id, 'geo_address', 'London, UK' );
+
+		$post   = get_post( $post_id );
+		$object = Post::transform( $post )->to_object();
+
+		$location = $object->get_location();
+
+		$this->assertIsArray( $location );
+		$this->assertSame( 'Place', $location['type'] );
+		$this->assertSame( 51.5074, $location['latitude'] );
+		$this->assertSame( -0.1278, $location['longitude'] );
+		$this->assertSame( 'London, UK', $location['name'] );
+	}
 }

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -1341,6 +1341,41 @@ class Test_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_location method with zero coordinates (Equator/Prime Meridian).
+	 *
+	 * @covers ::get_location
+	 */
+	public function test_get_location_with_zero_coordinates() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post at Null Island',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Set geodata to 0,0 (Null Island - valid coordinates).
+		\update_post_meta( $post_id, 'geo_latitude', '0' );
+		\update_post_meta( $post_id, 'geo_longitude', '0' );
+
+		$post        = get_post( $post_id );
+		$transformer = new Post( $post );
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_location' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$location = $method->invoke( $transformer );
+
+		$this->assertIsArray( $location, 'Location should not be null for coordinates 0,0' );
+		$this->assertSame( 'Place', $location['type'] );
+		$this->assertSame( 0.0, $location['latitude'] );
+		$this->assertSame( 0.0, $location['longitude'] );
+	}
+
+	/**
 	 * Test get_location method with only latitude (missing longitude).
 	 *
 	 * @covers ::get_location


### PR DESCRIPTION
Fixes #2754

## Proposed changes:

* Add `get_location` method to Post transformer that creates a Place object from WordPress Geodata post meta fields
* Map geodata fields to ActivityPub Place properties:
  - `geo_latitude` → `latitude`
  - `geo_longitude` → `longitude`
  - `geo_address` → `name`
* Respect `geo_public` setting - location is hidden when set to `0`
* Add `activitypub_post_location` filter for extending/customizing location data

### Other information:

This implements location support similar to Pixelfed and Vernissage. The location is only included when both latitude and longitude are present and `geo_public` is not explicitly set to `0`.

Plugins like [Geolocation](https://wordpress.org/plugins/geolocation/) can set these meta fields.

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Install a geolocation plugin or manually set post meta:
   ```php
   update_post_meta( $post_id, 'geo_latitude', '52.5200' );
   update_post_meta( $post_id, 'geo_longitude', '13.4050' );
   update_post_meta( $post_id, 'geo_address', 'Berlin, Germany' );
   ```
2. View the ActivityPub JSON output for the post (add `?activitypub` to the URL)
3. Verify the post includes a `location` property with a Place object

Example expected output:
```json
{
  "location": {
    "type": "Place",
    "latitude": 52.52,
    "longitude": 13.405,
    "name": "Berlin, Germany"
  }
}
```

Or run the tests:
```bash
npm run env-test -- --filter "test_get_location"
npm run env-test -- --filter "test_location_in_to_object"
```

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add location support for posts using WordPress Geodata post meta fields.

</details>