### PR TITLE
Fix reply block embed appearing squished at 200x200

### DIFF
--- a/.github/changelog/2848-from-description
+++ b/.github/changelog/2848-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Federated Reply block embed appearing squished at 200x200 pixels for same-site embeds by passing explicit width to wp_oembed_get().

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -348,7 +348,9 @@ class Blocks {
 		// Try to get and append the embed if requested.
 		$embed = null;
 		if ( $show_embed ) {
-			$embed = wp_oembed_get( $attrs['url'] );
+			// Use the theme's content width or a reasonable default to avoid narrow embeds.
+			$embed_width = ! empty( $GLOBALS['content_width'] ) ? $GLOBALS['content_width'] : 600;
+			$embed       = wp_oembed_get( $attrs['url'], array( 'width' => $embed_width ) );
 			if ( $embed ) {
 				$html .= $embed;
 				\wp_enqueue_script( 'wp-embed' );

--- a/tests/phpunit/tests/includes/class-test-blocks.php
+++ b/tests/phpunit/tests/includes/class-test-blocks.php
@@ -816,7 +816,7 @@ class Test_Blocks extends \WP_UnitTestCase {
 	 */
 	public function test_render_reply_block_embed_uses_proper_width() {
 		// Create a post to embed.
-		$post_id = self::factory()->post->create(
+		$post_id  = self::factory()->post->create(
 			array(
 				'post_title'   => 'Test Embed Post',
 				'post_content' => 'Test content for embedding.',
@@ -858,11 +858,11 @@ class Test_Blocks extends \WP_UnitTestCase {
 	 */
 	public function test_render_reply_block_embed_respects_content_width() {
 		// Set a custom content_width.
-		$original_content_width    = isset( $GLOBALS['content_width'] ) ? $GLOBALS['content_width'] : null;
+		$original_content_width   = isset( $GLOBALS['content_width'] ) ? $GLOBALS['content_width'] : null;
 		$GLOBALS['content_width'] = 800;
 
 		// Create a post to embed.
-		$post_id = self::factory()->post->create(
+		$post_id  = self::factory()->post->create(
 			array(
 				'post_title'   => 'Test Content Width Post',
 				'post_content' => 'Test content.',

--- a/tests/phpunit/tests/includes/class-test-blocks.php
+++ b/tests/phpunit/tests/includes/class-test-blocks.php
@@ -805,6 +805,104 @@ class Test_Blocks extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the reply block with embedPost uses proper width for same-site embeds.
+	 *
+	 * When rendering same-site embeds, WordPress Core's get_oembed_response_data()
+	 * clamps width to min=200 if no width is provided. This test verifies that
+	 * render_reply_block() passes an explicit width to wp_oembed_get() to avoid
+	 * the 200x200 minimum dimension issue.
+	 *
+	 * @covers ::render_reply_block
+	 */
+	public function test_render_reply_block_embed_uses_proper_width() {
+		// Create a post to embed.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Embed Post',
+				'post_content' => 'Test content for embedding.',
+				'post_status'  => 'publish',
+			)
+		);
+		$post_url = get_permalink( $post_id );
+
+		// Track the width passed to wp_oembed_get via the pre_oembed_result filter.
+		$captured_width = null;
+		$capture_width  = function ( $result, $url, $args ) use ( &$captured_width, $post_url ) {
+			if ( false !== strpos( $url, $post_url ) || false !== strpos( $post_url, $url ) ) {
+				$captured_width = isset( $args['width'] ) ? $args['width'] : null;
+			}
+			// Return a mock embed to avoid actual HTTP request.
+			return '<iframe src="' . esc_url( $url ) . '" width="600" height="338"></iframe>';
+		};
+
+		add_filter( 'pre_oembed_result', $capture_width, 5, 3 ); // Priority 5 to run before wp_filter_pre_oembed_result.
+
+		$block_markup = sprintf(
+			'<!-- wp:activitypub/reply {"url":"%s","embedPost":true} /-->',
+			esc_url( $post_url )
+		);
+
+		do_blocks( $block_markup );
+
+		remove_filter( 'pre_oembed_result', $capture_width, 5 );
+
+		// Width should be set (not null) and should be a reasonable value (not 0).
+		$this->assertNotNull( $captured_width, 'Width should be passed to wp_oembed_get()' );
+		$this->assertGreaterThan( 200, $captured_width, 'Width should be greater than the 200px minimum to avoid squished embeds' );
+	}
+
+	/**
+	 * Test the reply block embed respects content_width global when set.
+	 *
+	 * @covers ::render_reply_block
+	 */
+	public function test_render_reply_block_embed_respects_content_width() {
+		// Set a custom content_width.
+		$original_content_width    = isset( $GLOBALS['content_width'] ) ? $GLOBALS['content_width'] : null;
+		$GLOBALS['content_width'] = 800;
+
+		// Create a post to embed.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Test Content Width Post',
+				'post_content' => 'Test content.',
+				'post_status'  => 'publish',
+			)
+		);
+		$post_url = get_permalink( $post_id );
+
+		// Track the width passed to wp_oembed_get.
+		$captured_width = null;
+		$capture_width  = function ( $result, $url, $args ) use ( &$captured_width, $post_url ) {
+			if ( false !== strpos( $url, $post_url ) || false !== strpos( $post_url, $url ) ) {
+				$captured_width = isset( $args['width'] ) ? $args['width'] : null;
+			}
+			return '<iframe src="' . esc_url( $url ) . '" width="800" height="450"></iframe>';
+		};
+
+		add_filter( 'pre_oembed_result', $capture_width, 5, 3 );
+
+		$block_markup = sprintf(
+			'<!-- wp:activitypub/reply {"url":"%s","embedPost":true} /-->',
+			esc_url( $post_url )
+		);
+
+		do_blocks( $block_markup );
+
+		remove_filter( 'pre_oembed_result', $capture_width, 5 );
+
+		// Restore original content_width.
+		if ( null === $original_content_width ) {
+			unset( $GLOBALS['content_width'] );
+		} else {
+			$GLOBALS['content_width'] = $original_content_width;
+		}
+
+		// Width should match the content_width we set.
+		$this->assertSame( 800, $captured_width, 'Width should use $content_width when available' );
+	}
+
+	/**
 	 * Test Extra Fields block preserves HTML in field content.
 	 *
 	 * @covers ::get_user_id


### PR DESCRIPTION
Fixes #1027 (follow-up - the embed feature works but displays at wrong size)

## Proposed changes:
* Pass explicit width argument to `wp_oembed_get()` when rendering the Federated Reply block embed
* Use the theme's `$content_width` global if available, otherwise default to 600px
* This prevents WordPress Core from defaulting to the minimum 200x200 embed size

### Other information:

- [x] Have you written new tests for your changes, if applicable?

**Root cause:** When `wp_oembed_get()` is called without a width argument for same-site embeds, WordPress Core's `wp_filter_pre_oembed_result()` intercepts the request and calls `get_oembed_response_data()` with `width=0`. That function clamps width to min=200, max=600, so `max(200, 0) = 200`. Height is also calculated as 200. Result: 200x200 square embed instead of a properly sized one.

## Testing instructions:

* Go to a WordPress site with the ActivityPub plugin active
* Create a new post and add a Federated Reply block
* Enter a URL to another post **on the same site** (same-site embeds trigger this code path)
* Enable "Embed Post" in the block settings
* Publish the post
* View the post on the frontend

**Before fix:** The embed displays as a tiny 200x200 pixel square, content is unreadable
**After fix:** The embed displays at proper width (up to 600px), content is readable

**Note:** If testing on an existing post, you may need to clear object cache (Redis/Memcached) as WordPress may have cached the old 200x200 oEmbed response.

## Screenshots
Before:
<img width="873" height="1005" alt="Screenshot 2026-01-30 at 17 43 57" src="https://github.com/user-attachments/assets/67908e1d-d43b-4718-9a36-490a3e040ad8" />
After:
<img width="873" height="1005" alt="Screenshot 2026-01-30 at 17 43 26" src="https://github.com/user-attachments/assets/7b5972b0-5c34-434d-918f-5647734e7b3c" />


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed Federated Reply block embed appearing squished at 200x200 pixels for same-site embeds by passing explicit width to wp_oembed_get().

</details>