### PR TITLE
Add Fediverse Stats dashboard widget

### DIFF
--- a/.github/changelog/add-dashboard-stats-widget
+++ b/.github/changelog/add-dashboard-stats-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a Fediverse Stats dashboard widget displaying followers, likes, reposts, and comment counts with onboarding tips for new users.

--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -401,6 +401,61 @@ input.blog-user-identifier {
 	}
 }
 
+/* stylelint-disable no-descending-specificity */
+
+/* Dashboard Stats Widget */
+.activitypub-dashboard-stats-grid {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 12px;
+	margin-bottom: 12px;
+}
+
+.activitypub-dashboard-stat-card {
+	background: #f6f7f7;
+	border-radius: 4px;
+	padding: 16px;
+	display: flex;
+	flex-direction: column;
+}
+
+.activitypub-dashboard-stat-card .dashicons {
+	font-size: 20px;
+	width: 20px;
+	height: 20px;
+	color: #50575e;
+	margin-bottom: 8px;
+}
+
+.activitypub-dashboard-stat-label {
+	font-size: 12px;
+	color: #50575e;
+	margin-bottom: 4px;
+}
+
+.activitypub-dashboard-stat-value {
+	font-size: 28px;
+	font-weight: 600;
+	line-height: 1.2;
+	color: #1d2327;
+}
+
+.activitypub-dashboard-onboarding {
+	border-top: 1px solid #f0f0f1;
+	padding-top: 12px;
+}
+
+.activitypub-dashboard-onboarding p {
+	margin: 0 0 8px;
+	font-size: 13px;
+	color: #50575e;
+}
+
+.activitypub-dashboard-onboarding p:last-child {
+	margin-bottom: 0;
+}
+/* stylelint-enable no-descending-specificity */
+
 @media screen and (max-width: 782px) {
 
 	.activitypub-settings {
@@ -410,5 +465,9 @@ input.blog-user-identifier {
 	.activitypub-settings .row > div {
 		max-width: calc(100% - 36px);
 		width: 100%;
+	}
+
+	.activitypub-dashboard-stats-grid {
+		grid-template-columns: 1fr;
 	}
 }

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -11,7 +11,6 @@ use Activitypub\Blocklist_Subscriptions;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 use Activitypub\Comment;
-use Activitypub\Model\Blog;
 use Activitypub\Moderation;
 use Activitypub\Scheduler\Actor;
 use Activitypub\Tombstone;
@@ -75,6 +74,8 @@ class Admin {
 		\add_action( 'admin_print_footer_scripts-settings_page_activitypub', array( self::class, 'open_help_tab' ) );
 
 		\add_action( 'wp_dashboard_setup', array( self::class, 'add_dashboard_widgets' ) );
+
+		Dashboard_Widget::init();
 
 		\add_action( 'wp_ajax_activitypub_moderation_settings', array( self::class, 'ajax_moderation_settings' ) );
 		\add_action( 'wp_ajax_activitypub_blocklist_subscription', array( self::class, 'ajax_blocklist_subscription' ) );
@@ -959,12 +960,6 @@ class Admin {
 	 */
 	public static function add_dashboard_widgets() {
 		\wp_add_dashboard_widget( 'activitypub_blog', \__( 'ActivityPub Plugin News', 'activitypub' ), array( self::class, 'blog_dashboard_widget' ) );
-		if ( user_can_activitypub( \get_current_user_id() ) && ! is_user_type_disabled( 'user' ) ) {
-			\wp_add_dashboard_widget( 'activitypub_profile', \__( 'ActivityPub Author profile', 'activitypub' ), array( self::class, 'profile_dashboard_widget' ) );
-		}
-		if ( ! is_user_type_disabled( 'blog' ) ) {
-			\wp_add_dashboard_widget( 'activitypub_blog_profile', \__( 'ActivityPub Blog profile', 'activitypub' ), array( self::class, 'blogprofile_dashboard_widget' ) );
-		}
 	}
 
 	/**
@@ -982,48 +977,6 @@ class Admin {
 			)
 		);
 		echo '</div>';
-	}
-
-	/**
-	 * Add the ActivityPub Author profile as a Dashboard widget.
-	 */
-	public static function profile_dashboard_widget() {
-		$user = Actors::get_by_id( \get_current_user_id() );
-		?>
-		<p>
-			<?php \esc_html_e( 'People can follow you by using your author name:', 'activitypub' ); ?>
-		</p>
-		<p><label for="activitypub-user-identifier"><?php \esc_html_e( 'Username', 'activitypub' ); ?></label><input type="text" class="large-text code" id="activitypub-user-identifier" value="<?php echo \esc_attr( $user->get_webfinger() ); ?>" readonly /></p>
-		<p><label for="activitypub-user-url"><?php \esc_html_e( 'Profile URL', 'activitypub' ); ?></label><input type="text" class="large-text code" id="activitypub-user-url" value="<?php echo \esc_attr( $user->get_url() ); ?>" readonly /></p>
-		<p>
-			<?php \esc_html_e( 'Authors who can not access this settings page will find their username on the "Edit Profile" page.', 'activitypub' ); ?>
-			<a href="<?php echo \esc_url( \admin_url( '/profile.php#activitypub' ) ); ?>">
-			<?php \esc_html_e( 'Customize username on "Edit Profile" page.', 'activitypub' ); ?>
-			</a>
-		</p>
-		<?php
-	}
-
-	/**
-	 * Add the ActivityPub Blog profile as a Dashboard widget.
-	 */
-	public static function blogprofile_dashboard_widget() {
-		$user = new Blog();
-		?>
-		<p>
-			<?php \esc_html_e( 'People can follow your blog by using:', 'activitypub' ); ?>
-		</p>
-		<p><label for="activitypub-user-identifier"><?php \esc_html_e( 'Username', 'activitypub' ); ?></label><input type="text" class="large-text code" id="activitypub-user-identifier" value="<?php echo \esc_attr( $user->get_webfinger() ); ?>" readonly /></p>
-		<p><label for="activitypub-user-url"><?php \esc_html_e( 'Profile URL', 'activitypub' ); ?></label><input type="text" class="large-text code" id="activitypub-user-url" value="<?php echo \esc_attr( $user->get_url() ); ?>" readonly /></p>
-		<p>
-			<?php \esc_html_e( 'This blog profile will federate all posts written on your blog, regardless of the author who posted it.', 'activitypub' ); ?>
-			<?php if ( current_user_can( 'manage_options' ) ) : ?>
-			<a href="<?php echo \esc_url( \admin_url( '/options-general.php?page=activitypub&tab=blog-profile' ) ); ?>">
-				<?php \esc_html_e( 'Customize the blog profile.', 'activitypub' ); ?>
-			</a>
-			<?php endif; ?>
-		</p>
-		<?php
 	}
 
 	/**

--- a/includes/wp-admin/class-dashboard-widget.php
+++ b/includes/wp-admin/class-dashboard-widget.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Dashboard Widget Class.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\WP_Admin;
+
+use Activitypub\Collection\Actors;
+use Activitypub\Collection\Following;
+
+use function Activitypub\count_followers;
+use function Activitypub\is_user_type_disabled;
+use function Activitypub\user_can_activitypub;
+
+/**
+ * ActivityPub Dashboard Widget.
+ *
+ * Provides a Fediverse Stats widget for the WordPress dashboard.
+ */
+class Dashboard_Widget {
+
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_action( 'wp_dashboard_setup', array( self::class, 'register' ) );
+	}
+
+	/**
+	 * Register the dashboard widget.
+	 */
+	public static function register() {
+		if ( ! user_can_activitypub( \get_current_user_id() ) && ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		\wp_add_dashboard_widget(
+			'activitypub_stats',
+			\__( 'Fediverse Stats', 'activitypub' ),
+			array( self::class, 'render' )
+		);
+	}
+
+	/**
+	 * Get the user ID for stats.
+	 *
+	 * Returns the blog user ID if user type is disabled, otherwise the current user ID.
+	 *
+	 * @return int The user ID.
+	 */
+	private static function get_stats_user_id() {
+		if ( is_user_type_disabled( 'user' ) ) {
+			return Actors::BLOG_USER_ID;
+		}
+
+		return \get_current_user_id();
+	}
+
+	/**
+	 * Render the dashboard widget.
+	 */
+	public static function render() {
+		$user_id = self::get_stats_user_id();
+		$stats   = self::get_stats( $user_id );
+
+		\add_filter( 'number_format_i18n', '\Activitypub\custom_large_numbers', 10, 2 );
+
+		self::render_stats_grid( $stats );
+		self::render_onboarding( $stats, $user_id );
+
+		\remove_filter( 'number_format_i18n', '\Activitypub\custom_large_numbers' );
+	}
+
+	/**
+	 * Get stats for a given user.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return array {
+	 *     Stats for the user.
+	 *
+	 *     @type int $followers Number of followers.
+	 *     @type int $following Number of accounts being followed.
+	 *     @type int $likes     Number of likes received.
+	 *     @type int $reposts   Number of reposts received.
+	 *     @type int $comments  Number of federated comments received.
+	 * }
+	 */
+	public static function get_stats( $user_id ) {
+		$post_author_query = array();
+
+		if ( Actors::BLOG_USER_ID !== $user_id ) {
+			$post_author_query = array( 'post_author' => $user_id );
+		}
+
+		$following_count = 0;
+		if ( '1' === \get_option( 'activitypub_following_ui', '0' ) ) {
+			$following_count = (int) Following::count( $user_id );
+		}
+
+		return array(
+			'followers' => (int) count_followers( $user_id ),
+			'following' => $following_count,
+			'likes'     => (int) self::count_interactions_by_type( 'like', $post_author_query ),
+			'reposts'   => (int) self::count_interactions_by_type( 'repost', $post_author_query ),
+			'comments'  => (int) self::count_interactions_by_type( 'comment', $post_author_query ),
+		);
+	}
+
+	/**
+	 * Count interactions by comment type with activitypub protocol meta.
+	 *
+	 * @param string $type               The comment type (e.g. 'like', 'repost').
+	 * @param array  $post_author_query  Optional. Array with 'post_author' key to scope to a specific user's posts.
+	 *
+	 * @return int The count of matching interactions.
+	 */
+	private static function count_interactions_by_type( $type, $post_author_query ) {
+		$args = array(
+			'status'     => 'approve',
+			'type'       => $type,
+			'count'      => true,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query' => array(
+				array(
+					'key'   => 'protocol',
+					'value' => 'activitypub',
+				),
+			),
+		);
+
+		if ( ! empty( $post_author_query['post_author'] ) ) {
+			$args['post_author'] = $post_author_query['post_author'];
+		}
+
+		return (int) \get_comments( $args );
+	}
+
+	/**
+	 * Render the stats grid.
+	 *
+	 * @param array $stats The stats array from get_stats().
+	 */
+	private static function render_stats_grid( $stats ) {
+		$cards = array(
+			array(
+				'icon'  => 'dashicons-groups',
+				'label' => \__( 'Followers', 'activitypub' ),
+				'value' => $stats['followers'],
+			),
+		);
+
+		if ( '1' === \get_option( 'activitypub_following_ui', '0' ) ) {
+			$cards[] = array(
+				'icon'  => 'dashicons-admin-users',
+				'label' => \__( 'Following', 'activitypub' ),
+				'value' => $stats['following'],
+			);
+		}
+
+		$cards[] = array(
+			'icon'  => 'dashicons-heart',
+			'label' => \__( 'Likes', 'activitypub' ),
+			'value' => $stats['likes'],
+		);
+		$cards[] = array(
+			'icon'  => 'dashicons-controls-repeat',
+			'label' => \__( 'Reposts', 'activitypub' ),
+			'value' => $stats['reposts'],
+		);
+		$cards[] = array(
+			'icon'  => 'dashicons-admin-comments',
+			'label' => \__( 'Comments', 'activitypub' ),
+			'value' => $stats['comments'],
+		);
+
+		?>
+		<div class="activitypub-dashboard-stats-grid">
+			<?php foreach ( $cards as $card ) : ?>
+				<div class="activitypub-dashboard-stat-card">
+					<span class="dashicons <?php echo \esc_attr( $card['icon'] ); ?>" aria-hidden="true"></span>
+					<span class="activitypub-dashboard-stat-label"><?php echo \esc_html( $card['label'] ); ?></span>
+					<span class="activitypub-dashboard-stat-value"><?php echo \esc_html( \number_format_i18n( $card['value'] ) ); ?></span>
+				</div>
+			<?php endforeach; ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render onboarding tips.
+	 *
+	 * @param array $stats   The stats array from get_stats().
+	 * @param int   $user_id The user ID.
+	 */
+	private static function render_onboarding( $stats, $user_id ) {
+		$tips = array();
+
+		if ( 0 === $stats['followers'] ) {
+			$tips[] = \sprintf(
+				/* translators: %s: URL to the ActivityPub settings page. */
+				\__( 'Share your Fediverse handle from the <a href="%s">settings page</a> so people can find and follow you.', 'activitypub' ),
+				\esc_url( \admin_url( 'options-general.php?page=activitypub' ) )
+			);
+
+			if ( \wp_is_block_theme() ) {
+				$tips[] = \sprintf(
+					/* translators: %s: URL to the site editor. */
+					\__( 'Add a <strong>Follow Me</strong> block to your site using the <a href="%s">site editor</a>.', 'activitypub' ),
+					\esc_url( \admin_url( 'site-editor.php' ) )
+				);
+			}
+		}
+
+		/**
+		 * Filters the dashboard widget onboarding tips.
+		 *
+		 * @param array $tips    The array of tip HTML strings.
+		 * @param array $stats   The stats array.
+		 * @param int   $user_id The user ID.
+		 */
+		$tips = \apply_filters( 'activitypub_dashboard_widget_tips', $tips, $stats, $user_id );
+
+		if ( empty( $tips ) ) {
+			return;
+		}
+
+		?>
+		<div class="activitypub-dashboard-onboarding">
+			<?php foreach ( $tips as $tip ) : ?>
+				<p><?php echo \wp_kses_post( $tip ); ?></p>
+			<?php endforeach; ?>
+		</div>
+		<?php
+	}
+}

--- a/tests/phpunit/tests/includes/wp-admin/class-test-dashboard-widget.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-dashboard-widget.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Collection\Actors;
 use Activitypub\WP_Admin\Dashboard_Widget;
 
 /**
@@ -174,5 +175,18 @@ class Test_Dashboard_Widget extends \WP_UnitTestCase {
 		Dashboard_Widget::register();
 
 		$this->assertArrayHasKey( 'activitypub_stats', $wp_meta_boxes['dashboard']['normal']['core'] );
+	}
+
+	/**
+	 * Test get_stats with blog user ID.
+	 *
+	 * @covers ::get_stats
+	 */
+	public function test_get_stats_for_blog_user() {
+		$stats = Dashboard_Widget::get_stats( Actors::BLOG_USER_ID );
+
+		$this->assertArrayHasKey( 'followers', $stats );
+		$this->assertArrayHasKey( 'likes', $stats );
+		$this->assertSame( 0, $stats['followers'] );
 	}
 }

--- a/tests/phpunit/tests/includes/wp-admin/class-test-dashboard-widget.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-dashboard-widget.php
@@ -153,4 +153,26 @@ class Test_Dashboard_Widget extends \WP_UnitTestCase {
 
 		$this->assertSame( 1, $stats['comments'] );
 	}
+
+	/**
+	 * Test register adds widget to global.
+	 *
+	 * @covers ::register
+	 */
+	public function test_register_adds_widget() {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'activitypub' );
+
+		wp_set_current_user( $user_id );
+		set_current_screen( 'dashboard' );
+
+		Dashboard_Widget::register();
+
+		$this->assertArrayHasKey( 'activitypub_stats', $wp_meta_boxes['dashboard']['normal']['core'] );
+	}
 }

--- a/tests/phpunit/tests/includes/wp-admin/class-test-dashboard-widget.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-dashboard-widget.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Test file for Dashboard_Widget.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+use Activitypub\WP_Admin\Dashboard_Widget;
+
+/**
+ * Test class for Dashboard_Widget.
+ *
+ * @coversDefaultClass \Activitypub\WP_Admin\Dashboard_Widget
+ */
+class Test_Dashboard_Widget extends \WP_UnitTestCase {
+
+	/**
+	 * Test that get_stats returns an array with the expected keys, all integers.
+	 *
+	 * @covers ::get_stats
+	 */
+	public function test_get_stats_returns_expected_keys() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'activitypub' );
+		\wp_set_current_user( $user_id );
+
+		$stats = Dashboard_Widget::get_stats( $user_id );
+
+		$this->assertIsArray( $stats );
+		$this->assertArrayHasKey( 'followers', $stats );
+		$this->assertArrayHasKey( 'following', $stats );
+		$this->assertArrayHasKey( 'likes', $stats );
+		$this->assertArrayHasKey( 'reposts', $stats );
+		$this->assertArrayHasKey( 'comments', $stats );
+
+		$this->assertIsInt( $stats['followers'] );
+		$this->assertIsInt( $stats['following'] );
+		$this->assertIsInt( $stats['likes'] );
+		$this->assertIsInt( $stats['reposts'] );
+		$this->assertIsInt( $stats['comments'] );
+	}
+
+	/**
+	 * Test that a fresh user has all zeros for stats.
+	 *
+	 * @covers ::get_stats
+	 */
+	public function test_get_stats_returns_zero_for_new_user() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'activitypub' );
+		\wp_set_current_user( $user_id );
+
+		$stats = Dashboard_Widget::get_stats( $user_id );
+
+		$this->assertSame( 0, $stats['followers'] );
+		$this->assertSame( 0, $stats['following'] );
+		$this->assertSame( 0, $stats['likes'] );
+		$this->assertSame( 0, $stats['reposts'] );
+		$this->assertSame( 0, $stats['comments'] );
+	}
+
+	/**
+	 * Test that get_stats counts likes correctly.
+	 *
+	 * @covers ::get_stats
+	 */
+	public function test_get_stats_counts_likes() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'activitypub' );
+		\wp_set_current_user( $user_id );
+
+		$post_id = self::factory()->post->create( array( 'post_author' => $user_id ) );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_type'     => 'like',
+				'comment_approved' => 1,
+			)
+		);
+		\add_comment_meta( $comment_id, 'protocol', 'activitypub' );
+
+		$stats = Dashboard_Widget::get_stats( $user_id );
+
+		$this->assertSame( 1, $stats['likes'] );
+	}
+
+	/**
+	 * Test that get_stats counts reposts correctly.
+	 *
+	 * @covers ::get_stats
+	 */
+	public function test_get_stats_counts_reposts() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'activitypub' );
+		\wp_set_current_user( $user_id );
+
+		$post_id = self::factory()->post->create( array( 'post_author' => $user_id ) );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_type'     => 'repost',
+				'comment_approved' => 1,
+			)
+		);
+		\add_comment_meta( $comment_id, 'protocol', 'activitypub' );
+
+		$stats = Dashboard_Widget::get_stats( $user_id );
+
+		$this->assertSame( 1, $stats['reposts'] );
+	}
+
+	/**
+	 * Test that get_stats counts only federated comments, not local ones.
+	 *
+	 * @covers ::get_stats
+	 */
+	public function test_get_stats_counts_federated_comments() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'activitypub' );
+		\wp_set_current_user( $user_id );
+
+		$post_id = self::factory()->post->create( array( 'post_author' => $user_id ) );
+
+		// Federated comment (has protocol meta).
+		$federated_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_type'     => 'comment',
+				'comment_approved' => 1,
+			)
+		);
+		\add_comment_meta( $federated_comment_id, 'protocol', 'activitypub' );
+
+		// Local comment (no protocol meta).
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_type'     => 'comment',
+				'comment_approved' => 1,
+			)
+		);
+
+		$stats = Dashboard_Widget::get_stats( $user_id );
+
+		$this->assertSame( 1, $stats['comments'] );
+	}
+}


