### PR TITLE
Improve NodeInfo active user counting

### DIFF
--- a/.github/changelog/2943-from-description
+++ b/.github/changelog/2943-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improved active user counting for NodeInfo to include all federated content types and comments.

--- a/includes/functions-user.php
+++ b/includes/functions-user.php
@@ -225,31 +225,68 @@ function is_single_user() {
 /**
  * Get active users based on a given duration.
  *
+ * Counts users who published posts (of any ActivityPub-enabled post type)
+ * or approved comments within the given time period.
+ *
  * @param int $duration Optional. The duration to check in month(s). Default 1.
  *
  * @return int The number of active users.
  */
 function get_active_users( $duration = 1 ) {
-	$duration      = intval( $duration );
-	$transient_key = sprintf( 'monthly_active_users_%d', $duration );
-	$count         = get_transient( $transient_key );
+	$duration      = \intval( $duration );
+	$transient_key = \sprintf( 'monthly_active_users_%d', $duration );
+	$count         = \get_transient( $transient_key );
 
 	if ( false === $count ) {
 		global $wpdb;
 
+		$post_types   = \get_post_types_by_support( 'activitypub' );
+		$post_authors = array();
+
+		if ( ! empty( $post_types ) ) {
+			$placeholders = \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) );
+
+			// Get distinct user IDs who published posts of AP-enabled post types.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$post_authors = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT DISTINCT post_author FROM {$wpdb->posts} WHERE post_type IN ( {$placeholders} ) AND post_status = 'publish' AND post_date >= DATE_SUB( NOW(), INTERVAL %d MONTH )",
+					\array_merge( $post_types, array( $duration ) )
+				)
+			);
+		}
+
+		// Get distinct user IDs who made approved comments.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$count = $wpdb->get_var(
+		$comment_authors = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT COUNT( DISTINCT post_author ) FROM {$wpdb->posts} WHERE post_type = 'post' AND post_status = 'publish' AND post_modified >= DATE_SUB( NOW(), INTERVAL %d MONTH )",
+				"SELECT DISTINCT user_id FROM {$wpdb->comments} WHERE comment_approved = '1' AND user_id != 0 AND comment_date >= DATE_SUB( NOW(), INTERVAL %d MONTH )",
 				$duration
 			)
 		);
 
-		set_transient( $transient_key, $count, DAY_IN_SECONDS );
+		// Deduplicate and filter out anonymous (0) entries.
+		$active_ids = \array_unique( \array_filter( \array_map( 'absint', \array_merge( $post_authors, $comment_authors ) ) ) );
+
+		if ( empty( $active_ids ) ) {
+			$count = 0;
+		} else {
+			// Count only users who have the activitypub capability.
+			$user_query = new \WP_User_Query(
+				array(
+					'capability__in' => array( 'activitypub' ),
+					'include'        => $active_ids,
+					'number'         => 1,
+				)
+			);
+			$count      = $user_query->get_total();
+		}
+
+		\set_transient( $transient_key, $count, DAY_IN_SECONDS );
 	}
 
 	// If 0 authors were active.
