### PR TITLE
Fix outbox invalidation canceling pending Accept/Reject activities

### DIFF
--- a/.github/changelog/2911-from-description
+++ b/.github/changelog/2911-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix outbox invalidation canceling pending Accept/Reject responses to QuoteRequests for the same post.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -126,8 +126,13 @@ class Outbox {
 	 * @return void
 	 */
 	private static function invalidate_existing_items( $object_id, $activity_type, $current_id ) {
-		// Do not invalidate items for Announce activities.
-		if ( 'Announce' === $activity_type ) {
+		/*
+		 * Do not invalidate items for Announce, Accept, or Reject activities.
+		 * Accept/Reject are per-request responses (e.g. to individual incoming
+		 * QuoteRequests) and must not cancel each other even when they share
+		 * the same object ID.
+		 */
+		if ( in_array( $activity_type, array( 'Announce', 'Accept', 'Reject' ), true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes:

* Skip outbox invalidation for Accept and Reject activities (matching existing Announce behavior) so that individual responses to QuoteRequests are dispatched independently.

When multiple QuoteRequests arrive for the same post, each Accept/Reject response ends up with the same `_activitypub_object_id` (the quoted post URL). The `invalidate_existing_items` method was unscheduling and marking earlier pending responses as published, preventing their federation. This meant only the last queued Accept would actually be delivered.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Existing QuoteRequest and Outbox test suites pass (74 tests, 244 assertions). The change is a single-line guard addition following the existing Announce pattern.

## Testing instructions:

* Set up two remote actors that can send QuoteRequests (e.g. two Mastodon accounts)
* Have both quote the same local post in quick succession
* Verify that both remote actors receive their respective Accept responses
* Alternatively, inspect the `ap_outbox` posts: both Accept items should remain `pending` until dispatched, rather than the first being prematurely set to `publish`

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix outbox invalidation canceling pending Accept/Reject responses to QuoteRequests for the same post.

</details>