### PR TITLE
Fix podcast integrations ignoring content template settings

### DIFF
--- a/.github/changelog/2897-from-description
+++ b/.github/changelog/2897-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix podcast integrations ignoring user-configured content template settings.

--- a/integration/class-podlove-podcast-publisher.php
+++ b/integration/class-podlove-podcast-publisher.php
@@ -9,7 +9,6 @@ namespace Activitypub\Integration;
 
 use Activitypub\Transformer\Post;
 
-use function Activitypub\generate_post_summary;
 use function Activitypub\object_to_uri;
 use function Activitypub\seconds_to_iso8601;
 
@@ -160,17 +159,6 @@ class Podlove_Podcast_Publisher extends Post {
 	 */
 	public function get_type() {
 		return 'Note';
-	}
-
-	/**
-	 * Returns the content for the ActivityPub Item.
-	 *
-	 * The content will be generated based on the user settings.
-	 *
-	 * @return string The content.
-	 */
-	public function get_content() {
-		return generate_post_summary( $this->item );
 	}
 
 	/**

--- a/integration/class-seriously-simple-podcasting.php
+++ b/integration/class-seriously-simple-podcasting.php
@@ -9,7 +9,6 @@ namespace Activitypub\Integration;
 
 use Activitypub\Transformer\Post;
 
-use function Activitypub\generate_post_summary;
 use function Activitypub\object_to_uri;
 
 /**
@@ -57,16 +56,5 @@ class Seriously_Simple_Podcasting extends Post {
 	 */
 	public function get_type() {
 		return 'Note';
-	}
-
-	/**
-	 * Returns the content for the ActivityPub Item.
-	 *
-	 * The content will be generated based on the user settings.
-	 *
-	 * @return string The content.
-	 */
-	public function get_content() {
-		return generate_post_summary( $this->item );
 	}
 }

--- a/tests/phpunit/tests/integration/class-test-podlove-podcast-publisher.php
+++ b/tests/phpunit/tests/integration/class-test-podlove-podcast-publisher.php
@@ -41,7 +41,7 @@ class Test_Podlove_Podcast_Publisher extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_content returns summary.
+	 * Test that content is generated using the template engine.
 	 *
 	 * @covers ::get_content
 	 */
@@ -58,10 +58,10 @@ class Test_Podlove_Podcast_Publisher extends \WP_UnitTestCase {
 		$post = \get_post( $post );
 
 		$transformer = new \Activitypub\Integration\Podlove_Podcast_Publisher( $post );
-		$content     = $transformer->get_content();
+		$object      = $transformer->to_object();
 
-		$this->assertNotEmpty( $content );
-		$this->assertIsString( $content );
+		$this->assertNotEmpty( $object->get_content() );
+		$this->assertIsString( $object->get_content() );
 
 		// Clean up.
 		\wp_delete_post( $post->ID, true );


### PR DESCRIPTION
Fixes #2896

## Proposed changes:
* Remove `get_content()` overrides from Podlove Podcast Publisher and Seriously Simple Podcasting integrations that were bypassing the template engine by using `generate_post_summary()` directly.
* Podcast episodes now use the parent `Post::get_content()` method, which properly applies user-configured content templates.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install and activate either Podlove Podcast Publisher or Seriously Simple Podcasting alongside ActivityPub.
* Go to Settings > ActivityPub and configure a custom content template (e.g. include `[ap_permalink]`).
* Create or update a podcast episode.
* Verify the federated post uses the configured template instead of a plain text summary.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix podcast integrations ignoring user-configured content template settings.

</details>