### PR TITLE
Hide admin REST endpoints from API index

### DIFF
--- a/.github/changelog/fix-hide-admin-rest-routes
+++ b/.github/changelog/fix-hide-admin-rest-routes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide admin REST API endpoints from discovery index.

--- a/includes/rest/admin/class-actions-controller.php
+++ b/includes/rest/admin/class-actions-controller.php
@@ -55,6 +55,7 @@ class Actions_Controller extends \WP_REST_Controller {
 					'methods'             => \WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'unfollow_actor' ),
 					'permission_callback' => array( $this, 'check_permission' ),
+					'show_in_index'       => false,
 				),
 			)
 		);
@@ -76,6 +77,7 @@ class Actions_Controller extends \WP_REST_Controller {
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'block_actor' ),
 					'permission_callback' => array( $this, 'check_permission' ),
+					'show_in_index'       => false,
 					'args'                => array(
 						'site_wide' => array(
 							'description' => 'Whether to block site-wide (admin only).',
@@ -104,6 +106,7 @@ class Actions_Controller extends \WP_REST_Controller {
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'follow_actor' ),
 					'permission_callback' => array( $this, 'check_permission' ),
+					'show_in_index'       => false,
 				),
 			)
 		);


### PR DESCRIPTION
## Proposed changes:
* Add `show_in_index => false` to admin actor REST endpoints (unfollow, block, follow) so they don't appear in the `/wp-json/` REST API discovery index.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Visit `http://localhost:8888/wp-json/activitypub/1.0/`
* Verify that no `/admin/actors/` routes appear in the response
* The endpoints still function normally when called directly

### Changelog entry

Changelog entry already committed to branch.