### PR TITLE
Add Site Health test to detect excessive outbox activity

### DIFF
--- a/.github/changelog/2928-from-description
+++ b/.github/changelog/2928-from-description
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add Site Health test to detect excessive outbox activity rates.
+Add a Site Health check that warns when plugins are causing too many federation updates.

--- a/.github/changelog/2928-from-description
+++ b/.github/changelog/2928-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Site Health test to detect excessive outbox activity rates.

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -8,6 +8,7 @@
 namespace Activitypub\WP_Admin;
 
 use Activitypub\Collection\Actors;
+use Activitypub\Collection\Outbox;
 use Activitypub\Http;
 use Activitypub\Sanitize;
 use Activitypub\Scheduler;
@@ -140,6 +141,11 @@ class Health_Check {
 		$tests['direct']['activitypub_test_rest_api_accessibility'] = array(
 			'label' => \__( 'REST API Accessibility Test', 'activitypub' ),
 			'test'  => array( self::class, 'test_rest_api_accessibility' ),
+		);
+
+		$tests['direct']['activitypub_test_outbox_rate'] = array(
+			'label' => \__( 'Outbox Activity Rate Test', 'activitypub' ),
+			'test'  => array( self::class, 'test_outbox_rate' ),
 		);
 
 		return $tests;
@@ -391,6 +397,26 @@ class Health_Check {
 		$info['activitypub']['fields']['authorized_fetch'] = array(
 			'label'   => \__( 'Authorized Fetch', 'activitypub' ),
 			'value'   => \esc_attr( (int) \get_option( 'activitypub_authorized_fetch', '0' ) ),
+			'private' => false,
+		);
+
+		$info['activitypub']['fields']['outbox_total_count'] = array(
+			'label'   => \__( 'Outbox Total Items', 'activitypub' ),
+			'value'   => self::get_outbox_count(),
+			'private' => false,
+		);
+
+		$info['activitypub']['fields']['outbox_pending_count'] = array(
+			'label'   => \__( 'Outbox Pending Items', 'activitypub' ),
+			'value'   => self::get_outbox_count( 'pending' ),
+			'private' => false,
+		);
+
+		$outbox_rate_data = self::get_outbox_rate_data();
+
+		$info['activitypub']['fields']['outbox_last_hour_count'] = array(
+			'label'   => \__( 'Outbox Items (Last Hour)', 'activitypub' ),
+			'value'   => $outbox_rate_data['total'],
 			'private' => false,
 		);
 
@@ -741,6 +767,171 @@ class Health_Check {
 		);
 
 		return $result;
+	}
+
+	/**
+	 * Outbox activity rate test.
+	 *
+	 * Detects abnormally high outbox creation rates that may indicate
+	 * a third-party plugin is triggering excessive wp_update_post() calls.
+	 *
+	 * @since unreleased
+	 *
+	 * @return array The test result.
+	 */
+	public static function test_outbox_rate() {
+		$result = array(
+			'label'       => \__( 'Outbox activity rate is normal', 'activitypub' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => \__( 'ActivityPub', 'activitypub' ),
+				'color' => 'green',
+			),
+			'description' => \sprintf(
+				'<p>%s</p>',
+				\__( 'The outbox activity rate is within normal limits.', 'activitypub' )
+			),
+			'actions'     => '',
+			'test'        => 'test_outbox_rate',
+		);
+
+		$data  = self::get_outbox_rate_data();
+		$total = $data['total'];
+
+		if ( $total <= 10 ) {
+			return $result;
+		}
+
+		// Build top objects description.
+		$top_objects = \array_slice( $data['by_object'], 0, 3, true );
+		$object_list = array();
+		foreach ( $top_objects as $object_id => $count ) {
+			$object_list[] = \sprintf(
+				'<code>%s</code> (%d)',
+				\esc_html( $object_id ),
+				$count
+			);
+		}
+
+		$details = \sprintf(
+			/* translators: %d: Number of outbox items. */
+			\__( '%d outbox items were created in the last hour.', 'activitypub' ),
+			$total
+		);
+
+		if ( ! empty( $object_list ) ) {
+			$details .= ' ' . \sprintf(
+				/* translators: %s: Comma-separated list of object URLs with counts. */
+				\__( 'Most active objects: %s.', 'activitypub' ),
+				\implode( ', ', $object_list )
+			);
+		}
+
+		if ( $total > 50 ) {
+			$result['status']         = 'critical';
+			$result['label']          = \__( 'Excessive outbox activity detected', 'activitypub' );
+			$result['badge']['color'] = 'red';
+			$result['description']    = \sprintf(
+				'<p>%s</p><p>%s</p>',
+				$details,
+				\__( 'A plugin may be calling wp_update_post() on published posts at a very high rate, causing excessive federation activity. This can impact site performance and may flood federated servers.', 'activitypub' )
+			);
+		} else {
+			$result['status']         = 'recommended';
+			$result['label']          = \__( 'Unusual outbox activity detected', 'activitypub' );
+			$result['badge']['color'] = 'orange';
+			$result['description']    = \sprintf(
+				'<p>%s</p><p>%s</p>',
+				$details,
+				\__( 'Check for plugins that may be triggering frequent updates to published posts, such as editorial calendars or cloud sync services.', 'activitypub' )
+			);
+		}
+
+		$result['actions'] = \sprintf(
+			'<p>%s</p>',
+			\sprintf(
+				/* translators: %s: Plugins page URL. */
+				\__( 'Review your <a href="%s">active plugins</a> for any that may be modifying published posts frequently.', 'activitypub' ),
+				\esc_url( \admin_url( 'plugins.php' ) )
+			)
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Get outbox activity rate data for the last hour.
+	 *
+	 * @since unreleased
+	 *
+	 * @return array {
+	 *     Outbox rate data.
+	 *
+	 *     @type int   $total     Total items created in the last hour.
+	 *     @type array $by_object Object ID => count, sorted descending.
+	 * }
+	 */
+	public static function get_outbox_rate_data() {
+		$posts = \get_posts(
+			array(
+				'post_type'      => Outbox::POST_TYPE,
+				'post_status'    => 'any',
+				'posts_per_page' => 100,
+				'date_query'     => array(
+					array(
+						'after' => '1 hour ago',
+					),
+				),
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
+
+		$by_object = array();
+
+		foreach ( $posts as $post ) {
+			$object_id = \get_post_meta( $post->ID, '_activitypub_object_id', true );
+
+			if ( ! $object_id ) {
+				continue;
+			}
+
+			if ( ! isset( $by_object[ $object_id ] ) ) {
+				$by_object[ $object_id ] = 0;
+			}
+
+			++$by_object[ $object_id ];
+		}
+
+		\arsort( $by_object );
+
+		return array(
+			'total'     => \count( $posts ),
+			'by_object' => $by_object,
+		);
+	}
+
+	/**
+	 * Get the count of outbox items.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $status Optional. Post status to count. Default 'any' for all statuses.
+	 *
+	 * @return int The number of outbox items.
+	 */
+	public static function get_outbox_count( $status = 'any' ) {
+		$counts = \wp_count_posts( Outbox::POST_TYPE );
+
+		if ( 'any' === $status ) {
+			$total = 0;
+			foreach ( (array) $counts as $count ) {
+				$total += (int) $count;
+			}
+			return $total;
+		}
+
+		return isset( $counts->$status ) ? (int) $counts->$status : 0;
 	}
 
 	/**

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -812,7 +812,7 @@ class Health_Check {
 			$result['description']    = \sprintf(
 				'<p>%s</p><p>%s</p>',
 				$details,
-				\__( 'A plugin may be calling wp_update_post() on published posts at a very high rate, causing excessive federation activity. This can impact site performance and may flood federated servers.', 'activitypub' )
+				\__( 'A plugin may be triggering updates to published posts at a very high rate, causing excessive federation activity. This can impact site performance and may flood federated servers.', 'activitypub' )
 			);
 		} else {
 			$result['status']         = 'recommended';

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -412,11 +412,9 @@ class Health_Check {
 			'private' => false,
 		);
 
-		$outbox_rate_data = self::get_outbox_rate_data();
-
 		$info['activitypub']['fields']['outbox_last_hour_count'] = array(
 			'label'   => \__( 'Outbox Items (Last Hour)', 'activitypub' ),
-			'value'   => $outbox_rate_data['total'],
+			'value'   => self::get_outbox_rate_count(),
 			'private' => false,
 		);
 
@@ -795,22 +793,10 @@ class Health_Check {
 			'test'        => 'test_outbox_rate',
 		);
 
-		$data  = self::get_outbox_rate_data();
-		$total = $data['total'];
+		$total = self::get_outbox_rate_count();
 
 		if ( $total <= 10 ) {
 			return $result;
-		}
-
-		// Build top objects description.
-		$top_objects = \array_slice( $data['by_object'], 0, 3, true );
-		$object_list = array();
-		foreach ( $top_objects as $object_id => $count ) {
-			$object_list[] = \sprintf(
-				'<code>%s</code> (%d)',
-				\esc_html( $object_id ),
-				$count
-			);
 		}
 
 		$details = \sprintf(
@@ -818,14 +804,6 @@ class Health_Check {
 			\__( '%d outbox items were created in the last hour.', 'activitypub' ),
 			$total
 		);
-
-		if ( ! empty( $object_list ) ) {
-			$details .= ' ' . \sprintf(
-				/* translators: %s: Comma-separated list of object URLs with counts. */
-				\__( 'Most active objects: %s.', 'activitypub' ),
-				\implode( ', ', $object_list )
-			);
-		}
 
 		if ( $total > 50 ) {
 			$result['status']         = 'critical';
@@ -860,55 +838,28 @@ class Health_Check {
 	}
 
 	/**
-	 * Get outbox activity rate data for the last hour.
+	 * Count outbox items created in the last hour.
 	 *
 	 * @since unreleased
 	 *
-	 * @return array {
-	 *     Outbox rate data.
-	 *
-	 *     @type int   $total     Total items created in the last hour.
-	 *     @type array $by_object Object ID => count, sorted descending.
-	 * }
+	 * @return int Total items created in the last hour.
 	 */
-	public static function get_outbox_rate_data() {
-		$posts = \get_posts(
+	public static function get_outbox_rate_count() {
+		$query = new \WP_Query(
 			array(
 				'post_type'      => Outbox::POST_TYPE,
 				'post_status'    => 'any',
-				'posts_per_page' => 100,
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
 				'date_query'     => array(
 					array(
 						'after' => '1 hour ago',
 					),
 				),
-				'orderby'        => 'date',
-				'order'          => 'DESC',
 			)
 		);
 
-		$by_object = array();
-
-		foreach ( $posts as $post ) {
-			$object_id = \get_post_meta( $post->ID, '_activitypub_object_id', true );
-
-			if ( ! $object_id ) {
-				continue;
-			}
-
-			if ( ! isset( $by_object[ $object_id ] ) ) {
-				$by_object[ $object_id ] = 0;
-			}
-
-			++$by_object[ $object_id ];
-		}
-
-		\arsort( $by_object );
-
-		return array(
-			'total'     => \count( $posts ),
-			'by_object' => $by_object,
-		);
+		return (int) $query->found_posts;
 	}
 
 	/**

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -829,7 +829,7 @@ class Health_Check {
 			'<p>%s</p>',
 			\sprintf(
 				/* translators: %s: Plugins page URL. */
-				\__( 'Review your <a href="%s">active plugins</a> for any that may be modifying published posts frequently.', 'activitypub' ),
+				\__( 'Review your <a href="%s">active plugins</a> for any that may be frequently modifying published posts.', 'activitypub' ),
 				\esc_url( \admin_url( 'plugins.php' ) )
 			)
 		);

--- a/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
@@ -564,7 +564,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 		$this->assertEquals( 'Excessive outbox activity detected', $result['label'] );
 		$this->assertEquals( 'red', $result['badge']['color'] );
 		$this->assertStringContainsString( '55 outbox items', $result['description'] );
-		$this->assertStringContainsString( 'wp_update_post()', $result['description'] );
+		$this->assertStringContainsString( 'excessive federation activity', $result['description'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
@@ -547,7 +547,6 @@ class Test_Health_Check extends WP_UnitTestCase {
 		$this->assertEquals( 'Unusual outbox activity detected', $result['label'] );
 		$this->assertEquals( 'orange', $result['badge']['color'] );
 		$this->assertStringContainsString( '15 outbox items', $result['description'] );
-		$this->assertStringContainsString( 'example.com/post/1', $result['description'] );
 	}
 
 	/**
@@ -569,30 +568,16 @@ class Test_Health_Check extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_outbox_rate_data groups by object ID.
+	 * Test get_outbox_rate_count returns correct total.
 	 */
-	public function test_outbox_rate_data_groups_by_object() {
+	public function test_outbox_rate_count() {
 		$this->delete_all_outbox_items();
 
 		$this->create_outbox_items( 5, 'https://example.com/post/a' );
 		$this->create_outbox_items( 3, 'https://example.com/post/b' );
 		$this->create_outbox_items( 7, 'https://example.com/post/c' );
 
-		$data = Health_Check::get_outbox_rate_data();
-
-		$this->assertEquals( 15, $data['total'] );
-		$this->assertArrayHasKey( 'https://example.com/post/c', $data['by_object'] );
-		$this->assertArrayHasKey( 'https://example.com/post/a', $data['by_object'] );
-		$this->assertArrayHasKey( 'https://example.com/post/b', $data['by_object'] );
-		$this->assertEquals( 7, $data['by_object']['https://example.com/post/c'] );
-		$this->assertEquals( 5, $data['by_object']['https://example.com/post/a'] );
-		$this->assertEquals( 3, $data['by_object']['https://example.com/post/b'] );
-
-		// Verify sorted descending.
-		$counts = array_values( $data['by_object'] );
-		$this->assertEquals( 7, $counts[0] );
-		$this->assertEquals( 5, $counts[1] );
-		$this->assertEquals( 3, $counts[2] );
+		$this->assertEquals( 15, Health_Check::get_outbox_rate_count() );
 	}
 
 	/**
@@ -628,9 +613,9 @@ class Test_Health_Check extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test outbox rate shows top 3 objects only.
+	 * Test outbox rate recommended status with multiple objects.
 	 */
-	public function test_outbox_rate_shows_top_3_objects() {
+	public function test_outbox_rate_recommended_multiple_objects() {
 		$this->delete_all_outbox_items();
 
 		$this->create_outbox_items( 4, 'https://example.com/post/1' );
@@ -642,12 +627,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 
 		// 12 items total, should be "recommended".
 		$this->assertEquals( 'recommended', $result['status'] );
-
-		// Should show top 3 objects.
-		$this->assertStringContainsString( 'example.com/post/1', $result['description'] );
-		// Posts 2 and 4 are tied at 3 each, so both could appear in top 3.
-		// Post 3 has only 2, so it should not appear.
-		$this->assertStringNotContainsString( 'example.com/post/3', $result['description'] );
+		$this->assertStringContainsString( '12 outbox items', $result['description'] );
 	}
 
 	/**
@@ -662,12 +642,8 @@ class Test_Health_Check extends WP_UnitTestCase {
 		// Create 20 old items (2 hours ago — outside the window).
 		$this->create_outbox_items( 20, 'https://example.com/post/old', '2 hours ago' );
 
-		$data = Health_Check::get_outbox_rate_data();
-
 		// Only the 15 recent items should be counted.
-		$this->assertEquals( 15, $data['total'] );
-		$this->assertArrayHasKey( 'https://example.com/post/recent', $data['by_object'] );
-		$this->assertArrayNotHasKey( 'https://example.com/post/old', $data['by_object'] );
+		$this->assertEquals( 15, Health_Check::get_outbox_rate_count() );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
@@ -5,6 +5,7 @@
  * @package Activitypub
  */
 
+use Activitypub\Collection\Outbox;
 use Activitypub\Scheduler;
 use Activitypub\WP_Admin\Health_Check;
 
@@ -503,5 +504,198 @@ class Test_Health_Check extends WP_UnitTestCase {
 		$this->assertEquals( 'hourly', $schedules['activitypub_update_remote_actors'] );
 		$this->assertEquals( 'daily', $schedules['activitypub_cleanup_remote_actors'] );
 		$this->assertEquals( 'weekly', $schedules['activitypub_sync_blocklist_subscriptions'] );
+	}
+
+	/**
+	 * Test that outbox rate test is registered.
+	 */
+	public function test_outbox_rate_test_registered() {
+		$tests  = array();
+		$result = Health_Check::add_tests( $tests );
+
+		$this->assertArrayHasKey( 'activitypub_test_outbox_rate', $result['direct'] );
+
+		$test = $result['direct']['activitypub_test_outbox_rate'];
+		$this->assertArrayHasKey( 'label', $test );
+		$this->assertArrayHasKey( 'test', $test );
+		$this->assertEquals( array( Health_Check::class, 'test_outbox_rate' ), $test['test'] );
+	}
+
+	/**
+	 * Test outbox rate returns good status with no outbox items.
+	 */
+	public function test_outbox_rate_good() {
+		$result = Health_Check::test_outbox_rate();
+
+		$this->assertEquals( 'good', $result['status'] );
+		$this->assertEquals( 'Outbox activity rate is normal', $result['label'] );
+		$this->assertEquals( 'green', $result['badge']['color'] );
+	}
+
+	/**
+	 * Test outbox rate returns recommended status with moderate activity.
+	 */
+	public function test_outbox_rate_recommended() {
+		$this->delete_all_outbox_items();
+
+		// Create 15 outbox items (above 10, below 50).
+		$this->create_outbox_items( 15, 'https://example.com/post/1' );
+
+		$result = Health_Check::test_outbox_rate();
+
+		$this->assertEquals( 'recommended', $result['status'] );
+		$this->assertEquals( 'Unusual outbox activity detected', $result['label'] );
+		$this->assertEquals( 'orange', $result['badge']['color'] );
+		$this->assertStringContainsString( '15 outbox items', $result['description'] );
+		$this->assertStringContainsString( 'example.com/post/1', $result['description'] );
+	}
+
+	/**
+	 * Test outbox rate returns critical status with excessive activity.
+	 */
+	public function test_outbox_rate_critical() {
+		$this->delete_all_outbox_items();
+
+		// Create 55 outbox items (above 50).
+		$this->create_outbox_items( 55, 'https://example.com/post/2' );
+
+		$result = Health_Check::test_outbox_rate();
+
+		$this->assertEquals( 'critical', $result['status'] );
+		$this->assertEquals( 'Excessive outbox activity detected', $result['label'] );
+		$this->assertEquals( 'red', $result['badge']['color'] );
+		$this->assertStringContainsString( '55 outbox items', $result['description'] );
+		$this->assertStringContainsString( 'wp_update_post()', $result['description'] );
+	}
+
+	/**
+	 * Test get_outbox_rate_data groups by object ID.
+	 */
+	public function test_outbox_rate_data_groups_by_object() {
+		$this->delete_all_outbox_items();
+
+		$this->create_outbox_items( 5, 'https://example.com/post/a' );
+		$this->create_outbox_items( 3, 'https://example.com/post/b' );
+		$this->create_outbox_items( 7, 'https://example.com/post/c' );
+
+		$data = Health_Check::get_outbox_rate_data();
+
+		$this->assertEquals( 15, $data['total'] );
+		$this->assertArrayHasKey( 'https://example.com/post/c', $data['by_object'] );
+		$this->assertArrayHasKey( 'https://example.com/post/a', $data['by_object'] );
+		$this->assertArrayHasKey( 'https://example.com/post/b', $data['by_object'] );
+		$this->assertEquals( 7, $data['by_object']['https://example.com/post/c'] );
+		$this->assertEquals( 5, $data['by_object']['https://example.com/post/a'] );
+		$this->assertEquals( 3, $data['by_object']['https://example.com/post/b'] );
+
+		// Verify sorted descending.
+		$counts = array_values( $data['by_object'] );
+		$this->assertEquals( 7, $counts[0] );
+		$this->assertEquals( 5, $counts[1] );
+		$this->assertEquals( 3, $counts[2] );
+	}
+
+	/**
+	 * Test get_outbox_count returns correct counts.
+	 */
+	public function test_get_outbox_count() {
+		$this->create_outbox_items( 3, 'https://example.com/post/count-test' );
+
+		// Outbox items are created with 'pending' status.
+		$pending_count = Health_Check::get_outbox_count( 'pending' );
+		$this->assertGreaterThanOrEqual( 3, $pending_count );
+
+		$total_count = Health_Check::get_outbox_count();
+		$this->assertGreaterThanOrEqual( 3, $total_count );
+	}
+
+	/**
+	 * Test debug_information includes outbox stats.
+	 */
+	public function test_debug_information_includes_outbox_stats() {
+		$info   = array();
+		$result = Health_Check::debug_information( $info );
+
+		$fields = $result['activitypub']['fields'];
+
+		$this->assertArrayHasKey( 'outbox_total_count', $fields );
+		$this->assertArrayHasKey( 'outbox_pending_count', $fields );
+		$this->assertArrayHasKey( 'outbox_last_hour_count', $fields );
+
+		$this->assertEquals( 'Outbox Total Items', $fields['outbox_total_count']['label'] );
+		$this->assertEquals( 'Outbox Pending Items', $fields['outbox_pending_count']['label'] );
+		$this->assertEquals( 'Outbox Items (Last Hour)', $fields['outbox_last_hour_count']['label'] );
+	}
+
+	/**
+	 * Test outbox rate shows top 3 objects only.
+	 */
+	public function test_outbox_rate_shows_top_3_objects() {
+		$this->delete_all_outbox_items();
+
+		$this->create_outbox_items( 4, 'https://example.com/post/1' );
+		$this->create_outbox_items( 3, 'https://example.com/post/2' );
+		$this->create_outbox_items( 2, 'https://example.com/post/3' );
+		$this->create_outbox_items( 3, 'https://example.com/post/4' );
+
+		$result = Health_Check::test_outbox_rate();
+
+		// 12 items total, should be "recommended".
+		$this->assertEquals( 'recommended', $result['status'] );
+
+		// Should show top 3 objects.
+		$this->assertStringContainsString( 'example.com/post/1', $result['description'] );
+		// Posts 2 and 4 are tied at 3 each, so both could appear in top 3.
+		// Post 3 has only 2, so it should not appear.
+		$this->assertStringNotContainsString( 'example.com/post/3', $result['description'] );
+	}
+
+	/**
+	 * Delete all existing outbox items to ensure a clean test state.
+	 */
+	private function delete_all_outbox_items() {
+		$posts = get_posts(
+			array(
+				'post_type'      => Outbox::POST_TYPE,
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+
+		foreach ( $posts as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	/**
+	 * Helper to create outbox items for testing.
+	 *
+	 * @param int    $count     Number of items to create.
+	 * @param string $object_id The object ID meta value.
+	 *
+	 * @return int[] Array of created post IDs.
+	 */
+	private function create_outbox_items( $count, $object_id ) {
+		$post_ids = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$post_id = $this->factory()->post->create(
+				array(
+					'post_type'   => Outbox::POST_TYPE,
+					'post_status' => 'pending',
+					'post_title'  => '[Update] Test Post',
+					'post_date'   => \current_time( 'mysql' ),
+					'meta_input'  => array(
+						'_activitypub_object_id'     => $object_id,
+						'_activitypub_activity_type' => 'Update',
+					),
+				)
+			);
+
+			$post_ids[] = $post_id;
+		}
+
+		return $post_ids;
 	}
 }

--- a/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
@@ -651,6 +651,26 @@ class Test_Health_Check extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that outbox rate only counts items from the last hour.
+	 */
+	public function test_outbox_rate_excludes_old_items() {
+		$this->delete_all_outbox_items();
+
+		// Create 15 recent items (within the last hour).
+		$this->create_outbox_items( 15, 'https://example.com/post/recent' );
+
+		// Create 20 old items (2 hours ago — outside the window).
+		$this->create_outbox_items( 20, 'https://example.com/post/old', '2 hours ago' );
+
+		$data = Health_Check::get_outbox_rate_data();
+
+		// Only the 15 recent items should be counted.
+		$this->assertEquals( 15, $data['total'] );
+		$this->assertArrayHasKey( 'https://example.com/post/recent', $data['by_object'] );
+		$this->assertArrayNotHasKey( 'https://example.com/post/old', $data['by_object'] );
+	}
+
+	/**
 	 * Delete all existing outbox items to ensure a clean test state.
 	 */
 	private function delete_all_outbox_items() {
@@ -676,8 +696,18 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 *
 	 * @return int[] Array of created post IDs.
 	 */
-	private function create_outbox_items( $count, $object_id ) {
-		$post_ids = array();
+	/**
+	 * Helper to create outbox items for testing.
+	 *
+	 * @param int    $count     Number of items to create.
+	 * @param string $object_id The object ID meta value.
+	 * @param string $post_date Optional. The post date. Default current time.
+	 *
+	 * @return int[] Array of created post IDs.
+	 */
+	private function create_outbox_items( $count, $object_id, $post_date = '' ) {
+		$post_ids  = array();
+		$base_time = $post_date ? \strtotime( $post_date ) : \time();
 
 		for ( $i = 0; $i < $count; $i++ ) {
 			$post_id = $this->factory()->post->create(
@@ -685,7 +715,7 @@ class Test_Health_Check extends WP_UnitTestCase {
 					'post_type'   => Outbox::POST_TYPE,
 					'post_status' => 'pending',
 					'post_title'  => '[Update] Test Post',
-					'post_date'   => \current_time( 'mysql' ),
+					'post_date'   => \gmdate( 'Y-m-d H:i:s', $base_time - $i ),
 					'meta_input'  => array(
 						'_activitypub_object_id'     => $object_id,
 						'_activitypub_activity_type' => 'Update',

--- a/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
+++ b/tests/phpunit/tests/includes/wp-admin/class-test-health-check.php
@@ -669,14 +669,6 @@ class Test_Health_Check extends WP_UnitTestCase {
 	 *
 	 * @param int    $count     Number of items to create.
 	 * @param string $object_id The object ID meta value.
-	 *
-	 * @return int[] Array of created post IDs.
-	 */
-	/**
-	 * Helper to create outbox items for testing.
-	 *
-	 * @param int    $count     Number of items to create.
-	 * @param string $object_id The object ID meta value.
 	 * @param string $post_date Optional. The post date. Default current time.
 	 *
 	 * @return int[] Array of created post IDs.


### PR DESCRIPTION
Related #2927

## Proposed changes:
* Add a new Site Health test (`test_outbox_rate`) that queries recent `ap_outbox` posts to detect abnormal creation rates — good (≤10/hr), recommended (11–50/hr), critical (>50/hr).
* Show the top 3 most-active object URLs when elevated rates are detected, helping admins identify which posts are being updated excessively.
* Add outbox stats (total, pending, last-hour count) to the Site Health debug info section for support visibility.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Go to **Tools → Site Health → Status** and verify the new "Outbox Activity Rate Test" appears with a "good" badge on a clean install.
* Go to **Tools → Site Health → Info → ActivityPub** and verify the new outbox stats fields appear (Outbox Total Items, Outbox Pending Items, Outbox Items (Last Hour)).
* Run `npm run env-test -- --filter=Health_Check` — all 32 tests should pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Added - for new features

#### Message

Add Site Health test to detect excessive outbox activity rates.

</details>