### PR TITLE
Move Jest mocks from root to tests/js directory

### DIFF
--- a/.github/changelog/2841-from-description
+++ b/.github/changelog/2841-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move Jest mocks to tests/js directory for better project organization.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,12 +4,12 @@ module.exports = {
 	...defaultConfig,
 	testMatch: [ '**/tests/js/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)' ],
 	testPathIgnorePatterns: [
+		'/build/',
 		'/node_modules/',
 		'/tests/e2e/',
+		'/tests/js/__mocks__/',
 		'/tests/phpunit/',
 		'/vendor/',
-		'/build/',
-		'/tests/js/__mocks__/',
 	],
 	setupFilesAfterEnv: [ '<rootDir>/jest.setup.js' ],
 	moduleNameMapper: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		'/tests/phpunit/',
 		'/vendor/',
 		'/build/',
-		'/__mocks__/',
+		'/tests/js/__mocks__/',
 	],
 	setupFilesAfterEnv: [ '<rootDir>/jest.setup.js' ],
 	moduleNameMapper: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,10 +3,17 @@ const defaultConfig = require( '@wordpress/scripts/config/jest-unit.config.js' )
 module.exports = {
 	...defaultConfig,
 	testMatch: [ '**/tests/js/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)' ],
-	testPathIgnorePatterns: [ '/node_modules/', '/tests/e2e/', '/tests/phpunit/', '/vendor/', '/build/' ],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'/tests/e2e/',
+		'/tests/phpunit/',
+		'/vendor/',
+		'/build/',
+		'/__mocks__/',
+	],
 	setupFilesAfterEnv: [ '<rootDir>/jest.setup.js' ],
 	moduleNameMapper: {
 		...defaultConfig.moduleNameMapper,
-		'^@wordpress/interactivity$': '<rootDir>/__mocks__/@wordpress/interactivity.js',
+		'^@wordpress/interactivity$': '<rootDir>/tests/js/__mocks__/@wordpress/interactivity.js',
 	},
 };

--- a/tests/js/__mocks__/@wordpress/interactivity.js
+++ b/tests/js/__mocks__/@wordpress/interactivity.js
@@ -1,3 +1,4 @@
+/* global jest */
 /**
  * Mock for @wordpress/interactivity
  *


### PR DESCRIPTION
## Proposed changes:

* Move `__mocks__/@wordpress/interactivity.js` to `tests/js/__mocks__/@wordpress/interactivity.js`
* Update `jest.config.js` to reference the new path and exclude mocks from test file matching
* Sort `testPathIgnorePatterns` alphabetically

### Other information:

- [x] Have you written new tests for your changes, if applicable?

N/A - this is a project structure change, existing tests still pass.

## Testing instructions:

* Run `npm run test:unit` to verify all tests pass
* Verify there is no `__mocks__` folder in the project root

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Move Jest mocks to tests/js directory for better project organization.

</details>