### PR TITLE
Add end-user friendly changelog guidance to PR skill

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -38,11 +38,16 @@ gh pr create --assignee @me --reviewer Automattic/fediverse
 
 ## Changelog
 
-End all changelog messages with punctuation:
+**Write changelog messages for end users, not developers.** Users read these in the WordPress plugin update screen. Avoid internal jargon (OOM, batching, N+1), class names, or method names. Describe what the user experiences or what changed from their perspective.
+
 ```
-✅ Add support for custom post types.
-❌ Add support for custom post types
+✅ Fix automatic cleanup of old activities failing silently on sites with many items.
+✅ Add a Site Health check that warns when plugins are causing too many federation updates.
+❌ Fix collection purge methods to batch deletions and enforce a hard item cap.
+❌ Add Site Health test to detect excessive outbox activity rates.
 ```
+
+End all changelog messages with punctuation.
 
 Add manually if forgotten:
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ npm run dev                     # Development watch mode.
 - **Never edit WordPress core files.** Only modify plugin code.
 - **Pre-commit hooks modify files.** If the hook changed files, stage and commit again — do not assume the first commit succeeded.
 - **`remove_all_filters('pre_http_request')` is forbidden in tests.** The pre-commit hook blocks this. Use targeted filter removal.
-- **Changelog entries MUST end with punctuation.** CI enforces this.
+- **Changelog entries MUST be end-user friendly and end with punctuation.** Users see these in the WordPress update screen. Describe what changed from their perspective — no jargon, class names, or method names.
 - **`post_date_gmt` may be empty.** Check for `0000-00-00` or empty values; causes issues on PHP 7.2.
 
 ## Pre-commit Hooks


### PR DESCRIPTION
## Proposed changes:
* Update the PR skill to explicitly require changelog entries written for end users, not developers.
* Add good/bad examples showing user-friendly vs developer-jargon messages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

N/A — documentation-only change.

## Testing instructions:

* Review `.agents/skills/pr/SKILL.md` and confirm the changelog section is clear.

### Changelog entry

<!-- No changelog needed for agent skill documentation. -->