### PR TITLE
Change sideloading changelog significance to patch

### DIFF
--- a/.github/changelog/add-disable-sideloading-option
+++ b/.github/changelog/add-disable-sideloading-option
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Add option to disable direct file sideloading via `ACTIVITYPUB_DISABLE_SIDELOADING` constant or `activitypub_sideloading_enabled` filter, and `activitypub_remote_media_url` filter for CDN proxying.


### PR DESCRIPTION
## Proposed changes:
* Change the `add-disable-sideloading-option` changelog entry significance from `minor` to `patch`, since the sideloading disable option is a configuration-only addition that doesn't affect default behavior.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Verify the changelog file at `.github/changelog/add-disable-sideloading-option` has `Significance: patch`.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [x] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [ ] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Change sideloading changelog significance from minor to patch.

</details>