### PR TITLE
Add rewrite rule for Mastodon's authorize_interaction endpoint

### DIFF
--- a/.github/changelog/2922-from-description
+++ b/.github/changelog/2922-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Add rewrite rule for Mastodon's `authorize_interaction` endpoint to fix follow button redirects.
+Fix follow button redirect from Mastodon not being recognized.

--- a/.github/changelog/2922-from-description
+++ b/.github/changelog/2922-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add rewrite rule for Mastodon's `authorize_interaction` endpoint to fix follow button redirects.

--- a/.github/changelog/fix-authorize-interaction-rewrite
+++ b/.github/changelog/fix-authorize-interaction-rewrite
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix follow button redirect from Mastodon not being recognized.

--- a/.github/changelog/fix-authorize-interaction-rewrite
+++ b/.github/changelog/fix-authorize-interaction-rewrite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix follow button redirect from Mastodon not being recognized.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -220,6 +220,10 @@ class Migration {
 			\wp_schedule_single_event( \time(), 'activitypub_migrate_actor_emoji' );
 		}
 
+		if ( \version_compare( $version_from_db, 'unreleased', '<' ) ) {
+			Activitypub::flush_rewrite_rules();
+		}
+
 		// Ensure all required cron schedules are registered.
 		Scheduler::register_schedules();
 

--- a/includes/class-router.php
+++ b/includes/class-router.php
@@ -41,6 +41,12 @@ class Router {
 			return;
 		}
 
+		\add_rewrite_rule(
+			'^authorize_interaction',
+			'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/interactions',
+			'top'
+		);
+
 		if ( ! \class_exists( 'Webfinger' ) ) {
 			\add_rewrite_rule(
 				'^.well-known/webfinger',

--- a/includes/class-router.php
+++ b/includes/class-router.php
@@ -42,7 +42,7 @@ class Router {
 		}
 
 		\add_rewrite_rule(
-			'^authorize_interaction',
+			'^authorize_interaction/?$',
 			'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/interactions',
 			'top'
 		);

--- a/tests/phpunit/tests/includes/class-test-router.php
+++ b/tests/phpunit/tests/includes/class-test-router.php
@@ -434,6 +434,84 @@ class Test_Router extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the authorize_interaction rewrite rule is registered.
+	 *
+	 * @covers ::add_rewrite_rules
+	 */
+	public function test_authorize_interaction_rewrite_rule() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		Router::add_rewrite_rules();
+		\flush_rewrite_rules();
+
+		$rules = get_option( 'rewrite_rules' );
+
+		$this->assertArrayHasKey( '^authorize_interaction/?$', $rules );
+		$this->assertSame(
+			'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/interactions',
+			$rules['^authorize_interaction/?$']
+		);
+	}
+
+	/**
+	 * Test that the webfinger rewrite rule is registered when no Webfinger plugin is active.
+	 *
+	 * @covers ::add_rewrite_rules
+	 */
+	public function test_webfinger_rewrite_rule() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		Router::add_rewrite_rules();
+		\flush_rewrite_rules();
+
+		$rules = get_option( 'rewrite_rules' );
+
+		$this->assertArrayHasKey( '^.well-known/webfinger', $rules );
+		$this->assertSame(
+			'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/webfinger',
+			$rules['^.well-known/webfinger']
+		);
+	}
+
+	/**
+	 * Test that the nodeinfo rewrite rule is registered when blog is public.
+	 *
+	 * @covers ::add_rewrite_rules
+	 */
+	public function test_nodeinfo_rewrite_rule() {
+		$this->set_permalink_structure( '/%postname%/' );
+		\update_option( 'blog_public', 1 );
+
+		Router::add_rewrite_rules();
+		\flush_rewrite_rules();
+
+		$rules = get_option( 'rewrite_rules' );
+
+		$this->assertArrayHasKey( '^.well-known/nodeinfo', $rules );
+		$this->assertSame(
+			'index.php?rest_route=/' . ACTIVITYPUB_REST_NAMESPACE . '/nodeinfo',
+			$rules['^.well-known/nodeinfo']
+		);
+	}
+
+	/**
+	 * Test that the actor rewrite rule is registered.
+	 *
+	 * @covers ::add_rewrite_rules
+	 */
+	public function test_actor_rewrite_rule() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		Router::add_rewrite_rules();
+		\flush_rewrite_rules();
+
+		$rules = get_option( 'rewrite_rules' );
+
+		$this->assertArrayHasKey( '^@([\w\-\.]+)\/?$', $rules );
+		$this->assertSame( 'index.php?actor=$matches[1]', $rules['^@([\w\-\.]+)\/?$'] );
+	}
+
+	/**
 	 * Test that the activitypub_supported_taxonomies filter is actually used by the Router.
 	 *
 	 * This verifies that adding a custom taxonomy via the filter allows redirects for that taxonomy.


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/follow-button-redirect-from-mastodon-not-recognized/

## Proposed changes:
* Add a WordPress rewrite rule mapping `authorize_interaction` to the existing ActivityPub REST interactions endpoint (`/wp-json/activitypub/1.0/interactions`).
* Mastodon's "Follow" button redirects users to `https://{instance}/authorize_interaction?uri={acct}`, which WordPress didn't handle. This rewrite rule makes it work by routing the request to the existing `Interaction_Controller`.
* Add a migration to flush rewrite rules on upgrade so existing installations pick up the new rule.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install the plugin on a WordPress site with ActivityPub enabled.
* From a Mastodon instance, visit a profile and click the "Follow" button.
* Enter your WordPress site URL when prompted.
* Verify that you are redirected to your WordPress instance (e.g. the following UI or admin page) instead of getting a 404.
* Alternatively, visit `https://your-site.com/authorize_interaction?uri=@user@mastodon.social` directly and confirm it resolves to the interactions endpoint.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix follow button redirect from Mastodon not being recognized.

</details>