### PR TITLE
Add site health check for REST API accessibility

### DIFF
--- a/.github/changelog/2768-from-description
+++ b/.github/changelog/2768-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add site health check to detect when security plugins block REST API access.

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -643,45 +643,68 @@ class Health_Check {
 	}
 
 	/**
-	 * Check if REST API is accessible to unauthenticated requests.
+	 * Check if ActivityPub endpoints are accessible to unauthenticated requests.
 	 *
-	 * This checks if a security plugin is blocking all unauthenticated REST API access
-	 * via the `rest_authentication_errors` filter. This is different from AUTHORIZED_FETCH
-	 * which uses HTTP Signature verification on ActivityPub-specific endpoints.
+	 * Makes an actual HTTP request to the ActivityPub inbox endpoint.
+	 * Only reports errors from security plugins (error titles not starting
+	 * with 'activitypub_').
 	 *
 	 * @return bool|\WP_Error True if accessible, WP_Error otherwise.
 	 */
 	public static function is_rest_api_accessible() {
-		// Temporarily remove our own authentication to test what other plugins do.
-		$current_user = \wp_get_current_user();
-		\wp_set_current_user( 0 );
+		// Test the application actor's inbox endpoint (always available).
+		$actor = Actors::get_by_id( Actors::APPLICATION_USER_ID );
+		$url   = $actor->get_inbox();
 
-		/**
-		 * Simulate what happens when an unauthenticated REST API request comes in.
-		 * Security plugins hook into `rest_authentication_errors` to block access.
-		 *
-		 * Pass `null` to indicate no authentication has been performed yet,
-		 * which is what WordPress does for unauthenticated requests.
-		 */
-		$authentication_error = \apply_filters( 'rest_authentication_errors', null );
+		// Make an unauthenticated request.
+		$response = \wp_remote_get(
+			$url,
+			array(
+				'timeout'   => 5,
+				'cookies'   => array(),
+				'sslverify' => false,
+			)
+		);
 
-		// Restore the current user.
-		\wp_set_current_user( $current_user->ID );
-
-		// If a WP_Error is returned, REST API is being blocked.
-		if ( \is_wp_error( $authentication_error ) ) {
+		if ( \is_wp_error( $response ) ) {
 			return new \WP_Error(
-				'rest_api_restricted',
+				'rest_api_not_accessible',
 				\sprintf(
-					/* translators: %s: Error message from the blocking plugin. */
-					\__( 'Error: %s', 'activitypub' ),
-					$authentication_error->get_error_message()
+					/* translators: %s: Error message. */
+					\__( 'Could not connect to REST API: %s', 'activitypub' ),
+					$response->get_error_message()
 				)
 			);
 		}
 
-		// If `true` is returned, someone short-circuited authentication (unusual but possible).
-		// If `null` is returned, no plugin is blocking - this is the expected case.
-		return true;
+		$status_code = \wp_remote_retrieve_response_code( $response );
+
+		// Success - endpoint is accessible.
+		if ( $status_code >= 200 && $status_code < 300 ) {
+			return true;
+		}
+
+		// Error response - check if it's from a security plugin (not our own error).
+		$body  = \wp_remote_retrieve_body( $response );
+		$data  = \json_decode( $body, true );
+		$title = isset( $data['title'] ) ? $data['title'] : '';
+
+		// If the error title starts with 'activitypub_', it's our own error, not a security plugin.
+		if ( \str_starts_with( $title, 'activitypub_' ) ) {
+			return true;
+		}
+
+		// Security plugin is blocking access.
+		$message = isset( $data['message'] ) ? $data['message'] : $body;
+
+		return new \WP_Error(
+			'rest_api_restricted',
+			\sprintf(
+				/* translators: 1: HTTP status code, 2: Response body or error message. */
+				\__( 'HTTP %1$d: %2$s', 'activitypub' ),
+				$status_code,
+				\esc_html( \wp_trim_words( $message, 20 ) )
+			)
+		);
 	}
 }

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -672,7 +672,7 @@ class Health_Check {
 				\sprintf(
 					/* translators: %s: Error message. */
 					\__( 'Could not connect to REST API: %s', 'activitypub' ),
-					$response->get_error_message()
+					\esc_html( $response->get_error_message() )
 				)
 			);
 		}

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -114,6 +114,11 @@ class Health_Check {
 			'test'  => array( self::class, 'test_wp_cron' ),
 		);
 
