### PR TITLE
Store temp files in uploads directory instead of system temp

### DIFF
--- a/.github/changelog/fix-temp-file-storage-in-uploads
+++ b/.github/changelog/fix-temp-file-storage-in-uploads
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Store temporary download files in uploads directory instead of system temp to avoid issues on hosts that restrict operations on /tmp/ files.

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -43,6 +43,13 @@ class Attachments {
 	public static $emoji_dir = '/activitypub/emoji/';
 
 	/**
+	 * Directory for storing temporary files during downloads.
+	 *
+	 * @var string
+	 */
+	public static $temp_dir = '/activitypub/tmp/';
+
+	/**
 	 * Maximum width for imported images.
 	 *
 	 * @var int
@@ -62,6 +69,59 @@ class Attachments {
 	public static function init() {
 		\add_action( 'before_delete_post', array( self::class, 'delete_ap_posts_directory' ) );
 		\add_action( 'before_delete_post', array( self::class, 'delete_actors_directory' ) );
+	}
+
+	/**
+	 * Download a URL to a temp file in the uploads directory.
+	 *
+	 * Unlike download_url(), this stores temp files in uploads/activitypub/tmp/
+	 * to avoid issues with hosts that restrict operations on system temp files.
+	 *
+	 * @param string $url     The URL to download.
+	 * @param int    $timeout Timeout in seconds. Default 300.
+	 *
+	 * @return string|\WP_Error Path to temp file on success, WP_Error on failure.
+	 */
+	public static function download_to_temp( $url, $timeout = 300 ) {
+		if ( ! $url ) {
+			return new \WP_Error( 'http_no_url', \__( 'Invalid URL provided.', 'activitypub' ) );
+		}
+
+		$upload_dir = \wp_upload_dir();
+		$temp_dir   = $upload_dir['basedir'] . self::$temp_dir;
+
+		if ( ! \wp_mkdir_p( $temp_dir ) ) {
+			return new \WP_Error( 'temp_dir_failed', \__( 'Could not create temp directory.', 'activitypub' ) );
+		}
+
+		// Generate unique temp filename.
+		$temp_file = $temp_dir . \wp_unique_filename( $temp_dir, 'download-' . \wp_generate_password( 12, false ) . '.tmp' );
+
+		$response = \wp_safe_remote_get(
+			$url,
+			array(
+				'timeout'  => $timeout,
+				'stream'   => true,
+				'filename' => $temp_file,
+			)
+		);
+
+		if ( \is_wp_error( $response ) ) {
+			\wp_delete_file( $temp_file );
+			return $response;
+		}
+
+		$response_code = \wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			\wp_delete_file( $temp_file );
+			return new \WP_Error(
+				'http_error',
+				/* translators: %d: HTTP response code */
+				\sprintf( \__( 'Download failed with response code %d.', 'activitypub' ), $response_code )
+			);
+		}
+
+		return $temp_file;
 	}
 
 	/**
@@ -225,12 +285,8 @@ class Attachments {
 			}
 		}
 
-		if ( ! \function_exists( 'download_url' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		// Download the emoji.
-		$tmp_file = \download_url( $emoji_url, 10 ); // 10 second timeout for emoji downloads.
+		// Download the emoji to uploads temp directory.
+		$tmp_file = self::download_to_temp( $emoji_url, 10 ); // 10 second timeout for emoji downloads.
 		if ( \is_wp_error( $tmp_file ) ) {
 			return false;
 		}
@@ -615,7 +671,7 @@ class Attachments {
 	 */
 	private static function save_attachment( $attachment_data, $post_id, $author_id = 0 ) {
 		// Ensure required WordPress functions are loaded.
-		if ( ! \function_exists( 'media_handle_sideload' ) || ! \function_exists( 'download_url' ) ) {
+		if ( ! \function_exists( 'media_handle_sideload' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/media.php';
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 			require_once ABSPATH . 'wp-admin/includes/image.php';
@@ -640,12 +696,15 @@ class Attachments {
 				return new \WP_Error( 'file_not_found', sprintf( \__( 'File not found: %s', 'activitypub' ), $attachment_data['url'] ) );
 			}
 
-			// Copy to temp file so media_handle_sideload doesn't move the original.
-			$tmp_file = \wp_tempnam( \basename( $attachment_data['url'] ) );
+			// Copy to temp file in uploads so media_handle_sideload doesn't move the original.
+			$upload_dir = \wp_upload_dir();
+			$temp_dir   = $upload_dir['basedir'] . self::$temp_dir;
+			\wp_mkdir_p( $temp_dir );
+			$tmp_file = $temp_dir . \wp_unique_filename( $temp_dir, \basename( $attachment_data['url'] ) );
 			$wp_filesystem->copy( $attachment_data['url'], $tmp_file, true );
 		} else {
-			// Download remote URL.
-			$tmp_file = \download_url( $attachment_data['url'] );
+			// Download remote URL to uploads temp directory.
+			$tmp_file = self::download_to_temp( $attachment_data['url'] );
 
 			if ( \is_wp_error( $tmp_file ) ) {
 				return $tmp_file;
@@ -739,12 +798,8 @@ class Attachments {
 			);
 		}
 
-		if ( ! \function_exists( 'download_url' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		// Download remote URL.
-		$tmp_file = \download_url( $attachment_data['url'] );
+		// Download remote URL to uploads temp directory.
+		$tmp_file = self::download_to_temp( $attachment_data['url'] );
 
 		if ( \is_wp_error( $tmp_file ) ) {
 			return $tmp_file;
@@ -768,6 +823,7 @@ class Attachments {
 		}
 
 		if ( ! $wp_filesystem ) {
+			\wp_delete_file( $tmp_file );
 			return new \WP_Error( 'filesystem_error', \__( 'Could not initialize filesystem.', 'activitypub' ) );
 		}
 

--- a/includes/class-attachments.php
+++ b/includes/class-attachments.php
@@ -69,6 +69,41 @@ class Attachments {
 	public static function init() {
 		\add_action( 'before_delete_post', array( self::class, 'delete_ap_posts_directory' ) );
 		\add_action( 'before_delete_post', array( self::class, 'delete_actors_directory' ) );
+		\add_action( 'activitypub_cleanup_temp_files', array( self::class, 'cleanup_temp_files' ) );
+
+		// Schedule cleanup if not already scheduled.
+		if ( ! \wp_next_scheduled( 'activitypub_cleanup_temp_files' ) ) {
+			\wp_schedule_event( time(), 'hourly', 'activitypub_cleanup_temp_files' );
+		}
+	}
+
+	/**
+	 * Clean up old temporary files.
+	 *
+	 * Removes temp files older than 1 hour to prevent accumulation
+	 * from failed or interrupted downloads.
+	 */
+	public static function cleanup_temp_files() {
+		$upload_dir = \wp_upload_dir();
+		$temp_dir   = $upload_dir['basedir'] . self::$temp_dir;
+
+		if ( ! \is_dir( $temp_dir ) ) {
+			return;
+		}
+
+		$max_age = HOUR_IN_SECONDS;
+		$now     = time();
+		$files   = \glob( $temp_dir . '*' );
+
+		if ( ! $files ) {
+			return;
+		}
+
+		foreach ( $files as $file ) {
+			if ( \is_file( $file ) && ( $now - \filemtime( $file ) ) > $max_age ) {
+				\wp_delete_file( $file );
+			}
+		}
 	}
 
 	/**
@@ -83,7 +118,7 @@ class Attachments {
 	 * @return string|\WP_Error Path to temp file on success, WP_Error on failure.
 	 */
 	public static function download_to_temp( $url, $timeout = 300 ) {
-		if ( ! $url ) {
+		if ( ! \is_string( $url ) || ! \filter_var( $url, FILTER_VALIDATE_URL ) ) {
 			return new \WP_Error( 'http_no_url', \__( 'Invalid URL provided.', 'activitypub' ) );
 		}
 
@@ -107,13 +142,17 @@ class Attachments {
 		);
 
 		if ( \is_wp_error( $response ) ) {
-			\wp_delete_file( $temp_file );
+			if ( \file_exists( $temp_file ) ) {
+				\wp_delete_file( $temp_file );
+			}
 			return $response;
 		}
 
 		$response_code = \wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $response_code ) {
-			\wp_delete_file( $temp_file );
+			if ( \file_exists( $temp_file ) ) {
+				\wp_delete_file( $temp_file );
+			}
 			return new \WP_Error(
 				'http_error',
 				/* translators: %d: HTTP response code */
@@ -690,18 +729,51 @@ class Attachments {
 		$is_local = ! preg_match( '#^https?://#i', $attachment_data['url'] );
 
 		if ( $is_local ) {
-			// Read local file from disk.
-			if ( ! $wp_filesystem->exists( $attachment_data['url'] ) ) {
+			// Resolve real path to prevent directory traversal attacks.
+			$real_path = \realpath( $attachment_data['url'] );
+			if ( false === $real_path ) {
 				/* translators: %s: file path */
-				return new \WP_Error( 'file_not_found', sprintf( \__( 'File not found: %s', 'activitypub' ), $attachment_data['url'] ) );
+				return new \WP_Error( 'file_not_found', \sprintf( \__( 'File not found: %s', 'activitypub' ), $attachment_data['url'] ) );
+			}
+
+			// Validate that path is within WordPress uploads or temp directories.
+			$upload_dir   = \wp_upload_dir();
+			$allowed_dirs = array(
+				\realpath( $upload_dir['basedir'] ),
+				\realpath( \sys_get_temp_dir() ),
+				\realpath( ABSPATH ),
+			);
+			$allowed_dirs = \array_filter( $allowed_dirs ); // Remove any false values.
+
+			$path_allowed = false;
+			foreach ( $allowed_dirs as $allowed_dir ) {
+				if ( 0 === \strpos( $real_path, $allowed_dir . DIRECTORY_SEPARATOR ) ) {
+					$path_allowed = true;
+					break;
+				}
+			}
+
+			if ( ! $path_allowed ) {
+				return new \WP_Error( 'invalid_path', \__( 'File path is not within allowed directories.', 'activitypub' ) );
+			}
+
+			// Read local file from disk.
+			if ( ! $wp_filesystem->exists( $real_path ) ) {
+				/* translators: %s: file path */
+				return new \WP_Error( 'file_not_found', \sprintf( \__( 'File not found: %s', 'activitypub' ), $attachment_data['url'] ) );
 			}
 
 			// Copy to temp file in uploads so media_handle_sideload doesn't move the original.
 			$upload_dir = \wp_upload_dir();
 			$temp_dir   = $upload_dir['basedir'] . self::$temp_dir;
-			\wp_mkdir_p( $temp_dir );
+			if ( ! \wp_mkdir_p( $temp_dir ) ) {
+				return new \WP_Error( 'mkdir_failed', \__( 'Could not create temporary directory.', 'activitypub' ) );
+			}
 			$tmp_file = $temp_dir . \wp_unique_filename( $temp_dir, \basename( $attachment_data['url'] ) );
-			$wp_filesystem->copy( $attachment_data['url'], $tmp_file, true );
+			if ( ! $wp_filesystem->copy( $real_path, $tmp_file, true ) ) {
+				/* translators: %s: file path */
+				return new \WP_Error( 'file_copy_error', \sprintf( \__( 'Failed to copy file to temporary location: %s', 'activitypub' ), $tmp_file ) );
+			}
 		} else {
 			// Download remote URL to uploads temp directory.
 			$tmp_file = self::download_to_temp( $attachment_data['url'] );


### PR DESCRIPTION
## Proposed changes:
* Add new `download_to_temp()` method that stores temporary files in `/uploads/activitypub/tmp/` instead of system `/tmp/`
* Replace all `download_url()` calls with the new method
* This avoids issues on hosts (like WordPress.com) that have security filters validating file paths in `wp_delete_file()` must be within the uploads directory

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Test emoji import from a federated post - emojis should be cached locally
* Test avatar caching for remote actors - avatars should download and display
* Test attachment sideloading for incoming posts
* Verify no warnings about file deletion in `/tmp/`

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed - for any bug fixes

#### Message

Store temporary download files in uploads directory instead of system temp to avoid issues on hosts that restrict operations on /tmp/ files.

</details>