### PR TITLE
Fix case-insensitive Digest header algorithm matching

### DIFF
--- a/.github/changelog/2949-from-description
+++ b/.github/changelog/2949-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix signature verification rejecting valid requests that use lowercase algorithm names in the Digest header.

--- a/includes/signature/class-http-signature-draft.php
+++ b/includes/signature/class-http-signature-draft.php
@@ -209,9 +209,10 @@ class Http_Signature_Draft implements Http_Signature {
 		}
 
 		list( $alg, $digest ) = \explode( '=', $headers['digest'][0], 2 );
+		$alg                  = \strtolower( $alg );
 		$map                  = array(
-			'SHA-256' => 'sha256',
-			'SHA-512' => 'sha512',
+			'sha-256' => 'sha256',
+			'sha-512' => 'sha512',
 		);
 
 		if ( ! isset( $map[ $alg ] ) ) {


### PR DESCRIPTION
Fixes #2934

## Proposed changes:
* Normalize the Digest header algorithm to lowercase before lookup in the Draft Cavage signature verification.
* Some servers (e.g. tags.pub) send `sha-256` instead of `SHA-256`, which was rejected with a 401.
* This aligns with the RFC 9421 implementation which already uses lowercase keys.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Existing `test_verify_http_signature_with_digest` covers this path. The change is a case normalization — both `SHA-256` and `sha-256` now resolve correctly.

## Testing instructions:

* Send a POST to the shared inbox with a `Digest: sha-256=...` header (lowercase algorithm). It should no longer return a 401.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix signature verification rejecting valid requests that use lowercase algorithm names in the Digest header.

</details>