### PR TITLE
Migrate actor IDs from permalink to query-param format

### DIFF
--- a/.github/changelog/fix-account-move-verification
+++ b/.github/changelog/fix-account-move-verification
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Fediverse account migration so a move only takes effect once the destination is verified, and so other servers accept it.

--- a/.github/changelog/fix-account-move-verification
+++ b/.github/changelog/fix-account-move-verification
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix Fediverse account migration so a move only takes effect once the destination is verified, and so other servers accept it.
+Fix Fediverse account migration so a move is verified before it takes effect and reliably reaches your followers on other servers.

--- a/.github/changelog/migrate-permalink-ids-to-query-param
+++ b/.github/changelog/migrate-permalink-ids-to-query-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use a stable Fediverse profile ID that no longer breaks your followers when you change your handle, and migrate existing profiles to it automatically.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -14,6 +14,8 @@ use Activitypub\Collection\Following;
 use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
+use Activitypub\Model\Blog;
+use Activitypub\Model\User;
 use Activitypub\Transformer\Factory;
 
 /**
@@ -223,6 +225,9 @@ class Migration {
 		if ( \version_compare( $version_from_db, '9.1.0', '<' ) ) {
 			self::migrate_application_keypair_option();
 			self::delete_application_outbox_items();
+		}
+		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
+			self::migrate_permalink_ids_to_query_param();
 		}
 
 		/*
@@ -1392,6 +1397,47 @@ class Migration {
 
 		foreach ( $items as $item_id ) {
 			\wp_delete_post( $item_id, true );
+		}
+	}
+
+	/**
+	 * Migrate actors from a permalink-based id to the stable query-param id.
+	 *
+	 * A permalink id (`/@handle` for the blog, the author archive URL for a user) changes whenever
+	 * the handle changes, which strands followers. This moves every actor that used one to the
+	 * stable `?author=ID` form: it federates a Move to the old id's audience and keeps the old id
+	 * resolving with a `movedTo`. Actors whose old id already matched the query-param form are
+	 * skipped.
+	 *
+	 * @since unreleased
+	 */
+	public static function migrate_permalink_ids_to_query_param() {
+		if ( \get_option( 'activitypub_use_permalink_as_id_for_blog', false ) ) {
+			$blog   = new Blog();
+			$old_id = \esc_url_raw( \home_url( '/@' . $blog->get_preferred_username() ) );
+
+			if ( $old_id !== $blog->get_id() ) {
+				Move::internally_by_actor( $blog, $blog, $old_id, $blog->get_id() );
+				Move::store_retired_permalink( $blog, $old_id );
+			}
+		}
+
+		$users = \get_users( array( 'capability__in' => array( 'activitypub' ) ) );
+
+		foreach ( $users as $wp_user ) {
+			if ( '1' !== \get_user_option( 'activitypub_use_permalink_as_id', $wp_user->ID ) ) {
+				continue;
+			}
+
+			$user   = new User( $wp_user->ID );
+			$old_id = \esc_url_raw( \get_author_posts_url( $wp_user->ID ) );
+
+			if ( $old_id === $user->get_id() ) {
+				continue;
+			}
+
+			Move::internally_by_actor( $user, $user, $old_id, $user->get_id() );
+			Move::store_retired_permalink( $user, $old_id );
 		}
 	}
 }

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -15,6 +15,8 @@ use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Transformer\Factory;
 
