### PR TITLE
Add fixture-based Create handler tests for GoToSocial and Akkoma

### DIFF
--- a/tests/phpunit/data/create/akkoma-reply.json
+++ b/tests/phpunit/data/create/akkoma-reply.json
@@ -1,0 +1,85 @@
+{
+	"@context": [
+		"https://www.w3.org/ns/activitystreams",
+		"https://akkoma.example.com/schemas/litepub-0.1.jsonld",
+		{
+			"@language": "und"
+		}
+	],
+	"id": "https://akkoma.example.com/activities/create/2ec68a36-b298-488d-9f99-25b21c336a0f",
+	"type": "Create",
+	"actor": "https://akkoma.example.com/users/testuser",
+	"to": [ "https://www.w3.org/ns/activitystreams#Public" ],
+	"cc": [ "https://akkoma.example.com/users/testuser/followers" ],
+	"object": {
+		"actor": "https://akkoma.example.com/users/testuser",
+		"attachment": [],
+		"attributedTo": "https://akkoma.example.com/users/testuser",
+		"cc": [ "https://akkoma.example.com/users/testuser/followers" ],
+		"content": "@<a href=\"https://example.com/@someone\" rel=\"ugc\">someone@example.com</a> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+		"contentMap": {
+			"en": "@<a href=\"https://example.com/@someone\" rel=\"ugc\">someone@example.com</a> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+		},
+		"context": "https://example.com/context/12345",
+		"conversation": "https://example.com/context/12345",
+		"formerRepresentations": {
+			"orderedItems": [
+				{
+					"actor": "https://akkoma.example.com/users/testuser",
+					"attachment": [],
+					"attributedTo": "https://akkoma.example.com/users/testuser",
+					"cc": [ "https://akkoma.example.com/users/testuser/followers" ],
+					"content": "@<a href=\"https://example.com/@someone\" rel=\"ugc\">someone@example.com</a> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+					"contentMap": {
+						"en": "@<a href=\"https://example.com/@someone\" rel=\"ugc\">someone@example.com</a> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+					},
+					"context": "https://example.com/context/12345",
+					"conversation": "https://example.com/context/12345",
+					"inReplyTo": "{{LOCAL_POST_URL}}",
+					"published": "2026-02-05T16:00:07.036477Z",
+					"sensitive": true,
+					"source": {
+						"content": "@someone@example.com Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+						"mediaType": "text/plain"
+					},
+					"summary": "",
+					"tag": [
+						{
+							"href": "https://example.com/?author=0",
+							"name": "@someone@example.com",
+							"type": "Mention"
+						}
+					],
+					"to": [ "https://example.com/?author=0", "https://www.w3.org/ns/activitystreams#Public" ],
+					"type": "Note"
+				}
+			],
+			"totalItems": 1,
+			"type": "OrderedCollection"
+		},
+		"id": "https://akkoma.example.com/objects/2ec68a36-b298-488d-9f99-25b21c336a0f",
+		"inReplyTo": "{{LOCAL_POST_URL}}",
+		"published": "2026-02-05T16:00:07.036477Z",
+		"replies": {
+			"items": [ "https://akkoma.example.com/objects/495613a4-084a-44c4-a234-f5498e43a78b" ],
+			"type": "Collection"
+		},
+		"repliesCount": 1,
+		"sensitive": true,
+		"source": {
+			"content": "@someone@example.com Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+			"mediaType": "text/plain"
+		},
+		"summary": "",
+		"tag": [
+			{
+				"href": "https://example.com/?author=0",
+				"name": "@someone@example.com",
+				"type": "Mention"
+			}
+		],
+		"to": [ "https://example.com/?author=0", "https://www.w3.org/ns/activitystreams#Public" ],
+		"type": "Note",
+		"updated": "2026-02-05T16:00:25.855603Z"
+	}
+}

