### PR TITLE
Fix comment count to properly exclude likes, shares, and notes

### DIFF
--- a/.github/changelog/2913-from-description
+++ b/.github/changelog/2913-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix comment count filter conflict with Gutenberg by running at a later priority and always recalculating to exclude ActivityPub comment types.

--- a/.github/changelog/2913-from-description
+++ b/.github/changelog/2913-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix comment count filter conflict with Gutenberg by running at a later priority and always recalculating to exclude ActivityPub comment types.
+Fix comment count to properly exclude likes, shares, and notes.

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -42,7 +42,7 @@ class Activitypub {
 		self::flush_rewrite_rules();
 		Scheduler::register_schedules();
 
-		\add_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
+		\add_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 5, 3 );
 		Migration::update_comment_counts();
 
 		if ( \is_multisite() && $network_wide && ! \wp_is_large_network() ) {
@@ -64,7 +64,7 @@ class Activitypub {
 		self::flush_rewrite_rules();
 		Scheduler::deregister_schedules();
 
-		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ) );
+		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 5 );
 		Migration::update_comment_counts( 2000 );
 
 		if ( \is_multisite() && $network_wide && ! \wp_is_large_network() ) {
@@ -83,7 +83,7 @@ class Activitypub {
 	public static function uninstall() {
 		Scheduler::deregister_schedules();
 
-		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ) );
+		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 5 );
 		Migration::update_comment_counts( 2000 );
 
 		Posts::delete_all();

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -42,7 +42,7 @@ class Activitypub {
 		self::flush_rewrite_rules();
 		Scheduler::register_schedules();
 
-		\add_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
+		\add_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 20, 3 );
 		Migration::update_comment_counts();
 
 		if ( \is_multisite() && $network_wide && ! \wp_is_large_network() ) {
@@ -64,7 +64,7 @@ class Activitypub {
 		self::flush_rewrite_rules();
 		Scheduler::deregister_schedules();
 
-		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ) );
+		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 20 );
 		Migration::update_comment_counts( 2000 );
 
 		if ( \is_multisite() && $network_wide && ! \wp_is_large_network() ) {
@@ -83,7 +83,7 @@ class Activitypub {
 	public static function uninstall() {
 		Scheduler::deregister_schedules();
 
-		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ) );
+		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 20 );
 		Migration::update_comment_counts( 2000 );
 
 		Posts::delete_all();

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -42,7 +42,7 @@ class Activitypub {
 		self::flush_rewrite_rules();
 		Scheduler::register_schedules();
 
-		\add_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 20, 3 );
+		\add_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
 		Migration::update_comment_counts();
 
 		if ( \is_multisite() && $network_wide && ! \wp_is_large_network() ) {
@@ -64,7 +64,7 @@ class Activitypub {
 		self::flush_rewrite_rules();
 		Scheduler::deregister_schedules();
 
-		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 20 );
+		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ) );
 		Migration::update_comment_counts( 2000 );
 
 		if ( \is_multisite() && $network_wide && ! \wp_is_large_network() ) {
@@ -83,7 +83,7 @@ class Activitypub {
 	public static function uninstall() {
 		Scheduler::deregister_schedules();
 
-		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ), 20 );
+		\remove_filter( 'pre_wp_update_comment_count_now', array( Comment::class, 'pre_wp_update_comment_count_now' ) );
 		Migration::update_comment_counts( 2000 );
 
 		Posts::delete_all();

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -33,7 +33,7 @@ class Comment {
 		\add_filter( 'get_avatar_comment_types', array( static::class, 'get_avatar_comment_types' ), 99 );
 		\add_action( 'update_option_activitypub_allow_likes', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_action( 'update_option_activitypub_allow_reposts', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
-		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
+		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 5, 3 );
 		\add_filter( 'get_comment_author', array( static::class, 'render_emoji' ), 10, 2 );
 		\add_filter( 'comment_author', array( static::class, 'unescape_emoji' ), 20 ); // After esc_html().
 		\add_filter( 'rest_comment_query', array( static::class, 'rest_comment_query' ) );
@@ -921,11 +921,20 @@ class Comment {
 			$excluded_types = array_filter( self::get_comment_type_slugs(), array( self::class, 'is_comment_type_enabled' ) );
 
 			if ( ! empty( $excluded_types ) ) {
+				/*
+				 * Include 'note' type when Gutenberg's filter is registered, so a
+				 * single query excludes both ActivityPub and Gutenberg types.
+				 */
+				if ( \has_filter( 'pre_wp_update_comment_count_now', 'gutenberg_exclude_notes_from_comment_count' ) ) {
+					$excluded_types[] = 'note';
+				}
+
 				/**
 				 * Filters the comment types excluded from the comment count.
 				 *
-				 * Other plugins can add their own comment types to this list
-				 * so a single query excludes all non-public types.
+				 * Runs at priority 5 on `pre_wp_update_comment_count_now` so that
+				 * a single query can exclude types from multiple plugins. Other
+				 * plugins can hook here to add their own comment types.
 				 *
 				 * @since unreleased
 				 *

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -33,7 +33,7 @@ class Comment {
 		\add_filter( 'get_avatar_comment_types', array( static::class, 'get_avatar_comment_types' ), 99 );
 		\add_action( 'update_option_activitypub_allow_likes', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_action( 'update_option_activitypub_allow_reposts', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
-		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 20, 3 );
+		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
 		\add_filter( 'get_comment_author', array( static::class, 'render_emoji' ), 10, 2 );
 		\add_filter( 'comment_author', array( static::class, 'unescape_emoji' ), 20 ); // After esc_html().
 		\add_filter( 'rest_comment_query', array( static::class, 'rest_comment_query' ) );
@@ -917,13 +917,29 @@ class Comment {
 	 * @return int|null The updated comment count, or null to use the default query.
 	 */
 	public static function pre_wp_update_comment_count_now( $new_count, $old_count, $post_id ) {
-		$excluded_types = array_filter( self::get_comment_type_slugs(), array( self::class, 'is_comment_type_enabled' ) );
+		if ( null === $new_count ) {
+			$excluded_types = array_filter( self::get_comment_type_slugs(), array( self::class, 'is_comment_type_enabled' ) );
 
-		if ( ! empty( $excluded_types ) ) {
-			global $wpdb;
+			if ( ! empty( $excluded_types ) ) {
+				/**
+				 * Filters the comment types excluded from the comment count.
+				 *
+				 * Other plugins can add their own comment types to this list
+				 * so a single query excludes all non-public types.
+				 *
+				 * @since unreleased
+				 *
+				 * @param string[] $excluded_types The comment type slugs to exclude.
+				 * @param int      $post_id        The post ID.
+				 */
+				$excluded_types = \apply_filters( 'activitypub_excluded_comment_types', $excluded_types, $post_id );
+				$excluded_types = array_unique( array_filter( $excluded_types ) );
 
-			// phpcs:ignore WordPress.DB
-			$new_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type NOT IN ('" . implode( "','", $excluded_types ) . "')", $post_id ) );
+				global $wpdb;
+
+				// phpcs:ignore WordPress.DB
+				$new_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type NOT IN ('" . implode( "','", $excluded_types ) . "')", $post_id ) );
+			}
 		}
 
 		return $new_count;

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -33,7 +33,7 @@ class Comment {
 		\add_filter( 'get_avatar_comment_types', array( static::class, 'get_avatar_comment_types' ), 99 );
 		\add_action( 'update_option_activitypub_allow_likes', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
 		\add_action( 'update_option_activitypub_allow_reposts', array( self::class, 'maybe_update_comment_counts' ), 10, 2 );
-		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 10, 3 );
+		\add_filter( 'pre_wp_update_comment_count_now', array( static::class, 'pre_wp_update_comment_count_now' ), 20, 3 );
 		\add_filter( 'get_comment_author', array( static::class, 'render_emoji' ), 10, 2 );
 		\add_filter( 'comment_author', array( static::class, 'unescape_emoji' ), 20 ); // After esc_html().
 		\add_filter( 'rest_comment_query', array( static::class, 'rest_comment_query' ) );
@@ -917,15 +917,13 @@ class Comment {
 	 * @return int|null The updated comment count, or null to use the default query.
 	 */
 	public static function pre_wp_update_comment_count_now( $new_count, $old_count, $post_id ) {
-		if ( null === $new_count ) {
-			$excluded_types = array_filter( self::get_comment_type_slugs(), array( self::class, 'is_comment_type_enabled' ) );
+		$excluded_types = array_filter( self::get_comment_type_slugs(), array( self::class, 'is_comment_type_enabled' ) );
 
-			if ( ! empty( $excluded_types ) ) {
-				global $wpdb;
+		if ( ! empty( $excluded_types ) ) {
+			global $wpdb;
 
-				// phpcs:ignore WordPress.DB
-				$new_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type NOT IN ('" . implode( "','", $excluded_types ) . "')", $post_id ) );
-			}
+			// phpcs:ignore WordPress.DB
+			$new_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type NOT IN ('" . implode( "','", $excluded_types ) . "')", $post_id ) );
 		}
 
 		return $new_count;

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -230,7 +230,7 @@ class Test_Comment extends \WP_UnitTestCase {
 		// Case 4: $new is not null (set by another filter), should return $new unmodified.
 		$this->assertSame( 10, Comment::pre_wp_update_comment_count_now( 10, 0, $post_id ) );
 
-		// Case 5: Other plugins can add excluded types via the filter.
+		// Case 5: Other plugins can exclude additional types via the filter.
 		$add_note = function ( $types ) {
 			$types[] = 'note';
 			return $types;
@@ -249,6 +249,10 @@ class Test_Comment extends \WP_UnitTestCase {
 		$this->assertSame( 5, Comment::pre_wp_update_comment_count_now( null, 0, $post_id ) );
 
 		\remove_filter( 'activitypub_excluded_comment_types', $add_note );
+
+		// Case 6: Without the filter, 'note' types are counted normally.
+		// 5 regular + 2 note = 7 (only like excluded).
+		$this->assertSame( 7, Comment::pre_wp_update_comment_count_now( null, 0, $post_id ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -227,8 +227,8 @@ class Test_Comment extends \WP_UnitTestCase {
 		self::factory()->comment->create_post_comments( $post_id, 3, array( 'comment_approved' => '1' ) );
 		$this->assertSame( 5, Comment::pre_wp_update_comment_count_now( null, 0, $post_id ) );
 
-		// Case 4: $new is not null, should return $new unmodified.
-		$this->assertSame( 10, Comment::pre_wp_update_comment_count_now( 10, 0, $post_id ) );
+		// Case 4: $new is not null (set by another filter), should still recalculate to exclude ActivityPub types.
+		$this->assertSame( 5, Comment::pre_wp_update_comment_count_now( 10, 0, $post_id ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -227,8 +227,28 @@ class Test_Comment extends \WP_UnitTestCase {
 		self::factory()->comment->create_post_comments( $post_id, 3, array( 'comment_approved' => '1' ) );
 		$this->assertSame( 5, Comment::pre_wp_update_comment_count_now( null, 0, $post_id ) );
 
-		// Case 4: $new is not null (set by another filter), should still recalculate to exclude ActivityPub types.
-		$this->assertSame( 5, Comment::pre_wp_update_comment_count_now( 10, 0, $post_id ) );
+		// Case 4: $new is not null (set by another filter), should return $new unmodified.
+		$this->assertSame( 10, Comment::pre_wp_update_comment_count_now( 10, 0, $post_id ) );
+
+		// Case 5: Other plugins can add excluded types via the filter.
+		$add_note = function ( $types ) {
+			$types[] = 'note';
+			return $types;
+		};
+		\add_filter( 'activitypub_excluded_comment_types', $add_note );
+
+		self::factory()->comment->create_post_comments(
+			$post_id,
+			2,
+			array(
+				'comment_approved' => '1',
+				'comment_type'     => 'note',
+			)
+		);
+		// 5 regular + 2 note + 3 like = 10 total, but like and note excluded = 5.
+		$this->assertSame( 5, Comment::pre_wp_update_comment_count_now( null, 0, $post_id ) );
+
+		\remove_filter( 'activitypub_excluded_comment_types', $add_note );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2910

## Proposed changes:

Ensures that likes, shares, and other ActivityPub interactions are properly excluded from the comment count, even when other plugins (like Gutenberg) also filter the count.

Previously, only one plugin's exclusions would take effect depending on load order, leading to incorrect comment counts.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Activate both the ActivityPub plugin and the Gutenberg plugin.
2. Create a post and add some regular comments, along with some likes and reposts via ActivityPub.
3. Check the comment count on the post — likes, shares, and notes should not be included.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix comment count to properly exclude likes, shares, and notes.

</details>