### PR TITLE
Filter comments on AP posts from REST API

### DIFF
--- a/.github/changelog/2777-from-description
+++ b/.github/changelog/2777-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Filter comments on ActivityPub posts from REST API responses.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -737,14 +737,14 @@ class Comment {
 			return;
 		}
 
-		// Do not exclude likes and reposts on REST requests.
+		// Do not exclude likes and reposts on REST requests (handled by rest_comment_query).
 		if ( \wp_is_serving_rest_request() ) {
 			return;
 		}
 
-		// Do only exclude interactions of `ap_post` post type.
+		// Filter post types for admin requests.
 		if ( \is_admin() ) {
-			$query->query_vars['post_type'] = array_diff( \get_post_types_by_support( 'comments' ), self::hide_for() );
+			$query->query_vars['post_type'] = self::get_allowed_comment_post_types();
 			return;
 		}
 
@@ -753,7 +753,7 @@ class Comment {
 			return;
 		}
 
-		// Do not exclude likes and reposts if the query is for comments.
+		// Do not exclude likes and reposts if the query is for specific types.
 		if ( ! empty( $query->query_vars['type__in'] ) || ! empty( $query->query_vars['type'] ) ) {
 			return;
 		}
@@ -763,11 +763,10 @@ class Comment {
 	}
 
 	/**
-	 * Filter comments in REST API requests.
+	 * Filters comments in REST API requests.
 	 *
 	 * Excludes comments on ActivityPub post types and ActivityPub comment
-	 * types (likes, reposts) from the REST API to prevent them from
-	 * appearing in mobile apps and other clients.
+	 * types (likes, reposts) from the REST API.
 	 *
 	 * @param array $prepared_args Array of arguments for WP_Comment_Query.
 	 *
@@ -775,12 +774,7 @@ class Comment {
 	 */
 	public static function rest_comment_query( $prepared_args ) {
 		// Exclude comments on ActivityPub post types.
-		$hide_for = self::hide_for();
-
-		if ( ! empty( $hide_for ) ) {
-			$post_types                 = \array_diff( \get_post_types_by_support( 'comments' ), $hide_for );
-			$prepared_args['post_type'] = $post_types;
-		}
+		$prepared_args['post_type'] = self::get_allowed_comment_post_types();
 
 		// Exclude ActivityPub comment types (likes, reposts) unless explicitly requested.
 		if ( empty( $prepared_args['type'] ) && empty( $prepared_args['type__in'] ) ) {
@@ -788,6 +782,21 @@ class Comment {
 		}
 
 		return $prepared_args;
+	}
+
+	/**
+	 * Returns post types that should show comments (excluding hidden post types).
+	 *
+	 * @return array Array of post type names.
+	 */
+	private static function get_allowed_comment_post_types() {
+		$hide_for = self::hide_for();
+
+		if ( empty( $hide_for ) ) {
+			return \get_post_types_by_support( 'comments' );
+		}
+
+		return \array_diff( \get_post_types_by_support( 'comments' ), $hide_for );
 	}
 
 	/**

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -36,6 +36,7 @@ class Comment {
 		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
 		\add_filter( 'get_comment_author', array( static::class, 'render_emoji' ), 10, 2 );
 		\add_filter( 'comment_author', array( static::class, 'unescape_emoji' ), 20 ); // After esc_html().
+		\add_filter( 'rest_comment_query', array( static::class, 'rest_comment_query' ) );
 	}
 
 	/**
@@ -759,6 +760,34 @@ class Comment {
 
 		// Exclude likes and reposts by the ActivityPub plugin.
 		$query->query_vars['type__not_in'] = self::get_comment_type_slugs();
+	}
+
+	/**
+	 * Filter comments in REST API requests.
+	 *
+	 * Excludes comments on ActivityPub post types and ActivityPub comment
+	 * types (likes, reposts) from the REST API to prevent them from
+	 * appearing in mobile apps and other clients.
+	 *
+	 * @param array $prepared_args Array of arguments for WP_Comment_Query.
+	 *
+	 * @return array Modified array of arguments.
+	 */
+	public static function rest_comment_query( $prepared_args ) {
+		// Exclude comments on ActivityPub post types.
+		$hide_for = self::hide_for();
+
+		if ( ! empty( $hide_for ) ) {
+			$post_types                 = \array_diff( \get_post_types_by_support( 'comments' ), $hide_for );
+			$prepared_args['post_type'] = $post_types;
+		}
+
+		// Exclude ActivityPub comment types (likes, reposts) unless explicitly requested.
+		if ( empty( $prepared_args['type'] ) && empty( $prepared_args['type__in'] ) ) {
+			$prepared_args['type__not_in'] = self::get_comment_type_slugs();
+		}
+
+		return $prepared_args;
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -1459,7 +1459,7 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rest_comment_query excludes ActivityPub comment types via REST API.
+	 * Test comment_query_filter excludes ActivityPub comment types via REST API.
 	 *
 	 * @covers ::rest_comment_query
 	 */
@@ -1508,25 +1508,39 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rest_comment_query does not add type__not_in when type is explicitly set.
+	 * Test comment_query does not add type__not_in when type is explicitly set.
 	 *
-	 * @covers ::rest_comment_query
+	 * @covers ::comment_query
 	 */
-	public function test_rest_comment_query_respects_explicit_type() {
-		// Apply the REST API filter with explicit type.
-		$args = Comment::rest_comment_query( array( 'type' => 'like' ) );
+	public function test_comment_query_respects_explicit_type() {
+		$post_id = self::factory()->post->create();
 
-		// type__not_in should not be set when type is explicitly requested.
-		$this->assertArrayNotHasKey( 'type__not_in', $args, 'type__not_in should not be set when type is explicitly requested' );
-		$this->assertEquals( 'like', $args['type'], 'type should be preserved' );
+		// Create a like comment.
+		$like_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_type'         => 'like',
+				'comment_content'      => 'Like',
+				'comment_approved'     => '1',
+				'comment_author_email' => 'like@example.com',
+			)
+		);
+
+		// Query with explicit type - should include like comments.
+		$query    = new \WP_Comment_Query();
+		$comments = $query->query( array( 'type' => 'like' ) );
+
+		$comment_ids = wp_list_pluck( $comments, 'comment_ID' );
+
+		$this->assertContains( (string) $like_comment_id, $comment_ids, 'Like should be included when explicitly requested via type' );
 	}
 
 	/**
-	 * Test rest_comment_query does not filter when type__in is explicitly set via filter.
+	 * Test comment_query does not filter when type__in is explicitly set.
 	 *
-	 * @covers ::rest_comment_query
+	 * @covers ::comment_query
 	 */
-	public function test_rest_comment_query_respects_explicit_type_in() {
+	public function test_comment_query_respects_explicit_type_in() {
 		$post_id = self::factory()->post->create();
 
 		// Create comments of different types.
@@ -1549,15 +1563,9 @@ class Test_Comment extends \WP_UnitTestCase {
 			)
 		);
 
-		// Apply the REST API filter with explicit type__in (simulates custom code setting type__in).
-		$args = Comment::rest_comment_query( array( 'type__in' => array( 'like', 'repost' ) ) );
-
-		// type__not_in should not be set when type__in is explicitly requested.
-		$this->assertArrayNotHasKey( 'type__not_in', $args, 'type__not_in should not be set when type__in is explicitly requested' );
-
-		// Query with the filtered args.
+		// Query with explicit type__in - should include likes and reposts.
 		$query    = new \WP_Comment_Query();
-		$comments = $query->query( $args );
+		$comments = $query->query( array( 'type__in' => array( 'like', 'repost' ) ) );
 
 		$comment_ids = wp_list_pluck( $comments, 'comment_ID' );
 

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -1418,4 +1418,150 @@ class Test_Comment extends \WP_UnitTestCase {
 		// Should contain the remote reply block.
 		$this->assertStringContainsString( 'activitypub-remote-reply', $result, 'Should show remote reply block for non-logged-in users.' );
 	}
+
+	/**
+	 * Test rest_comment_query excludes comments on ap_post via REST API.
+	 *
+	 * @covers ::rest_comment_query
+	 */
+	public function test_rest_comment_query_excludes_ap_post_comments() {
+		// Create a regular post and an ap_post.
+		$regular_post_id = self::factory()->post->create();
+		$ap_post_id      = self::factory()->post->create( array( 'post_type' => 'ap_post' ) );
+
+		// Create comments on both.
+		$regular_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $regular_post_id,
+				'comment_content'      => 'Comment on regular post',
+				'comment_approved'     => '1',
+				'comment_author_email' => 'test@example.com',
+			)
+		);
+		$ap_comment_id      = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $ap_post_id,
+				'comment_content'      => 'Comment on ap_post',
+				'comment_approved'     => '1',
+				'comment_author_email' => 'test2@example.com',
+			)
+		);
+
+		// Make a REST API request to the comments endpoint.
+		$request  = new \WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$comment_ids = wp_list_pluck( $data, 'id' );
+
+		$this->assertContains( $regular_comment_id, $comment_ids, 'Regular post comment should be included in REST API' );
+		$this->assertNotContains( $ap_comment_id, $comment_ids, 'AP post comment should be excluded from REST API' );
+	}
+
+	/**
+	 * Test rest_comment_query excludes ActivityPub comment types via REST API.
+	 *
+	 * @covers ::rest_comment_query
+	 */
+	public function test_rest_comment_query_excludes_activitypub_comment_types() {
+		$post_id = self::factory()->post->create();
+
+		// Create different comment types.
+		$regular_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_type'         => 'comment',
+				'comment_content'      => 'Regular comment',
+				'comment_approved'     => '1',
+				'comment_author_email' => 'regular@example.com',
+			)
+		);
+		$like_comment_id    = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_type'         => 'like',
+				'comment_content'      => 'Like',
+				'comment_approved'     => '1',
+				'comment_author_email' => 'like@example.com',
+			)
+		);
+		$repost_comment_id  = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_type'         => 'repost',
+				'comment_content'      => 'Repost',
+				'comment_approved'     => '1',
+				'comment_author_email' => 'repost@example.com',
+			)
+		);
+
+		// Make a REST API request to the comments endpoint.
+		$request  = new \WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$comment_ids = wp_list_pluck( $data, 'id' );
+
+		$this->assertContains( $regular_comment_id, $comment_ids, 'Regular comment should be included in REST API' );
+		$this->assertNotContains( $like_comment_id, $comment_ids, 'Like should be excluded from REST API' );
+		$this->assertNotContains( $repost_comment_id, $comment_ids, 'Repost should be excluded from REST API' );
+	}
+
+	/**
+	 * Test rest_comment_query does not add type__not_in when type is explicitly set.
+	 *
+	 * @covers ::rest_comment_query
+	 */
+	public function test_rest_comment_query_respects_explicit_type() {
+		// Apply the REST API filter with explicit type.
+		$args = Comment::rest_comment_query( array( 'type' => 'like' ) );
+
+		// type__not_in should not be set when type is explicitly requested.
+		$this->assertArrayNotHasKey( 'type__not_in', $args, 'type__not_in should not be set when type is explicitly requested' );
+		$this->assertEquals( 'like', $args['type'], 'type should be preserved' );
+	}
+
+	/**
+	 * Test rest_comment_query does not filter when type__in is explicitly set via filter.
+	 *
+	 * @covers ::rest_comment_query
+	 */
+	public function test_rest_comment_query_respects_explicit_type_in() {
+		$post_id = self::factory()->post->create();
+
+		// Create comments of different types.
+		$like_comment_id   = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_type'         => 'like',
+				'comment_content'      => 'Like',
+				'comment_approved'     => '1',
+				'comment_author_email' => 'like@example.com',
+			)
+		);
+		$repost_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_type'         => 'repost',
+				'comment_content'      => 'Repost',
+				'comment_approved'     => '1',
+				'comment_author_email' => 'repost@example.com',
+			)
+		);
+
+		// Apply the REST API filter with explicit type__in (simulates custom code setting type__in).
+		$args = Comment::rest_comment_query( array( 'type__in' => array( 'like', 'repost' ) ) );
+
+		// type__not_in should not be set when type__in is explicitly requested.
+		$this->assertArrayNotHasKey( 'type__not_in', $args, 'type__not_in should not be set when type__in is explicitly requested' );
+
+		// Query with the filtered args.
+		$query    = new \WP_Comment_Query();
+		$comments = $query->query( $args );
+
+		$comment_ids = wp_list_pluck( $comments, 'comment_ID' );
+
+		$this->assertContains( (string) $like_comment_id, $comment_ids, 'Like should be included when explicitly requested via type__in' );
+		$this->assertContains( (string) $repost_comment_id, $comment_ids, 'Repost should be included when explicitly requested via type__in' );
+	}
 }


### PR DESCRIPTION
## Proposed changes:

* Add `rest_comment_query` filter to exclude comments on ActivityPub post types (`ap_post`) from REST API results
* This prevents internal comments from appearing in mobile apps and other REST API clients

Fixes #2776

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Query the `/wp-json/wp/v2/comments` endpoint
* Verify that comments on `ap_post` type posts are not included in the results
* Test with a mobile app that uses the WordPress REST API

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Filter comments on ActivityPub posts from REST API responses.

</details>