### PR DESCRIPTION
Fixes #451

> [!CAUTION]
> This is just a proof of concept, nothing more for now. It has now been fully tested or vetted.

## Proposed changes:

* Add a new **Fediverse Stats** dashboard widget that displays key ActivityPub metrics: followers, following (when enabled), likes, reposts, and federated comments.
* Each stat is shown as a card in a 2-column grid with a dashicon, label, and large formatted number (using `number_format_i18n` with the existing `custom_large_numbers` filter for K/M/B suffixes).
* Include onboarding tips when a user has no followers yet — linking to the settings page and suggesting the Follow Me block for block themes.
* Onboarding tips are filterable via `activitypub_dashboard_widget_tips`.
* Remove the old profile/blog-profile dashboard widgets (replaced by this unified widget).
* Responsive: switches to single-column layout on mobile.

See also #1736 for related discussion.

<img width="458" height="463" alt="Screenshot 2026-02-10 at 21 49 15" src="https://github.com/user-attachments/assets/df0dbbdb-7188-489e-9814-85b42d9cf215" />


### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Go to the WordPress admin dashboard (wp-admin).
* Verify a **Fediverse Stats** widget appears with cards for Followers, Likes, Reposts, and Comments (all showing 0 for a fresh install).
* If the Following UI is enabled (`activitypub_following_ui` option set to `1`), verify a Following card also appears.
* With 0 followers, verify onboarding tips are displayed:
  * A link to the ActivityPub settings page.
  * If using a block theme, a suggestion to add the Follow Me block via the site editor.
* Create a post, then simulate ActivityPub interactions (likes, reposts, comments with `protocol` = `activitypub` comment meta) and verify the counts update.
* Verify numbers are properly formatted for the current locale.
* Test on a narrow viewport (< 782px) to confirm the grid switches to single-column.
* Verify the widget only shows for users with `activitypub` capability or `manage_options`.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add a Fediverse Stats dashboard widget displaying followers, likes, reposts, and comment counts with onboarding tips for new users.

</details>