### PR TITLE
Delete superseded outbox items instead of publishing them

### DIFF
--- a/.github/changelog/2932-from-description
+++ b/.github/changelog/2932-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Superseded outbox activities are now removed instead of kept, reducing clutter in the outbox.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -116,25 +116,32 @@ class Outbox {
 	}
 
 	/**
-	 * Delete pending outbox items that have been superseded by a newer item
-	 * with the same activity type and object ID.
+	 * Delete pending outbox items that have been superseded by a newer item.
+	 *
+	 * For most activity types, only items with the same type and object ID are
+	 * deleted. Delete activities are a special case: they supersede all pending
+	 * items for the same object regardless of type.
 	 *
 	 * Unschedules all federation events before deleting each item.
-	 * Skips Announce, Accept, and Reject activities, as those are
+	 * Skips Follow, Announce, Accept, and Reject activities, as those are
 	 * independent per-request responses that must not cancel each other.
 	 *
 	 * @param string $object_id     The ActivityPub object ID (URL).
 	 * @param string $activity_type The activity type (e.g. 'Create', 'Update', 'Delete').
 	 * @param int    $exclude_id    The ID of the newly added outbox item to keep.
+	 *
+	 * @return void
 	 */
 	private static function delete_superseded_items( $object_id, $activity_type, $exclude_id ) {
 		/*
-		 * Do not delete items for Announce, Accept, or Reject activities.
+		 * Do not delete items for Follow, Announce, Accept, or Reject activities.
+		 * Follow activities from different users share the same object ID but are
+		 * independent and must survive until their Accept is received.
 		 * Accept/Reject are per-request responses (e.g. to individual incoming
 		 * QuoteRequests) and must not cancel each other even when they share
 		 * the same object ID.
 		 */
-		if ( in_array( $activity_type, array( 'Announce', 'Accept', 'Reject' ), true ) ) {
+		if ( in_array( $activity_type, array( 'Follow', 'Announce', 'Accept', 'Reject' ), true ) ) {
 			return;
 		}
 

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -110,24 +110,26 @@ class Outbox {
 			return false;
 		}
 
-		self::invalidate_existing_items( $object_id, $activity->get_type(), $id );
+		self::delete_superseded_items( $object_id, $activity->get_type(), $id );
 
 		return $id;
 	}
 
 	/**
-	 * Invalidate existing outbox items with the same activity type and object ID
-	 * by setting their status to 'publish'.
+	 * Delete pending outbox items that have been superseded by a newer item
+	 * with the same activity type and object ID.
 	 *
-	 * @param string $object_id     The ID of the activity object.
-	 * @param string $activity_type The type of the activity.
-	 * @param int    $current_id    The ID of the current outbox item to exclude.
+	 * Unschedules all federation events before deleting each item.
+	 * Skips Announce, Accept, and Reject activities, as those are
+	 * independent per-request responses that must not cancel each other.
 	 *
-	 * @return void
+	 * @param string $object_id     The ActivityPub object ID (URL).
+	 * @param string $activity_type The activity type (e.g. 'Create', 'Update', 'Delete').
+	 * @param int    $exclude_id    The ID of the newly added outbox item to keep.
 	 */
-	private static function invalidate_existing_items( $object_id, $activity_type, $current_id ) {
+	private static function delete_superseded_items( $object_id, $activity_type, $exclude_id ) {
 		/*
-		 * Do not invalidate items for Announce, Accept, or Reject activities.
+		 * Do not delete items for Announce, Accept, or Reject activities.
 		 * Accept/Reject are per-request responses (e.g. to individual incoming
 		 * QuoteRequests) and must not cancel each other even when they share
 		 * the same object ID.
@@ -143,7 +145,8 @@ class Outbox {
 			),
 		);
 
-		// For non-Delete activities, only invalidate items of the same type.
+		// For non-Delete activities, only delete items of the same type.
+		// Delete activities supersede all pending items for the same object.
 		if ( 'Delete' !== $activity_type ) {
 			$meta_query[] = array(
 				'key'   => '_activitypub_activity_type',
@@ -155,7 +158,7 @@ class Outbox {
 			array(
 				'post_type'   => self::POST_TYPE,
 				'post_status' => 'pending',
-				'exclude'     => array( $current_id ),
+				'exclude'     => array( $exclude_id ),
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query'  => $meta_query,
 				'fields'      => 'ids',
@@ -164,7 +167,7 @@ class Outbox {
 
 		foreach ( $existing_items as $existing_item_id ) {
 			Scheduler::unschedule_events_for_item( $existing_item_id );
-			\wp_publish_post( $existing_item_id );
+			\wp_delete_post( $existing_item_id, true );
 		}
 	}
 

--- a/tests/phpunit/tests/includes/collection/class-test-outbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-outbox.php
@@ -399,12 +399,15 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		$id = \Activitypub\add_to_outbox( $data, $type, self::$user_id );
 
+		// Capture permalink before undo — Delete supersedes the original item.
+		$permalink = \get_permalink( $id );
+
 		$undo_id  = Outbox::undo( $id );
 		$activity = Outbox::get_activity( $undo_id );
 
 		// Only ID for Deletes.
 		if ( 'Delete' === $expected ) {
-			$this->assertSame( \get_permalink( $id ), $activity->get_object() );
+			$this->assertSame( $permalink, $activity->get_object() );
 		} else {
 			$outbox_activity = \json_decode( \get_post( $undo_id )->post_content, true );
 			$this->assertEquals( $outbox_activity['object'], $activity->get_object()->to_array( false ) );

--- a/tests/phpunit/tests/includes/collection/class-test-outbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-outbox.php
@@ -211,11 +211,11 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	}
 
 	/**
-	 * Test invalidating existing outbox items.
+	 * Test that superseded outbox items are deleted.
 	 *
-	 * @covers ::invalidate_existing_items
+	 * @covers ::delete_superseded_items
 	 */
-	public function test_invalidate_existing_items() {
+	public function test_delete_superseded_items() {
 		$object        = $this->get_dummy_activity_object();
 		$activity_type = 'Create';
 
@@ -228,42 +228,42 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$second_id = \Activitypub\add_to_outbox( $object, $activity_type, 1 );
 		$this->assertNotFalse( $second_id );
 
-		// First item should now be published (invalidated).
-		$this->assertEquals( 'publish', \get_post_status( $first_id ) );
+		// First item should be deleted (superseded).
+		$this->assertFalse( \get_post_status( $first_id ) );
 		// New item should still be pending.
 		$this->assertEquals( 'pending', \get_post_status( $second_id ) );
 	}
 
 	/**
-	 * Test that only items with matching object_id and activity_type are invalidated.
+	 * Test that only items with matching object_id and activity_type are deleted.
 	 *
-	 * @covers ::invalidate_existing_items
+	 * @covers ::delete_superseded_items
 	 */
-	public function test_selective_invalidation() {
+	public function test_selective_superseding() {
 		$object1 = $this->get_dummy_activity_object();
 		$object2 = $this->get_dummy_activity_object();
 		$object2->set_id( 'https://example.com/different-object' );
 
 		// Create items with different combinations.
-		$item1 = \Activitypub\add_to_outbox( $object1, 'Create', 1 ); // Should be invalidated.
+		$item1 = \Activitypub\add_to_outbox( $object1, 'Create', 1 ); // Should be deleted.
 		$item2 = \Activitypub\add_to_outbox( $object2, 'Create', 1 ); // Should stay pending (different object).
 		$item3 = \Activitypub\add_to_outbox( $object1, 'Update', 1 ); // Should stay pending (different activity).
 
-		// Add new item that should trigger invalidation of item1.
+		// Add new item that should trigger deletion of item1.
 		$new_item = \Activitypub\add_to_outbox( $object1, 'Create', 1 );
 
-		$this->assertEquals( 'publish', \get_post_status( $item1 ) );
+		$this->assertFalse( \get_post_status( $item1 ) );
 		$this->assertEquals( 'pending', \get_post_status( $item2 ) );
 		$this->assertEquals( 'pending', \get_post_status( $item3 ) );
 		$this->assertEquals( 'pending', \get_post_status( $new_item ) );
 	}
 
 	/**
-	 * Test that Delete activities invalidate all existing items for the object.
+	 * Test that Delete activities delete all pending items for the object.
 	 *
-	 * @covers ::invalidate_existing_items
+	 * @covers ::delete_superseded_items
 	 */
-	public function test_delete_invalidates_all_activities() {
+	public function test_delete_supersedes_all_activities() {
 		$object = $this->get_dummy_activity_object();
 
 		// Create items with different activity types.
@@ -278,10 +278,10 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		// Add Delete activity.
 		$delete_id = \Activitypub\add_to_outbox( $object, 'Delete', 1 );
 
-		// All previous activities should be published (invalidated).
-		$this->assertEquals( 'publish', \get_post_status( $create_id ) );
-		$this->assertEquals( 'publish', \get_post_status( $update_id ) );
-		$this->assertEquals( 'publish', \get_post_status( $like_id ) );
+		// All previous activities should be deleted (superseded).
+		$this->assertFalse( \get_post_status( $create_id ) );
+		$this->assertFalse( \get_post_status( $update_id ) );
+		$this->assertFalse( \get_post_status( $like_id ) );
 		// Delete activity should still be pending.
 		$this->assertEquals( 'pending', \get_post_status( $delete_id ) );
 	}


### PR DESCRIPTION
Related #2927

## Proposed changes:
* Superseded pending outbox items were previously marked as `publish`, which is semantically incorrect — they were never actually federated. This changes them to be hard-deleted instead, keeping the outbox clean.
* Rename `invalidate_existing_items` to `delete_superseded_items` with improved PHPDocs and parameter naming.
* Update tests to assert deletion (`assertFalse`) instead of status change (`assertEquals 'publish'`).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a post and verify an outbox item is created with `pending` status.
* Update the same post quickly (before federation completes) and verify the first outbox item is deleted (not published), and a new pending item exists.
* Delete the post and verify all pending outbox items for that post are removed.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Changed - for changes in existing functionality

#### Message

Superseded outbox activities are now removed instead of kept, reducing clutter in the outbox.

</details>