### PR TITLE
Fix PHP 7.x string offset issue in public key extraction

### DIFF
--- a/.github/changelog/2948-from-description
+++ b/.github/changelog/2948-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix compatibility with actors that use a URL reference for their public key on older PHP versions.

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -697,8 +697,8 @@ class Remote_Actors {
 	 * @return string|false The public key PEM string, or false if not found.
 	 */
 	private static function extract_public_key_pem( $data ) {
-		// Standard actor with nested publicKey.
-		if ( isset( $data['publicKey']['publicKeyPem'] ) ) {
+		// Standard actor with nested publicKey (must check is_array to avoid PHP 7.x string offset quirk).
+		if ( \is_array( $data['publicKey'] ) && isset( $data['publicKey']['publicKeyPem'] ) ) {
 			return $data['publicKey']['publicKeyPem'];
 		}
 


### PR DESCRIPTION
Fixes a follow-up issue from #2947.

## Proposed changes:
* Add `is_array()` guard before `isset($data['publicKey']['publicKeyPem'])` in `extract_public_key_pem()` to prevent PHP 7.x string offset quirk.

On PHP 7.x, `isset($string['nonNumericKey'])` silently casts the key to integer 0, then checks `isset($string[0])` which returns `true` for non-empty strings. This means when `publicKey` is a URL string (as with tags.pub), the nested `isset` check incorrectly returns `true`, causing the method to return the first character of the URL instead of falling through to the URL reference handling.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Tests were added in #2947. The existing `test_get_public_key_url_reference` test covers this code path.

## Testing instructions:

* Verify that actors with `publicKey` as a URL string (e.g. tags.pub) correctly resolve the key via the URL reference path.
* Verify that actors with `publicKey` as a nested object (e.g. Mastodon) continue to work as before.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix compatibility with actors that use a URL reference for their public key on older PHP versions.

</details>