### PR TITLE
Fix duplicate media attachments in Classic Editor posts

### DIFF
--- a/.github/changelog/2814-from-description
+++ b/.github/changelog/2814-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix duplicate media attachments when featured image is also in post content.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -390,8 +390,6 @@ class Post extends Base {
 		}
 
 		$media = $this->filter_media_by_object_type( $media, \get_post_format( $this->item ), $this->item );
-		$media = $this->filter_unique_attachments( $media );
-		$media = \array_slice( $media, 0, $max_media );
 
 		/**
 		 * Filter the attachment IDs for a post.
@@ -402,6 +400,10 @@ class Post extends Base {
 		 * @return array The filtered attachment IDs.
 		 */
 		$media = \apply_filters( 'activitypub_attachment_ids', $media, $this->item );
+
+		// Deduplicate and limit after filter to ensure plugins adding attachments don't cause duplicates.
+		$media = $this->filter_unique_attachments( $media );
+		$media = \array_slice( $media, 0, $max_media );
 
 		$attachments = \array_filter( \array_map( array( $this, 'transform_attachment' ), $media ) );
 

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -1480,4 +1480,55 @@ class Test_Post extends \WP_UnitTestCase {
 		$this->assertSame( -0.1278, $location['longitude'] );
 		$this->assertSame( 'London, UK', $location['name'] );
 	}
+
+	/**
+	 * Test that duplicate attachments are filtered after activitypub_attachment_ids filter.
+	 *
+	 * This ensures that when plugins add attachments via the filter (like Classic Editor),
+	 * duplicates are properly removed to prevent the same image appearing multiple times.
+	 *
+	 * @covers ::get_attachment
+	 */
+	public function test_duplicate_attachments_filtered_after_filter() {
+		// Create an image attachment.
+		$attachment_id  = $this->create_upload_object( AP_TESTS_DIR . '/data/assets/test.jpg' );
+		$attachment_url = \wp_get_attachment_url( $attachment_id );
+
+		// Create a post with the image as featured image.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Post with Duplicate Image',
+				'post_content' => sprintf( '<p>Test content with image</p><img src="%s" />', $attachment_url ),
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Set the same image as featured image.
+		\set_post_thumbnail( $post_id, $attachment_id );
+
+		// Add a filter that simulates Classic Editor behavior - adding attached images.
+		$filter = function ( $attachments ) use ( $attachment_id ) {
+			// Simulate Classic Editor adding the same attachment again.
+			$attachments[] = array( 'id' => $attachment_id );
+			return $attachments;
+		};
+		\add_filter( 'activitypub_attachment_ids', $filter, 10, 1 );
+
+		$post   = get_post( $post_id );
+		$object = Post::transform( $post )->to_object();
+
+		// Get the attachments.
+		$attachments = $object->get_attachment();
+
+		// Remove the filter.
+		\remove_filter( 'activitypub_attachment_ids', $filter );
+
+		// Clean up.
+		\delete_post_thumbnail( $post_id );
+		\wp_delete_attachment( $attachment_id, true );
+
+		// There should be only ONE attachment, not duplicates.
+		$this->assertCount( 1, $attachments, 'Duplicate attachments should be filtered out' );
+		$this->assertSame( $attachment_url, $attachments[0]['url'] );
+	}
 }


### PR DESCRIPTION
Fixes #2813

## Proposed changes:
* Move `filter_unique_attachments()` after the `activitypub_attachment_ids` filter to ensure plugins adding attachments don't cause duplicates.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create a new post using Classic Editor
2. Add an image to the post content using "Add Media"
3. Set the same image as the Featured Image
4. Publish the post
5. Check the ActivityPub object (view source or use the API) - the image should appear only once in the `attachment` array

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix duplicate media attachments when featured image is also in post content.

</details>