-	if ( 0 === $count ) {
+	if ( ! $count ) {
 		return 0;
 	}
 
@@ -267,7 +304,7 @@ function get_active_users( $duration = 1 ) {
 	}
 
 	// Ensure active users doesn't exceed total users.
-	return min( $active, get_total_users() );
+	return \min( $active, get_total_users() );
 }
 
 /**
@@ -281,17 +318,14 @@ function get_total_users() {
 		return 1;
 	}
 
-	$users = \get_users(
+	$user_query = new \WP_User_Query(
 		array(
 			'capability__in' => array( 'activitypub' ),
+			'number'         => 1,
 		)
 	);
 
-	if ( is_array( $users ) ) {
-		$users = count( $users );
-	} else {
-		$users = 1;
-	}
+	$users = $user_query->get_total();
 
 	// If blog user is disabled.
 	if ( ! user_can_activitypub( Actors::BLOG_USER_ID ) ) {

--- a/includes/functions-user.php
+++ b/includes/functions-user.php
@@ -250,6 +250,7 @@ function get_active_users( $duration = 1 ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$post_authors = $wpdb->get_col(
 				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"SELECT DISTINCT post_author FROM {$wpdb->posts} WHERE post_type IN ( {$placeholders} ) AND post_status = 'publish' AND post_date >= DATE_SUB( NOW(), INTERVAL %d MONTH )",
 					\array_merge( $post_types, array( $duration ) )
 				)

--- a/includes/functions-user.php
+++ b/includes/functions-user.php
@@ -277,7 +277,7 @@ function get_active_users( $duration = 1 ) {
 				array(
 					'capability__in' => array( 'activitypub' ),
 					'include'        => $active_ids,
-					'number'         => 1,
+					'number'         => 1, // Minimize memory; get_total() still returns full count.
 				)
 			);
 			$count      = $user_query->get_total();
@@ -287,7 +287,7 @@ function get_active_users( $duration = 1 ) {
 	}
 
 	// If 0 authors were active.
-	if ( ! $count ) {
+	if ( 0 === (int) $count ) {
 		return 0;
 	}
 

--- a/tests/phpunit/tests/includes/class-test-functions-user.php
+++ b/tests/phpunit/tests/includes/class-test-functions-user.php
@@ -101,4 +101,84 @@ class Test_Functions_User extends \WP_UnitTestCase {
 		\delete_transient( 'monthly_active_users_1' );
 		\delete_transient( 'monthly_active_users_6' );
 	}
+
+	/**
+	 * Test get_active_users counts users who only comment.
+	 *
+	 * @covers \Activitypub\get_active_users
+	 */
+	public function test_get_active_users_with_comments() {
+		\delete_transient( 'monthly_active_users_1' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		// Create a user with activitypub capability but no posts.
+		$commenter = self::factory()->user->create_and_get();
+		$commenter->add_cap( 'activitypub' );
+
+		// Create a post by another user for the comment to attach to.
+		$post_id = self::factory()->post->create();
+
+		// Create an approved comment by the user.
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'user_id'          => $commenter->ID,
+				'comment_approved' => '1',
+			)
+		);
+
+		\delete_transient( 'monthly_active_users_1' );
+
+		$active_users = \Activitypub\get_active_users( 1 );
+		$this->assertGreaterThanOrEqual( 1, $active_users, 'Users who only comment should be counted as active.' );
+
+		\delete_transient( 'monthly_active_users_1' );
+	}
+
+	/**
+	 * Test get_active_users counts custom post types with ActivityPub support.
+	 *
+	 * @covers \Activitypub\get_active_users
+	 */
+	public function test_get_active_users_with_custom_post_types() {
+		\delete_transient( 'monthly_active_users_1' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		// Register a custom post type with ActivityPub support.
+		\register_post_type(
+			'ap_test_cpt',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'editor', 'activitypub' ),
+			)
+		);
+
+		// Ensure cleanup even if assertion fails.
+		$cleanup = function () {
+			\delete_transient( 'monthly_active_users_1' );
+			\unregister_post_type( 'ap_test_cpt' );
+		};
+
+		try {
+			// Create a user with activitypub capability.
+			$user = self::factory()->user->create_and_get();
+			$user->add_cap( 'activitypub' );
+
+			// Create a post of the custom type.
+			self::factory()->post->create(
+				array(
+					'post_author' => $user->ID,
+					'post_status' => 'publish',
+					'post_type'   => 'ap_test_cpt',
+				)
+			);
+
+			\delete_transient( 'monthly_active_users_1' );
+
+			$active_users = \Activitypub\get_active_users( 1 );
+			$this->assertGreaterThanOrEqual( 1, $active_users, 'Users publishing custom post types with ActivityPub support should be counted as active.' );
+		} finally {
+			$cleanup();
+		}
+	}
 }


### PR DESCRIPTION
## Proposed changes:
* Count all ActivityPub-enabled post types for active user stats, not just the `post` type.
* Include comment authors in active user counting — users who only comment are now counted as active.
* Use `WP_User_Query::get_total()` for efficient DB-level counting instead of loading full user objects.
* Filter active users to only those with the `activitypub` capability, improving accuracy.
* Use `post_date` instead of `post_modified` so editing old posts doesn't inflate the active user count.
* Guard against empty post types array to prevent SQL syntax errors.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Enable ActivityPub on a site with multiple users and custom post types (e.g., pages) with ActivityPub support enabled.
* Visit the NodeInfo endpoint at `/wp-json/activitypub/v1/nodeinfo/2.0`.
* Verify `usage.users.total`, `usage.users.activeMonth`, and `usage.users.activeHalfyear` reflect users who published any AP-enabled post type or made comments.
* Test with a user who has only commented (no posts) — they should appear in the active user count.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Changed - for changes in existing functionality

#### Message

Improved active user counting for NodeInfo to include all federated content types and comments.

</details>