### PR TITLE
Add Social Web item to the admin bar

### DIFF
--- a/.github/changelog/add-social-web-admin-bar
+++ b/.github/changelog/add-social-web-admin-bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Social Web item to the admin bar for quick access to the reader.

--- a/activitypub.php
+++ b/activitypub.php
@@ -124,7 +124,7 @@ function plugin_admin_init() {
 	// Screen Options and Menus are set before `admin_init`.
 	\add_action( 'init', array( __NAMESPACE__ . '\WP_Admin\Heartbeat', 'init' ), 9 ); // Before script loader.
 	\add_filter( 'init', array( __NAMESPACE__ . '\WP_Admin\Screen_Options', 'init' ) );
-	\add_action( 'admin_menu', array( __NAMESPACE__ . '\WP_Admin\Menu', 'admin_menu' ) );
+	\add_action( 'init', array( __NAMESPACE__ . '\WP_Admin\Menu', 'init' ) );
 
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Admin', 'init' ) );
 	\add_action( 'admin_init', array( __NAMESPACE__ . '\WP_Admin\Advanced_Settings_Fields', 'init' ) );

--- a/assets/css/activitypub-admin-bar.css
+++ b/assets/css/activitypub-admin-bar.css
@@ -1,0 +1,7 @@
+/* Admin Bar Social Web Icon */
+#wpadminbar .activitypub-admin-bar-social-web .ab-item::before {
+	content: "\2042"; /* ⁂ Asterism */
+	font-family: Arial, Helvetica, sans-serif;
+	font-weight: 700;
+	top: 2px;
+}

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -117,21 +117,13 @@ class Menu {
 			return;
 		}
 
-		$icon_styles = '<style>
-			#wpadminbar #wp-admin-bar-activitypub-social-web > .ab-item:before {
-				content: "\2042";
-				font: normal 20px/1 sans-serif;
-			}
-		</style>';
-
 		$wp_admin_bar->add_node(
 			array(
 				'id'    => 'activitypub-social-web',
-				'title' => \__( 'Social Web', 'activitypub' ),
+				'title' => '⁂ ' . \__( 'Social Web', 'activitypub' ),
 				'href'  => \admin_url( 'admin.php?page=activitypub-social-web' ),
 				'meta'  => array(
 					'title' => \__( 'View your Social Web feed', 'activitypub' ),
-					'html'  => $icon_styles,
 				),
 			)
 		);

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -120,12 +120,21 @@ class Menu {
 		$wp_admin_bar->add_node(
 			array(
 				'id'    => 'activitypub-social-web',
-				'title' => \_x( '⁂', 'Fediverse symbol', 'activitypub' ) . ' ' . \__( 'Social Web', 'activitypub' ),
+				'title' => \__( 'Social Web', 'activitypub' ),
 				'href'  => \admin_url( 'admin.php?page=activitypub-social-web' ),
 				'meta'  => array(
+					'class' => 'activitypub-admin-bar-social-web',
 					'title' => \__( 'View your Social Web feed', 'activitypub' ),
 				),
 			)
+		);
+
+		// Enqueue styles for the admin bar icon.
+		\wp_enqueue_style(
+			'activitypub-admin-bar-styles',
+			\plugins_url( 'assets/css/activitypub-admin-bar.css', ACTIVITYPUB_PLUGIN_FILE ),
+			array(),
+			ACTIVITYPUB_PLUGIN_VERSION
 		);
 	}
 }

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -120,7 +120,7 @@ class Menu {
 		$wp_admin_bar->add_node(
 			array(
 				'id'    => 'activitypub-social-web',
-				'title' => '⁂ ' . \__( 'Social Web', 'activitypub' ),
+				'title' => \_x( '⁂', 'Fediverse symbol', 'activitypub' ) . ' ' . \__( 'Social Web', 'activitypub' ),
 				'href'  => \admin_url( 'admin.php?page=activitypub-social-web' ),
 				'meta'  => array(
 					'title' => \__( 'View your Social Web feed', 'activitypub' ),

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -117,6 +117,13 @@ class Menu {
 			return;
 		}
 
+		$icon_styles = '<style>
+			#wpadminbar #wp-admin-bar-activitypub-social-web > .ab-item:before {
+				content: "\2042";
+				font: normal 20px/1 sans-serif;
+			}
+		</style>';
+
 		$wp_admin_bar->add_node(
 			array(
 				'id'    => 'activitypub-social-web',
@@ -124,6 +131,7 @@ class Menu {
 				'href'  => \admin_url( 'admin.php?page=activitypub-social-web' ),
 				'meta'  => array(
 					'title' => \__( 'View your Social Web feed', 'activitypub' ),
+					'html'  => $icon_styles,
 				),
 			)
 		);

--- a/includes/wp-admin/class-menu.php
+++ b/includes/wp-admin/class-menu.php
@@ -15,6 +15,14 @@ use function Activitypub\user_can_activitypub;
 class Menu {
 
 	/**
+	 * Initialize the Menu class.
+	 */
+	public static function init() {
+		\add_action( 'admin_menu', array( self::class, 'admin_menu' ) );
+		\add_action( 'admin_bar_menu', array( self::class, 'admin_bar_menu' ), 100 );
+	}
+
+	/**
 	 * Add admin menu entry.
 	 */
 	public static function admin_menu() {
@@ -90,5 +98,34 @@ class Menu {
 				\esc_url( \admin_url( '/edit.php?post_type=ap_extrafield' ) )
 			);
 		}
+	}
+
+	/**
+	 * Add Social Web item to the admin bar.
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 */
+	public static function admin_bar_menu( $wp_admin_bar ) {
+		// Only show if reader UI is enabled and WordPress version supports it.
+		if ( ! \get_option( 'activitypub_reader_ui', '0' ) || \version_compare( \get_bloginfo( 'version' ), '6.9-alpha', '<' ) ) {
+			return;
+		}
+
+		// Check user capability based on actor mode.
+		$capability = ACTIVITYPUB_BLOG_MODE === \get_option( 'activitypub_actor_mode' ) ? 'manage_options' : 'activitypub';
+		if ( ! \current_user_can( $capability ) ) {
+			return;
+		}
+
+		$wp_admin_bar->add_node(
+			array(
+				'id'    => 'activitypub-social-web',
+				'title' => \__( 'Social Web', 'activitypub' ),
+				'href'  => \admin_url( 'admin.php?page=activitypub-social-web' ),
+				'meta'  => array(
+					'title' => \__( 'View your Social Web feed', 'activitypub' ),
+				),
+			)
+		);
 	}
 }


### PR DESCRIPTION
Fixes #2804

## Proposed changes:

* Add a "Social Web" link to the WordPress admin bar for quick access to the reader.
* Visible on both frontend and backend when logged in.
* Only shows when the reader UI is enabled and WordPress version is 6.9+.
* Respects the same capability checks as the dashboard menu item.

<img width="681" height="157" alt="Screenshot 2026-01-22 at 09 21 27" src="https://github.com/user-attachments/assets/52307802-c080-414e-9d52-6a5d46787d93" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Go to 'Settings → ActivityPub → Advanced' and enable the Reader option.
* Visit the frontend of your site while logged in.
* Verify "Social Web" appears in the admin bar.
* Click the link and verify it opens the Social Web reader.
* Go to any admin page and verify the "Social Web" link also appears there.
* Disable the Reader option and verify the admin bar item disappears.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add Social Web item to the admin bar for quick access to the reader.

</details>