### PR TITLE
Fix visibility default for old posts to respect 'Do not federate' setting

### DIFF
--- a/.github/changelog/2618-from-description
+++ b/.github/changelog/2618-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix visibility default for old posts to prevent unintentional federation when editing posts older than 1 month.

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -283,6 +283,20 @@ function get_content_visibility( $post_id ) {
 
 	if ( in_array( $visibility, $options, true ) ) {
 		$_visibility = $visibility;
+	} elseif ( ! \metadata_exists( 'post', $post->ID, 'activitypub_content_visibility' ) ) {
+		// Apply default visibility logic for posts without explicit visibility.
+		// Posts older than 1 month default to 'local' (not federated).
+		$object_state = get_wp_object_state( $post );
+
+		// If post was already federated, keep it public.
+		if ( ACTIVITYPUB_OBJECT_STATE_FEDERATED !== $object_state ) {
+			$post_timestamp = \strtotime( $post->post_date_gmt );
+			$one_month_ago  = time() - ( 30 * DAY_IN_SECONDS );
+
+			if ( $post_timestamp > 0 && $post_timestamp < $one_month_ago ) {
+				$_visibility = ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL;
+			}
+		}
 	}
 
 	/**

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -138,6 +138,14 @@ class Classic_Editor {
 		$default_quote_policy  = \get_option( 'activitypub_default_quote_policy', ACTIVITYPUB_INTERACTION_POLICY_ANYONE );
 		$quote_interaction     = \get_post_meta( $post->ID, 'activitypub_interaction_policy_quote', true ) ?: $default_quote_policy;
 
+		// Persist default visibility for old posts if not already set.
+		// This ensures old posts get their "do not federate" default saved immediately,
+		// matching the block editor behavior.
+		$saved_visibility = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
+		if ( empty( $saved_visibility ) && ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC !== $content_visibility ) {
+			\update_post_meta( $post->ID, 'activitypub_content_visibility', $content_visibility );
+		}
+
 		?>
 		<p>
 			<label for="activitypub_content_warning">

--- a/tests/phpunit/tests/includes/class-test-functions-post.php
+++ b/tests/phpunit/tests/includes/class-test-functions-post.php
@@ -299,4 +299,116 @@ class Test_Functions_Post extends \WP_UnitTestCase {
 		);
 		$this->assertFalse( \Activitypub\is_ap_post( $custom_id ), 'Should return false for custom post type' );
 	}
+
+	/**
+	 * Test get_content_visibility defaults for old posts.
+	 *
+	 * @covers \Activitypub\get_content_visibility
+	 */
+	public function test_get_content_visibility_defaults_to_local_for_old_posts() {
+		// Create a post with a date older than 1 month.
+		$old_date    = gmdate( 'Y-m-d H:i:s', time() - ( 31 * DAY_IN_SECONDS ) );
+		$old_post_id = wp_insert_post(
+			array(
+				'post_type'     => 'post',
+				'post_title'    => 'Old Post',
+				'post_content'  => 'This post is more than a month old',
+				'post_status'   => 'publish',
+				'post_date'     => $old_date,
+				'post_date_gmt' => $old_date,
+			)
+		);
+
+		// Without explicit visibility meta, old posts should default to 'local'.
+		$visibility = \Activitypub\get_content_visibility( $old_post_id );
+		$this->assertEquals(
+			ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL,
+			$visibility,
+			'Old posts without explicit visibility should default to local'
+		);
+	}
+
+	/**
+	 * Test get_content_visibility defaults for new posts.
+	 *
+	 * @covers \Activitypub\get_content_visibility
+	 */
+	public function test_get_content_visibility_defaults_to_public_for_new_posts() {
+		// Create a recent post.
+		$new_post_id = wp_insert_post(
+			array(
+				'post_type'    => 'post',
+				'post_title'   => 'New Post',
+				'post_content' => 'This is a recent post',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Recent posts should default to 'public'.
+		$visibility = \Activitypub\get_content_visibility( $new_post_id );
+		$this->assertEquals(
+			ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
+			$visibility,
+			'Recent posts without explicit visibility should default to public'
+		);
+	}
+
+	/**
+	 * Test get_content_visibility respects explicitly set values.
+	 *
+	 * @covers \Activitypub\get_content_visibility
+	 */
+	public function test_get_content_visibility_respects_explicit_values() {
+		// Create an old post with explicit quiet_public visibility.
+		$old_date    = gmdate( 'Y-m-d H:i:s', time() - ( 31 * DAY_IN_SECONDS ) );
+		$old_post_id = wp_insert_post(
+			array(
+				'post_type'     => 'post',
+				'post_title'    => 'Old Post with Explicit Visibility',
+				'post_content'  => 'This post has explicit visibility set',
+				'post_status'   => 'publish',
+				'post_date'     => $old_date,
+				'post_date_gmt' => $old_date,
+			)
+		);
+		add_post_meta( $old_post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC );
+
+		// Should respect the explicit value even for old posts.
+		$visibility = \Activitypub\get_content_visibility( $old_post_id );
+		$this->assertEquals(
+			ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC,
+			$visibility,
+			'Explicitly set visibility should be respected even for old posts'
+		);
+	}
+
+	/**
+	 * Test get_content_visibility respects federated status.
+	 *
+	 * @covers \Activitypub\get_content_visibility
+	 */
+	public function test_get_content_visibility_respects_federated_status() {
+		// Create an old post that was already federated.
+		$old_date    = gmdate( 'Y-m-d H:i:s', time() - ( 31 * DAY_IN_SECONDS ) );
+		$old_post_id = wp_insert_post(
+			array(
+				'post_type'     => 'post',
+				'post_title'    => 'Old Federated Post',
+				'post_content'  => 'This post was already federated',
+				'post_status'   => 'publish',
+				'post_date'     => $old_date,
+				'post_date_gmt' => $old_date,
+			)
+		);
+		// Mark it as federated.
+		add_post_meta( $old_post_id, 'activitypub_status', ACTIVITYPUB_OBJECT_STATE_FEDERATED );
+
+		// Old posts that were already federated should remain public.
+		$visibility = \Activitypub\get_content_visibility( $old_post_id );
+		$this->assertEquals(
+			ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
+			$visibility,
+			'Old posts that were already federated should remain public'
+		);
+	}
 }

--- a/tests/phpunit/tests/integration/class-test-classic-editor.php
+++ b/tests/phpunit/tests/integration/class-test-classic-editor.php
@@ -445,4 +445,105 @@ class Test_Classic_Editor extends \WP_UnitTestCase {
 		Classic_Editor::add_meta_box( 'page' );
 		$this->assertArrayNotHasKey( 'page', $wp_meta_boxes );
 	}
+
+	/**
+	 * Test that rendering meta box persists default visibility for old posts.
+	 *
+	 * @covers ::render_meta_box
+	 * @covers ::get_default_visibility
+	 */
+	public function test_render_meta_box_persists_default_visibility_for_old_posts() {
+		// Create an old post (older than 30 days).
+		$old_post_id = self::factory()->post->create(
+			array(
+				'post_author'  => self::$user_id,
+				'post_status'  => 'publish',
+				'post_content' => 'Old post content',
+				'post_date'    => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+			)
+		);
+
+		// Ensure visibility is not set yet.
+		$this->assertEmpty( \get_post_meta( $old_post_id, 'activitypub_content_visibility', true ) );
+
+		// Render the meta box.
+		$post = \get_post( $old_post_id );
+		ob_start();
+		Classic_Editor::render_meta_box( $post );
+		ob_end_clean();
+
+		// Verify that the default visibility (local) was persisted.
+		$saved_visibility = \get_post_meta( $old_post_id, 'activitypub_content_visibility', true );
+		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL, $saved_visibility );
+
+		// Clean up.
+		\wp_delete_post( $old_post_id, true );
+	}
+
+	/**
+	 * Test that rendering meta box does not persist visibility for new posts.
+	 *
+	 * @covers ::render_meta_box
+	 * @covers ::get_default_visibility
+	 */
+	public function test_render_meta_box_does_not_persist_public_for_new_posts() {
+		// Create a new post.
+		$new_post_id = self::factory()->post->create(
+			array(
+				'post_author'  => self::$user_id,
+				'post_status'  => 'publish',
+				'post_content' => 'New post content',
+			)
+		);
+
+		// Ensure visibility is not set yet.
+		$this->assertEmpty( \get_post_meta( $new_post_id, 'activitypub_content_visibility', true ) );
+
+		// Render the meta box.
+		$post = \get_post( $new_post_id );
+		ob_start();
+		Classic_Editor::render_meta_box( $post );
+		ob_end_clean();
+
+		// Verify that visibility was NOT persisted (because default is public).
+		$saved_visibility = \get_post_meta( $new_post_id, 'activitypub_content_visibility', true );
+		$this->assertEmpty( $saved_visibility );
+
+		// Clean up.
+		\wp_delete_post( $new_post_id, true );
+	}
+
+	/**
+	 * Test that rendering meta box does not overwrite existing visibility.
+	 *
+	 * @covers ::render_meta_box
+	 * @covers ::get_default_visibility
+	 */
+	public function test_render_meta_box_does_not_overwrite_existing_visibility() {
+		// Create an old post with explicit visibility set.
+		$old_post_id = self::factory()->post->create(
+			array(
+				'post_author'  => self::$user_id,
+				'post_status'  => 'publish',
+				'post_content' => 'Old post content',
+				'post_date'    => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+			)
+		);
+
+		// Set visibility to public (explicitly).
+		\update_post_meta( $old_post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC );
+
+		// Render the meta box.
+		$post = \get_post( $old_post_id );
+		ob_start();
+		Classic_Editor::render_meta_box( $post );
+		ob_end_clean();
+
+		// Verify that visibility was NOT changed.
+		$saved_visibility = \get_post_meta( $old_post_id, 'activitypub_content_visibility', true );
+		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, $saved_visibility );
+
+		// Clean up.
+		\wp_delete_post( $old_post_id, true );
+	}
 }