+use function Activitypub\add_to_outbox;
+
 /**
  * ActivityPub Migration Class
  *

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -15,6 +15,7 @@ use Activitypub\Collection\Following;
 use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Model\Blog;
+use Activitypub\Model\User;
 use Activitypub\Transformer\Factory;
 
 /**
@@ -219,6 +220,7 @@ class Migration {
 
 		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
 			self::migrate_blog_user_to_query_param_id();
+			self::migrate_users_to_query_param_id();
 		}
 
 		// Ensure all required cron schedules are registered.
@@ -1113,6 +1115,40 @@ class Migration {
 		$activity->set_target( $blog->get_id() );
 
 		Outbox::add( $activity, Actors::BLOG_USER_ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+	}
+
+	/**
+	 * Migrate users from permalink-based ID to query param ID.
+	 *
+	 * This sends a Move activity from the old author URL to the new ?author= URL
+	 * for each user that had the permalink-as-id setting.
+	 */
+	private static function migrate_users_to_query_param_id() {
+		$users = \get_users(
+			array(
+				'capability__in' => array( 'activitypub' ),
+			)
+		);
+
+		foreach ( $users as $wp_user ) {
+			$use_permalink = \get_user_option( 'activitypub_use_permalink_as_id', $wp_user->ID );
+
+			if ( '1' !== $use_permalink ) {
+				continue;
+			}
+
+			$user   = new User( $wp_user->ID );
+			$old_id = $user->get_url();
+
+			$activity = new Activity();
+			$activity->set_type( 'Move' );
+			$activity->set_actor( $old_id );
+			$activity->set_origin( $old_id );
+			$activity->set_object( $old_id );
+			$activity->set_target( $user->get_id() );
+
+			Outbox::add( $activity, $wp_user->ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+		}
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -1102,13 +1102,14 @@ class Migration {
 			return;
 		}
 
-		$blog = new Blog();
+		$blog   = new Blog();
+		$old_id = \esc_url( \trailingslashit( get_home_url() ) . '@' . $blog->get_preferred_username() );
 
 		$activity = new Activity();
 		$activity->set_type( 'Move' );
-		$activity->set_actor( $blog->get_url() );
-		$activity->set_origin( $blog->get_url() );
-		$activity->set_object( $blog->get_url() );
+		$activity->set_actor( $old_id );
+		$activity->set_origin( $old_id );
+		$activity->set_object( $old_id );
 		$activity->set_target( $blog->get_id() );
 
 		Outbox::add( $activity, Actors::BLOG_USER_ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -215,6 +215,10 @@ class Migration {
 			\wp_schedule_single_event( \time(), 'activitypub_migrate_avatar_to_remote_actors' );
 		}
 
+		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
+			self::migrate_blog_user_to_query_param_id();
+		}
+
 		// Ensure all required cron schedules are registered.
 		Scheduler::register_schedules();
 
@@ -1081,6 +1085,36 @@ class Migration {
 		foreach ( $inbox_ids as $post_id ) {
 			\wp_delete_post( $post_id, true );
 		}
+	}
+
+	/**
+	 * Migrate blog user from permalink-based ID to query param ID.
+	 *
+	 * This sends a Move activity from the old @username URL to the new ?author= URL
+	 * for the blog actor, allowing followers to update their records.
+	 */
+	private static function migrate_blog_user_to_query_param_id() {
+		$use_permalink = \get_option( 'activitypub_use_permalink_as_id_for_blog', false );
+
+		if ( ! $use_permalink ) {
+			return;
+		}
+
+		$blog = new Model\Blog();
+
+		// Old ID was the @username format.
+		$old_id = \esc_url( \trailingslashit( \get_home_url() ) . '@' . $blog->get_preferred_username() );
+		// New ID is the query param format.
+		$new_id = \add_query_arg( 'author', Actors::BLOG_USER_ID, \home_url( '/' ) );
+
+		$activity = new Activity\Activity();
+		$activity->set_type( 'Move' );
+		$activity->set_actor( $old_id );
+		$activity->set_origin( $old_id );
+		$activity->set_object( $old_id );
+		$activity->set_target( $new_id );
+
+		add_to_outbox( $activity, null, Actors::BLOG_USER_ID, ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -7,15 +7,15 @@
 
 namespace Activitypub;
 
+use Activitypub\Activity\Activity;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
 use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
+use Activitypub\Model\Blog;
 use Activitypub\Transformer\Factory;
-
-use function Activitypub\add_to_outbox;
 
 /**
  * ActivityPub Migration Class
@@ -1102,21 +1102,17 @@ class Migration {
 			return;
 		}
 
-		$blog = new Model\Blog();
+		$blog = new Blog();
 
-		// Old ID was the @username format.
-		$old_id = \esc_url( \trailingslashit( \get_home_url() ) . '@' . $blog->get_preferred_username() );
-		// New ID is the query param format.
-		$new_id = \add_query_arg( 'author', Actors::BLOG_USER_ID, \home_url( '/' ) );
-
-		$activity = new Activity\Activity();
+		$activity = new Activity();
 		$activity->set_type( 'Move' );
-		$activity->set_actor( $old_id );
-		$activity->set_origin( $old_id );
-		$activity->set_object( $old_id );
-		$activity->set_target( $new_id );
+		$activity->set_actor( $blog->get_url() );
+		$activity->set_origin( $blog->get_url() );
+		$activity->set_object( $blog->get_url() );
+		$activity->set_target( $blog->get_id() );
+		$activity->set_to( Remote_Actors::get_inboxes() );
 
-		add_to_outbox( $activity, null, Actors::BLOG_USER_ID, ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
+		Outbox::add( $activity, Actors::BLOG_USER_ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -1110,7 +1110,6 @@ class Migration {
 		$activity->set_origin( $blog->get_url() );
 		$activity->set_object( $blog->get_url() );
 		$activity->set_target( $blog->get_id() );
-		$activity->set_to( Remote_Actors::get_inboxes() );
 
 		Outbox::add( $activity, Actors::BLOG_USER_ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 	}

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -1114,7 +1114,7 @@ class Migration {
 		$activity->set_object( $old_id );
 		$activity->set_target( $blog->get_id() );
 
-		Outbox::add( $activity, Actors::BLOG_USER_ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+		add_to_outbox( $activity, null, Actors::BLOG_USER_ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 	}
 
 	/**
@@ -1147,7 +1147,7 @@ class Migration {
 			$activity->set_object( $old_id );
 			$activity->set_target( $user->get_id() );
 
-			Outbox::add( $activity, $wp_user->ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+			add_to_outbox( $activity, null, $wp_user->ID, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 		}
 	}
 

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -81,13 +81,6 @@ class Move {
 			return $user;
 		}
 
-		// Update the movedTo property.
-		if ( $user->get__id() > 0 ) {
-			\update_user_option( $user->get__id(), 'activitypub_moved_to', $to );
-		} else {
-			\update_option( 'activitypub_blog_user_moved_to', $to );
-		}
-
 		$response = Http::get_remote_object( $to );
 
 		if ( \is_wp_error( $response ) ) {
@@ -97,10 +90,21 @@ class Move {
 		$target_actor = new Actor();
 		$target_actor->from_array( $response );
 
-		// Check if the `Move` Activity is valid.
+		/*
+		 * The move is only valid if the target links back. Receiving servers accept it only when the
+		 * id we send as the Move's `object` is listed in the target's `alsoKnownAs`, so verify that
+		 * exact id, not the (possibly non-canonical) input URL.
+		 */
 		$also_known_as = $target_actor->get_also_known_as() ?? array();
-		if ( ! \in_array( $from, $also_known_as, true ) ) {
+		if ( ! \in_array( $user->get_id(), $also_known_as, true ) ) {
 			return new \WP_Error( 'invalid_target', \__( 'Invalid target', 'activitypub' ) );
+		}
+
+		// Advertise the move only after the target is verified, so a failed attempt never leaves the actor pointing at an unverified target.
+		if ( $user->get__id() > 0 ) {
+			\update_user_option( $user->get__id(), 'activitypub_moved_to', $to );
+		} else {
+			\update_option( 'activitypub_blog_user_moved_to', $to );
 		}
 
 		$activity = new Activity();
@@ -139,13 +143,25 @@ class Move {
 			return $user;
 		}
 
-		// Add the old account URL to alsoKnownAs.
+		// Point the old actor at the new one.
 		if ( $user->get__id() > 0 ) {
-			self::update_user_also_known_as( $user->get__id(), $from );
 			\update_user_option( $user->get__id(), 'activitypub_moved_to', $to );
 		} else {
-			self::update_blog_also_known_as( $from );
 			\update_option( 'activitypub_blog_user_moved_to', $to );
+		}
+
+		/*
+		 * The old account URL belongs in the *target's* alsoKnownAs, not the source's: receiving
+		 * servers accept the Move only when the new actor links back to the old one. For a domain
+		 * change the source and target resolve to the same actor, so it is still recorded there.
+		 */
+		$target = Actors::get_by_various( $to );
+		if ( ! \is_wp_error( $target ) ) {
+			if ( $target->get__id() > 0 ) {
+				self::update_user_also_known_as( $target->get__id(), $from );
+			} else {
+				self::update_blog_also_known_as( $from );
+			}
 		}
 
 		// check if `$from` is a URL or an ID.

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -45,6 +45,10 @@ class Move {
 				}
 			}
 		}
+
+		// Serve the retired representation (with movedTo) when an actor is fetched via its old
+		// permalink id. Always registered, since the id migration is not gated by domain moves.
+		\add_action( 'activitypub_construct_model_actor', array( self::class, 'maybe_initiate_retired_actor' ) );
 	}
 
 	/**
@@ -151,49 +155,64 @@ class Move {
 			return $user;
 		}
 
+		// The old id is the input when it is a URL, otherwise the source's canonical id.
+		$old_id = \filter_var( $from, FILTER_VALIDATE_URL ) ? $from : $user->get_id();
+
+		return self::internally_by_actor( $user, Actors::get_by_various( $to ), $old_id, $to );
+	}
+
+	/**
+	 * Perform an internal Move for already-resolved actors.
+	 *
+	 * Used when the caller already holds the source and target actors and the exact old/new ids,
+	 * rather than a URL that still resolves. The id migration relies on this because the old
+	 * permalink URL no longer resolves once `get_id()` stops emitting it.
+	 *
+	 * @since unreleased
+	 *
+	 * @param User|Blog           $source The actor being moved (the old identity).
+	 * @param User|Blog|\WP_Error $target The actor the move points to; may equal the source for a self re-identification.
+	 * @param string              $old_id The old actor id (the Move's `object`).
+	 * @param string              $new_id The new actor id (the Move's `target`).
+	 *
+	 * @return int|bool|\WP_Error The ID of the outbox item or false or WP_Error on failure.
+	 */
+	public static function internally_by_actor( $source, $target, $old_id, $new_id ) {
 		// Point the old actor at the new one.
-		if ( $user->get__id() > 0 ) {
-			\update_user_option( $user->get__id(), 'activitypub_moved_to', $to );
+		if ( $source->get__id() > 0 ) {
+			\update_user_option( $source->get__id(), 'activitypub_moved_to', $new_id );
 		} else {
-			\update_option( 'activitypub_blog_user_moved_to', $to );
+			\update_option( 'activitypub_blog_user_moved_to', $new_id );
 		}
 
 		/*
-		 * The old account URL belongs in the *target's* alsoKnownAs, not the source's: receiving
-		 * servers accept the Move only when the new actor links back to the old one. For a domain
-		 * change the source and target resolve to the same actor, so it is still recorded there.
+		 * The old id belongs in the *target's* alsoKnownAs, not the source's: receiving servers
+		 * accept the Move only when the new actor links back to the old one. For a self
+		 * re-identification the source and target are the same actor, so it is recorded there.
 		 */
-		$target = Actors::get_by_various( $to );
 		if ( ! \is_wp_error( $target ) ) {
 			if ( $target->get__id() > 0 ) {
-				self::update_user_also_known_as( $target->get__id(), $from );
+				self::update_user_also_known_as( $target->get__id(), $old_id );
 			} else {
-				self::update_blog_also_known_as( $from );
+				self::update_blog_also_known_as( $old_id );
 			}
-		}
-
-		// check if `$from` is a URL or an ID.
-		if ( \filter_var( $from, FILTER_VALIDATE_URL ) ) {
-			$actor = $from;
-		} else {
-			$actor = $user->get_id();
 		}
 
 		$activity = new Activity();
 		$activity->set_type( 'Move' );
-		$activity->set_actor( $actor );
-		$activity->set_origin( $actor );
-		$activity->set_object( $actor );
-		$activity->set_target( $to );
+		$activity->set_actor( $old_id );
+		$activity->set_origin( $old_id );
+		$activity->set_object( $old_id );
+		$activity->set_target( $new_id );
 
-		$outbox_id = add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
+		$outbox_id = add_to_outbox( $activity, null, $source->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
 
 		/*
 		 * Notify followers of the changed profile on both actors by federating an Update (FEP-7628).
 		 * Queued after the Move so a follower that reacts to `movedTo` still processes the migration first.
 		 */
-		Actor_Scheduler::schedule_profile_update( $user->get__id() );
-		if ( ! \is_wp_error( $target ) && $target->get__id() !== $user->get__id() ) {
+		Actor_Scheduler::schedule_profile_update( $source->get__id() );
+		if ( ! \is_wp_error( $target ) && $target->get__id() !== $source->get__id() ) {
 			Actor_Scheduler::schedule_profile_update( $target->get__id() );
 		}
 
@@ -310,6 +329,64 @@ class Move {
 
 		if ( ! empty( $cached_data ) ) {
 			$instance->from_json( $cached_data );
+		}
+	}
+
+	/**
+	 * Store the retired representation of an actor's old permalink id.
+	 *
+	 * Snapshots the actor document with its id set to the old permalink URL, so a later request to
+	 * that URL can serve it. The `movedTo` is not stored here: it is derived at read time from the
+	 * `activitypub_moved_to` option (set by the move) against this old id, exactly as the domain
+	 * move does.
+	 *
+	 * @since unreleased
+	 *
+	 * @param User|Blog $actor  The migrated actor (already resolved to its new id).
+	 * @param string    $old_id The old permalink id to keep serving.
+	 */
+	public static function store_retired_permalink( $actor, $old_id ) {
+		$data = \json_decode( $actor->to_json(), true );
+
+		if ( ! \is_array( $data ) ) {
+			return;
+		}
+
+		$data['id'] = $old_id;
+		$json       = \wp_json_encode( $data );
+
+		if ( $actor->get__id() > 0 ) {
+			\update_user_option( $actor->get__id(), 'activitypub_retired_permalink_data', $json );
+		} else {
+			\update_option( 'activitypub_blog_user_retired_permalink_data', $json );
+		}
+	}
+
+	/**
+	 * Serve the retired permalink representation when the actor is fetched via its old id.
+	 *
+	 * Mirrors {@see self::maybe_initiate_old_user()}: the model stays unaware of the request, and
+	 * this loads the stored snapshot only when {@see Query::is_permalink_actor_request()} matches.
+	 *
+	 * @since unreleased
+	 *
+	 * @param Blog|User $instance The Blog or User instance to populate.
+	 */
+	public static function maybe_initiate_retired_actor( $instance ) {
+		if ( ! Query::get_instance()->is_permalink_actor_request() ) {
+			return;
+		}
+
+		if ( $instance instanceof Blog ) {
+			$data = \get_option( 'activitypub_blog_user_retired_permalink_data' );
+		} elseif ( $instance instanceof User ) {
+			$data = \get_user_option( 'activitypub_retired_permalink_data', $instance->get__id() );
+		} else {
+			return;
+		}
+
+		if ( ! empty( $data ) ) {
+			$instance->from_json( $data );
 		}
 	}
 

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -12,6 +12,7 @@ use Activitypub\Activity\Actor;
 use Activitypub\Collection\Actors;
 use Activitypub\Model\Blog;
 use Activitypub\Model\User;
+use Activitypub\Scheduler\Actor as Actor_Scheduler;
 
 /**
  * ActivityPub (Account) Move Class
@@ -114,8 +115,15 @@ class Move {
 		$activity->set_object( $user->get_id() );
 		$activity->set_target( $target_actor->get_id() );
 
-		// Add to outbox.
-		return add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+		$outbox_id = add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+
+		/*
+		 * Notify followers of the new movedTo by federating a profile Update (FEP-7628). Queue it
+		 * after the Move so a follower that reacts to `movedTo` still processes the migration first.
+		 */
+		Actor_Scheduler::schedule_profile_update( $user->get__id() );
+
+		return $outbox_id;
 	}
 
 	/**
@@ -178,7 +186,18 @@ class Move {
 		$activity->set_object( $actor );
 		$activity->set_target( $to );
 
-		return add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
+		$outbox_id = add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
+
+		/*
+		 * Notify followers of the changed profile on both actors by federating an Update (FEP-7628).
+		 * Queued after the Move so a follower that reacts to `movedTo` still processes the migration first.
+		 */
+		Actor_Scheduler::schedule_profile_update( $user->get__id() );
+		if ( ! \is_wp_error( $target ) && $target->get__id() !== $user->get__id() ) {
+			Actor_Scheduler::schedule_profile_update( $target->get__id() );
+		}
+
+		return $outbox_id;
 	}
 
 	/**

--- a/includes/class-move.php
+++ b/includes/class-move.php
@@ -111,7 +111,7 @@ class Move {
 		$activity->set_target( $target_actor->get_id() );
 
 		// Add to outbox.
-		return add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+		return add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 	}
 
 	/**
@@ -162,7 +162,7 @@ class Move {
 		$activity->set_object( $actor );
 		$activity->set_target( $to );
 
-		return add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
+		return add_to_outbox( $activity, null, $user->get__id(), ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
 	}
 
 	/**

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -359,6 +359,23 @@ class Query {
 	}
 
 	/**
+	 * Check if the current request is for an actor's retired permalink id.
+	 *
+	 * After an actor migrates from a permalink-based id to the query-param id, the old URL must
+	 * keep resolving with a `movedTo`. Those URLs carry a distinct query var: the blog `/@handle`
+	 * form sets `actor`, and the pretty author-archive `/author/handle` form sets `author_name`,
+	 * whereas the canonical `?author=ID` sets neither. This lets the model serve the retired
+	 * representation without inspecting the raw request itself.
+	 *
+	 * @since unreleased
+	 *
+	 * @return bool True if the request targets a retired permalink id.
+	 */
+	public function is_permalink_actor_request() {
+		return (bool) \get_query_var( 'actor' ) || (bool) \get_query_var( 'author_name' );
+	}
+
+	/**
 	 * Check if the current request is from the old host.
 	 *
 	 * @return bool True if the request is from the old host, false otherwise.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -276,7 +276,7 @@ class Scheduler {
 	 * @param int $id     The ID of the outbox item.
 	 * @param int $offset The offset to add to the scheduled time.
 	 */
-	public static function schedule_outbox_activity_for_federation( $id, $offset = 0 ) {
+	public static function schedule_outbox_activity_for_federation( $id, $offset = 5 ) {
 		$hook = 'activitypub_process_outbox';
 		$args = array( $id );
 

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -12,6 +12,7 @@ use Activitypub\Tombstone;
 
 use function Activitypub\get_remote_metadata_by_actor;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_same_domain;
 use function Activitypub\is_same_host;
 use function Activitypub\object_to_uri;
 
@@ -409,8 +410,15 @@ class Followers {
 	 */
 	public static function get_inboxes_for_activity( $json, $actor_id, $batch_size = 50, $offset = 0 ) {
 		$activity = \json_decode( $json, true );
-		// Only if this is a Delete. Create handles its own "Announce" in dual user mode.
-		if ( 'Delete' === ( $activity['type'] ?? null ) ) {
+		$type     = $activity['type'] ?? null;
+
+		/*
+		 * A Delete, and a Move that re-identifies a local actor (an id-format, host, or handle
+		 * change, whose target is on this site), must reach every server that cached the actor, not
+		 * just its followers. A Move to a remote account only needs the followers, who re-follow the
+		 * target per FEP-7628. Create handles its own "Announce" in dual user mode.
+		 */
+		if ( 'Delete' === $type || ( 'Move' === $type && is_same_domain( $activity['target'] ?? '' ) ) ) {
 			$inboxes = Remote_Actors::get_inboxes();
 		} else {
 			$inboxes = self::get_inboxes( $actor_id );

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -403,8 +403,9 @@ class Followers {
 	 */
 	public static function get_inboxes_for_activity( $json, $actor_id, $batch_size = 50, $offset = 0 ) {
 		$activity = \json_decode( $json, true );
-		// Only if this is a Delete. Create handles its own "Announce" in dual user mode.
-		if ( 'Delete' === ( $activity['type'] ?? null ) ) {
+		// Delete and Move activities should be sent to all known inboxes.
+		// Create handles its own "Announce" in dual user mode.
+		if ( \in_array( $activity['type'] ?? null, array( 'Delete', 'Move' ), true ) ) {
 			$inboxes = Remote_Actors::get_inboxes();
 		} else {
 			$inboxes = self::get_inboxes( $actor_id );

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -91,12 +91,6 @@ class Blog extends Actor {
 			return $id;
 		}
 
-		$permalink = \get_option( 'activitypub_use_permalink_as_id_for_blog', false );
-
-		if ( $permalink ) {
-			return \esc_url_raw( \home_url( '/@' . $this->get_preferred_username() ) );
-		}
-
 		return \add_query_arg( 'author', $this->_id, \home_url( '/' ) );
 	}
 

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -90,12 +90,6 @@ class Blog extends Actor {
 			return $id;
 		}
 
-		$permalink = \get_option( 'activitypub_use_permalink_as_id_for_blog', false );
-
-		if ( $permalink ) {
-			return \esc_url( \trailingslashit( get_home_url() ) . '@' . $this->get_preferred_username() );
-		}
-
 		return \add_query_arg( 'author', $this->_id, \home_url( '/' ) );
 	}
 
@@ -555,11 +549,31 @@ class Blog extends Actor {
 	/**
 	 * Returns the movedTo.
 	 *
-	 * @return string The movedTo.
+	 * @return string|null The movedTo URL or null.
 	 */
 	public function get_moved_to() {
 		$moved_to = \get_option( 'activitypub_blog_user_moved_to' );
 
-		return $moved_to && $moved_to !== $this->get_id() ? $moved_to : null;
+		if ( $moved_to && $moved_to !== $this->get_id() ) {
+			return $moved_to;
+		}
+
+		// If the blog had the old permalink-as-id setting and is being accessed
+		// via the old permalink URL (no author in query string), return the new ID.
+		$use_permalink = \get_option( 'activitypub_use_permalink_as_id_for_blog', false );
+
+		if ( $use_permalink ) {
+			$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? \esc_url_raw( \wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+			$query_string = \wp_parse_url( $request_uri, \PHP_URL_QUERY );
+			$query_params = array();
+
+			\wp_parse_str( $query_string ?? '', $query_params );
+
+			if ( ! isset( $query_params['author'] ) ) {
+				return $this->get_id();
+			}
+		}
+
+		return null;
 	}
 }

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -116,12 +116,6 @@ class User extends Actor {
 			return $id;
 		}
 
-		$permalink = \get_user_option( 'activitypub_use_permalink_as_id', $this->_id );
-
-		if ( '1' === $permalink ) {
-			return $this->get_url();
-		}
-
 		return \add_query_arg( 'author', $this->_id, \home_url( '/' ) );
 	}
 

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -116,12 +116,6 @@ class User extends Actor {
 			return $id;
 		}
 
-		$permalink = \get_user_option( 'activitypub_use_permalink_as_id', $this->_id );
-
-		if ( '1' === $permalink ) {
-			return $this->get_url();
-		}
-
 		return \add_query_arg( 'author', $this->_id, \home_url( '/' ) );
 	}
 
@@ -460,11 +454,31 @@ class User extends Actor {
 	/**
 	 * Returns the movedTo.
 	 *
-	 * @return string The movedTo.
+	 * @return string|null The movedTo URL or null.
 	 */
 	public function get_moved_to() {
 		$moved_to = \get_user_option( 'activitypub_moved_to', $this->_id );
 
-		return $moved_to && $moved_to !== $this->get_id() ? $moved_to : null;
+		if ( $moved_to && $moved_to !== $this->get_id() ) {
+			return $moved_to;
+		}
+
+		// If this user had the old permalink-as-id setting and is being accessed
+		// via the old permalink URL (no author in query string), return the new ID.
+		$use_permalink = \get_user_option( 'activitypub_use_permalink_as_id', $this->_id );
+
+		if ( '1' === $use_permalink ) {
+			$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? \esc_url_raw( \wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+			$query_string = \wp_parse_url( $request_uri, \PHP_URL_QUERY );
+			$query_params = array();
+
+			\wp_parse_str( $query_string ?? '', $query_params );
+
+			if ( ! isset( $query_params['author'] ) ) {
+				return $this->get_id();
+			}
+		}
+
+		return null;
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-migration.php
+++ b/tests/phpunit/tests/includes/class-test-migration.php
@@ -16,6 +16,8 @@ use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Comment;
 use Activitypub\Migration;
+use Activitypub\Model\Blog;
+use Activitypub\Move;
 use Activitypub\Scheduler;
 use Activitypub\Tombstone;
 
@@ -1684,5 +1686,54 @@ class Test_Migration extends \WP_UnitTestCase {
 		$remaining = \get_option( 'activitypub_tombstone_urls', false );
 		$this->assertIsArray( $remaining, 'Legacy option must remain to back exists_local().' );
 		$this->assertEqualsCanonicalizing( $urls, $remaining );
+	}
+
+	/**
+	 * Migrating a permalink-id blog actor moves it to the query-param id and keeps the old id resolving.
+	 *
+	 * @covers ::migrate_permalink_ids_to_query_param
+	 */
+	public function test_migrate_permalink_ids_to_query_param() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		\update_option( 'activitypub_use_permalink_as_id_for_blog', '1' );
+
+		$blog      = new Blog();
+		$canonical = $blog->get_id();
+		$old_id    = \esc_url_raw( \home_url( '/@' . $blog->get_preferred_username() ) );
+
+		$this->assertNotEquals( $old_id, $canonical, 'Precondition: the old permalink id differs from the query-param id.' );
+
+		Migration::migrate_permalink_ids_to_query_param();
+
+		// The blog now points at the query-param id, and a Move was queued for the old id.
+		$this->assertEquals( $canonical, \get_option( 'activitypub_blog_user_moved_to' ) );
+		$moves = \get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'any',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Move',
+					),
+				),
+			)
+		);
+		$this->assertNotEmpty( $moves, 'A Move should be queued for the migrated blog actor.' );
+
+		// Fetched via its old permalink URL, the actor serves the old id with a movedTo, and the
+		// model never inspects the request to do it.
+		\set_query_var( 'actor', $blog->get_preferred_username() );
+		$retired = new Blog();
+		$this->assertEquals( $old_id, $retired->get_id(), 'The old permalink URL serves the old id.' );
+		$this->assertEquals( $canonical, $retired->get_moved_to(), 'The old id advertises movedTo to the query-param id.' );
+
+		\set_query_var( 'actor', '' );
+		\delete_option( 'activitypub_actor_mode' );
+		\delete_option( 'activitypub_use_permalink_as_id_for_blog' );
+		\delete_option( 'activitypub_blog_user_moved_to' );
+		\delete_option( 'activitypub_blog_user_retired_permalink_data' );
+		\delete_option( 'activitypub_blog_user_also_known_as' );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-move.php
+++ b/tests/phpunit/tests/includes/class-test-move.php
@@ -40,11 +40,20 @@ class Test_Move extends \WP_UnitTestCase {
 		$from = Actors::get_by_id( self::$user_id )->get_id();
 		$to   = 'https://newsite.com/user/1';
 
-		add_filter( 'pre_http_request', '__return_false' );
+		$filter = function () use ( $from ) {
+			return array(
+				'body'     => wp_json_encode( array( 'alsoKnownAs' => array( $from ) ) ),
+				'response' => array( 'code' => 200 ),
+			);
+		};
+		add_filter( 'pre_http_request', $filter );
+
 		Move::externally( $from, $to );
 
 		$moved_to = Actors::get_by_id( self::$user_id )->get_moved_to();
 		$this->assertEquals( $to, $moved_to );
+
+		remove_filter( 'pre_http_request', $filter );
 	}
 
 	/**
@@ -81,7 +90,37 @@ class Test_Move extends \WP_UnitTestCase {
 		$this->assertWPError( $result );
 		$this->assertEquals( 'http_request_failed', $result->get_error_code() );
 
+		// A move that never verified must not leave the actor pointing at the target.
+		$this->assertNull( Actors::get_by_id( self::$user_id )->get_moved_to() );
+
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+	}
+
+	/**
+	 * A target that does not link back is rejected and the actor is not moved.
+	 *
+	 * @covers ::externally
+	 */
+	public function test_account_rejects_unlinked_target() {
+		$from = Actors::get_by_id( self::$user_id )->get_id();
+		$to   = 'https://newsite.com/user/1';
+
+		// Target resolves, but its alsoKnownAs does not list this actor.
+		$filter = function () {
+			return array(
+				'body'     => wp_json_encode( array( 'alsoKnownAs' => array( 'https://newsite.com/user/999' ) ) ),
+				'response' => array( 'code' => 200 ),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter );
+
+		$result = Move::externally( $from, $to );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'invalid_target', $result->get_error_code() );
+		$this->assertNull( Actors::get_by_id( self::$user_id )->get_moved_to() );
+
+		\remove_filter( 'pre_http_request', $filter );
 	}
 
 	/**
@@ -123,11 +162,20 @@ class Test_Move extends \WP_UnitTestCase {
 		$from = Actors::get_by_id( Actors::BLOG_USER_ID )->get_id();
 		$to   = 'https://newsite.com/user/0';
 
+		$filter = function () use ( $from ) {
+			return array(
+				'body'     => wp_json_encode( array( 'alsoKnownAs' => array( $from ) ) ),
+				'response' => array( 'code' => 200 ),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter );
+
 		Move::externally( $from, $to );
 
 		$moved_to = Actors::get_by_id( Actors::BLOG_USER_ID )->get_moved_to();
 		$this->assertEquals( $to, $moved_to );
 
+		\remove_filter( 'pre_http_request', $filter );
 		\delete_option( 'activitypub_actor_mode' );
 	}
 
@@ -151,6 +199,29 @@ class Test_Move extends \WP_UnitTestCase {
 
 		$also_known_as = Actors::get_by_id( self::$user_id )->get_also_known_as();
 		$this->assertContains( $from, $also_known_as );
+	}
+
+	/**
+	 * An internal move between two different local users links the target back to the source.
+	 *
+	 * @covers ::internally
+	 */
+	public function test_internally_between_distinct_users() {
+		$target_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$from = Actors::get_by_id( self::$user_id )->get_id();
+		$to   = Actors::get_by_id( $target_id )->get_id();
+
+		Move::internally( $from, $to );
+
+		wp_cache_delete( self::$user_id, 'users' );
+		wp_cache_delete( $target_id, 'users' );
+
+		// The source points at the target.
+		$this->assertEquals( $to, Actors::get_by_id( self::$user_id )->get_moved_to() );
+
+		// The target links back to the source via alsoKnownAs, so receiving servers accept the move.
+		$this->assertContains( $from, Actors::get_by_id( $target_id )->get_also_known_as() );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-move.php
+++ b/tests/phpunit/tests/includes/class-test-move.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Tests;
 
 use Activitypub\Collection\Actors;
+use Activitypub\Collection\Outbox;
 use Activitypub\Move;
 
 /**
@@ -94,6 +95,45 @@ class Test_Move extends \WP_UnitTestCase {
 		$this->assertNull( Actors::get_by_id( self::$user_id )->get_moved_to() );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+	}
+
+	/**
+	 * A verified move federates a profile Update so followers refresh the actor (FEP-7628).
+	 *
+	 * @covers ::externally
+	 */
+	public function test_move_federates_profile_update() {
+		$from = Actors::get_by_id( self::$user_id )->get_id();
+		$to   = 'https://newsite.com/user/1';
+
+		$filter = function () use ( $from ) {
+			return array(
+				'body'     => wp_json_encode( array( 'alsoKnownAs' => array( $from ) ) ),
+				'response' => array( 'code' => 200 ),
+			);
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		Move::externally( $from, $to );
+
+		remove_filter( 'pre_http_request', $filter );
+
+		$updates = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'any',
+				'author'      => self::$user_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Update',
+					),
+				),
+			)
+		);
+
+		$this->assertNotEmpty( $updates, 'A move should federate a profile Update.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/collection/class-test-followers.php
+++ b/tests/phpunit/tests/includes/collection/class-test-followers.php
@@ -523,6 +523,32 @@ class Test_Followers extends \WP_UnitTestCase {
 		);
 		$this->assertCount( 3, $inboxes, 'Should include blog user followers in dual mode.' );
 		$this->assertContains( self::$actors['sally@example.org']['inbox'], $inboxes, 'Should contain blog user inbox.' );
+
+		// A Move that re-identifies a local actor (same-domain target) broadcasts to all inboxes, like a Delete.
+		$local_move = wp_json_encode(
+			array(
+				'type'   => 'Move',
+				'target' => \home_url( '/?author=1' ),
+			)
+		);
+		$this->assertEquals(
+			Followers::get_inboxes_for_activity( '{"type":"Delete"}', $actor_id, 50, 0 ),
+			Followers::get_inboxes_for_activity( $local_move, $actor_id, 50, 0 ),
+			'A same-domain Move should broadcast to all inboxes like a Delete.'
+		);
+
+		// A Move to a remote account reaches only the followers, like a Create.
+		$remote_move = wp_json_encode(
+			array(
+				'type'   => 'Move',
+				'target' => 'https://remote.example/users/foo',
+			)
+		);
+		$this->assertEquals(
+			Followers::get_inboxes_for_activity( '{"type":"Create"}', $actor_id, 50, 0 ),
+			Followers::get_inboxes_for_activity( $remote_move, $actor_id, 50, 0 ),
+			'A remote Move should reach only followers like a Create.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Stacked on #3585 (the account-move fixes), which it depends on. Review and merge that one first; this PR's base is set to it so the diff shows only the migration.

## Proposed changes:

A permalink-based actor id embeds the handle (`/@handle` for the blog, the author-archive URL for a user), so changing the handle changes the id and strands followers. This moves every actor that used a permalink id to the stable `?author=ID` form, which does not contain the handle.

* Drop the permalink branch from `Blog::get_id()` / `User::get_id()`, so ids are always the query-param form.
* A migration federates a `Move` for every permalink-id actor, from the old id to the new one, and keeps the old id resolving with a `movedTo`.
* The migration reuses the corrected `Move::internally_by_actor()` from #3585, so each move also records the target's `alsoKnownAs` and sends the follow-up profile `Update`.
* A `Move` that re-identifies a local actor (a same-domain target) is broadcast to all known inboxes, not just followers, so every server that cached the old id updates. A `Move` to a remote account stays followers-only per FEP-7628.

The old id keeps resolving without the model ever inspecting the request: `Query::is_permalink_actor_request()` recognizes the old-URL request from its query vars (`actor` for `/@handle`, `author_name` for `/author/handle`, neither for `?author=ID`), and a construct-hook handler serves a stored snapshot, exactly as the domain-move path already does.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Enable a permalink id: set the `activitypub_use_permalink_as_id_for_blog` option (blog) or the `activitypub_use_permalink_as_id` user option (user) to `1`.
* Lower `activitypub_db_version` to force the migration (e.g. `wp option update activitypub_db_version 9.1.0`) and load the site.
* The actor's id is now `?author=ID`, the outbox has a `Move` from the old id, and fetching the old `/@handle` (or `/author/handle`) URL returns the old id with `movedTo` pointing at the new one.

### Changelog entry

Included in the branch (`.github/changelog/migrate-permalink-ids-to-query-param`).

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Changed

#### Message

Use a stable Fediverse profile ID that no longer breaks your followers when you change your handle, and migrate existing profiles to it automatically.

</details>
