### PR TITLE
Add missing object validation to Reject handler

### DIFF
--- a/.github/changelog/2912-from-description
+++ b/.github/changelog/2912-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed missing object validation in the Reject handler that could cause PHP errors when processing malformed Reject activities.

--- a/includes/handler/class-reject.php
+++ b/includes/handler/class-reject.php
@@ -102,6 +102,14 @@ class Reject {
 			return false;
 		}
 
+		if ( ! \is_array( $activity['object'] ) ) {
+			return false;
+		}
+
+		if ( ! isset( $activity['object']['id'], $activity['object']['type'], $activity['object']['actor'] ) ) {
+			return false;
+		}
+
 		return $valid;
 	}
 }

--- a/tests/phpunit/tests/includes/handler/class-test-reject.php
+++ b/tests/phpunit/tests/includes/handler/class-test-reject.php
@@ -67,13 +67,13 @@ class Test_Reject extends \WP_UnitTestCase {
 	public function validate_object_provider() {
 		return array(
 			// Invalid cases.
-			'missing_type'            => array(
+			'missing_type'                       => array(
 				array(),
 				true,
 				false,
 				'Should return false when type is missing',
 			),
-			'missing_required_fields' => array(
+			'missing_required_fields'            => array(
 				array(
 					'type'  => 'Reject',
 					'actor' => 'foo',
@@ -82,15 +82,67 @@ class Test_Reject extends \WP_UnitTestCase {
 				false,
 				'Should return false when required fields are missing',
 			),
+			'object_is_string'                   => array(
+				array(
+					'type'   => 'Reject',
+					'actor'  => 'https://example.com/actor/1',
+					'object' => 'https://example.com/activity/1',
+				),
+				true,
+				false,
+				'Should return false when object is a string instead of an array',
+			),
+			'object_missing_id'                  => array(
+				array(
+					'type'   => 'Reject',
+					'actor'  => 'https://example.com/actor/1',
+					'object' => array(
+						'actor'  => 'https://example.com/actor/2',
+						'type'   => 'Follow',
+						'object' => 'https://example.com/actor/1',
+					),
+				),
+				true,
+				false,
+				'Should return false when object is missing id',
+			),
+			'object_missing_type'                => array(
+				array(
+					'type'   => 'Reject',
+					'actor'  => 'https://example.com/actor/1',
+					'object' => array(
+						'id'     => 'https://example.com/activity/1',
+						'actor'  => 'https://example.com/actor/2',
+						'object' => 'https://example.com/actor/1',
+					),
+				),
+				true,
+				false,
+				'Should return false when object is missing type',
+			),
+			'object_missing_actor'               => array(
+				array(
+					'type'   => 'Reject',
+					'actor'  => 'https://example.com/actor/1',
+					'object' => array(
+						'id'     => 'https://example.com/activity/1',
+						'type'   => 'Follow',
+						'object' => 'https://example.com/actor/1',
+					),
+				),
+				true,
+				false,
+				'Should return false when object is missing actor',
+			),
 			// Valid cases - non-Reject type should pass through.
-			'type_not_reject'         => array(
+			'type_not_reject'                    => array(
 				array( 'type' => 'Follow' ),
 				true,
 				true,
 				'Should return true when type is not Reject',
 			),
 			// Valid Reject activity.
-			'valid_reject_activity'   => array(
+			'valid_reject_activity'              => array(
 				array(
 					'type'   => 'Reject',
 					'actor'  => 'foo',
@@ -105,8 +157,23 @@ class Test_Reject extends \WP_UnitTestCase {
 				true,
 				'Should return true for valid Reject activity',
 			),
+			// Valid Reject without optional object.object field.
+			'valid_reject_without_object_object' => array(
+				array(
+					'type'   => 'Reject',
+					'actor'  => 'https://example.com/actor/1',
+					'object' => array(
+						'id'    => 'https://example.com/activity/1',
+						'actor' => 'https://example.com/actor/2',
+						'type'  => 'Follow',
+					),
+				),
+				true,
+				true,
+				'Should return true for valid Reject activity without object.object',
+			),
 			// Test with input_valid false.
-			'input_valid_false'       => array(
+			'input_valid_false'                  => array(
 				array( 'type' => 'Follow' ),
 				false,
 				false,


### PR DESCRIPTION
## Proposed changes:

* Add validation in `Reject::validate_object` to ensure the activity's `object` field is a well-formed array with required `id`, `type`, and `actor` properties, matching the validation already present in `Accept::validate_object`.

### Context

The `Reject` handler's `validate_object` method was not validating the structure of the nested `object` field. It only checked that `actor` and `object` existed on the top-level activity, but did not verify that `object` was an array or that it contained `id`, `type`, and `actor` keys.

This meant that malformed Reject activities would pass REST API validation but then cause PHP errors in:
- `handle_reject` (line 36) when accessing `$reject['object']['id']`
- `reject_follow` (line 59) when accessing `$reject['object']['actor']`

The `Accept` handler already had proper validation for these fields. This PR brings the `Reject` handler to parity.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Run the Reject handler test suite: `npm run env-test -- --filter='Test_Reject'`
2. Verify all 11 tests pass, including the new validation test cases:
   - `object_is_string` - rejects when object is a URI string
   - `object_missing_id` - rejects when object array lacks `id`
   - `object_missing_type` - rejects when object array lacks `type`
   - `object_missing_actor` - rejects when object array lacks `actor`
   - `valid_reject_without_object_object` - accepts valid Reject even without `object.object`

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fixed missing object validation in the Reject handler that could cause PHP errors when processing malformed Reject activities.

</details>