### PR TITLE
Add snippets folder with community-contributed extensions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,6 +28,7 @@
 
 # Source and tests (build/ is distributed, src/ is not)
 /docs/               export-ignore
+/snippets/           export-ignore
 /src/                export-ignore
 /tests/              export-ignore
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can test out the plugin (settings) with [WordPress Playground](https://wordp
 - [Pull Request Guidelines](docs/pull-request.md) - How to submit pull requests.
 - [Release Process](docs/release-process.md) - Guide for releasing new versions.
 - [Translations](docs/translations.md) - Information about translating the plugin.
+- [Snippets](snippets/) - Community-contributed snippets to extend or customize the plugin.
 
 ## Federation
 

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -2,10 +2,28 @@
 
 ## Table of Contents
 - [Introduction](#introduction)
+- [Snippets](#snippets)
 - [Extending the Settings Interface](#extending-the-settings-interface)
 
 ## Introduction
 This documentation provides information for developers who want to extend and build upon the ActivityPub plugin. Whether you're developing a complementary plugin or integrating ActivityPub features into your existing WordPress plugin, this guide will help you understand the available hooks and customization options.
+
+## Snippets
+
+The plugin ships with a collection of community-contributed [snippets](../snippets/) that extend or customize its behavior. Snippets are small, self-contained WordPress plugins that hook into the ActivityPub plugin to add or modify functionality.
+
+This follows a concept similar to WordPress' [feature plugins](https://make.wordpress.org/core/handbook/about/release-cycle/features-as-plugins/) -- experimental ideas are developed as snippets, and mature ones may eventually be integrated into the main plugin.
+
+### Using Snippets
+
+1. Copy the desired snippet folder from `snippets/` into your `wp-content/plugins/` directory.
+2. Activate the plugin from the WordPress admin.
+
+Alternatively, copy the snippet's main PHP file to `wp-content/mu-plugins/` for automatic activation.
+
+### Contributing Snippets
+
+See the [Snippets README](../snippets/README.md) for guidelines on contributing new snippets.
 
 ## Extending the Settings Interface
 

--- a/docs/developer-docs.md
+++ b/docs/developer-docs.md
@@ -10,7 +10,7 @@ This documentation provides information for developers who want to extend and bu
 
 ## Snippets
 
-The plugin ships with a collection of community-contributed [snippets](../snippets/) that extend or customize its behavior. Snippets are small, self-contained WordPress plugins that hook into the ActivityPub plugin to add or modify functionality.
+The repository includes a collection of community-contributed [snippets](../snippets/) that extend or customize its behavior. Snippets are small, self-contained WordPress plugins that hook into the ActivityPub plugin to add or modify functionality.
 
 This follows a concept similar to WordPress' [feature plugins](https://make.wordpress.org/core/handbook/about/release-cycle/features-as-plugins/) -- experimental ideas are developed as snippets, and mature ones may eventually be integrated into the main plugin.
 

--- a/snippets/README.md
+++ b/snippets/README.md
@@ -1,0 +1,69 @@
+# Snippets
+
+This folder contains community-contributed snippets that extend or customize the ActivityPub plugin. Each snippet is a small, self-contained WordPress plugin that hooks into the ActivityPub plugin to add or modify functionality.
+
+Think of snippets as a testing ground, similar to WordPress' [feature plugin](https://make.wordpress.org/core/handbook/about/release-cycle/features-as-plugins/) concept. Experimental ideas are developed here, and mature, valuable ones may eventually be integrated into the main plugin.
+
+## Available Snippets
+
+| Snippet | Description |
+|---------|-------------|
+| [FediBlog Tag](fediblog-tag/) | Automatically adds the `FediBlog` tag to standard format blog posts. |
+
+## How to Use
+
+1. Copy the snippet folder you want to use into your `wp-content/plugins/` directory.
+2. Activate the snippet plugin from the WordPress admin under **Plugins**.
+3. The snippet will require the ActivityPub plugin to be active.
+
+Alternatively, you can copy the snippet's main PHP file directly into your `wp-content/mu-plugins/` directory for automatic activation.
+
+## How to Contribute
+
+We welcome new snippets! To contribute:
+
+1. **Create a new folder** in `snippets/` with a descriptive, kebab-case name (e.g., `my-snippet-name/`).
+2. **Add a main PHP file** with proper WordPress plugin headers, including `Requires Plugins: activitypub`.
+3. **Use the `Activitypub\Snippets` namespace** to keep things consistent.
+4. **Add a `README.md`** to your snippet folder explaining what it does, how it works, and any configuration options.
+5. **Update this file** by adding your snippet to the "Available Snippets" table above.
+6. **Submit a pull request** following the [Pull Request Guidelines](../docs/pull-request.md).
+
+### Snippet Structure
+
+Each snippet folder should contain at minimum:
+
+```
+snippets/
+  my-snippet/
+    my-snippet.php   # Main plugin file with WordPress plugin headers
+    README.md        # Documentation for the snippet
+```
+
+### Plugin Header Template
+
+```php
+<?php
+/**
+ * Plugin Name:       My Snippet Name
+ * Plugin URI:        https://github.com/Automattic/wordpress-activitypub
+ * Description:       Brief description of what this snippet does.
+ * Version:           1.0.0
+ * Requires at least: 5.9
+ * Requires PHP:      7.4
+ * Author:            Your Name
+ * Author URI:        https://example.com/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Requires Plugins:  activitypub
+ */
+
+namespace Activitypub\Snippets;
+```
+
+### Guidelines
+
+- Keep snippets small and focused on a single feature or behavior.
+- Use WordPress coding standards ([WPCS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)).
+- Snippets must not break the core ActivityPub plugin when deactivated.
+- Include inline documentation for hooks and filters.

--- a/snippets/fediblog-tag/README.md
+++ b/snippets/fediblog-tag/README.md
@@ -1,0 +1,27 @@
+# FediBlog Tag
+
+Automatically adds the `FediBlog` tag to standard format blog posts when they are saved.
+
+## What It Does
+
+[FediBlog](https://fediblog.net/) is a directory of blogs in the Fediverse. This snippet automatically tags your standard format blog posts with `FediBlog`, making them discoverable on platforms that aggregate content by this tag.
+
+The snippet hooks into WordPress' `save_post` action and:
+
+1. Checks that the post is not a revision.
+2. Checks that the post uses the standard format (no specific post format assigned).
+3. Adds the `FediBlog` tag to the post without removing existing tags.
+
+## Installation
+
+Copy this folder to `wp-content/plugins/` and activate **FediBlog Tag** from the WordPress admin, or copy `fediblog-tag.php` to `wp-content/mu-plugins/` for automatic activation.
+
+## Requirements
+
+- WordPress 5.9+
+- PHP 7.4+
+- [ActivityPub](https://wordpress.org/plugins/activitypub/) plugin
+
+## Origin
+
+Based on a [suggestion by Tim Chambers](https://indieweb.social/@tchambers/114197659039490619) to nudge blog authors into adding the `#FediBlog` hashtag to help with discovery of blogs in the Fediverse.

--- a/snippets/fediblog-tag/README.md
+++ b/snippets/fediblog-tag/README.md
@@ -2,16 +2,6 @@
 
 Automatically adds the `FediBlog` tag to standard format blog posts when they are saved.
 
-## What It Does
-
-[FediBlog](https://fediblog.net/) is a directory of blogs in the Fediverse. This snippet automatically tags your standard format blog posts with `FediBlog`, making them discoverable on platforms that aggregate content by this tag.
-
-The snippet hooks into WordPress' `save_post` action and:
-
-1. Checks that the post is not a revision.
-2. Checks that the post uses the standard format (no specific post format assigned).
-3. Adds the `FediBlog` tag to the post without removing existing tags.
-
 ## Installation
 
 Copy this folder to `wp-content/plugins/` and activate **FediBlog Tag** from the WordPress admin, or copy `fediblog-tag.php` to `wp-content/mu-plugins/` for automatic activation.

--- a/snippets/fediblog-tag/fediblog-tag.php
+++ b/snippets/fediblog-tag/fediblog-tag.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plugin Name:       FediBlog Tag
+ * Plugin URI:        https://github.com/Automattic/wordpress-activitypub
+ * Description:       Automatically adds the `FediBlog` tag to standard format blog posts.
+ * Version:           1.0.0
+ * Requires at least: 5.9
+ * Requires PHP:      7.4
+ * Author:            Matthias Pfefferle
+ * Author URI:        https://notiz.blog/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       activitypub-fediblog
+ * Requires Plugins:  activitypub
+ */
+
+namespace Activitypub\Snippets;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Add fediblog tag to standard format posts.
+ *
+ * @param int $post_id The post ID.
+ */
+function add_fediblog_tag( $post_id ) {
+	// Skip revisions and autosaves.
+	if ( \wp_is_post_revision( $post_id ) || \wp_is_post_autosave( $post_id ) ) {
+		return;
+	}
+
+	// Only apply to blog posts with standard format.
+	if ( 'post' === \get_post_type( $post_id ) && false === \get_post_format( $post_id ) ) {
+		\wp_set_post_tags( $post_id, 'FediBlog', true );
+	}
+}
+
+// Hook into the save_post action.
+\add_action( 'save_post', __NAMESPACE__ . '\add_fediblog_tag' );

--- a/snippets/fediblog-tag/fediblog-tag.php
+++ b/snippets/fediblog-tag/fediblog-tag.php
@@ -34,11 +34,11 @@ function add_fediblog_tag( $post_id ) {
 		return;
 	}
 
-	// Only apply to blog posts with standard format.
-	if ( 'post' === \get_post_type( $post_id ) && false === \get_post_format( $post_id ) ) {
+	// Only apply to standard-format posts.
+	if ( false === \get_post_format( $post_id ) ) {
 		\wp_set_post_tags( $post_id, 'FediBlog', true );
 	}
 }
 
-// Hook into the save_post action.
-\add_action( 'save_post', __NAMESPACE__ . '\add_fediblog_tag' );
+// Hook into the post-type-specific save_post_post action.
+\add_action( 'save_post_post', __NAMESPACE__ . '\add_fediblog_tag' );

--- a/snippets/fediblog-tag/fediblog-tag.php
+++ b/snippets/fediblog-tag/fediblog-tag.php
@@ -12,6 +12,8 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       activitypub-fediblog
  * Requires Plugins:  activitypub
+ *
+ * @package Activitypub
  */
 
 namespace Activitypub\Snippets;


### PR DESCRIPTION
## Proposed changes:
* Add a `snippets/` folder as a home for community-contributed mini-plugins that extend the ActivityPub plugin.
* Include the first snippet: **FediBlog Tag**, which automatically adds the `#FediBlog` tag to standard format blog posts for better discovery in the Fediverse.
* Add documentation in `snippets/README.md` with usage instructions and contribution guidelines.
* Add a Snippets section to `docs/developer-docs.md`.
* Link snippets from the main `README.md` Documentation section.
* Exclude `snippets/` from distribution archives via `.gitattributes`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Not applicable — snippets are standalone plugins distributed as examples, not part of the main plugin's runtime.

## Testing instructions:

* Review the new `snippets/` folder structure and documentation.
* Optionally copy `snippets/fediblog-tag/` to `wp-content/plugins/`, activate it, and publish a standard format blog post to verify the `FediBlog` tag is added.

### Changelog entry

<!-- No changelog needed — this adds development/community resources excluded from distribution. -->