### PR TITLE
Simplify issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Helps us improve our product!
-labels: ['Needs triage', '[Type] Bug']
+labels: ['Needs triage', 'Bug']
 type: 'Bug'
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an idea for the ActivityPub plugin!
 title: 'Feature Request:'
-labels: ['[Type] Feature Request']
+labels: ['Enhancement']
 type: 'Enhancement'
 body:
   - type: markdown


### PR DESCRIPTION
## Proposed changes:

* Simplify GitHub issue template labels by removing `[Type]` prefix
* Bug report: `[Type] Bug` → `Bug`
* Feature request: `[Type] Feature Request` → `Enhancement`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a new issue using the bug report template and verify the `Bug` label is applied
* Create a new issue using the feature request template and verify the `Enhancement` label is applied

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.