--- a/tests/phpunit/tests/integration/class-test-classic-editor.php
+++ b/tests/phpunit/tests/integration/class-test-classic-editor.php
@@ -454,12 +454,14 @@ class Test_Classic_Editor extends \WP_UnitTestCase {
 	 */
 	public function test_render_meta_box_persists_default_visibility_for_old_posts() {
 		// Create an old post (older than 30 days).
+		$old_date    = gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) );
 		$old_post_id = self::factory()->post->create(
 			array(
-				'post_author'  => self::$user_id,
-				'post_status'  => 'publish',
-				'post_content' => 'Old post content',
-				'post_date'    => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+				'post_author'   => self::$user_id,
+				'post_status'   => 'publish',
+				'post_content'  => 'Old post content',
+				'post_date'     => $old_date,
+				'post_date_gmt' => $old_date,
 			)
 		);
 
@@ -521,12 +523,14 @@ class Test_Classic_Editor extends \WP_UnitTestCase {
 	 */
 	public function test_render_meta_box_does_not_overwrite_existing_visibility() {
 		// Create an old post with explicit visibility set.
+		$old_date    = gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) );
 		$old_post_id = self::factory()->post->create(
 			array(
-				'post_author'  => self::$user_id,
-				'post_status'  => 'publish',
-				'post_content' => 'Old post content',
-				'post_date'    => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+				'post_author'   => self::$user_id,
+				'post_status'   => 'publish',
+				'post_content'  => 'Old post content',
+				'post_date'     => $old_date,
+				'post_date_gmt' => $old_date,
 			)
 		);
 


