### PR TITLE
Use `is_activity_public()` in Dispatcher and fix empty-recipients visibility

### DIFF
--- a/.github/changelog/2944-from-description
+++ b/.github/changelog/2944-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve handling of all public audience identifiers when sending activities to followers and relays.

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -376,7 +376,7 @@ class Dispatcher {
 		$audience = array_merge( $cc, $to );
 
 		// Remove "public placeholder" from the audience.
-		$audience = array_diff( $audience, array( 'https://www.w3.org/ns/activitystreams#Public' ) );
+		$audience = array_diff( $audience, ACTIVITYPUB_PUBLIC_AUDIENCE_IDENTIFIERS );
 
 		if ( $audience ) {
 			$mentioned_inboxes = Mention::get_inboxes( $audience );
@@ -441,16 +441,15 @@ class Dispatcher {
 	}
 
 	/**
-	 * Check if passed Activity is public.
+	 * Check if an Activity should be sent to followers.
 	 *
 	 * @param Activity                                        $activity    The Activity object.
 	 * @param \Activitypub\Model\User|\Activitypub\Model\Blog $actor       The Actor object.
 	 * @param \WP_Post                                        $outbox_item The Outbox item.
 	 *
-	 * @return boolean True if public, false if not.
+	 * @return boolean True if the Activity should be sent to followers, false if not.
 	 */
 	protected static function should_send_to_followers( $activity, $actor, $outbox_item ) {
-		// Check if follower endpoint is set.
 		$cc = $activity->get_cc() ?? array();
 		$to = $activity->get_to() ?? array();
 
@@ -458,7 +457,7 @@ class Dispatcher {
 
 		$send = (
 			// Check if activity is public.
-			in_array( 'https://www.w3.org/ns/activitystreams#Public', $audience, true ) ||
+			is_activity_public( $activity ) ||
 			// ...or check if follower endpoint is set.
 			in_array( $actor->get_followers(), $audience, true )
 		);
@@ -491,14 +490,8 @@ class Dispatcher {
 	 * @return array The filtered Inboxes.
 	 */
 	public static function add_inboxes_of_relays( $inboxes, $actor_id, $activity ) {
-		// Check if follower endpoint is set.
-		$cc = $activity->get_cc() ?? array();
-		$to = $activity->get_to() ?? array();
-
-		$audience = array_merge( $cc, $to );
-
 		// Check if activity is public.
-		if ( ! in_array( 'https://www.w3.org/ns/activitystreams#Public', $audience, true ) ) {
+		if ( ! is_activity_public( $activity ) ) {
 			return $inboxes;
 		}
 

--- a/includes/functions-activity.php
+++ b/includes/functions-activity.php
@@ -109,12 +109,6 @@ function get_activity_visibility( $activity ) {
 		return ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC;
 	}
 
-	// Activities with no recipients are treated as public.
-	$recipients = extract_recipients_from_activity( $activity );
-	if ( empty( $recipients ) ) {
-		return ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC;
-	}
-
 	return ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE;
 }
 
@@ -122,6 +116,7 @@ function get_activity_visibility( $activity ) {
  * Check if passed Activity is Public.
  *
  * @see https://github.com/w3c/activitypub/issues/404#issuecomment-2926310561
+ * @see https://www.w3.org/TR/activitypub/#delivery (Section 7.1, "Silent and private activities")
  *
  * @param Base_Object|array $data The Activity object as Base_Object or array.
  *
@@ -135,7 +130,7 @@ function is_activity_public( $data ) {
 	$recipients = extract_recipients_from_activity( $data );
 
 	if ( empty( $recipients ) ) {
-		return true;
+		return false;
 	}
 
 	return ! empty( array_intersect( $recipients, ACTIVITYPUB_PUBLIC_AUDIENCE_IDENTIFIERS ) );

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -411,7 +411,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 		}
 
 		// Check for an Actor in the Object field.
-		if ( empty( $user_ids ) ) {
+		if ( empty( $user_ids ) && ! empty( $activity['object'] ) ) {
 			$user_id = Actors::get_id_by_resource( $activity['object'] );
 
 			if ( ! \is_wp_error( $user_id ) && user_can_activitypub( $user_id ) ) {

--- a/tests/phpunit/tests/includes/class-test-dispatcher.php
+++ b/tests/phpunit/tests/includes/class-test-dispatcher.php
@@ -203,12 +203,10 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_actions = null;
 
-		$private_activity = Outbox::get_activity( $outbox_item->ID );
-		$private_activity->set_to( null );
-		$private_activity->set_cc( null );
-
-		// Clone object.
-		$private_activity = clone $private_activity;
+		$private_activity = new Activity();
+		$private_activity->set_type( 'Create' );
+		$private_activity->set_to( array() );
+		$private_activity->set_cc( array() );
 
 		try {
 			$send_to_additional_inboxes->invoke( null, $private_activity, Actors::get_by_id( self::$user_id ), $outbox_item );
@@ -264,28 +262,10 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 	 * @return Activity
 	 */
 	private function get_activity_mock() {
-		$activity = $this->createMock( Activity::class );
-
-		// Mock the static method using reflection.
-		$activity->expects( $this->any() )
-			->method( '__call' )
-			->willReturnCallback(
-				function ( $name ) {
-					if ( 'get_to' === $name ) {
-						return array( 'https://www.w3.org/ns/activitystreams#Public' );
-					}
-
-					if ( 'get_cc' === $name ) {
-						return array();
-					}
-
-					if ( 'get_type' === $name ) {
-						return 'Create';
-					}
-
-					return null;
-				}
-			);
+		$activity = new Activity();
+		$activity->set_type( 'Create' );
+		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );
+		$activity->set_cc( array() );
 
 		return $activity;
 	}

--- a/tests/phpunit/tests/includes/class-test-functions-activity.php
+++ b/tests/phpunit/tests/includes/class-test-functions-activity.php
@@ -351,7 +351,7 @@ class Test_Functions_Activity extends \WP_UnitTestCase {
 						'monkey' => 'https://www.w3.org/ns/activitystreams#Public',
 					),
 				),
-				true,
+				false,
 			),
 			array(
 				array(
@@ -738,13 +738,13 @@ class Test_Functions_Activity extends \WP_UnitTestCase {
 				'expected'    => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
 				'description' => 'Public visibility via as:Public identifier',
 			),
-			// Empty activity - no recipients means public.
+			// Empty activity - no recipients means private per spec Section 7.1.
 			array(
 				'activity'    => array(
 					'type' => 'Create',
 				),
-				'expected'    => ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC,
-				'description' => 'Empty activity (no recipients) is treated as public',
+				'expected'    => ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE,
+				'description' => 'Empty activity (no recipients) is treated as private per spec',
 			),
 		);
 	}

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -75,9 +75,9 @@ class Test_Inbox extends \WP_UnitTestCase {
 		$remote_actor_meta = \get_post_meta( $inbox_id, '_activitypub_activity_remote_actor', true );
 		$this->assertEquals( 'https://remote.example.com/users/testuser', $remote_actor_meta );
 
-		// Activities with no recipients are treated as public.
+		// Activities with no recipients are treated as private per spec.
 		$visibility_meta = \get_post_meta( $inbox_id, 'activitypub_content_visibility', true );
-		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC, $visibility_meta );
+		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility_meta );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/handler/class-test-update.php
+++ b/tests/phpunit/tests/includes/handler/class-test-update.php
@@ -34,6 +34,7 @@ class Test_Update extends \WP_UnitTestCase {
 			'id'     => 'https://example.com/activities/12345',
 			'type'   => 'Update',
 			'actor'  => $test_actor,
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
 			'object' => array(
 				'id'           => 'https://example.com/objects/12345',
 				'type'         => 'Note',

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -498,9 +498,8 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		}
 
 		$result = $method->invoke( $this->inbox_controller, $activity );
-		// Activities with no recipients are treated as public and delivered to followers only.
-		$this->assertNotEmpty( $result, 'Should return followers when no recipients (treated as public)' );
-		$this->assertContains( self::$user_id, $result, 'Should contain the follower' );
+		// Activities with no recipients are treated as private per spec.
+		$this->assertEmpty( $result, 'Should return no recipients when no addressing is specified' );
 
 		// Clean up.
 		\delete_option( 'activitypub_actor_mode' );


### PR DESCRIPTION
## Proposed changes:
* Replace inline public-audience checks in the Dispatcher with the shared `is_activity_public()` helper and `ACTIVITYPUB_PUBLIC_AUDIENCE_IDENTIFIERS` constant, so all three public identifiers (`https://www.w3.org/ns/activitystreams#Public`, `as:Public`, `Public`) are handled consistently.
* Fix `is_activity_public()` and `get_activity_visibility()` to treat activities with no recipients as private, per [W3C ActivityPub spec Section 7.1](https://www.w3.org/TR/activitypub/#delivery) ("Silent and private activities").
* Fix pre-existing undefined array key notice in `Inbox_Controller::get_local_recipients()` when `$activity['object']` is missing.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run env-test` — all 1831 tests should pass.
* Verify that public posts still federate normally to followers and relays.
* Verify that activities using `as:Public` or `Public` (compact forms) are correctly recognized as public by the Dispatcher.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Improve handling of all public audience identifiers when sending activities to followers and relays.

</details>