+		$tests['direct']['activitypub_test_rest_api_accessibility'] = array(
+			'label' => \__( 'REST API Accessibility Test', 'activitypub' ),
+			'test'  => array( self::class, 'test_rest_api_accessibility' ),
+		);
+
 		return $tests;
 	}
 
@@ -589,5 +594,94 @@ class Health_Check {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * REST API accessibility test.
+	 *
+	 * Checks if a security plugin is blocking unauthenticated REST API access.
+	 * This is different from AUTHORIZED_FETCH which uses HTTP Signatures.
+	 *
+	 * @return array The test result.
+	 */
+	public static function test_rest_api_accessibility() {
+		$result = array(
+			'label'       => \__( 'REST API is accessible', 'activitypub' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => \__( 'ActivityPub', 'activitypub' ),
+				'color' => 'green',
+			),
+			'description' => \sprintf(
+				'<p>%s</p>',
+				\__( 'Your REST API is accessible to remote servers, allowing ActivityPub federation to work properly.', 'activitypub' )
+			),
+			'actions'     => '',
+			'test'        => 'test_rest_api_accessibility',
+		);
+
+		$check = self::is_rest_api_accessible();
+
+		if ( true === $check ) {
+			return $result;
+		}
+
+		$result['status']         = 'critical';
+		$result['label']          = \__( 'REST API is restricted to authenticated users', 'activitypub' );
+		$result['badge']['color'] = 'red';
+		$result['description']    = \sprintf(
+			'<p>%s</p><p>%s</p>',
+			\__( 'A plugin or custom code is restricting REST API access to authenticated users only. This prevents remote ActivityPub servers from interacting with your site.', 'activitypub' ),
+			$check->get_error_message()
+		);
+		$result['actions']        = \sprintf(
+			'<p>%s</p>',
+			\__( 'Check your security plugin settings (Wordfence, Disable REST API, Patchstack, Solid Security, etc.) and ensure ActivityPub endpoints are accessible to unauthenticated requests.', 'activitypub' )
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Check if REST API is accessible to unauthenticated requests.
+	 *
+	 * This checks if a security plugin is blocking all unauthenticated REST API access
+	 * via the `rest_authentication_errors` filter. This is different from AUTHORIZED_FETCH
+	 * which uses HTTP Signature verification on ActivityPub-specific endpoints.
+	 *
+	 * @return bool|\WP_Error True if accessible, WP_Error otherwise.
+	 */
+	public static function is_rest_api_accessible() {
+		// Temporarily remove our own authentication to test what other plugins do.
+		$current_user = \wp_get_current_user();
+		\wp_set_current_user( 0 );
+
+		/**
+		 * Simulate what happens when an unauthenticated REST API request comes in.
+		 * Security plugins hook into `rest_authentication_errors` to block access.
+		 *
+		 * Pass `null` to indicate no authentication has been performed yet,
+		 * which is what WordPress does for unauthenticated requests.
+		 */
+		$authentication_error = \apply_filters( 'rest_authentication_errors', null );
+
+		// Restore the current user.
+		\wp_set_current_user( $current_user->ID );
+
+		// If a WP_Error is returned, REST API is being blocked.
+		if ( \is_wp_error( $authentication_error ) ) {
+			return new \WP_Error(
+				'rest_api_restricted',
+				\sprintf(
+					/* translators: %s: Error message from the blocking plugin. */
+					\__( 'Error: %s', 'activitypub' ),
+					$authentication_error->get_error_message()
+				)
+			);
+		}
+
+		// If `true` is returned, someone short-circuited authentication (unusual but possible).
+		// If `null` is returned, no plugin is blocking - this is the expected case.
+		return true;
 	}
 }

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -632,11 +632,11 @@ class Health_Check {
 		$result['description']    = \sprintf(
 			'<p>%s</p><p>%s</p>',
 			\__( 'A plugin or custom code is restricting REST API access to authenticated users only. This prevents remote ActivityPub servers from interacting with your site.', 'activitypub' ),
-			$check->get_error_message()
+			\esc_html( $check->get_error_message() )
 		);
 		$result['actions']        = \sprintf(
 			'<p>%s</p>',
-			\__( 'Check your security plugin settings (Wordfence, Disable REST API, Patchstack, Solid Security, etc.) and ensure ActivityPub endpoints are accessible to unauthenticated requests.', 'activitypub' )
+			\__( 'Check your security plugin settings and ensure ActivityPub endpoints are accessible to unauthenticated requests.', 'activitypub' )
 		);
 
 		return $result;

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -660,9 +660,8 @@ class Health_Check {
 		$response = \wp_remote_get(
 			$url,
 			array(
-				'timeout'   => 5,
-				'cookies'   => array(),
-				'sslverify' => false,
+				'timeout' => 5,
+				'cookies' => array(),
 			)
 		);
 

--- a/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
@@ -234,6 +234,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * @return array Mocked response.
 	 */
 	public function mock_activitypub_accessible( $response, $parsed_args, $url ) {
+		unset( $response, $parsed_args, $url );
 		return array(
 			'response' => array(
 				'code'    => 200,
@@ -253,6 +254,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * @return array Mocked response.
 	 */
 	public function mock_activitypub_blocked( $response, $parsed_args, $url ) {
+		unset( $response, $parsed_args, $url );
 		return array(
 			'response' => array(
 				'code'    => 401,
@@ -272,6 +274,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * @return array Mocked response.
 	 */
 	public function mock_activitypub_own_error( $response, $parsed_args, $url ) {
+		unset( $response, $parsed_args, $url );
 		return array(
 			'response' => array(
 				'code'    => 401,
@@ -291,6 +294,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * @return WP_Error Mocked error response.
 	 */
 	public function mock_activitypub_connection_error( $response, $parsed_args, $url ) {
+		unset( $response, $parsed_args, $url );
 		return new WP_Error( 'http_request_failed', 'Connection refused' );
 	}
 

--- a/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
@@ -208,4 +208,175 @@ class Test_Health_Check extends WP_UnitTestCase {
 		$this->assertContains( 'Another Plugin', $filtered );
 		$this->assertNotContains( false, $filtered );
 	}
+
+	/**
+	 * Test that REST API accessibility test is registered.
+	 */
+	public function test_rest_api_accessibility_test_registered() {
+		$tests  = array();
+		$result = Health_Check::add_tests( $tests );
+
+		$this->assertArrayHasKey( 'activitypub_test_rest_api_accessibility', $result['direct'] );
+
+		$test = $result['direct']['activitypub_test_rest_api_accessibility'];
+		$this->assertArrayHasKey( 'label', $test );
+		$this->assertArrayHasKey( 'test', $test );
+		$this->assertEquals( array( Health_Check::class, 'test_rest_api_accessibility' ), $test['test'] );
+	}
+
+	/**
+	 * Mock HTTP response for accessible ActivityPub endpoint.
+	 *
+	 * @param mixed  $response    The response.
+	 * @param array  $parsed_args The parsed args.
+	 * @param string $url         The URL.
+	 *
+	 * @return array Mocked response.
+	 */
+	public function mock_activitypub_accessible( $response, $parsed_args, $url ) {
+		return array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => '{"@context":"https://www.w3.org/ns/activitystreams","type":"OrderedCollection","totalItems":0}',
+		);
+	}
+
+	/**
+	 * Mock HTTP response for blocked ActivityPub endpoint (security plugin).
+	 *
+	 * @param mixed  $response    The response.
+	 * @param array  $parsed_args The parsed args.
+	 * @param string $url         The URL.
+	 *
+	 * @return array Mocked response.
+	 */
+	public function mock_activitypub_blocked( $response, $parsed_args, $url ) {
+		return array(
+			'response' => array(
+				'code'    => 401,
+				'message' => 'Unauthorized',
+			),
+			'body'     => '{"title":"rest_login_required","message":"REST API restricted to authenticated users.","data":{"status":401}}',
+		);
+	}
+
+	/**
+	 * Mock HTTP response for ActivityPub's own error (not a security plugin).
+	 *
+	 * @param mixed  $response    The response.
+	 * @param array  $parsed_args The parsed args.
+	 * @param string $url         The URL.
+	 *
+	 * @return array Mocked response.
+	 */
+	public function mock_activitypub_own_error( $response, $parsed_args, $url ) {
+		return array(
+			'response' => array(
+				'code'    => 401,
+				'message' => 'Unauthorized',
+			),
+			'body'     => '{"title":"activitypub_signature_verification_failed","message":"Signature verification failed."}',
+		);
+	}
+
+	/**
+	 * Mock HTTP response for connection error.
+	 *
+	 * @param mixed  $response    The response.
+	 * @param array  $parsed_args The parsed args.
+	 * @param string $url         The URL.
+	 *
+	 * @return WP_Error Mocked error response.
+	 */
+	public function mock_activitypub_connection_error( $response, $parsed_args, $url ) {
+		return new WP_Error( 'http_request_failed', 'Connection refused' );
+	}
+
+	/**
+	 * Test REST API accessibility when ActivityPub endpoint is accessible.
+	 */
+	public function test_rest_api_accessible() {
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_accessible' ), 10, 3 );
+
+		$result = Health_Check::test_rest_api_accessibility();
+
+		$this->assertEquals( 'good', $result['status'] );
+		$this->assertEquals( 'REST API is accessible', $result['label'] );
+		$this->assertEquals( 'green', $result['badge']['color'] );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_activitypub_accessible' ) );
+	}
+
+	/**
+	 * Test REST API accessibility when endpoint is blocked.
+	 */
+	public function test_rest_api_blocked() {
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_blocked' ), 10, 3 );
+
+		$result = Health_Check::test_rest_api_accessibility();
+
+		$this->assertEquals( 'critical', $result['status'] );
+		$this->assertEquals( 'REST API is restricted to authenticated users', $result['label'] );
+		$this->assertEquals( 'red', $result['badge']['color'] );
+		$this->assertStringContainsString( 'security plugin settings', $result['actions'] );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_activitypub_blocked' ) );
+	}
+
+	/**
+	 * Test REST API accessibility with connection error.
+	 */
+	public function test_rest_api_connection_error() {
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_connection_error' ), 10, 3 );
+
+		$result = Health_Check::test_rest_api_accessibility();
+
+		$this->assertEquals( 'critical', $result['status'] );
+		$this->assertStringContainsString( 'Could not connect to REST API', $result['description'] );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_activitypub_connection_error' ) );
+	}
+
+	/**
+	 * Test is_rest_api_accessible returns true for successful response.
+	 */
+	public function test_is_rest_api_accessible_returns_true() {
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_accessible' ), 10, 3 );
+
+		$result = Health_Check::is_rest_api_accessible();
+
+		$this->assertTrue( $result );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_activitypub_accessible' ) );
+	}
+
+	/**
+	 * Test is_rest_api_accessible returns WP_Error when blocked by security plugin.
+	 */
+	public function test_is_rest_api_accessible_returns_error_when_blocked() {
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_blocked' ), 10, 3 );
+
+		$result = Health_Check::is_rest_api_accessible();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'rest_api_restricted', $result->get_error_code() );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_activitypub_blocked' ) );
+	}
+
+	/**
+	 * Test is_rest_api_accessible ignores ActivityPub's own errors.
+	 */
+	public function test_is_rest_api_accessible_ignores_activitypub_errors() {
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_own_error' ), 10, 3 );
+
+		$result = Health_Check::is_rest_api_accessible();
+
+		// Should return true because error title starts with 'activitypub_'.
+		$this->assertTrue( $result );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_activitypub_own_error' ) );
+	}
 }

--- a/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
@@ -227,14 +227,9 @@ class Test_Health_Check extends WP_UnitTestCase {
 	/**
 	 * Mock HTTP response for accessible ActivityPub endpoint.
 	 *
-	 * @param mixed  $response    The response.
-	 * @param array  $parsed_args The parsed args.
-	 * @param string $url         The URL.
-	 *
 	 * @return array Mocked response.
 	 */
-	public function mock_activitypub_accessible( $response, $parsed_args, $url ) {
-		unset( $response, $parsed_args, $url );
+	public function mock_activitypub_accessible() {
 		return array(
 			'response' => array(
 				'code'    => 200,
@@ -247,14 +242,9 @@ class Test_Health_Check extends WP_UnitTestCase {
 	/**
 	 * Mock HTTP response for blocked ActivityPub endpoint (security plugin).
 	 *
-	 * @param mixed  $response    The response.
-	 * @param array  $parsed_args The parsed args.
-	 * @param string $url         The URL.
-	 *
 	 * @return array Mocked response.
 	 */
-	public function mock_activitypub_blocked( $response, $parsed_args, $url ) {
-		unset( $response, $parsed_args, $url );
+	public function mock_activitypub_blocked() {
 		return array(
 			'response' => array(
 				'code'    => 401,
@@ -267,14 +257,9 @@ class Test_Health_Check extends WP_UnitTestCase {
 	/**
 	 * Mock HTTP response for ActivityPub's own error (not a security plugin).
 	 *
-	 * @param mixed  $response    The response.
-	 * @param array  $parsed_args The parsed args.
-	 * @param string $url         The URL.
-	 *
 	 * @return array Mocked response.
 	 */
-	public function mock_activitypub_own_error( $response, $parsed_args, $url ) {
-		unset( $response, $parsed_args, $url );
+	public function mock_activitypub_own_error() {
 		return array(
 			'response' => array(
 				'code'    => 401,
@@ -287,14 +272,9 @@ class Test_Health_Check extends WP_UnitTestCase {
 	/**
 	 * Mock HTTP response for connection error.
 	 *
-	 * @param mixed  $response    The response.
-	 * @param array  $parsed_args The parsed args.
-	 * @param string $url         The URL.
-	 *
 	 * @return WP_Error Mocked error response.
 	 */
-	public function mock_activitypub_connection_error( $response, $parsed_args, $url ) {
-		unset( $response, $parsed_args, $url );
+	public function mock_activitypub_connection_error() {
 		return new WP_Error( 'http_request_failed', 'Connection refused' );
 	}
 
@@ -302,7 +282,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * Test REST API accessibility when ActivityPub endpoint is accessible.
 	 */
 	public function test_rest_api_accessible() {
-		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_accessible' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_accessible' ) );
 
 		$result = Health_Check::test_rest_api_accessibility();
 
@@ -317,7 +297,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * Test REST API accessibility when endpoint is blocked.
 	 */
 	public function test_rest_api_blocked() {
-		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_blocked' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_blocked' ) );
 
 		$result = Health_Check::test_rest_api_accessibility();
 
@@ -333,7 +313,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * Test REST API accessibility with connection error.
 	 */
 	public function test_rest_api_connection_error() {
-		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_connection_error' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_connection_error' ) );
 
 		$result = Health_Check::test_rest_api_accessibility();
 
@@ -347,7 +327,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * Test is_rest_api_accessible returns true for successful response.
 	 */
 	public function test_is_rest_api_accessible_returns_true() {
-		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_accessible' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_accessible' ) );
 
 		$result = Health_Check::is_rest_api_accessible();
 
@@ -360,7 +340,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * Test is_rest_api_accessible returns WP_Error when blocked by security plugin.
 	 */
 	public function test_is_rest_api_accessible_returns_error_when_blocked() {
-		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_blocked' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_blocked' ) );
 
 		$result = Health_Check::is_rest_api_accessible();
 
@@ -374,7 +354,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 * Test is_rest_api_accessible ignores ActivityPub's own errors.
 	 */
 	public function test_is_rest_api_accessible_ignores_activitypub_errors() {
-		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_own_error' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_activitypub_own_error' ) );
 
 		$result = Health_Check::is_rest_api_accessible();
 


### PR DESCRIPTION
Fixes #2767

## Proposed changes:

* Add a new Site Health check that detects when security plugins are blocking unauthenticated REST API access
* Uses the `rest_authentication_errors` filter to detect blanket API restrictions
* Does NOT falsely flag AUTHORIZED_FETCH as an issue (that uses HTTP Signatures on specific endpoints, not blanket blocking)
* Shows a critical warning with guidance on which plugins to check (Wordfence, Disable REST API, Patchstack, Solid Security, etc.)

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install the "Disable WP REST API" plugin and activate it
* Go to Tools → Site Health
* Verify the "REST API is restricted to authenticated users" critical warning appears
* Deactivate the plugin and verify the check passes
* Enable AUTHORIZED_FETCH in ActivityPub settings
* Verify the health check still passes (not falsely flagged)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add site health check to detect when security plugins block REST API access.

</details>