### PR TITLE
Release/7.8.5

### DIFF
--- a/.github/changelog/2765-from-description
+++ b/.github/changelog/2765-from-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Only disable blocks for ClassicPress, not when Classic Editor plugin is installed.

--- a/.github/changelog/2765-from-description
+++ b/.github/changelog/2765-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only disable blocks for ClassicPress, not when Classic Editor plugin is installed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.8.5] - 2026-01-14
+### Fixed
+- Only disable blocks for ClassicPress, not when Classic Editor plugin is installed. [#2765]
+
 ## [7.8.4] - 2026-01-13
 ### Fixed
 - Fix Follow requests from Pixelfed and other implementations that don't set audience fields. [#2755]
@@ -1640,6 +1644,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - initial
 
+[7.8.5]: https://github.com/Automattic/wordpress-activitypub/compare/7.8.4...7.8.5
 [7.8.4]: https://github.com/Automattic/wordpress-activitypub/compare/7.8.3...7.8.4
 [7.8.3]: https://github.com/Automattic/wordpress-activitypub/compare/7.8.2...7.8.3
 [7.8.2]: https://github.com/Automattic/wordpress-activitypub/compare/7.8.1...7.8.2

--- a/activitypub.php
+++ b/activitypub.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActivityPub
  * Plugin URI: https://github.com/Automattic/wordpress-activitypub
  * Description: The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
- * Version: 7.8.4
+ * Version: 7.8.5
  * Author: Matthias Pfefferle & Automattic
  * Author URI: https://automattic.com/
  * License: MIT
@@ -17,7 +17,7 @@
 
 namespace Activitypub;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '7.8.4' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '7.8.5' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -20,9 +20,12 @@ class Classic_Editor {
 	public static function init() {
 		\add_filter( 'activitypub_attachments_media_markup', array( self::class, 'filter_attachments_media_markup' ), 10, 2 );
 		\add_filter( 'activitypub_attachment_ids', array( self::class, 'filter_attached_media_ids' ), 10, 2 );
-		\add_filter( 'activitypub_site_supports_blocks', '__return_false' );
 		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ) );
 		\add_action( 'save_post', array( self::class, 'save_meta_data' ) );
+
+		if ( \function_exists( 'classicpress_version' ) ) {
+			\add_filter( 'activitypub_site_supports_blocks', '__return_false' );
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaf
 Tags: fediverse, activitypub, indieweb, activitystream, social web
 Requires at least: 6.5
 Tested up to: 6.9
-Stable tag: 7.8.4
+Stable tag: 7.8.5
 Requires PHP: 7.2
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -109,6 +109,10 @@ For reasons of data protection, it is not possible to see the followers of other
 5. A Blog-Profile on Mastodon
 
 == Changelog ==
+
+### 7.8.5 - 2026-01-14
+#### Fixed
+- Only disable blocks for ClassicPress, not when Classic Editor plugin is installed.
 
 ### 7.8.4 - 2026-01-13
 #### Fixed


### PR DESCRIPTION
This pull request releases version 7.8.5 of the ActivityPub plugin, primarily fixing an issue where block editor support was disabled incorrectly. Now, block support is only disabled for ClassicPress, not when the Classic Editor plugin is installed. The release also updates version numbers and changelogs accordingly.

Bug Fix:

* Updated logic in `integration/class-classic-editor.php` to only disable block editor support when running on ClassicPress, not when the Classic Editor plugin is installed.

Release and Documentation Updates:

* Bumped the plugin version to 7.8.5 in `activitypub.php` and `readme.txt`. [[1]](diffhunk://#diff-d33bfd446d4ad05f88e9c8e907f31b2e4c06eca40c7f28cee7e58f3a2302958bL6-R6) [[2]](diffhunk://#diff-d33bfd446d4ad05f88e9c8e907f31b2e4c06eca40c7f28cee7e58f3a2302958bL20-R20) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Added changelog entries for version 7.8.5 in `CHANGELOG.md` and `readme.txt`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R11) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R113-R116)
* Added comparison link for 7.8.5 in `CHANGELOG.md`.<!--- Provide a general summary of your changes in the Title above -->