### PR TITLE
Fix comments with empty type not being federated

### DIFF
--- a/.github/changelog/2831-from-description
+++ b/.github/changelog/2831-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix older comments with empty type not being federated.

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -57,6 +57,7 @@ class Comment {
 		 */
 		$allowed_types   = Comment_Utils::get_comment_type_slugs();
 		$allowed_types[] = 'comment'; // Add core WordPress comment types.
+		$allowed_types[] = '';        // Be backwards compatible with comments that have an empty type.
 
 		// Check if comment type is in allowed list.
 		if ( ! in_array( $comment->comment_type, $allowed_types, true ) ) {

--- a/includes/scheduler/class-comment.php
+++ b/includes/scheduler/class-comment.php
@@ -55,12 +55,17 @@ class Comment {
 		 * Check against supported comment types.
 		 * Only federate registered ActivityPub comment types and standard WordPress comments.
 		 */
+		$comment_type = $comment->comment_type;
+		if ( '' === $comment_type ) {
+			// Be backwards compatible with comments that have an empty type by treating them as standard comments.
+			$comment_type = 'comment';
+		}
+
 		$allowed_types   = Comment_Utils::get_comment_type_slugs();
 		$allowed_types[] = 'comment'; // Add core WordPress comment types.
-		$allowed_types[] = '';        // Be backwards compatible with comments that have an empty type.
 
 		// Check if comment type is in allowed list.
-		if ( ! in_array( $comment->comment_type, $allowed_types, true ) ) {
+		if ( ! in_array( $comment_type, $allowed_types, true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes:

* Add backwards compatibility for comments that have an empty `comment_type`.
* Older WordPress versions used an empty string as the default comment type, so these comments were being filtered out and not federated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a comment with an empty `comment_type` (e.g., via direct database insert or from an older WordPress installation)
* Verify the comment is now federated correctly

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix older comments with empty type not being federated.

</details>