### PR TITLE
Add Locale from Tags snippet

### DIFF
--- a/.github/changelog/2923-from-description
+++ b/.github/changelog/2923-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Locale from Tags community snippet.

--- a/snippets/README.md
+++ b/snippets/README.md
@@ -9,6 +9,7 @@ Think of snippets as a testing ground, similar to WordPress' [feature plugin](ht
 | Snippet | Description |
 |---------|-------------|
 | [FediBlog Tag](fediblog-tag/) | Automatically adds the `FediBlog` tag to standard format blog posts. |
+| [Locale from Tags](locale-from-tags/) | Sets a post's ActivityPub language based on post tags matching language codes. |
 
 ## How to Use
 

--- a/snippets/locale-from-tags/README.md
+++ b/snippets/locale-from-tags/README.md
@@ -1,0 +1,36 @@
+# Locale from Tags
+
+Sets a post's ActivityPub language based on post tags that match language codes.
+
+If you write in multiple languages and tag your posts with a language identifier (e.g. `en`, `fr`, `de`), this snippet ensures the correct language is set in the ActivityPub representation of your post. This helps federated platforms display accurate language metadata and enables automatic translation features.
+
+When no matching language tag is found, the site's default locale is used.
+
+## Installation
+
+Copy this folder to `wp-content/plugins/` and activate **Locale from Tags** from the WordPress admin, or copy `locale-from-tags.php` to `wp-content/mu-plugins/` for automatic activation.
+
+## Requirements
+
+- WordPress 5.9+
+- PHP 7.4+
+- [ActivityPub](https://wordpress.org/plugins/activitypub/) plugin
+
+## Configuration
+
+By default, the snippet looks for these language code tags: `en`, `fr`, `de`, `es`, `it`, `pt`, `nl`, `ja`, `zh`, `ko`.
+
+To customize the list, use the `activitypub_snippet_locale_from_tags_codes` filter:
+
+```php
+add_filter(
+	'activitypub_snippet_locale_from_tags_codes',
+	function () {
+		return array( 'en', 'fr', 'hu' );
+	}
+);
+```
+
+## Origin
+
+Based on a [blog post by Jeremy Herve](https://herve.bzh/wordpress-set-a-posts-language-in-its-activitypub-representation-based-on-post-tags/).

--- a/snippets/locale-from-tags/locale-from-tags.php
+++ b/snippets/locale-from-tags/locale-from-tags.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Plugin Name:       Locale from Tags
+ * Plugin URI:        https://github.com/Automattic/wordpress-activitypub
+ * Description:       Sets a post's ActivityPub language based on post tags matching language codes.
+ * Version:           1.0.0
+ * Requires at least: 5.9
+ * Requires PHP:      7.4
+ * Author:            Jeremy Herve
+ * Author URI:        https://herve.bzh/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       activitypub-locale-from-tags
+ * Requires Plugins:  activitypub
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Snippets;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Set a post's language in its ActivityPub representation based on post tags.
+ *
+ * When a post has tags matching configured language codes,
+ * the first matching tag is used as the post's locale for ActivityPub.
+ * When no matching tags are found, the default locale is preserved.
+ *
+ * @see https://herve.bzh/wordpress-set-a-posts-language-in-its-activitypub-representation-based-on-post-tags/
+ *
+ * @param string $lang The locale of the post.
+ * @param mixed  $item The post object or other item being transformed.
+ *
+ * @return string The filtered locale of the post.
+ */
+function set_locale_from_tags( $lang, $item ) {
+	if ( ! $item instanceof \WP_Post ) {
+		return $lang;
+	}
+
+	$post_tags = \get_the_tags( $item->ID );
+
+	if ( empty( $post_tags ) ) {
+		return $lang;
+	}
+
+	/**
+	 * Filters the list of language codes to detect in post tags.
+	 *
+	 * Each entry should be an ISO 639-1 two-letter language code
+	 * that you use as a tag slug on your site.
+	 *
+	 * @param string[] $language_codes Array of language code strings to look for in tags.
+	 */
+	$language_codes = \apply_filters(
+		'activitypub_snippet_locale_from_tags_codes',
+		array( 'en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'ja', 'zh', 'ko' )
+	);
+
+	foreach ( $post_tags as $tag ) {
+		if ( \in_array( $tag->slug, $language_codes, true ) ) {
+			return $tag->slug;
+		}
+	}
+
+	return $lang;
+}
+
+// Hook into the ActivityPub locale filter.
+\add_filter( 'activitypub_locale', __NAMESPACE__ . '\set_locale_from_tags', 10, 2 );

--- a/snippets/locale-from-tags/locale-from-tags.php
+++ b/snippets/locale-from-tags/locale-from-tags.php
@@ -44,7 +44,7 @@ function set_locale_from_tags( $lang, $item ) {
 
 	$post_tags = \get_the_tags( $item->ID );
 
-	if ( empty( $post_tags ) ) {
+	if ( ! \is_array( $post_tags ) ) {
 		return $lang;
 	}
 


### PR DESCRIPTION
## Proposed changes:
* Add a new community snippet that sets a post's ActivityPub language based on post tags matching language codes (e.g. `en`, `fr`, `de`).
* Useful for multilingual blogs that tag their posts with a language identifier — the matching tag is then used as the post's locale in the ActivityPub representation.
* Based on https://herve.bzh/wordpress-set-a-posts-language-in-its-activitypub-representation-based-on-post-tags/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

This is a community snippet (a standalone micro-plugin in `snippets/`), not a change to the core plugin. No new tests are needed.

## Testing instructions:

1. Copy the `snippets/locale-from-tags/` folder into `wp-content/plugins/` and activate it.
2. Create or edit a post and add a tag matching one of the default language codes (e.g. `en`, `fr`, `de`).
3. Publish the post and check its ActivityPub JSON representation (append `?activitypub` or check the outbox) — the `contentMap` key should reflect the tag's language code instead of the site's default locale.
4. To test customization, add this to your theme's `functions.php`:
   ```php
   add_filter(
       'activitypub_snippet_locale_from_tags_codes',
       function () {
           return array( 'en', 'fr', 'hu' );
       }
   );
   ```
   Verify that only tags matching the custom list are recognized.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Added - for new features

#### Message

Add Locale from Tags community snippet.

</details>