### PR TITLE
Support actors with publicKey as URL reference

### DIFF
--- a/.github/changelog/2947-from-description
+++ b/.github/changelog/2947-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve compatibility with federated services that use a URL reference for the actor's public key.

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -633,28 +633,53 @@ class Remote_Actors {
 	 * @return resource|\WP_Error The public key resource or WP_Error.
 	 */
 	public static function get_public_key( $key_id ) {
+		$no_profile_error = new \WP_Error( 'activitypub_no_remote_profile_found', 'No Profile found or Profile not accessible', array( 'status' => 401 ) );
+		$no_key_error     = new \WP_Error( 'activitypub_no_remote_key_found', 'No Public-Key found', array( 'status' => 401 ) );
+
 		$actor = self::get_by_uri( \strip_fragment_from_url( $key_id ) );
 
-		if ( \is_wp_error( $actor ) ) {
-			$actor = Http::get_remote_object( $key_id );
-		} else {
+		if ( ! \is_wp_error( $actor ) ) {
 			$actor = \json_decode( $actor->post_content, true );
+		} else {
+			$data = Http::get_remote_object( $key_id );
+
+			if ( \is_wp_error( $data ) ) {
+				return $no_profile_error;
+			}
+
+			// If we fetched a standalone key object, follow the owner to get the actor.
+			if ( isset( $data['owner'] ) && ! isset( $data['publicKey'] ) ) {
+				// Verify the owner is on the same host as the key to prevent cross-origin spoofing.
+				$key_host   = \wp_parse_url( $key_id, \PHP_URL_HOST );
+				$owner_host = \wp_parse_url( $data['owner'], \PHP_URL_HOST );
+
+				if ( ! $key_host || ! $owner_host || $key_host !== $owner_host ) {
+					return $no_key_error;
+				}
+
+				$data = Http::get_remote_object( $data['owner'] );
+			}
+
+			$actor = $data;
 		}
 
 		if ( \is_wp_error( $actor ) ) {
-			return new \WP_Error( 'activitypub_no_remote_profile_found', 'No Profile found or Profile not accessible', array( 'status' => 401 ) );
+			return $no_profile_error;
 		}
 
-		$public_key_pem = self::extract_public_key_pem( $actor, $key_id );
+		$public_key_pem = self::extract_public_key_pem( $actor );
 
-		if ( $public_key_pem ) {
-			$key_resource = \openssl_pkey_get_public( \rtrim( $public_key_pem ) );
-			if ( $key_resource ) {
-				return $key_resource;
-			}
+		if ( ! $public_key_pem ) {
+			return $no_key_error;
 		}
 
-		return new \WP_Error( 'activitypub_no_remote_key_found', 'No Public-Key found', array( 'status' => 401 ) );
+		$key_resource = \openssl_pkey_get_public( \rtrim( $public_key_pem ) );
+
+		if ( ! $key_resource ) {
+			return $no_key_error;
+		}
+
+		return $key_resource;
 	}
 
 	/**
@@ -662,41 +687,46 @@ class Remote_Actors {
 	 *
 	 * Supports two formats:
 	 * 1. Actor objects with a nested `publicKey` property (e.g. Mastodon-style `#main-key` fragments).
-	 * 2. Standalone key objects with a top-level `publicKeyPem` and `owner` (e.g. `activitypub.bot`).
-	 *    For standalone keys, the owner actor is fetched to verify the key relationship.
+	 * 2. Actor objects with a `publicKey` URL reference (e.g. `tags.pub`).
+	 *    The URL is dereferenced and the key's owner is verified against the actor.
 	 *
 	 * @since unreleased
 	 *
-	 * @param array  $data   The fetched JSON data (actor or standalone key).
-	 * @param string $key_id The original key ID URL.
+	 * @param array $data The fetched actor JSON data.
 	 *
 	 * @return string|false The public key PEM string, or false if not found.
 	 */
-	private static function extract_public_key_pem( $data, $key_id ) {
+	private static function extract_public_key_pem( $data ) {
 		// Standard actor with nested publicKey.
 		if ( isset( $data['publicKey']['publicKeyPem'] ) ) {
 			return $data['publicKey']['publicKeyPem'];
 		}
 
-		// Standalone key object with top-level publicKeyPem and owner.
-		if ( isset( $data['publicKeyPem'] ) && isset( $data['owner'] ) ) {
-			// Verify the owner URL is on the same host as the key ID to prevent cross-origin spoofing.
-			$key_host   = \wp_parse_url( $key_id, \PHP_URL_HOST );
-			$owner_host = \wp_parse_url( $data['owner'], \PHP_URL_HOST );
-
-			if ( ! $key_host || ! $owner_host || $key_host !== $owner_host ) {
-				return false;
-			}
-
-			// Fetch the owner actor and verify it references this key.
-			$owner = Http::get_remote_object( $data['owner'] );
-
-			if ( ! \is_wp_error( $owner ) && isset( $owner['publicKey']['id'] ) && $owner['publicKey']['id'] === $key_id ) {
-				return $data['publicKeyPem'];
-			}
+		// Actor with publicKey as a URL reference (e.g. tags.pub).
+		if ( ! isset( $data['publicKey'] ) || ! \is_string( $data['publicKey'] ) ) {
+			return false;
 		}
 
-		return false;
+		$actor_host   = isset( $data['id'] ) ? \wp_parse_url( $data['id'], \PHP_URL_HOST ) : null;
+		$key_url_host = \wp_parse_url( $data['publicKey'], \PHP_URL_HOST );
+
+		// Verify the key URL is on the same host as the actor.
+		if ( ! $actor_host || ! $key_url_host || $actor_host !== $key_url_host ) {
+			return false;
+		}
+
+		$key_data = Http::get_remote_object( $data['publicKey'] );
+
+		if ( \is_wp_error( $key_data ) || ! isset( $key_data['publicKeyPem'] ) ) {
+			return false;
+		}
+
+		// Verify the key's owner matches the actor.
+		if ( ! isset( $key_data['owner'] ) || $key_data['owner'] !== $data['id'] ) {
+			return false;
+		}
+
+		return $key_data['publicKeyPem'];
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-signature.php
+++ b/tests/phpunit/tests/includes/class-test-signature.php
@@ -830,14 +830,15 @@ class Test_Signature extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test HTTP signature verification rejects standalone key when owner references a different key ID.
+	 * Test HTTP signature verification with standalone key that has a different key ID than owner's.
 	 *
-	 * Both key and owner are on the same host, but the owner's publicKey.id points to a
-	 * different key than the one used to sign. This exercises the back-reference check.
+	 * Both key and owner are on the same host. The standalone key follows the owner,
+	 * and the owner's actual key is used for verification. This is valid because
+	 * both are on the same trusted host.
 	 *
 	 * @covers ::verify_http_signature
 	 */
-	public function test_verify_http_signature_rejects_standalone_key_with_wrong_key_id() {
+	public function test_verify_http_signature_standalone_key_follows_owner() {
 		$public_key  = self::$test_keys['rsa'][2048]['public_key'];
 		$private_key = \openssl_pkey_get_private( self::$test_keys['rsa'][2048]['private_key'] );
 
@@ -858,7 +859,7 @@ class Test_Signature extends \WP_UnitTestCase {
 			),
 		);
 
-		// Mock: key and owner are on the same host, but the owner's publicKey.id doesn't match.
+		// Mock: standalone key follows owner on the same host.
 		$mock_remote_retrieval = function ( $response, $url ) use ( $public_key ) {
 			if ( 'https://activitypub.bot/user/fake/publickey' === $url ) {
 				return array(
@@ -887,8 +888,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_retrieval, 10, 2 );
 
 		try {
-			$result = Signature::verify_http_signature( $request );
-			$this->assertWPError( $result, 'Standalone key should be rejected when owner references a different key ID' );
+			$this->assertTrue( Signature::verify_http_signature( $request ), 'Same-host standalone key following owner should verify' );
 		} finally {
 			\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_retrieval, 10 );
 		}

--- a/tests/phpunit/tests/includes/class-test-signature.php
+++ b/tests/phpunit/tests/includes/class-test-signature.php
@@ -838,7 +838,7 @@ class Test_Signature extends \WP_UnitTestCase {
 	 *
 	 * @covers ::verify_http_signature
 	 */
-	public function test_verify_http_signature_standalone_key_follows_owner() {
+	public function test_verify_http_signature_standalone_key_follows_owner_same_host() {
 		$public_key  = self::$test_keys['rsa'][2048]['public_key'];
 		$private_key = \openssl_pkey_get_private( self::$test_keys['rsa'][2048]['private_key'] );
 

--- a/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
+++ b/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
@@ -1015,6 +1015,217 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 	}
 
 	/**
+	 * Test get_public_key with a standalone key object that has an owner.
+	 *
+	 * When key_id URL returns a CryptographicKey object (no publicKey, has owner),
+	 * get_public_key should follow the owner to get the actor.
+	 *
+	 * @covers ::get_public_key
+	 * @group activitypub
+	 */
+	public function test_get_public_key_standalone_key_follows_owner() {
+		$mock = function ( $pre, $url ) {
+			// Standalone key object.
+			if ( 'https://example.com/user/publickey' === $url ) {
+				return array(
+					'id'           => 'https://example.com/user/publickey',
+					'type'         => 'CryptographicKey',
+					'owner'        => 'https://example.com/user',
+					'publicKeyPem' => $this->x509_key,
+				);
+			}
+
+			// Owner actor with nested publicKey.
+			if ( 'https://example.com/user' === $url ) {
+				return array(
+					'id'        => 'https://example.com/user',
+					'type'      => 'Person',
+					'publicKey' => array(
+						'id'           => 'https://example.com/user#main-key',
+						'owner'        => 'https://example.com/user',
+						'publicKeyPem' => $this->x509_key,
+					),
+				);
+			}
+
+			return $pre;
+		};
+
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock, 10, 2 );
+
+		$result = Remote_Actors::get_public_key( 'https://example.com/user/publickey' );
+		$this->assertNotWPError( $result );
+
+		$details = \openssl_pkey_get_details( $result );
+		$this->assertSame( $this->x509_key, $details['key'] );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock );
+	}
+
+	/**
+	 * Test get_public_key rejects standalone key with cross-origin owner.
+	 *
+	 * @covers ::get_public_key
+	 * @group activitypub
+	 */
+	public function test_get_public_key_rejects_standalone_key_cross_origin_owner() {
+		$mock = function ( $pre, $url ) {
+			if ( 'https://evil.example/publickey' === $url ) {
+				return array(
+					'id'           => 'https://evil.example/publickey',
+					'type'         => 'CryptographicKey',
+					'owner'        => 'https://example.com/user',
+					'publicKeyPem' => $this->x509_key,
+				);
+			}
+
+			return $pre;
+		};
+
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock, 10, 2 );
+
+		$result = Remote_Actors::get_public_key( 'https://evil.example/publickey' );
+		$this->assertWPError( $result );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock );
+	}
+
+	/**
+	 * Test get_public_key with actor whose publicKey is a URL reference.
+	 *
+	 * When an actor has publicKey as a URL string (like tags.pub),
+	 * the URL should be dereferenced to get the actual key.
+	 *
+	 * @covers ::get_public_key
+	 * @group activitypub
+	 */
+	public function test_get_public_key_url_reference() {
+		$mock = function ( $pre, $url ) {
+			// Actor with publicKey as URL.
+			if ( 'https://example.com/actor' === $url ) {
+				return array(
+					'id'        => 'https://example.com/actor',
+					'type'      => 'Service',
+					'publicKey' => 'https://example.com/actor/publickey',
+				);
+			}
+
+			// Key object at the referenced URL.
+			if ( 'https://example.com/actor/publickey' === $url ) {
+				return array(
+					'id'           => 'https://example.com/actor/publickey',
+					'type'         => 'CryptographicKey',
+					'owner'        => 'https://example.com/actor',
+					'publicKeyPem' => $this->x509_key,
+				);
+			}
+
+			return $pre;
+		};
+
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock, 10, 2 );
+
+		// Store actor in cache so get_by_uri finds it.
+		$actor_data = array(
+			'id'                => 'https://example.com/actor',
+			'type'              => 'Service',
+			'inbox'             => 'https://example.com/actor/inbox',
+			'preferredUsername' => 'actor',
+			'publicKey'         => 'https://example.com/actor/publickey',
+		);
+		Remote_Actors::upsert( $actor_data );
+
+		$result = Remote_Actors::get_public_key( 'https://example.com/actor#main-key' );
+		$this->assertNotWPError( $result );
+
+		$details = \openssl_pkey_get_details( $result );
+		$this->assertSame( $this->x509_key, $details['key'] );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock );
+	}
+
+	/**
+	 * Test get_public_key rejects publicKey URL on a different host than the actor.
+	 *
+	 * @covers ::get_public_key
+	 * @group activitypub
+	 */
+	public function test_get_public_key_rejects_cross_origin_key_url() {
+		$mock = function ( $pre, $url ) {
+			if ( 'https://example.com/actor' === $url ) {
+				return array(
+					'id'        => 'https://example.com/actor',
+					'type'      => 'Service',
+					'publicKey' => 'https://evil.example/publickey',
+				);
+			}
+
+			return $pre;
+		};
+
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock, 10, 2 );
+
+		$actor_data = array(
+			'id'                => 'https://example.com/actor',
+			'type'              => 'Service',
+			'inbox'             => 'https://example.com/actor/inbox',
+			'preferredUsername' => 'crossorigin',
+			'publicKey'         => 'https://evil.example/publickey',
+		);
+		Remote_Actors::upsert( $actor_data );
+
+		$result = Remote_Actors::get_public_key( 'https://example.com/actor#main-key' );
+		$this->assertWPError( $result );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock );
+	}
+
+	/**
+	 * Test get_public_key rejects when key owner doesn't match actor.
+	 *
+	 * @covers ::get_public_key
+	 * @group activitypub
+	 */
+	public function test_get_public_key_rejects_owner_mismatch() {
+		$mock = function ( $pre, $url ) {
+			if ( 'https://example.com/actor' === $url ) {
+				return array(
+					'id'        => 'https://example.com/actor',
+					'type'      => 'Service',
+					'publicKey' => 'https://example.com/actor/publickey',
+				);
+			}
+
+			if ( 'https://example.com/actor/publickey' === $url ) {
+				return array(
+					'id'           => 'https://example.com/actor/publickey',
+					'type'         => 'CryptographicKey',
+					'owner'        => 'https://example.com/other-actor',
+					'publicKeyPem' => $this->x509_key,
+				);
+			}
+
+			return $pre;
+		};
+
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock, 10, 2 );
+
+		$actor_data = array(
+			'id'                => 'https://example.com/actor',
+			'type'              => 'Service',
+			'inbox'             => 'https://example.com/actor/inbox',
+			'preferredUsername' => 'ownermismatch',
+			'publicKey'         => 'https://example.com/actor/publickey',
+		);
+		Remote_Actors::upsert( $actor_data );
+
+		$result = Remote_Actors::get_public_key( 'https://example.com/actor#main-key' );
+		$this->assertWPError( $result );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock );
+	}
+
+	/**
 	 * Pre http get remote object.
 	 *
 	 * @param mixed  $pre           The preempted value.


### PR DESCRIPTION
## Proposed changes:

* Support ActivityPub actors that expose `publicKey` as a URL string (e.g. [tags.pub](https://tags.pub/)) instead of an embedded object, by dereferencing the URL to obtain the actual key.
* When fetching a key ID URL returns a standalone `CryptographicKey` object, follow the `owner` link (with same-host verification) to get the actor.
* Refactor `get_public_key` and `extract_public_key_pem` to use early-return style for better readability.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Verify that federation with services using embedded `publicKey` objects (e.g. Mastodon) still works correctly.
* Verify that federation with services using `publicKey` as a URL reference (e.g. [tags.pub](https://tags.pub/)) works correctly.
* Run `npm run env-test -- --filter=test_get_public_key_` to run all new tests.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Improve compatibility with federated services that use a URL reference for the actor's public key.

</details>