### PR DESCRIPTION
## Description

Fixes #2618

When editing posts older than 1 month that have never been federated, the visibility now defaults to 'local' (do not federate) instead of 'public'. This matches the intended behavior documented in the editor plugin and prevents unintentional federation of old posts.

## Problem

Previously, the JavaScript editor plugin attempted to set the default visibility to 'local' for old posts, but this was not enforced server-side when posts were saved. This meant that:
- Users could edit an old post (e.g., from 5 years ago)
- Even with the "Do not federate" setting visible in the sidebar
- The post would still be sent to ActivityPub followers upon saving
- This happened because the PHP-side visibility check had no concept of "old post defaults"

## Solution

Updated `get_content_visibility()` in `includes/functions-post.php` to apply the same default logic as the JavaScript editor plugin:
- Old posts (>30 days) without explicit visibility meta now default to 'local' instead of 'public'
- Posts that were already federated are not affected and remain public
- Explicit visibility settings are always respected
- The check uses `metadata_exists()` to distinguish between "not set" and "explicitly set to public"

## Testing

Added comprehensive tests in `tests/phpunit/tests/includes/class-test-functions-post.php`:
- Old posts without visibility meta default to 'local'
- New posts without visibility meta default to 'public'
- Explicit visibility settings are respected for old posts
- Federated old posts remain public

All tests pass.

## Test plan

1. Create or edit a post that is more than 1 month old
2. Check the visibility setting in the Fediverse sidebar panel
3. Save the post without changing the visibility
4. Verify the post is not sent to ActivityPub followers (check your Mastodon feed)
5. Edit the same post and explicitly set visibility to "Public"
6. Save and verify it IS sent to followers

## Changelog

- [x] Added to `.github/changelog/`