### PR TITLE
Fix QuoteRequest handler to derive actor from post author

### DIFF
--- a/.github/changelog/fix-quote-request-actor-derivation
+++ b/.github/changelog/fix-quote-request-actor-derivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix QuoteRequest handler to derive responding actor from post author instead of inbox recipient.

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -15,6 +15,7 @@ use Activitypub\Collection\Remote_Actors;
 
 use function Activitypub\add_to_outbox;
 use function Activitypub\object_to_uri;
+use function Activitypub\user_can_activitypub;
 
 /**
  * Handler for QuoteRequest activities.
@@ -40,17 +41,18 @@ class Quote_Request {
 	 * @param int|int[] $user_ids The user ID(s).
 	 */
 	public static function handle_quote_request( $activity, $user_ids ) {
-		// Extract the user ID (quote requests are always for a single user).
-		$user_id = \is_array( $user_ids ) ? \reset( $user_ids ) : $user_ids;
-
 		$state   = true;
 		$post_id = \url_to_postid( object_to_uri( $activity['object'] ) );
+		$post    = $post_id ? \get_post( $post_id ) : null;
 
-		if ( ! $post_id ) {
+		if ( ! $post ) {
+			$user_id = \is_array( $user_ids ) ? \reset( $user_ids ) : $user_ids;
 			self::queue_reject( $activity, $user_id );
 			return;
 		}
 
+		// Use the post author as the responding actor — they own the quoted content.
+		$user_id        = (int) $post->post_author;
 		$content_policy = \get_post_meta( $post_id, 'activitypub_interaction_policy_quote', true );
 
 		// Fall back to global default if not set.
@@ -97,7 +99,7 @@ class Quote_Request {
 	 * @param string         $type     The type of the activity.
 	 */
 	public static function handle_blocked_request( $activity, $user_ids, $type ) {
-		if ( 'quoterequest' !== \strtolower( $type ) ) {
+		if ( ! in_array( strtolower( $type ), array( 'quoterequest', 'quote_request' ), true ) ) {
 			return;
 		}
 
@@ -202,6 +204,11 @@ class Quote_Request {
 	 * @param int   $post_id         The post ID.
 	 */
 	public static function queue_accept( $activity_object, $user_id, $post_id ) {
+		// Fall back to the blog actor if the user has ActivityPub disabled.
+		if ( ! user_can_activitypub( $user_id ) ) {
+			$user_id = Actors::BLOG_USER_ID;
+		}
+
 		$actor = Actors::get_by_id( $user_id );
 
 		if ( \is_wp_error( $actor ) ) {
@@ -266,6 +273,11 @@ class Quote_Request {
 	 * @param int   $user_id  The user ID.
 	 */
 	public static function queue_reject( $activity_object, $user_id ) {
+		// Fall back to the blog actor if the user has ActivityPub disabled.
+		if ( ! user_can_activitypub( $user_id ) ) {
+			$user_id = Actors::BLOG_USER_ID;
+		}
+
 		$actor = Actors::get_by_id( $user_id );
 
 		if ( \is_wp_error( $actor ) ) {

--- a/tests/phpunit/tests/includes/handler/class-test-quote-request.php
+++ b/tests/phpunit/tests/includes/handler/class-test-quote-request.php
@@ -226,7 +226,7 @@ class Test_Quote_Request extends ActivityPub_Outbox_TestCase {
 	public function test_handle_blocked_request() {
 		$activity = $this->create_quote_request_activity();
 
-		Quote_Request::handle_blocked_request( $activity, self::$user_id, 'QuoteRequest' );
+		Quote_Request::handle_blocked_request( $activity, self::$user_id, 'quote_request' );
 
 		// Check outbox for Reject response.
 		$outbox_posts = get_posts(


### PR DESCRIPTION
## Proposed changes:

* **Fix actor derivation:** `handle_quote_request` now derives the responding actor from the post author (`$post->post_author`) instead of blindly using the inbox recipient. Previously, if a QuoteRequest was delivered to a different local actor (e.g. via shared-inbox recipient expansion), the handler would send Accept/Reject from the wrong actor and mutate `_activitypub_quoted_by` on someone else's post.
* **Fix blocked request type matching:** `handle_blocked_request` now matches both `quoterequest` and `quote_request`, since the inbox hook provides the type in snake_case via `camel_to_snake_case()`. The old guard only matched `quoterequest`, so blocked QuoteRequests were silently skipped.
* **Add blog-actor fallback:** `queue_accept` and `queue_reject` now fall back to `Actors::BLOG_USER_ID` when the post author has ActivityPub disabled, preventing silent failures.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Existing test updated to use the actual snake_cased type value (`quote_request`) that the hook provides, instead of the PascalCase value (`QuoteRequest`) which masked the bug.

## Testing instructions:

* Set up a multi-author site with ActivityPub enabled
* Send a QuoteRequest targeting a post authored by User A, but delivered to User B's inbox
* Verify the Accept/Reject is signed by User A (the post author), not User B
* Verify blocked actors receive a Reject response for QuoteRequests
* Run `composer test:wp-env -- --filter Test_Quote_Request` — all 20 tests pass

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed - for any bug fixes

#### Message

Fix QuoteRequest handler to derive responding actor from post author instead of inbox recipient.

</details>