--- a/tests/phpunit/data/create/gotosocial-reply.json
+++ b/tests/phpunit/data/create/gotosocial-reply.json
@@ -1,0 +1,58 @@
+{
+	"@context": [
+		"https://gotosocial.org/ns",
+		"https://www.w3.org/ns/activitystreams",
+		{
+			"sensitive": "as:sensitive"
+		}
+	],
+	"id": "https://gotosocial.example.com/users/testuser/statuses/create/01KH6H3G6HA0XX4JS79BWSRD4F",
+	"type": "Create",
+	"actor": "https://gotosocial.example.com/users/testuser",
+	"to": "https://www.w3.org/ns/activitystreams#Public",
+	"cc": [ "https://gotosocial.example.com/users/testuser/followers" ],
+	"object": {
+		"attachment": [],
+		"attributedTo": "https://gotosocial.example.com/users/testuser",
+		"cc": [ "https://gotosocial.example.com/users/testuser/followers" ],
+		"content": "<p><span class=\"h-card\"><a href=\"https://example.com/@someone\" class=\"u-url mention\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">@<span>someone</span></a></span> Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
+		"contentMap": {
+			"en": "<p><span class=\"h-card\"><a href=\"https://example.com/@someone\" class=\"u-url mention\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">@<span>someone</span></a></span> Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>"
+		},
+		"id": "https://gotosocial.example.com/users/testuser/statuses/01KH6H3G6HA0XX4JS79BWSRD4F",
+		"inReplyTo": "{{LOCAL_POST_URL}}",
+		"interactionPolicy": {
+			"canAnnounce": {
+				"always": [ "https://www.w3.org/ns/activitystreams#Public" ],
+				"approvalRequired": []
+			},
+			"canLike": {
+				"always": [ "https://www.w3.org/ns/activitystreams#Public" ],
+				"approvalRequired": []
+			},
+			"canReply": {
+				"always": [ "https://www.w3.org/ns/activitystreams#Public" ],
+				"approvalRequired": []
+			}
+		},
+		"published": "2026-02-11T15:18:55+01:00",
+		"replies": {
+			"first": {
+				"id": "https://gotosocial.example.com/users/testuser/statuses/01KH6H3G6HA0XX4JS79BWSRD4F/replies?page=true",
+				"type": "CollectionPage"
+			},
+			"id": "https://gotosocial.example.com/users/testuser/statuses/01KH6H3G6HA0XX4JS79BWSRD4F/replies",
+			"type": "Collection"
+		},
+		"sensitive": false,
+		"summary": "",
+		"tag": {
+			"href": "https://example.com/?author=0",
+			"name": "@someone@example.com",
+			"type": "Mention"
+		},
+		"to": "https://www.w3.org/ns/activitystreams#Public",
+		"type": "Note",
+		"url": "https://gotosocial.example.com/@testuser/statuses/01KH6H3G6HA0XX4JS79BWSRD4F"
+	}
+}

--- a/tests/phpunit/tests/includes/handler/class-test-create.php
+++ b/tests/phpunit/tests/includes/handler/class-test-create.php
@@ -787,4 +787,52 @@ class Test_Create extends \WP_UnitTestCase {
 		// Clean up.
 		\delete_option( 'activitypub_tombstone_urls' );
 	}
+
+	/**
+	 * Test Create handler with JSON fixtures from data/create/.
+	 *
+	 * Drop a JSON file into tests/phpunit/data/create/ and it will be
+	 * automatically picked up. Use `{{LOCAL_POST_URL}}` as a placeholder
+	 * in `inReplyTo` to target the local test post.
+	 *
+	 * @dataProvider create_fixture_provider
+	 * @covers ::handle_create
+	 *
+	 * @param string $path The path to the fixture JSON file.
+	 */
+	public function test_handle_create_from_fixture( $path ) {
+		$json = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$json = str_replace( '{{LOCAL_POST_URL}}', $this->post_permalink, $json );
+
+		$activity = json_decode( $json, true );
+
+		Create::handle_create( $activity, $this->user_id );
+
+		$comments = ( new \WP_Comment_Query(
+			array(
+				'type'    => 'comment',
+				'post_id' => $this->post_id,
+			)
+		) )->comments;
+
+		$this->assertCount( 1, $comments );
+		$this->assertInstanceOf( 'WP_Comment', $comments[0] );
+		$this->assertStringContainsString( \wp_strip_all_tags( $activity['object']['content'] ), \wp_strip_all_tags( $comments[0]->comment_content ) );
+	}
+
+	/**
+	 * Data provider that discovers JSON fixture files in data/create/.
+	 *
+	 * @return array Array of [ path ] arrays, keyed by fixture name.
+	 */
+	public function create_fixture_provider() {
+		$files    = glob( AP_TESTS_DIR . '/data/create/*.json' );
+		$fixtures = array();
+
+		foreach ( $files as $path ) {
+			$fixtures[ basename( $path, '.json' ) ] = array( $path );
+		}
+
+		return $fixtures;
+	}
 }


### PR DESCRIPTION
## Proposed changes:

* Add a data provider to `Test_Create` that auto-discovers JSON fixture files in `tests/phpunit/data/create/`.
* Add GoToSocial and Akkoma reply fixtures with platform-specific quirks (string `to`, object `tag`, `interactionPolicy`, litepub `@context`, `formerRepresentations`, etc.).
* New platform tests can be added by dropping a JSON file into the folder — no code changes needed.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run env-test -- --filter=test_handle_create_from_fixture`
* Verify both `gotosocial-reply` and `akkoma-reply` data sets pass.
* Optionally, add a new JSON file to `tests/phpunit/data/create/` and verify it is automatically picked up.