### PR TITLE
Add block patterns and FSE templates for ActivityPub blocks

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -105,6 +105,17 @@ Changelogs are managed automatically through the PR workflow:
 ❌ Fix signature verification bug
 ```
 
+**Write end-user friendly messages:**
+- Focus on user benefit, not implementation details.
+- Avoid technical jargon where possible.
+- Describe what users can now do, not how it works internally.
+```
+✅ Add pre-built block patterns for easy profile and sidebar setup.
+✅ Fix follow button not appearing on author pages.
+❌ Add register_patterns() method to class-blocks.php.
+❌ Refactor User class to use Actors collection.
+```
+
 **Never mention AI tools or coding assistants in changelog messages.**
 
 See [PR Workflow - Changelog](../pr/SKILL.md#changelog-management) for complete changelog requirements.

--- a/.github/changelog/2891-from-description
+++ b/.github/changelog/2891-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add pre-built Fediverse block patterns for easy profile, follow page, and sidebar setup.

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -135,8 +135,9 @@ class Blocks {
 			return;
 		}
 
+		// Use the core `author` hierarchy slug so WP can resolve this for author archives.
 		\register_block_template(
-			'activitypub//author-archive-fediverse',
+			'activitypub//author',
 			array(
 				'title'       => \__( 'Author Archive (Fediverse)', 'activitypub' ),
 				'description' => \__( 'Displays an author archive with Fediverse profile and follow options.', 'activitypub' ),

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -119,34 +119,35 @@ class Blocks {
 			)
 		);
 
-		// Scan patterns directory and register each pattern.
-		$patterns_dir = ACTIVITYPUB_PLUGIN_DIR . '/patterns';
-		if ( ! \is_dir( $patterns_dir ) ) {
-			return;
-		}
-
-		$pattern_files = \glob( $patterns_dir . '/*.php' );
-		if ( empty( $pattern_files ) ) {
-			return;
-		}
+		// Register each pattern directly.
+		$pattern_files = array(
+			'author-header',
+			'author-profile',
+			'follow-page',
+			'social-sidebar',
+		);
 
 		foreach ( $pattern_files as $pattern_file ) {
 			$pattern_data = self::get_pattern_data( $pattern_file );
-			if ( ! $pattern_data ) {
-				continue;
+			if ( $pattern_data ) {
+				\register_block_pattern( $pattern_data['slug'], $pattern_data );
 			}
-
-			\register_block_pattern( $pattern_data['slug'], $pattern_data );
 		}
 	}
 
 	/**
 	 * Get pattern data from a pattern file.
 	 *
-	 * @param string $file Path to the pattern file.
+	 * @param string $pattern_name The pattern filename without extension.
 	 * @return array|false Pattern data array or false on failure.
 	 */
-	private static function get_pattern_data( $file ) {
+	private static function get_pattern_data( $pattern_name ) {
+		$file = ACTIVITYPUB_PLUGIN_DIR . '/patterns/' . $pattern_name . '.php';
+
+		if ( ! \file_exists( $file ) ) {
+			return false;
+		}
+
 		$default_headers = array(
 			'title'         => 'Title',
 			'slug'          => 'Slug',
@@ -165,17 +166,9 @@ class Blocks {
 			return false;
 		}
 
-		// Validate file is within expected patterns directory to prevent path traversal.
-		$patterns_dir = \realpath( ACTIVITYPUB_PLUGIN_DIR . '/patterns' );
-		$real_file    = \realpath( $file );
-
-		if ( false === $real_file || false === $patterns_dir || 0 !== \strpos( $real_file, $patterns_dir . \DIRECTORY_SEPARATOR ) ) {
-			return false;
-		}
-
 		// Get pattern content via output buffering.
 		\ob_start();
-		include $real_file;
+		include $file;
 		$content = \ob_get_clean();
 
 		if ( empty( $content ) ) {

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -120,7 +120,7 @@ class Blocks {
 		);
 
 		// Scan patterns directory and register each pattern.
-		$patterns_dir = ACTIVITYPUB_PLUGIN_DIR . 'patterns';
+		$patterns_dir = ACTIVITYPUB_PLUGIN_DIR . '/patterns';
 		if ( ! \is_dir( $patterns_dir ) ) {
 			return;
 		}
@@ -165,9 +165,17 @@ class Blocks {
 			return false;
 		}
 
+		// Validate file is within expected patterns directory to prevent path traversal.
+		$patterns_dir = \realpath( ACTIVITYPUB_PLUGIN_DIR . '/patterns' );
+		$real_file    = \realpath( $file );
+
+		if ( false === $real_file || false === $patterns_dir || 0 !== \strpos( $real_file, $patterns_dir . \DIRECTORY_SEPARATOR ) ) {
+			return false;
+		}
+
 		// Get pattern content via output buffering.
 		\ob_start();
-		include $file;
+		include $real_file;
 		$content = \ob_get_clean();
 
 		if ( empty( $content ) ) {

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -19,6 +19,8 @@ class Blocks {
 	public static function init() {
 		// This is already being called on the init hook, so just add it.
 		self::register_blocks();
+		self::register_patterns();
+		self::register_templates();
 
 		\add_action( 'load-post-new.php', array( self::class, 'handle_in_reply_to_get_param' ) );
 		// Add editor plugin.
@@ -101,6 +103,149 @@ class Blocks {
 			ACTIVITYPUB_PLUGIN_DIR . '/build/reply',
 			array(
 				'render_callback' => array( self::class, 'render_reply_block' ),
+			)
+		);
+	}
+
+	/**
+	 * Register block patterns for ActivityPub.
+	 */
+	public static function register_patterns() {
+		// Register the ActivityPub pattern category.
+		\register_block_pattern_category(
+			'activitypub',
+			array(
+				'label' => \__( 'Fediverse', 'activitypub' ),
+			)
+		);
+
+		// Scan patterns directory and register each pattern.
+		$patterns_dir = ACTIVITYPUB_PLUGIN_DIR . 'patterns';
+		if ( ! \is_dir( $patterns_dir ) ) {
+			return;
+		}
+
+		$pattern_files = \glob( $patterns_dir . '/*.php' );
+		if ( empty( $pattern_files ) ) {
+			return;
+		}
+
+		foreach ( $pattern_files as $pattern_file ) {
+			$pattern_data = self::get_pattern_data( $pattern_file );
+			if ( ! $pattern_data ) {
+				continue;
+			}
+
+			\register_block_pattern( $pattern_data['slug'], $pattern_data );
+		}
+	}
+
+	/**
+	 * Get pattern data from a pattern file.
+	 *
+	 * @param string $file Path to the pattern file.
+	 * @return array|false Pattern data array or false on failure.
+	 */
+	private static function get_pattern_data( $file ) {
+		$default_headers = array(
+			'title'         => 'Title',
+			'slug'          => 'Slug',
+			'description'   => 'Description',
+			'categories'    => 'Categories',
+			'keywords'      => 'Keywords',
+			'viewportWidth' => 'Viewport Width',
+			'blockTypes'    => 'Block Types',
+			'inserter'      => 'Inserter',
+		);
+
+		$file_data = \get_file_data( $file, $default_headers );
+
+		// Title and Slug are required.
+		if ( empty( $file_data['title'] ) || empty( $file_data['slug'] ) ) {
+			return false;
+		}
+
+		// Get pattern content via output buffering.
+		\ob_start();
+		include $file;
+		$content = \ob_get_clean();
+
+		if ( empty( $content ) ) {
+			return false;
+		}
+
+		$pattern_data = array(
+			'title'   => $file_data['title'],
+			'slug'    => $file_data['slug'],
+			'content' => $content,
+		);
+
+		// Add optional fields.
+		if ( ! empty( $file_data['description'] ) ) {
+			$pattern_data['description'] = $file_data['description'];
+		}
+
+		if ( ! empty( $file_data['categories'] ) ) {
+			$pattern_data['categories'] = \array_map( 'trim', \explode( ',', $file_data['categories'] ) );
+		}
+
+		if ( ! empty( $file_data['keywords'] ) ) {
+			$pattern_data['keywords'] = \array_map( 'trim', \explode( ',', $file_data['keywords'] ) );
+		}
+
+		if ( ! empty( $file_data['viewportWidth'] ) ) {
+			$pattern_data['viewportWidth'] = \absint( $file_data['viewportWidth'] );
+		}
+
+		if ( ! empty( $file_data['blockTypes'] ) ) {
+			$pattern_data['blockTypes'] = \array_map( 'trim', \explode( ',', $file_data['blockTypes'] ) );
+		}
+
+		if ( ! empty( $file_data['inserter'] ) ) {
+			$pattern_data['inserter'] = 'false' !== \strtolower( $file_data['inserter'] );
+		}
+
+		return $pattern_data;
+	}
+
+	/**
+	 * Register FSE templates for block themes.
+	 */
+	public static function register_templates() {
+		// Only register templates for block themes on WP 6.7+.
+		if ( ! \function_exists( 'register_block_template' ) || ! \wp_is_block_theme() ) {
+			return;
+		}
+
+		\register_block_template(
+			'activitypub//author-archive-fediverse',
+			array(
+				'title'       => \__( 'Author Archive (Fediverse)', 'activitypub' ),
+				'description' => \__( 'Displays an author archive with Fediverse profile and follow options.', 'activitypub' ),
+				'content'     => '<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:pattern {"slug":"activitypub/author-profile"} /-->
+	<!-- wp:spacer {"height":"32px"} -->
+	<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template -->
+			<!-- wp:post-title {"isLink":true} /-->
+			<!-- wp:post-excerpt /-->
+		<!-- /wp:post-template -->
+		<!-- wp:query-pagination -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->',
+				'post_types'  => array(),
 			)
 		);
 	}

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -120,93 +120,17 @@ class Blocks {
 		);
 
 		// Register each pattern directly.
-		$pattern_files = array(
+		$patterns = array(
 			'author-header',
 			'author-profile',
 			'follow-page',
 			'social-sidebar',
 		);
 
-		foreach ( $pattern_files as $pattern_file ) {
-			$pattern_data = self::get_pattern_data( $pattern_file );
-			if ( $pattern_data ) {
-				\register_block_pattern( $pattern_data['slug'], $pattern_data );
-			}
+		foreach ( $patterns as $pattern ) {
+			$pattern_data = require ACTIVITYPUB_PLUGIN_DIR . '/patterns/' . $pattern . '.php';
+			\register_block_pattern( $pattern_data['slug'], $pattern_data );
 		}
-	}
-
-	/**
-	 * Get pattern data from a pattern file.
-	 *
-	 * @param string $pattern_name The pattern filename without extension.
-	 * @return array|false Pattern data array or false on failure.
-	 */
-	private static function get_pattern_data( $pattern_name ) {
-		$file = ACTIVITYPUB_PLUGIN_DIR . '/patterns/' . $pattern_name . '.php';
-
-		if ( ! \file_exists( $file ) ) {
-			return false;
-		}
-
-		$default_headers = array(
-			'title'         => 'Title',
-			'slug'          => 'Slug',
-			'description'   => 'Description',
-			'categories'    => 'Categories',
-			'keywords'      => 'Keywords',
-			'viewportWidth' => 'Viewport Width',
-			'blockTypes'    => 'Block Types',
-			'inserter'      => 'Inserter',
-		);
-
-		$file_data = \get_file_data( $file, $default_headers );
-
-		// Title and Slug are required.
-		if ( empty( $file_data['title'] ) || empty( $file_data['slug'] ) ) {
-			return false;
-		}
-
-		// Get pattern content via output buffering.
-		\ob_start();
-		include $file;
-		$content = \ob_get_clean();
-
-		if ( empty( $content ) ) {
-			return false;
-		}
-
-		$pattern_data = array(
-			'title'   => $file_data['title'],
-			'slug'    => $file_data['slug'],
-			'content' => $content,
-		);
-
-		// Add optional fields.
-		if ( ! empty( $file_data['description'] ) ) {
-			$pattern_data['description'] = $file_data['description'];
-		}
-
-		if ( ! empty( $file_data['categories'] ) ) {
-			$pattern_data['categories'] = \array_map( 'trim', \explode( ',', $file_data['categories'] ) );
-		}
-
-		if ( ! empty( $file_data['keywords'] ) ) {
-			$pattern_data['keywords'] = \array_map( 'trim', \explode( ',', $file_data['keywords'] ) );
-		}
-
-		if ( ! empty( $file_data['viewportWidth'] ) ) {
-			$pattern_data['viewportWidth'] = \absint( $file_data['viewportWidth'] );
-		}
-
-		if ( ! empty( $file_data['blockTypes'] ) ) {
-			$pattern_data['blockTypes'] = \array_map( 'trim', \explode( ',', $file_data['blockTypes'] ) );
-		}
-
-		if ( ! empty( $file_data['inserter'] ) ) {
-			$pattern_data['inserter'] = 'false' !== \strtolower( $file_data['inserter'] );
-		}
-
-		return $pattern_data;
 	}
 
 	/**

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -119,18 +119,11 @@ class Blocks {
 			)
 		);
 
-		// Register each pattern directly.
-		$patterns = array(
-			'author-header',
-			'author-profile',
-			'follow-page',
-			'social-sidebar',
-		);
-
-		foreach ( $patterns as $pattern ) {
-			$pattern_data = require ACTIVITYPUB_PLUGIN_DIR . '/patterns/' . $pattern . '.php';
-			\register_block_pattern( $pattern_data['slug'], $pattern_data );
-		}
+		// Register each pattern.
+		require ACTIVITYPUB_PLUGIN_DIR . '/patterns/author-header.php';
+		require ACTIVITYPUB_PLUGIN_DIR . '/patterns/author-profile.php';
+		require ACTIVITYPUB_PLUGIN_DIR . '/patterns/follow-page.php';
+		require ACTIVITYPUB_PLUGIN_DIR . '/patterns/social-sidebar.php';
 	}
 
 	/**

--- a/patterns/author-header.php
+++ b/patterns/author-header.php
@@ -5,21 +5,23 @@
  * @package Activitypub
  */
 
-return array(
-	'title'         => _x( 'Author Header with Follow', 'Block pattern title', 'activitypub' ),
-	'slug'          => 'activitypub/author-header',
-	'categories'    => array( 'activitypub' ),
-	'keywords'      => array(
-		_x( 'author', 'Block pattern keyword', 'activitypub' ),
-		_x( 'header', 'Block pattern keyword', 'activitypub' ),
-		_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
-		_x( 'follow', 'Block pattern keyword', 'activitypub' ),
-	),
-	'description'   => _x( 'Compact author header with follow button.', 'Block pattern description', 'activitypub' ),
-	'viewportWidth' => 1200,
-	'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
+\register_block_pattern(
+	'activitypub/author-header',
+	array(
+		'title'         => _x( 'Author Header with Follow', 'Block pattern title', 'activitypub' ),
+		'categories'    => array( 'activitypub' ),
+		'keywords'      => array(
+			_x( 'author', 'Block pattern keyword', 'activitypub' ),
+			_x( 'header', 'Block pattern keyword', 'activitypub' ),
+			_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+			_x( 'follow', 'Block pattern keyword', 'activitypub' ),
+		),
+		'description'   => _x( 'Compact author header with follow button.', 'Block pattern description', 'activitypub' ),
+		'viewportWidth' => 1200,
+		'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:activitypub/follow-me {"selectedUser":"inherit"} /-->
 </div>
 <!-- /wp:group -->',
+	)
 );

--- a/patterns/author-header.php
+++ b/patterns/author-header.php
@@ -1,18 +1,25 @@
 <?php
 /**
- * Title: Author Header with Follow
- * Slug: activitypub/author-header
- * Categories: activitypub
- * Keywords: author, header, fediverse, follow, activitypub
- * Description: Compact author header with follow button.
- * Viewport Width: 1200
+ * Author Header with Follow pattern.
  *
  * @package Activitypub
  */
 
-?>
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+return array(
+	'title'         => _x( 'Author Header with Follow', 'Block pattern title', 'activitypub' ),
+	'slug'          => 'activitypub/author-header',
+	'categories'    => array( 'activitypub' ),
+	'keywords'      => array(
+		_x( 'author', 'Block pattern keyword', 'activitypub' ),
+		_x( 'header', 'Block pattern keyword', 'activitypub' ),
+		_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+		_x( 'follow', 'Block pattern keyword', 'activitypub' ),
+	),
+	'description'   => _x( 'Compact author header with follow button.', 'Block pattern description', 'activitypub' ),
+	'viewportWidth' => 1200,
+	'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:activitypub/follow-me {"selectedUser":"inherit"} /-->
 </div>
-<!-- /wp:group -->
+<!-- /wp:group -->',
+);

--- a/patterns/author-header.php
+++ b/patterns/author-header.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Title: Author Header with Follow
+ * Slug: activitypub/author-header
+ * Categories: activitypub
+ * Keywords: author, header, fediverse, follow, activitypub
+ * Description: Compact author header with follow button.
+ * Viewport Width: 1200
+ *
+ * @package Activitypub
+ */
+
+?>
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:activitypub/follow-me {"selectedUser":"inherit"} /-->
+</div>
+<!-- /wp:group -->

--- a/patterns/author-profile.php
+++ b/patterns/author-profile.php
@@ -5,19 +5,20 @@
  * @package Activitypub
  */
 
-return array(
-	'title'         => _x( 'Author Profile with Follow', 'Block pattern title', 'activitypub' ),
-	'slug'          => 'activitypub/author-profile',
-	'categories'    => array( 'activitypub' ),
-	'keywords'      => array(
-		_x( 'author', 'Block pattern keyword', 'activitypub' ),
-		_x( 'profile', 'Block pattern keyword', 'activitypub' ),
-		_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
-		_x( 'follow', 'Block pattern keyword', 'activitypub' ),
-	),
-	'description'   => _x( 'Display author profile with follow button and extra fields.', 'Block pattern description', 'activitypub' ),
-	'viewportWidth' => 1200,
-	'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
+\register_block_pattern(
+	'activitypub/author-profile',
+	array(
+		'title'         => _x( 'Author Profile with Follow', 'Block pattern title', 'activitypub' ),
+		'categories'    => array( 'activitypub' ),
+		'keywords'      => array(
+			_x( 'author', 'Block pattern keyword', 'activitypub' ),
+			_x( 'profile', 'Block pattern keyword', 'activitypub' ),
+			_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+			_x( 'follow', 'Block pattern keyword', 'activitypub' ),
+		),
+		'description'   => _x( 'Display author profile with follow button and extra fields.', 'Block pattern description', 'activitypub' ),
+		'viewportWidth' => 1200,
+		'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:activitypub/follow-me {"selectedUser":"inherit","className":"is-style-profile"} /-->
 	<!-- wp:spacer {"height":"24px"} -->
@@ -26,4 +27,5 @@ return array(
 	<!-- wp:activitypub/extra-fields {"selectedUser":"inherit"} /-->
 </div>
 <!-- /wp:group -->',
+	)
 );

--- a/patterns/author-profile.php
+++ b/patterns/author-profile.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Title: Author Profile with Follow
+ * Slug: activitypub/author-profile
+ * Categories: activitypub
+ * Keywords: author, profile, fediverse, follow, activitypub
+ * Description: Display author profile with follow button and extra fields.
+ * Viewport Width: 1200
+ *
+ * @package Activitypub
+ */
+
+?>
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:activitypub/follow-me {"selectedUser":"inherit","className":"is-style-profile"} /-->
+	<!-- wp:spacer {"height":"24px"} -->
+	<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:activitypub/extra-fields {"selectedUser":"inherit"} /-->
+</div>
+<!-- /wp:group -->

--- a/patterns/author-profile.php
+++ b/patterns/author-profile.php
@@ -1,17 +1,23 @@
 <?php
 /**
- * Title: Author Profile with Follow
- * Slug: activitypub/author-profile
- * Categories: activitypub
- * Keywords: author, profile, fediverse, follow, activitypub
- * Description: Display author profile with follow button and extra fields.
- * Viewport Width: 1200
+ * Author Profile with Follow pattern.
  *
  * @package Activitypub
  */
 
-?>
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+return array(
+	'title'         => _x( 'Author Profile with Follow', 'Block pattern title', 'activitypub' ),
+	'slug'          => 'activitypub/author-profile',
+	'categories'    => array( 'activitypub' ),
+	'keywords'      => array(
+		_x( 'author', 'Block pattern keyword', 'activitypub' ),
+		_x( 'profile', 'Block pattern keyword', 'activitypub' ),
+		_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+		_x( 'follow', 'Block pattern keyword', 'activitypub' ),
+	),
+	'description'   => _x( 'Display author profile with follow button and extra fields.', 'Block pattern description', 'activitypub' ),
+	'viewportWidth' => 1200,
+	'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:activitypub/follow-me {"selectedUser":"inherit","className":"is-style-profile"} /-->
 	<!-- wp:spacer {"height":"24px"} -->
@@ -19,4 +25,5 @@
 	<!-- /wp:spacer -->
 	<!-- wp:activitypub/extra-fields {"selectedUser":"inherit"} /-->
 </div>
-<!-- /wp:group -->
+<!-- /wp:group -->',
+);

--- a/patterns/follow-page.php
+++ b/patterns/follow-page.php
@@ -5,20 +5,21 @@
  * @package Activitypub
  */
 
-return array(
-	'title'         => _x( 'Fediverse Follow Page', 'Block pattern title', 'activitypub' ),
-	'slug'          => 'activitypub/follow-page',
-	'categories'    => array( 'activitypub' ),
-	'keywords'      => array(
-		_x( 'follow', 'Block pattern keyword', 'activitypub' ),
-		_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
-		_x( 'page', 'Block pattern keyword', 'activitypub' ),
-		_x( 'followers', 'Block pattern keyword', 'activitypub' ),
-	),
-	'description'   => _x( 'Full follow page layout with profile, extra fields, and followers list.', 'Block pattern description', 'activitypub' ),
-	'viewportWidth' => 1200,
-	'blockTypes'    => array( 'core/post-content' ),
-	'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
+\register_block_pattern(
+	'activitypub/follow-page',
+	array(
+		'title'         => _x( 'Fediverse Follow Page', 'Block pattern title', 'activitypub' ),
+		'categories'    => array( 'activitypub' ),
+		'keywords'      => array(
+			_x( 'follow', 'Block pattern keyword', 'activitypub' ),
+			_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+			_x( 'page', 'Block pattern keyword', 'activitypub' ),
+			_x( 'followers', 'Block pattern keyword', 'activitypub' ),
+		),
+		'description'   => _x( 'Full follow page layout with profile, extra fields, and followers list.', 'Block pattern description', 'activitypub' ),
+		'viewportWidth' => 1200,
+		'blockTypes'    => array( 'core/post-content' ),
+		'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:heading {"level":1} -->
 	<h1 class="wp-block-heading">' . esc_html_x( 'Follow Us on the Fediverse', 'Block pattern content', 'activitypub' ) . '</h1>
@@ -44,4 +45,5 @@ return array(
 	<!-- /wp:activitypub/followers -->
 </div>
 <!-- /wp:group -->',
+	)
 );

--- a/patterns/follow-page.php
+++ b/patterns/follow-page.php
@@ -1,24 +1,30 @@
 <?php
 /**
- * Title: Fediverse Follow Page
- * Slug: activitypub/follow-page
- * Categories: activitypub
- * Keywords: follow, fediverse, activitypub, page, followers
- * Description: Full follow page layout with profile, extra fields, and followers list.
- * Viewport Width: 1200
- * Block Types: core/post-content
+ * Fediverse Follow Page pattern.
  *
  * @package Activitypub
  */
 
-?>
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+return array(
+	'title'         => _x( 'Fediverse Follow Page', 'Block pattern title', 'activitypub' ),
+	'slug'          => 'activitypub/follow-page',
+	'categories'    => array( 'activitypub' ),
+	'keywords'      => array(
+		_x( 'follow', 'Block pattern keyword', 'activitypub' ),
+		_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+		_x( 'page', 'Block pattern keyword', 'activitypub' ),
+		_x( 'followers', 'Block pattern keyword', 'activitypub' ),
+	),
+	'description'   => _x( 'Full follow page layout with profile, extra fields, and followers list.', 'Block pattern description', 'activitypub' ),
+	'viewportWidth' => 1200,
+	'blockTypes'    => array( 'core/post-content' ),
+	'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:heading {"level":1} -->
-	<h1 class="wp-block-heading"><?php esc_html_e( 'Follow Us on the Fediverse', 'activitypub' ); ?></h1>
+	<h1 class="wp-block-heading">' . esc_html_x( 'Follow Us on the Fediverse', 'Block pattern content', 'activitypub' ) . '</h1>
 	<!-- /wp:heading -->
 	<!-- wp:paragraph -->
-	<p><?php esc_html_e( 'Follow this blog on Mastodon or the Fediverse to receive updates directly in your feed.', 'activitypub' ); ?></p>
+	<p>' . esc_html_x( 'Follow this blog on Mastodon or the Fediverse to receive updates directly in your feed.', 'Block pattern content', 'activitypub' ) . '</p>
 	<!-- /wp:paragraph -->
 	<!-- wp:spacer {"height":"32px"} -->
 	<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -33,8 +39,9 @@
 	<!-- /wp:spacer -->
 	<!-- wp:activitypub/followers {"selectedUser":"blog"} -->
 	<!-- wp:heading {"level":3} -->
-	<h3 class="wp-block-heading"><?php esc_html_e( 'Our Fediverse Followers', 'activitypub' ); ?></h3>
+	<h3 class="wp-block-heading">' . esc_html_x( 'Our Fediverse Followers', 'Block pattern content', 'activitypub' ) . '</h3>
 	<!-- /wp:heading -->
 	<!-- /wp:activitypub/followers -->
 </div>
-<!-- /wp:group -->
+<!-- /wp:group -->',
+);

--- a/patterns/follow-page.php
+++ b/patterns/follow-page.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Title: Fediverse Follow Page
+ * Slug: activitypub/follow-page
+ * Categories: activitypub
+ * Keywords: follow, fediverse, activitypub, page, followers
+ * Description: Full follow page layout with profile, extra fields, and followers list.
+ * Viewport Width: 1200
+ * Block Types: core/post-content
+ *
+ * @package Activitypub
+ */
+
+?>
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:heading {"level":1} -->
+	<h1 class="wp-block-heading"><?php esc_html_e( 'Follow Us on the Fediverse', 'activitypub' ); ?></h1>
+	<!-- /wp:heading -->
+	<!-- wp:paragraph -->
+	<p><?php esc_html_e( 'Follow this blog on Mastodon or the Fediverse to receive updates directly in your feed.', 'activitypub' ); ?></p>
+	<!-- /wp:paragraph -->
+	<!-- wp:spacer {"height":"32px"} -->
+	<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:activitypub/follow-me {"selectedUser":"blog","className":"is-style-profile"} /-->
+	<!-- wp:spacer {"height":"24px"} -->
+	<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:activitypub/extra-fields {"selectedUser":"blog"} /-->
+	<!-- wp:spacer {"height":"32px"} -->
+	<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:activitypub/followers {"selectedUser":"blog"} -->
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading"><?php esc_html_e( 'Our Fediverse Followers', 'activitypub' ); ?></h3>
+	<!-- /wp:heading -->
+	<!-- /wp:activitypub/followers -->
+</div>
+<!-- /wp:group -->

--- a/patterns/social-sidebar.php
+++ b/patterns/social-sidebar.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Title: Fediverse Sidebar
+ * Slug: activitypub/social-sidebar
+ * Categories: activitypub
+ * Keywords: sidebar, widget, fediverse, follow, followers, activitypub
+ * Description: Compact sidebar widget with follow button and followers list.
+ * Viewport Width: 400
+ * Block Types: core/template-part/sidebar
+ *
+ * @package Activitypub
+ */
+
+?>
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading"><?php esc_html_e( 'Follow on Fediverse', 'activitypub' ); ?></h3>
+	<!-- /wp:heading -->
+	<!-- wp:activitypub/follow-me {"selectedUser":"inherit","className":"is-style-button"} /-->
+	<!-- wp:spacer {"height":"16px"} -->
+	<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:activitypub/followers {"selectedUser":"inherit","per_page":5} -->
+	<!-- wp:heading {"level":4} -->
+	<h4 class="wp-block-heading"><?php esc_html_e( 'Recent Followers', 'activitypub' ); ?></h4>
+	<!-- /wp:heading -->
+	<!-- /wp:activitypub/followers -->
+</div>
+<!-- /wp:group -->

--- a/patterns/social-sidebar.php
+++ b/patterns/social-sidebar.php
@@ -1,21 +1,28 @@
 <?php
 /**
- * Title: Fediverse Sidebar
- * Slug: activitypub/social-sidebar
- * Categories: activitypub
- * Keywords: sidebar, widget, fediverse, follow, followers, activitypub
- * Description: Compact sidebar widget with follow button and followers list.
- * Viewport Width: 400
- * Block Types: core/template-part/sidebar
+ * Fediverse Sidebar pattern.
  *
  * @package Activitypub
  */
 
-?>
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+return array(
+	'title'         => _x( 'Fediverse Sidebar', 'Block pattern title', 'activitypub' ),
+	'slug'          => 'activitypub/social-sidebar',
+	'categories'    => array( 'activitypub' ),
+	'keywords'      => array(
+		_x( 'sidebar', 'Block pattern keyword', 'activitypub' ),
+		_x( 'widget', 'Block pattern keyword', 'activitypub' ),
+		_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+		_x( 'follow', 'Block pattern keyword', 'activitypub' ),
+		_x( 'followers', 'Block pattern keyword', 'activitypub' ),
+	),
+	'description'   => _x( 'Compact sidebar widget with follow button and followers list.', 'Block pattern description', 'activitypub' ),
+	'viewportWidth' => 400,
+	'blockTypes'    => array( 'core/template-part/sidebar' ),
+	'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:heading {"level":3} -->
-	<h3 class="wp-block-heading"><?php esc_html_e( 'Follow on Fediverse', 'activitypub' ); ?></h3>
+	<h3 class="wp-block-heading">' . esc_html_x( 'Follow on Fediverse', 'Block pattern content', 'activitypub' ) . '</h3>
 	<!-- /wp:heading -->
 	<!-- wp:activitypub/follow-me {"selectedUser":"inherit","className":"is-style-button"} /-->
 	<!-- wp:spacer {"height":"16px"} -->
@@ -23,8 +30,9 @@
 	<!-- /wp:spacer -->
 	<!-- wp:activitypub/followers {"selectedUser":"inherit","per_page":5} -->
 	<!-- wp:heading {"level":4} -->
-	<h4 class="wp-block-heading"><?php esc_html_e( 'Recent Followers', 'activitypub' ); ?></h4>
+	<h4 class="wp-block-heading">' . esc_html_x( 'Recent Followers', 'Block pattern content', 'activitypub' ) . '</h4>
 	<!-- /wp:heading -->
 	<!-- /wp:activitypub/followers -->
 </div>
-<!-- /wp:group -->
+<!-- /wp:group -->',
+);

--- a/patterns/social-sidebar.php
+++ b/patterns/social-sidebar.php
@@ -5,21 +5,22 @@
  * @package Activitypub
  */
 
-return array(
-	'title'         => _x( 'Fediverse Sidebar', 'Block pattern title', 'activitypub' ),
-	'slug'          => 'activitypub/social-sidebar',
-	'categories'    => array( 'activitypub' ),
-	'keywords'      => array(
-		_x( 'sidebar', 'Block pattern keyword', 'activitypub' ),
-		_x( 'widget', 'Block pattern keyword', 'activitypub' ),
-		_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
-		_x( 'follow', 'Block pattern keyword', 'activitypub' ),
-		_x( 'followers', 'Block pattern keyword', 'activitypub' ),
-	),
-	'description'   => _x( 'Compact sidebar widget with follow button and followers list.', 'Block pattern description', 'activitypub' ),
-	'viewportWidth' => 400,
-	'blockTypes'    => array( 'core/template-part/sidebar' ),
-	'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
+\register_block_pattern(
+	'activitypub/social-sidebar',
+	array(
+		'title'         => _x( 'Fediverse Sidebar', 'Block pattern title', 'activitypub' ),
+		'categories'    => array( 'activitypub' ),
+		'keywords'      => array(
+			_x( 'sidebar', 'Block pattern keyword', 'activitypub' ),
+			_x( 'widget', 'Block pattern keyword', 'activitypub' ),
+			_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+			_x( 'follow', 'Block pattern keyword', 'activitypub' ),
+			_x( 'followers', 'Block pattern keyword', 'activitypub' ),
+		),
+		'description'   => _x( 'Compact sidebar widget with follow button and followers list.', 'Block pattern description', 'activitypub' ),
+		'viewportWidth' => 400,
+		'blockTypes'    => array( 'core/template-part/sidebar' ),
+		'content'       => '<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:heading {"level":3} -->
 	<h3 class="wp-block-heading">' . esc_html_x( 'Follow on Fediverse', 'Block pattern content', 'activitypub' ) . '</h3>
@@ -35,4 +36,5 @@ return array(
 	<!-- /wp:activitypub/followers -->
 </div>
 <!-- /wp:group -->',
+	)
 );


### PR DESCRIPTION
Fixes #2890

## Proposed changes:
* Add a "Fediverse" block pattern category with 4 pre-configured patterns:
  * **Author Profile with Follow** - Follow Me (profile style) + Extra Fields for author pages
  * **Fediverse Follow Page** - Complete page layout with heading, Follow Me, Extra Fields, and Followers
  * **Author Header with Follow** - Compact follow button for page headers
  * **Fediverse Sidebar** - Narrow widget with follow button and followers list
* Add FSE template "Author Archive (Fediverse)" for block themes (WP 6.7+ only)
* Patterns use `selectedUser: "inherit"` for automatic context awareness

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Activate plugin on a block theme (Twenty Twenty-Four or Twenty Twenty-Five)
2. Create a new page → Open block inserter → Search for "Fediverse" or browse the "Fediverse" pattern category
3. Insert each pattern and verify blocks render correctly in the editor
4. Preview the page to confirm frontend rendering
5. Go to Site Editor → Templates → Verify "Author Archive (Fediverse)" template appears
6. Test on a classic theme → Patterns should work, FSE template should not appear

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add pre-built Fediverse block patterns for easy profile, follow page, and sidebar setup.

</details>