### PR TITLE
Add Podlove Podcast Publisher integration

### DIFF
--- a/.github/changelog/add-podlove-podcast-publisher-integration
+++ b/.github/changelog/add-podlove-podcast-publisher-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Podlove Podcast Publisher integration for podcast episode federation.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -32,6 +32,41 @@ function snake_to_camel_case( $input ) {
 }
 
 /**
+ * Convert seconds to ISO 8601 duration format.
+ *
+ * @param int $seconds The duration in seconds.
+ *
+ * @return string The duration in ISO 8601 format (e.g., "PT1H23M45S").
+ */
+function seconds_to_iso8601( $seconds ) {
+	$seconds = (int) $seconds;
+
+	if ( $seconds <= 0 ) {
+		return 'PT0S';
+	}
+
+	$hours   = floor( $seconds / 3600 );
+	$minutes = floor( ( $seconds % 3600 ) / 60 );
+	$secs    = $seconds % 60;
+
+	$duration = 'PT';
+
+	if ( $hours > 0 ) {
+		$duration .= $hours . 'H';
+	}
+
+	if ( $minutes > 0 ) {
+		$duration .= $minutes . 'M';
+	}
+
+	if ( $secs > 0 || ( 0 === $hours && 0 === $minutes ) ) {
+		$duration .= $secs . 'S';
+	}
+
+	return $duration;
+}
+
+/**
  * Check if a site supports the block editor.
  *
  * @return boolean True if the site supports the block editor, false otherwise.

--- a/integration/class-podlove-podcast-publisher.php
+++ b/integration/class-podlove-podcast-publisher.php
@@ -11,6 +11,7 @@ use Activitypub\Transformer\Post;
 
 use function Activitypub\generate_post_summary;
 use function Activitypub\object_to_uri;
+use function Activitypub\seconds_to_iso8601;
 
 /**
  * Compatibility with the Podlove Podcast Publisher plugin.
@@ -91,7 +92,7 @@ class Podlove_Podcast_Publisher extends Post {
 			// Add duration if available (in ISO 8601 format).
 			$duration = $episode->get_duration( 'seconds' );
 			if ( $duration && is_numeric( $duration ) && (int) $duration > 0 ) {
-				$attachment['duration'] = $this->seconds_to_iso8601( (int) $duration );
+				$attachment['duration'] = seconds_to_iso8601( (int) $duration );
 			}
 
 			$attachments[] = $attachment;
@@ -190,35 +191,6 @@ class Podlove_Podcast_Publisher extends Post {
 			return null;
 		}
 
-		return $this->seconds_to_iso8601( $duration_seconds );
-	}
-
-	/**
-	 * Convert seconds to ISO 8601 duration format.
-	 *
-	 * @param int $seconds The duration in seconds.
-	 *
-	 * @return string The duration in ISO 8601 format (e.g., "PT1H23M45S").
-	 */
-	protected function seconds_to_iso8601( $seconds ) {
-		$hours   = floor( $seconds / 3600 );
-		$minutes = floor( ( $seconds % 3600 ) / 60 );
-		$secs    = $seconds % 60;
-
-		$iso_duration = 'PT';
-
-		if ( $hours > 0 ) {
-			$iso_duration .= $hours . 'H';
-		}
-
-		if ( $minutes > 0 ) {
-			$iso_duration .= $minutes . 'M';
-		}
-
-		if ( $secs > 0 || ( 0 === $hours && 0 === $minutes ) ) {
-			$iso_duration .= $secs . 'S';
-		}
-
-		return $iso_duration;
+		return seconds_to_iso8601( $duration_seconds );
 	}
 }

--- a/integration/class-podlove-podcast-publisher.php
+++ b/integration/class-podlove-podcast-publisher.php
@@ -88,10 +88,10 @@ class Podlove_Podcast_Publisher extends Post {
 				'name'      => \esc_attr( $episode->title() ?? '' ),
 			);
 
-			// Add duration if available.
+			// Add duration if available (in ISO 8601 format).
 			$duration = $episode->get_duration( 'seconds' );
 			if ( $duration && is_numeric( $duration ) && (int) $duration > 0 ) {
-				$attachment['duration'] = (int) $duration;
+				$attachment['duration'] = $this->seconds_to_iso8601( (int) $duration );
 			}
 
 			$attachments[] = $attachment;
