### PR TITLE
Initialize Scheduler before Migration to ensure hooks are registered

### DIFF
--- a/.github/changelog/2771-from-description
+++ b/.github/changelog/2771-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix migration activities not being scheduled for federation due to hook registration timing.

--- a/activitypub.php
+++ b/activitypub.php
@@ -85,7 +85,7 @@ function plugin_init() {
 	\add_action( 'init', array( __NAMESPACE__ . '\Options', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Post_Types', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Router', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ) );
+	\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ), 0 );
 	\add_action( 'init', array( __NAMESPACE__ . '\Search', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Signature', 'init' ) );
 

--- a/activitypub.php
+++ b/activitypub.php
@@ -85,6 +85,7 @@ function plugin_init() {
 	\add_action( 'init', array( __NAMESPACE__ . '\Options', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Post_Types', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Router', 'init' ) );
+	// Priority 0 ensures Scheduler hooks are registered before Migration (priority 1) runs.
 	\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ), 0 );
 	\add_action( 'init', array( __NAMESPACE__ . '\Search', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Signature', 'init' ) );

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -274,9 +274,9 @@ class Scheduler {
 	 * Schedule the outbox item for federation.
 	 *
 	 * @param int $id     The ID of the outbox item.
-	 * @param int $offset The offset to add to the scheduled time. Default 5 seconds.
+	 * @param int $offset The offset to add to the scheduled time. Default 3 seconds.
 	 */
-	public static function schedule_outbox_activity_for_federation( $id, $offset = 5 ) {
+	public static function schedule_outbox_activity_for_federation( $id, $offset = 3 ) {
 		$hook = 'activitypub_process_outbox';
 		$args = array( $id );
 

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -274,9 +274,9 @@ class Scheduler {
 	 * Schedule the outbox item for federation.
 	 *
 	 * @param int $id     The ID of the outbox item.
-	 * @param int $offset The offset to add to the scheduled time.
+	 * @param int $offset The offset to add to the scheduled time. Default 5 seconds.
 	 */
-	public static function schedule_outbox_activity_for_federation( $id, $offset = 0 ) {
+	public static function schedule_outbox_activity_for_federation( $id, $offset = 5 ) {
 		$hook = 'activitypub_process_outbox';
 		$args = array( $id );
 


### PR DESCRIPTION
## Proposed changes:

* Changed `Scheduler::init()` priority from 10 (default) to 0, so it runs before `Migration::init()` (priority 1)
* This ensures that the `post_activitypub_add_to_outbox` hooks are registered before any migration code calls `add_to_outbox()`

### Problem

When migration calls `add_to_outbox()` (e.g., for Move activities in #2766), the `post_activitypub_add_to_outbox` action fires but the scheduler hooks (`schedule_outbox_activity_for_federation`, `schedule_announce_activity`) aren't registered yet because:

- `Migration::init()` runs at `init` priority **1**
- `Scheduler::init()` runs at `init` priority **10** (default)

This causes activities added during migration to go to the outbox but never get scheduled for federation.

### Solution

Move `Scheduler::init()` to priority 0 so all scheduler hooks are registered before migration runs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Apply the changes from #2766 (or any migration that calls `add_to_outbox()`)
* Trigger migration by lowering `activitypub_db_version` option
* Verify that activities are properly scheduled for federation (check for `activitypub_process_outbox` cron events)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix migration activities not being scheduled for federation due to hook registration timing.

</details>