### PR TITLE
Add `wp activitypub fetch` CLI command

### DIFF
--- a/.github/changelog/2906-from-description
+++ b/.github/changelog/2906-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add `wp activitypub fetch` CLI command for fetching remote URLs with signed HTTP requests.

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -30,6 +30,7 @@ class Cli {
 	 * - wp activitypub self-destruct [--status] [--yes]
 	 * - wp activitypub move <from> <to>
 	 * - wp activitypub follow <remote_user>
+	 * - wp activitypub fetch <url>
 	 */
 	public static function register() {
 		// Register parent command with version subcommand.
@@ -94,6 +95,14 @@ class Cli {
 			'\Activitypub\Cli\Follow_Command',
 			array(
 				'shortdesc' => 'Follow a remote ActivityPub user.',
+			)
+		);
+
+		\WP_CLI::add_command(
+			'activitypub fetch',
+			'\Activitypub\Cli\Fetch_Command',
+			array(
+				'shortdesc' => 'Fetch a remote URL with a signed ActivityPub request.',
 			)
 		);
 	}

--- a/includes/cli/class-fetch-command.php
+++ b/includes/cli/class-fetch-command.php
@@ -33,7 +33,7 @@ class Fetch_Command extends \WP_CLI_Command {
 	 * : The URL to fetch.
 	 *
 	 * [--signature=<mode>]
-	 * : Signature mode: draft-cavage, rfc9421, double-knock, or none.
+	 * : Signature mode: default (plugin-configured), draft-cavage, rfc9421, double-knock, or none.
 	 * ---
 	 * default: default
 	 * options:
@@ -92,7 +92,7 @@ class Fetch_Command extends \WP_CLI_Command {
 		$cleanup();
 
 		if ( \is_wp_error( $response ) ) {
-			\WP_CLI::error( \sprintf( 'Request failed: %s (HTTP %s).', $response->get_error_message(), $response->get_error_code() ) );
+			\WP_CLI::error( \sprintf( 'Request failed: %s (Error code: %s).', $response->get_error_message(), $response->get_error_code() ) );
 		}
 
 		$code = \wp_remote_retrieve_response_code( $response );
@@ -121,7 +121,7 @@ class Fetch_Command extends \WP_CLI_Command {
 		} else {
 			$data = \json_decode( $body, true );
 
-			if ( null !== $data ) {
+			if ( \JSON_ERROR_NONE === \json_last_error() ) {
 				\WP_CLI::log( \wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 			} else {
 				\WP_CLI::log( $body );
@@ -145,6 +145,9 @@ class Fetch_Command extends \WP_CLI_Command {
 		$restore = array();
 
 		switch ( $mode ) {
+			case 'default':
+				break;
+
 			case 'none':
 				$args['key_id']      = null;
 				$args['private_key'] = null;
@@ -155,12 +158,13 @@ class Fetch_Command extends \WP_CLI_Command {
 				// Replace default signing to force RFC 9421. For rfc9421 mode,
 				// also disable double-knock to prevent an infinite retry loop.
 				// For double-knock mode, keep it active but skip re-signing on retry.
-				\remove_filter( 'http_request_args', array( Signature::class, 'sign_request' ), 0 );
+				$removed_sign_request = \remove_filter( 'http_request_args', array( Signature::class, 'sign_request' ), 0 );
 
-				$is_double_knock = 'double-knock' === $mode;
+				$is_double_knock      = 'double-knock' === $mode;
+				$removed_double_knock = false;
 
 				if ( ! $is_double_knock ) {
-					\remove_filter( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10 );
+					$removed_double_knock = \remove_filter( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10 );
 				}
 
 				$forced_signer = function ( $request_args, $url ) use ( $is_double_knock ) {
@@ -176,9 +180,12 @@ class Fetch_Command extends \WP_CLI_Command {
 				\add_filter( 'http_request_args', $forced_signer, 0, 2 );
 
 				$filters[] = array( 'http_request_args', $forced_signer, 0 );
-				$restore[] = array( 'http_request_args', array( Signature::class, 'sign_request' ), 0, 2 );
 
-				if ( ! $is_double_knock ) {
+				if ( $removed_sign_request ) {
+					$restore[] = array( 'http_request_args', array( Signature::class, 'sign_request' ), 0, 2 );
+				}
+
+				if ( $removed_double_knock ) {
 					$restore[] = array( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10, 3 );
 				}
 				break;
@@ -192,6 +199,14 @@ class Fetch_Command extends \WP_CLI_Command {
 
 				$filters[] = array( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
 				break;
+
+			default:
+				\WP_CLI::error(
+					\sprintf(
+						'Invalid signature mode "%s". Allowed modes: default, draft-cavage, rfc9421, double-knock, none.',
+						$mode
+					)
+				);
 		}
 
 		return function () use ( $filters, $restore ) {

--- a/includes/cli/class-fetch-command.php
+++ b/includes/cli/class-fetch-command.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Cli;
 
 use Activitypub\Http;
+use Activitypub\Signature;
 
 /**
  * Fetch a remote ActivityPub URL with signed HTTP requests.
@@ -86,7 +87,7 @@ class Fetch_Command extends \WP_CLI_Command {
 		$cleanup();
 
 		if ( \is_wp_error( $response ) ) {
-			\WP_CLI::error( \sprintf( 'Request failed (HTTP %s).', $response->get_error_code() ) );
+			\WP_CLI::error( \sprintf( 'Request failed: %s (HTTP %s).', $response->get_error_message(), $response->get_error_code() ) );
 		}
 
 		$code = \wp_remote_retrieve_response_code( $response );
@@ -115,7 +116,7 @@ class Fetch_Command extends \WP_CLI_Command {
 		} else {
 			$data = \json_decode( $body, true );
 
-			if ( $data ) {
+			if ( null !== $data ) {
 				\WP_CLI::log( \wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 			} else {
 				\WP_CLI::log( $body );
@@ -133,6 +134,7 @@ class Fetch_Command extends \WP_CLI_Command {
 	 */
 	private function apply_signature_mode( $mode, &$args ) {
 		$filters = array();
+		$restore = array();
 
 		switch ( $mode ) {
 			case 'none':
@@ -150,9 +152,11 @@ class Fetch_Command extends \WP_CLI_Command {
 
 				\add_filter( 'pre_option_activitypub_rfc9421_signature', $force_rfc9421 );
 				\add_filter( 'pre_option_activitypub_rfc9421_unsupported', $bypass_unsupported );
+				\remove_filter( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10 );
 
 				$filters[] = array( 'pre_option_activitypub_rfc9421_signature', $force_rfc9421 );
 				$filters[] = array( 'pre_option_activitypub_rfc9421_unsupported', $bypass_unsupported );
+				$restore[] = array( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10, 3 );
 				break;
 
 			case 'draft-cavage':
@@ -166,9 +170,12 @@ class Fetch_Command extends \WP_CLI_Command {
 				break;
 		}
 
-		return function () use ( $filters ) {
+		return function () use ( $filters, $restore ) {
 			foreach ( $filters as $filter ) {
 				\remove_filter( $filter[0], $filter[1] );
+			}
+			foreach ( $restore as $filter ) {
+				\add_filter( $filter[0], $filter[1], $filter[2], $filter[3] );
 			}
 		};
 	}

--- a/includes/cli/class-fetch-command.php
+++ b/includes/cli/class-fetch-command.php
@@ -9,6 +9,7 @@ namespace Activitypub\Cli;
 
 use Activitypub\Http;
 use Activitypub\Signature;
+use Activitypub\Signature\Http_Message_Signature;
 
 /**
  * Fetch a remote ActivityPub URL with signed HTTP requests.
@@ -125,12 +126,15 @@ class Fetch_Command extends \WP_CLI_Command {
 	}
 
 	/**
-	 * Apply signature mode overrides via option filters.
+	 * Apply signature mode overrides via filters.
+	 *
+	 * For rfc9421, replaces the default sign_request and disables double-knock
+	 * to avoid an infinite retry loop when the server returns 4xx.
 	 *
 	 * @param string $mode The signature mode.
 	 * @param array  $args The request arguments, passed by reference.
 	 *
-	 * @return callable Cleanup callback to remove added filters.
+	 * @return callable Cleanup callback to restore original filters.
 	 */
 	private function apply_signature_mode( $mode, &$args ) {
 		$filters = array();
@@ -143,19 +147,21 @@ class Fetch_Command extends \WP_CLI_Command {
 				break;
 
 			case 'rfc9421':
-				$force_rfc9421      = function () {
-					return '1';
-				};
-				$bypass_unsupported = function () {
-					return array();
-				};
-
-				\add_filter( 'pre_option_activitypub_rfc9421_signature', $force_rfc9421 );
-				\add_filter( 'pre_option_activitypub_rfc9421_unsupported', $bypass_unsupported );
+				// Replace default signing to force RFC 9421 and prevent
+				// double-knock from re-signing with Draft Cavage in a loop.
+				\remove_filter( 'http_request_args', array( Signature::class, 'sign_request' ), 0 );
 				\remove_filter( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10 );
 
-				$filters[] = array( 'pre_option_activitypub_rfc9421_signature', $force_rfc9421 );
-				$filters[] = array( 'pre_option_activitypub_rfc9421_unsupported', $bypass_unsupported );
+				$forced_signer = function ( $request_args, $url ) {
+					if ( ! isset( $request_args['key_id'], $request_args['private_key'] ) ) {
+						return $request_args;
+					}
+					return ( new Http_Message_Signature() )->sign( $request_args, $url );
+				};
+				\add_filter( 'http_request_args', $forced_signer, 0, 2 );
+
+				$filters[] = array( 'http_request_args', $forced_signer, 0 );
+				$restore[] = array( 'http_request_args', array( Signature::class, 'sign_request' ), 0, 2 );
 				$restore[] = array( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10, 3 );
 				break;
 
@@ -172,7 +178,7 @@ class Fetch_Command extends \WP_CLI_Command {
 
 		return function () use ( $filters, $restore ) {
 			foreach ( $filters as $filter ) {
-				\remove_filter( $filter[0], $filter[1] );
+				\remove_filter( $filter[0], $filter[1], $filter[2] ?? 10 );
 			}
 			foreach ( $restore as $filter ) {
 				\add_filter( $filter[0], $filter[1], $filter[2], $filter[3] );

--- a/includes/cli/class-fetch-command.php
+++ b/includes/cli/class-fetch-command.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Fetch CLI Command.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Cli;
+
+use Activitypub\Http;
+
+/**
+ * Fetch a remote ActivityPub URL with signed HTTP requests.
+ *
+ * Useful for debugging HTTP Signatures and federation issues.
+ * Signs requests as the application actor by default.
+ *
+ * @package Activitypub
+ */
+class Fetch_Command extends \WP_CLI_Command {
+
+	/**
+	 * Fetch a remote ActivityPub URL with a signed HTTP request.
+	 *
+	 * Signs the request as the application actor and displays the response.
+	 * Supports switching between signature modes for debugging.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <url>
+	 * : The URL to fetch.
+	 *
+	 * [--signature=<mode>]
+	 * : Signature mode: draft-cavage, rfc9421, or none.
+	 * ---
+	 * default: default
+	 * options:
+	 *   - default
+	 *   - draft-cavage
+	 *   - rfc9421
+	 *   - none
+	 * ---
+	 *
+	 * [--raw]
+	 * : Output the raw response body without formatting.
+	 *
+	 * [--include-headers]
+	 * : Show response headers alongside the body.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Fetch an actor profile with default signature
+	 *     $ wp activitypub fetch https://mastodon.social/@Gargron
+	 *
+	 *     # Fetch with RFC 9421 signature
+	 *     $ wp activitypub fetch https://mastodon.social/@Gargron --signature=rfc9421
+	 *
+	 *     # Fetch with Draft Cavage signature
+	 *     $ wp activitypub fetch https://mastodon.social/@Gargron --signature=draft-cavage
+	 *
+	 *     # Fetch without signature
+	 *     $ wp activitypub fetch https://mastodon.social/@Gargron --signature=none
+	 *
+	 *     # Show response headers
+	 *     $ wp activitypub fetch https://mastodon.social/@Gargron --include-headers
+	 *
+	 *     # Output raw response body
+	 *     $ wp activitypub fetch https://mastodon.social/@Gargron --raw
+	 *
+	 * @param array $args       The positional arguments.
+	 * @param array $assoc_args The associative arguments.
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$url             = $args[0];
+		$signature_mode  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'signature', 'default' );
+		$raw             = \WP_CLI\Utils\get_flag_value( $assoc_args, 'raw', false );
+		$include_headers = \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-headers', false );
+
+		\WP_CLI::log( \sprintf( 'Fetching: %s', $url ) );
+		\WP_CLI::log( \sprintf( 'Signature mode: %s', $signature_mode ) );
+
+		$get_args = array();
+		$cleanup  = $this->apply_signature_mode( $signature_mode, $get_args );
+		$response = Http::get( $url, $get_args, false );
+
+		$cleanup();
+
+		if ( \is_wp_error( $response ) ) {
+			\WP_CLI::error( \sprintf( 'Request failed (HTTP %s).', $response->get_error_code() ) );
+		}
+
+		$code = \wp_remote_retrieve_response_code( $response );
+
+		\WP_CLI::log( \sprintf( 'Response code: %d', $code ) );
+		\WP_CLI::log( '' );
+
+		// Show response headers if requested.
+		if ( $include_headers ) {
+			$headers = \wp_remote_retrieve_headers( $response );
+
+			\WP_CLI::log( '--- Response Headers ---' );
+
+			foreach ( $headers as $name => $value ) {
+				\WP_CLI::log( \sprintf( '%s: %s', $name, $value ) );
+			}
+
+			\WP_CLI::log( '' );
+		}
+
+		$body = \wp_remote_retrieve_body( $response );
+
+		// Output the body.
+		if ( $raw ) {
+			\WP_CLI::log( $body );
+		} else {
+			$data = \json_decode( $body, true );
+
+			if ( $data ) {
+				\WP_CLI::log( \wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+			} else {
+				\WP_CLI::log( $body );
+			}
+		}
+	}
+
+	/**
+	 * Apply signature mode overrides via option filters.
+	 *
+	 * @param string $mode The signature mode.
+	 * @param array  $args The request arguments, passed by reference.
+	 *
+	 * @return callable Cleanup callback to remove added filters.
+	 */
+	private function apply_signature_mode( $mode, &$args ) {
+		$filters = array();
+
+		switch ( $mode ) {
+			case 'none':
+				$args['key_id']      = null;
+				$args['private_key'] = null;
+				break;
+
+			case 'rfc9421':
+				$force_rfc9421      = function () {
+					return '1';
+				};
+				$bypass_unsupported = function () {
+					return array();
+				};
+
+				\add_filter( 'pre_option_activitypub_rfc9421_signature', $force_rfc9421 );
+				\add_filter( 'pre_option_activitypub_rfc9421_unsupported', $bypass_unsupported );
+
+				$filters[] = array( 'pre_option_activitypub_rfc9421_signature', $force_rfc9421 );
+				$filters[] = array( 'pre_option_activitypub_rfc9421_unsupported', $bypass_unsupported );
+				break;
+
+			case 'draft-cavage':
+				$force_cavage = function () {
+					return '0';
+				};
+
+				\add_filter( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
+
+				$filters[] = array( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
+				break;
+		}
+
+		return function () use ( $filters ) {
+			foreach ( $filters as $filter ) {
+				\remove_filter( $filter[0], $filter[1] );
+			}
+		};
+	}
+}

--- a/includes/cli/class-fetch-command.php
+++ b/includes/cli/class-fetch-command.php
@@ -33,13 +33,14 @@ class Fetch_Command extends \WP_CLI_Command {
 	 * : The URL to fetch.
 	 *
 	 * [--signature=<mode>]
-	 * : Signature mode: draft-cavage, rfc9421, or none.
+	 * : Signature mode: draft-cavage, rfc9421, double-knock, or none.
 	 * ---
 	 * default: default
 	 * options:
 	 *   - default
 	 *   - draft-cavage
 	 *   - rfc9421
+	 *   - double-knock
 	 *   - none
 	 * ---
 	 *
@@ -59,6 +60,9 @@ class Fetch_Command extends \WP_CLI_Command {
 	 *
 	 *     # Fetch with Draft Cavage signature
 	 *     $ wp activitypub fetch https://mastodon.social/@Gargron --signature=draft-cavage
+	 *
+	 *     # Fetch with double-knock (RFC 9421 first, Draft Cavage fallback on 4xx)
+	 *     $ wp activitypub fetch https://mastodon.social/@Gargron --signature=double-knock
 	 *
 	 *     # Fetch without signature
 	 *     $ wp activitypub fetch https://mastodon.social/@Gargron --signature=none
@@ -147,13 +151,24 @@ class Fetch_Command extends \WP_CLI_Command {
 				break;
 
 			case 'rfc9421':
-				// Replace default signing to force RFC 9421 and prevent
-				// double-knock from re-signing with Draft Cavage in a loop.
+			case 'double-knock':
+				// Replace default signing to force RFC 9421. For rfc9421 mode,
+				// also disable double-knock to prevent an infinite retry loop.
+				// For double-knock mode, keep it active but skip re-signing on retry.
 				\remove_filter( 'http_request_args', array( Signature::class, 'sign_request' ), 0 );
-				\remove_filter( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10 );
 
-				$forced_signer = function ( $request_args, $url ) {
+				$is_double_knock = 'double-knock' === $mode;
+
+				if ( ! $is_double_knock ) {
+					\remove_filter( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10 );
+				}
+
+				$forced_signer = function ( $request_args, $url ) use ( $is_double_knock ) {
 					if ( ! isset( $request_args['key_id'], $request_args['private_key'] ) ) {
+						return $request_args;
+					}
+					// In double-knock mode, skip if already signed (retry from maybe_double_knock).
+					if ( $is_double_knock && ! empty( $request_args['headers']['Signature'] ) ) {
 						return $request_args;
 					}
 					return ( new Http_Message_Signature() )->sign( $request_args, $url );
@@ -162,7 +177,10 @@ class Fetch_Command extends \WP_CLI_Command {
 
 				$filters[] = array( 'http_request_args', $forced_signer, 0 );
 				$restore[] = array( 'http_request_args', array( Signature::class, 'sign_request' ), 0, 2 );
-				$restore[] = array( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10, 3 );
+
+				if ( ! $is_double_knock ) {
+					$restore[] = array( 'http_response', array( Signature::class, 'maybe_double_knock' ), 10, 3 );
+				}
 				break;
 
 			case 'draft-cavage':


### PR DESCRIPTION
## Proposed changes:
* Add a new `wp activitypub fetch` CLI command for fetching remote ActivityPub URLs with signed HTTP requests.
* Support switching between signature modes (`draft-cavage`, `rfc9421`, `double-knock`, `none`) via the `--signature` flag for debugging federation and HTTP Signature issues.
* Delegates to `Http::get()` for request handling and uses filter overrides to force specific signature modes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `wp activitypub fetch https://mastodon.social/@Gargron` — should return the actor profile as pretty-printed JSON.
* Run `wp activitypub fetch https://mastodon.social/@Gargron --signature=rfc9421` — should fetch using RFC 9421 signature.
* Run `wp activitypub fetch https://mastodon.social/@Gargron --signature=draft-cavage` — should fetch using Draft Cavage signature.
* Run `wp activitypub fetch https://mastodon.social/@Gargron --signature=double-knock` — should try RFC 9421 first, fall back to Draft Cavage on 4xx.
* Run `wp activitypub fetch https://mastodon.social/@Gargron --signature=none` — should fetch without signing.
* Run `wp activitypub fetch https://mastodon.social/@Gargron --include-headers` — should show response headers.
* Run `wp activitypub fetch https://mastodon.social/@Gargron --raw` — should output the raw response body.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add `wp activitypub fetch` CLI command for fetching remote URLs with signed HTTP requests.

</details>