### PR TITLE
Fix null comment object in Quote_Request handler

### DIFF
--- a/.github/changelog/2895-from-description
+++ b/.github/changelog/2895-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix null comment object handling in Quote_Request handler.
+Fix PHP warning when deleting quote comments.

--- a/.github/changelog/2895-from-description
+++ b/.github/changelog/2895-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix null comment object handling in Quote_Request handler.

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -113,8 +113,8 @@ class Quote_Request {
 	 * When a local quote comment is deleted, send a Reject activity to revoke
 	 * the previously accepted QuoteRequest.
 	 *
-	 * @param int         $comment_id The comment ID being deleted.
-	 * @param \WP_Comment $comment    The comment object.
+	 * @param int              $comment_id The comment ID being deleted.
+	 * @param \WP_Comment|null $comment    The comment object, or null if not available.
 	 */
 	public static function handle_quote_delete( $comment_id, $comment ) {
 		// Try to get comment if not provided.

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -117,8 +117,13 @@ class Quote_Request {
 	 * @param \WP_Comment $comment    The comment object.
 	 */
 	public static function handle_quote_delete( $comment_id, $comment ) {
+		// Try to get comment if not provided.
+		if ( ! $comment ) {
+			$comment = \get_comment( $comment_id );
+		}
+
 		// Only handle quote comments.
-		if ( 'quote' !== $comment->comment_type ) {
+		if ( ! $comment || 'quote' !== $comment->comment_type ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes a PHP warning: "Attempt to read property 'comment_type' on null"

## Proposed changes:
* Handle edge case where the `delete_comment` hook passes a null comment object by attempting to retrieve it via `get_comment()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Delete a quote comment and verify no PHP warnings occur.
* The fix handles edge cases where the comment object might be null when passed to the `delete_comment` hook.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix null comment object handling in Quote_Request handler.

</details>