@@ -190,10 +190,20 @@ class Podlove_Podcast_Publisher extends Post {
 			return null;
 		}
 
-		// Convert seconds to ISO 8601 duration format.
-		$hours   = floor( $duration_seconds / 3600 );
-		$minutes = floor( ( $duration_seconds % 3600 ) / 60 );
-		$seconds = $duration_seconds % 60;
+		return $this->seconds_to_iso8601( $duration_seconds );
+	}
+
+	/**
+	 * Convert seconds to ISO 8601 duration format.
+	 *
+	 * @param int $seconds The duration in seconds.
+	 *
+	 * @return string The duration in ISO 8601 format (e.g., "PT1H23M45S").
+	 */
+	protected function seconds_to_iso8601( $seconds ) {
+		$hours   = floor( $seconds / 3600 );
+		$minutes = floor( ( $seconds % 3600 ) / 60 );
+		$secs    = $seconds % 60;
 
 		$iso_duration = 'PT';
 
@@ -205,8 +215,8 @@ class Podlove_Podcast_Publisher extends Post {
 			$iso_duration .= $minutes . 'M';
 		}
 
-		if ( $seconds > 0 || ( 0 === $hours && 0 === $minutes ) ) {
-			$iso_duration .= $seconds . 'S';
+		if ( $secs > 0 || ( 0 === $hours && 0 === $minutes ) ) {
+			$iso_duration .= $secs . 'S';
 		}
 
 		return $iso_duration;

--- a/integration/class-podlove-podcast-publisher.php
+++ b/integration/class-podlove-podcast-publisher.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Podlove Podcast Publisher integration file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Integration;
+
+use Activitypub\Transformer\Post;
+
+use function Activitypub\generate_post_summary;
+use function Activitypub\object_to_uri;
+
+/**
+ * Compatibility with the Podlove Podcast Publisher plugin.
+ *
+ * This is a transformer for the Podlove Podcast Publisher plugin,
+ * that extends the default transformer for WordPress posts.
+ *
+ * @see https://wordpress.org/plugins/podlove-podcasting-plugin-for-wordpress/
+ */
+class Podlove_Podcast_Publisher extends Post {
+	/**
+	 * The Podlove Episode object.
+	 *
+	 * @var \Podlove\Model\Episode|null
+	 */
+	private $episode = null;
+
+	/**
+	 * Get the Podlove Episode object.
+	 *
+	 * @return \Podlove\Model\Episode|null The episode object or null if not found.
+	 */
+	protected function get_episode() {
+		if ( null === $this->episode && \class_exists( '\Podlove\Model\Episode' ) ) {
+			$this->episode = \Podlove\Model\Episode::find_one_by_post_id( $this->item->ID );
+		}
+		return $this->episode;
+	}
+
+	/**
+	 * Gets the attachment for a podcast episode.
+	 *
+	 * This method is overridden to add the audio/video files as attachments.
+	 *
+	 * @return array The attachments array.
+	 */
+	public function get_attachment() {
+		$episode = $this->get_episode();
+
+		if ( ! $episode ) {
+			return parent::get_attachment();
+		}
+
+		$attachments = array();
+
+		// Get media files from Podlove.
+		$media_files = $episode->media_files();
+
+		foreach ( $media_files as $media_file ) {
+			if ( ! $media_file->is_valid() ) {
+				continue;
+			}
+
+			$episode_asset = $media_file->episode_asset();
+
+			if ( ! $episode_asset ) {
+				continue;
+			}
+
+			$file_type = $episode_asset->file_type();
+
+			if ( ! $file_type ) {
+				continue;
+			}
+
+			// Only include audio and video files.
+			if ( ! in_array( $file_type->type, array( 'audio', 'video' ), true ) ) {
+				continue;
+			}
+
+			$attachment = array(
+				'type'      => \esc_attr( ucfirst( $file_type->type ) ),
+				'url'       => \esc_url( $media_file->get_public_file_url( 'activitypub' ) ),
+				'mediaType' => \esc_attr( $file_type->mime_type ),
+				'name'      => \esc_attr( $episode->title() ?? '' ),
+			);
+
+			// Add duration if available.
+			$duration = $episode->get_duration( 'seconds' );
+			if ( $duration && is_numeric( $duration ) && (int) $duration > 0 ) {
+				$attachment['duration'] = (int) $duration;
+			}
+
+			$attachments[] = $attachment;
+		}
+
+		// If we have media files, add episode image as icon.
+		if ( ! empty( $attachments ) ) {
+			$icon = $this->get_episode_image();
+
+			if ( $icon ) {
+				foreach ( $attachments as $key => $attachment ) {
+					$attachments[ $key ]['icon'] = \esc_url( $icon );
+				}
+			}
+		}
+
+		// If no Podlove media files found, fall back to parent.
+		if ( empty( $attachments ) ) {
+			return parent::get_attachment();
+		}
+
+		return $attachments;
+	}
+
+	/**
+	 * Get the episode image URL.
+	 *
+	 * @return string|null The image URL or null if not found.
+	 */
+	protected function get_episode_image() {
+		$episode = $this->get_episode();
+
+		if ( ! $episode ) {
+			return null;
+		}
+
+		$image = $episode->cover_art_with_fallback();
+
+		if ( $image && method_exists( $image, 'url' ) ) {
+			return $image->url();
+		}
+
+		// Fall back to post thumbnail.
+		$icon = $this->get_icon();
+		if ( $icon ) {
+			return object_to_uri( $icon );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets the object type for a podcast episode.
+	 *
+	 * Always returns 'Note' for the best possible compatibility with ActivityPub.
+	 *
+	 * @return string The object type.
+	 */
+	public function get_type() {
+		return 'Note';
+	}
+
+	/**
+	 * Returns the content for the ActivityPub Item.
+	 *
+	 * The content will be generated based on the user settings.
+	 *
+	 * @return string The content.
+	 */
+	public function get_content() {
+		return generate_post_summary( $this->item );
+	}
+
+	/**
+	 * Get the duration of the episode in ISO 8601 format.
+	 *
+	 * @return string|null The duration in ISO 8601 format or null if not available.
+	 */
+	public function get_duration() {
+		$episode = $this->get_episode();
+
+		if ( ! $episode ) {
+			return null;
+		}
+
+		$duration_seconds = $episode->get_duration( 'seconds' );
+
+		// Ensure we have a valid numeric duration.
+		if ( ! $duration_seconds || ! is_numeric( $duration_seconds ) ) {
+			return null;
+		}
+
+		$duration_seconds = (int) $duration_seconds;
+
+		if ( $duration_seconds <= 0 ) {
+			return null;
+		}
+
+		// Convert seconds to ISO 8601 duration format.
+		$hours   = floor( $duration_seconds / 3600 );
+		$minutes = floor( ( $duration_seconds % 3600 ) / 60 );
+		$seconds = $duration_seconds % 60;
+
+		$iso_duration = 'PT';
+
+		if ( $hours > 0 ) {
+			$iso_duration .= $hours . 'H';
+		}
+
+		if ( $minutes > 0 ) {
+			$iso_duration .= $minutes . 'M';
+		}
+
+		if ( $seconds > 0 || ( 0 === $hours && 0 === $minutes ) ) {
+			$iso_duration .= $seconds . 'S';
+		}
+
+		return $iso_duration;
+	}
+}

--- a/integration/class-podlove-podcast-publisher.php
+++ b/integration/class-podlove-podcast-publisher.php
@@ -82,9 +82,16 @@ class Podlove_Podcast_Publisher extends Post {
 				continue;
 			}
 
+			// Use tracking URL if analytics is enabled, otherwise direct file URL.
+			if ( 'ptm_analytics' === \Podlove\get_setting( 'tracking', 'mode' ) ) {
+				$file_url = $media_file->get_public_file_url( 'activitypub' );
+			} else {
+				$file_url = $media_file->get_file_url();
+			}
+
 			$attachment = array(
 				'type'      => \esc_attr( ucfirst( $file_type->type ) ),
-				'url'       => \esc_url( $media_file->get_public_file_url( 'activitypub' ) ),
+				'url'       => \esc_url( $file_url ),
 				'mediaType' => \esc_attr( $file_type->mime_type ),
 				'name'      => \esc_attr( $episode->title() ?? '' ),
 			);

--- a/integration/load.php
+++ b/integration/load.php
@@ -109,7 +109,10 @@ function plugin_init() {
 	 * @see https://wordpress.org/plugins/podlove-podcasting-plugin-for-wordpress/
 	 */
 	if ( \class_exists( '\Podlove\Model\Episode' ) ) {
-		add_filter(
+		// Enable ActivityPub support for the podcast post type.
+		\add_post_type_support( 'podcast', 'activitypub' );
+
+		\add_filter(
 			'activitypub_transformer',
 			static function ( $transformer, $data, $object_class ) {
 				if (

--- a/integration/load.php
+++ b/integration/load.php
@@ -102,6 +102,31 @@ function plugin_init() {
 	}
 
 	/**
+	 * Adds Podlove Podcast Publisher support.
+	 *
+	 * This class handles the compatibility with Podlove Podcast Publisher.
+	 *
+	 * @see https://wordpress.org/plugins/podlove-podcasting-plugin-for-wordpress/
+	 */
+	if ( \class_exists( '\Podlove\Model\Episode' ) ) {
+		add_filter(
+			'activitypub_transformer',
+			static function ( $transformer, $data, $object_class ) {
+				if (
+					'WP_Post' === $object_class &&
+					'podcast' === $data->post_type &&
+					\Podlove\Model\Episode::find_one_by_post_id( $data->ID )
+				) {
+					return new Podlove_Podcast_Publisher( $data );
+				}
+				return $transformer;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
 	 * Adds Seriously Simple Podcasting support.
 	 *
 	 * This class handles the compatibility with Seriously Simple Podcasting.

--- a/integration/load.php
+++ b/integration/load.php
@@ -108,7 +108,7 @@ function plugin_init() {
 	 *
 	 * @see https://wordpress.org/plugins/podlove-podcasting-plugin-for-wordpress/
 	 */
-	if ( \class_exists( '\Podlove\Model\Episode' ) ) {
+	if ( \defined( 'Podlove\PLUGIN_FILE' ) ) {
 		// Enable ActivityPub support for the podcast post type.
 		\add_post_type_support( 'podcast', 'activitypub' );
 

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -243,4 +243,43 @@ class Test_Functions extends \WP_UnitTestCase {
 		$result = \Activitypub\esc_hashtag( 'test&#039;s tag' );
 		$this->assertSame( '#testSTag', $result );
 	}
+
+	/**
+	 * Data provider for seconds_to_iso8601 tests.
+	 *
+	 * @return array Test cases with input seconds and expected ISO 8601 duration.
+	 */
+	public function seconds_to_iso8601_provider() {
+		return array(
+			'zero_seconds'          => array( 0, 'PT0S' ),
+			'negative_seconds'      => array( -10, 'PT0S' ),
+			'one_second'            => array( 1, 'PT1S' ),
+			'thirty_seconds'        => array( 30, 'PT30S' ),
+			'one_minute'            => array( 60, 'PT1M' ),
+			'one_minute_30_seconds' => array( 90, 'PT1M30S' ),
+			'five_minutes'          => array( 300, 'PT5M' ),
+			'one_hour'              => array( 3600, 'PT1H' ),
+			'one_hour_30_minutes'   => array( 5400, 'PT1H30M' ),
+			'one_hour_one_second'   => array( 3601, 'PT1H1S' ),
+			'full_duration'         => array( 3661, 'PT1H1M1S' ),
+			'two_hours_15_min_30s'  => array( 8130, 'PT2H15M30S' ),
+			'podcast_length'        => array( 2745, 'PT45M45S' ),
+			'long_podcast'          => array( 7384, 'PT2H3M4S' ),
+			'string_input'          => array( '3600', 'PT1H' ),
+		);
+	}
+
+	/**
+	 * Test seconds_to_iso8601 function.
+	 *
+	 * @dataProvider seconds_to_iso8601_provider
+	 * @covers \Activitypub\seconds_to_iso8601
+	 *
+	 * @param int|string $seconds  The input seconds.
+	 * @param string     $expected The expected ISO 8601 duration.
+	 */
+	public function test_seconds_to_iso8601( $seconds, $expected ) {
+		$result = \Activitypub\seconds_to_iso8601( $seconds );
+		$this->assertSame( $expected, $result );
+	}
 }

--- a/tests/phpunit/tests/integration/class-test-podlove-podcast-publisher.php
+++ b/tests/phpunit/tests/integration/class-test-podlove-podcast-publisher.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Test file for Podlove Podcast Publisher integration.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Integration;
+
+/**
+ * Test class for Podlove Podcast Publisher integration.
+ *
+ * @group integration
+ * @coversDefaultClass \Activitypub\Integration\Podlove_Podcast_Publisher
+ */
+class Test_Podlove_Podcast_Publisher extends \WP_UnitTestCase {
+
+	/**
+	 * Test that the transformer returns Note type.
+	 *
+	 * @covers ::get_type
+	 */
+	public function test_get_type_returns_note() {
+		$post = \wp_insert_post(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Episode content',
+				'post_title'   => 'Episode title',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		$post = \get_post( $post );
+
+		$transformer = new \Activitypub\Integration\Podlove_Podcast_Publisher( $post );
+
+		$this->assertEquals( 'Note', $transformer->get_type() );
+
+		// Clean up.
+		\wp_delete_post( $post->ID, true );
+	}
+
+	/**
+	 * Test that get_content returns summary.
+	 *
+	 * @covers ::get_content
+	 */
+	public function test_get_content() {
+		$post = \wp_insert_post(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'This is the episode content that should be summarized.',
+				'post_title'   => 'Episode title',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		$post = \get_post( $post );
+
+		$transformer = new \Activitypub\Integration\Podlove_Podcast_Publisher( $post );
+		$content     = $transformer->get_content();
+
+		$this->assertNotEmpty( $content );
+		$this->assertIsString( $content );
+
+		// Clean up.
+		\wp_delete_post( $post->ID, true );
+	}
+
+	/**
+	 * Test that get_attachment returns parent attachments when no episode.
+	 *
+	 * @covers ::get_attachment
+	 */
+	public function test_get_attachment_without_episode() {
+		$post = \wp_insert_post(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Episode content',
+				'post_title'   => 'Episode title',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		$post = \get_post( $post );
+
+		$transformer = new \Activitypub\Integration\Podlove_Podcast_Publisher( $post );
+		$attachments = $transformer->get_attachment();
+
+		// Without Podlove Episode, should return parent's attachments (or empty array).
+		$this->assertIsArray( $attachments );
+
+		// Clean up.
+		\wp_delete_post( $post->ID, true );
+	}
+
+	/**
+	 * Test that get_duration returns null when no episode.
+	 *
+	 * @covers ::get_duration
+	 */
+	public function test_get_duration_without_episode() {
+		$post = \wp_insert_post(
+			array(
+				'post_author'  => 1,
+				'post_content' => 'Episode content',
+				'post_title'   => 'Episode title',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		$post = \get_post( $post );
+
+		$transformer = new \Activitypub\Integration\Podlove_Podcast_Publisher( $post );
+		$duration    = $transformer->get_duration();
+
+		// Without Podlove Episode, should return null.
+		$this->assertNull( $duration );
+
+		// Clean up.
+		\wp_delete_post( $post->ID, true );
+	}
+
+	/**
+	 * Test that the integration class exists and extends Post transformer.
+	 */
+	public function test_class_exists_and_extends_post() {
+		$this->assertTrue( class_exists( '\Activitypub\Integration\Podlove_Podcast_Publisher' ) );
+		$this->assertTrue( is_subclass_of( '\Activitypub\Integration\Podlove_Podcast_Publisher', '\Activitypub\Transformer\Post' ) );
+	}
+}


### PR DESCRIPTION
## Proposed changes:

* Add support for Podlove Podcast Publisher plugin, similar to the existing Seriously Simple Podcasting integration
* Include a transformer that handles podcast episodes with:
  - Audio/video file attachments with proper MIME types from Podlove's media files
  - Episode cover art as icon (with fallback to podcast cover)
  - Duration in ISO 8601 format
  - Content as post summary
  - Note type for best ActivityPub compatibility

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Install and activate Podlove Podcast Publisher plugin
2. Create a podcast episode with at least one media file (audio/video)
3. Publish the episode
4. Check the ActivityPub JSON-LD output for the episode (append `?activitypub` to the URL or check the outbox)
5. Verify the attachment includes:
   - `type`: "Audio" or "Video"
   - `url`: The media file URL
   - `mediaType`: The correct MIME type
   - `name`: The episode title
   - `icon`: Episode or podcast cover image (if available)
   - `duration`: Duration in seconds (if available)

### Changelog entry

Changelog entry has been added manually via `composer changelog:add`.