### PR TITLE
Only disable blocks for ClassicPress, not Classic Editor plugin

### DIFF
--- a/.github/changelog/2765-from-description
+++ b/.github/changelog/2765-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only disable blocks for ClassicPress, not when Classic Editor plugin is installed.

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -20,9 +20,12 @@ class Classic_Editor {
 	public static function init() {
 		\add_filter( 'activitypub_attachments_media_markup', array( self::class, 'filter_attachments_media_markup' ), 10, 2 );
 		\add_filter( 'activitypub_attachment_ids', array( self::class, 'filter_attached_media_ids' ), 10, 2 );
-		\add_filter( 'activitypub_site_supports_blocks', '__return_false' );
 		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ) );
 		\add_action( 'save_post', array( self::class, 'save_meta_data' ) );
+
+		if ( \function_exists( 'classicpress_version' ) ) {
+			\add_filter( 'activitypub_site_supports_blocks', '__return_false' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2764

## Proposed changes:

* Only disable blocks when ClassicPress is detected, not when the Classic Editor plugin is installed
* The Classic Editor plugin allows users to choose between classic and block editor on a per-user or per-post basis
* Having the plugin installed doesn't mean blocks aren't being used

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install and activate the Classic Editor plugin
* Go to Settings > Writing and set "Default editor for all users" to "Block editor"
* Go to Posts > Add New
* Verify ActivityPub blocks are available in the block editor
* Verify likes/boosts are displayed on published posts

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Only disable blocks for ClassicPress, not when Classic Editor plugin is installed.

</details>