### PR TITLE
Strip bto and bcc fields before delivery

### DIFF
--- a/.github/changelog/2956-from-description
+++ b/.github/changelog/2956-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Prevent private recipient lists from being shared when sending activities to other servers.

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -240,8 +240,13 @@ class Dispatcher {
 	 */
 	private static function send_to_inboxes( $inboxes, $outbox_item_id ) {
 		$outbox_item = \get_post( $outbox_item_id );
-		$json        = Outbox::get_activity( $outbox_item_id )->to_json();
-		$retries     = array();
+
+		// Strip bto and bcc before delivery per ActivityPub spec Section 6.2.
+		\add_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
+		$json = Outbox::get_activity( $outbox_item_id )->to_json();
+		\remove_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
+
+		$retries = array();
 
 		/**
 		 * Fires before sending an Activity to inboxes.
@@ -312,6 +317,34 @@ class Dispatcher {
 			),
 			'body'     => \wp_json_encode( $response->get_data() ),
 		);
+	}
+
+	/**
+	 * Strip bto and bcc fields from an Activity array before delivery.
+	 *
+	 * The ActivityPub spec (Section 6.2) requires servers to remove bto and bcc
+	 * from Activities and their embedded objects before delivery to prevent
+	 * revealing private recipient lists.
+	 *
+	 * Used as a temporary filter on `activitypub_activity_object_array` so that
+	 * `to_json()` handles encoding consistently.
+	 *
+	 * @since unreleased
+	 *
+	 * @see https://www.w3.org/TR/activitypub/#delivery
+	 *
+	 * @param array $array The Activity array.
+	 * @return array The sanitized array with bto and bcc removed.
+	 */
+	public static function strip_private_addressing( $array ) {
+		unset( $array['bto'], $array['bcc'] );
+
+		// Also strip from the embedded object, if present.
+		if ( isset( $array['object'] ) && \is_array( $array['object'] ) ) {
+			unset( $array['object']['bto'], $array['object']['bcc'] );
+		}
+
+		return $array;
 	}
 
 	/**

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -333,18 +333,18 @@ class Dispatcher {
 	 *
 	 * @see https://www.w3.org/TR/activitypub/#delivery
 	 *
-	 * @param array $array The Activity array.
+	 * @param array $data The Activity array.
 	 * @return array The sanitized array with bto and bcc removed.
 	 */
-	public static function strip_private_addressing( $array ) {
-		unset( $array['bto'], $array['bcc'] );
+	public static function strip_private_addressing( $data ) {
+		unset( $data['bto'], $data['bcc'] );
 
 		// Also strip from the embedded object, if present.
-		if ( isset( $array['object'] ) && \is_array( $array['object'] ) ) {
-			unset( $array['object']['bto'], $array['object']['bcc'] );
+		if ( isset( $data['object'] ) && \is_array( $data['object'] ) ) {
+			unset( $data['object']['bto'], $data['object']['bcc'] );
 		}
 
-		return $array;
+		return $data;
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-dispatcher.php
+++ b/tests/phpunit/tests/includes/class-test-dispatcher.php
@@ -622,6 +622,115 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test that bto and bcc are stripped before delivery.
+	 *
+	 * @covers ::strip_private_addressing
+	 */
+	public function test_strip_private_addressing() {
+		// Activity with bto and bcc at both activity and object level.
+		$array = array(
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/users/test',
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'     => array( 'https://example.com/users/test/followers' ),
+			'bto'    => array( 'https://example.com/users/secret' ),
+			'bcc'    => array( 'https://example.com/users/hidden' ),
+			'object' => array(
+				'type'    => 'Note',
+				'content' => 'Hello',
+				'bto'     => array( 'https://example.com/users/secret' ),
+				'bcc'     => array( 'https://example.com/users/hidden' ),
+			),
+		);
+
+		$result = Dispatcher::strip_private_addressing( $array );
+
+		// bto and bcc should be removed from the activity.
+		$this->assertArrayNotHasKey( 'bto', $result, 'bto should be stripped from activity' );
+		$this->assertArrayNotHasKey( 'bcc', $result, 'bcc should be stripped from activity' );
+
+		// bto and bcc should be removed from the embedded object.
+		$this->assertArrayNotHasKey( 'bto', $result['object'], 'bto should be stripped from object' );
+		$this->assertArrayNotHasKey( 'bcc', $result['object'], 'bcc should be stripped from object' );
+
+		// Other fields should be preserved.
+		$this->assertSame( 'Create', $result['type'] );
+		$this->assertArrayHasKey( 'to', $result );
+		$this->assertArrayHasKey( 'cc', $result );
+		$this->assertSame( 'Hello', $result['object']['content'] );
+	}
+
+	/**
+	 * Test that strip_private_addressing handles activities without bto/bcc.
+	 *
+	 * @covers ::strip_private_addressing
+	 */
+	public function test_strip_private_addressing_without_private_fields() {
+		$array = array(
+			'type'  => 'Create',
+			'actor' => 'https://example.com/users/test',
+			'to'    => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+		);
+
+		$result = Dispatcher::strip_private_addressing( $array );
+
+		$this->assertSame( 'Create', $result['type'] );
+		$this->assertArrayHasKey( 'to', $result );
+	}
+
+	/**
+	 * Test that bto and bcc are stripped during actual delivery.
+	 *
+	 * @covers ::send_to_inboxes
+	 */
+	public function test_send_to_inboxes_strips_bto_bcc() {
+		// Create a post and outbox item.
+		$post_id     = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$outbox_item = $this->get_latest_outbox_item( \add_query_arg( 'p', $post_id, \home_url( '/' ) ) );
+
+		// Add bto and bcc to the stored activity.
+		$activity_data        = \json_decode( $outbox_item->post_content, true );
+		$activity_data['bto'] = array( 'https://example.com/users/secret' );
+		$activity_data['bcc'] = array( 'https://example.com/users/hidden' );
+		\wp_update_post(
+			array(
+				'ID'           => $outbox_item->ID,
+				'post_content' => \wp_json_encode( $activity_data ),
+			)
+		);
+
+		// Capture the JSON that gets sent.
+		$sent_json = null;
+		$callback  = function ( $preempt, $args, $url ) use ( &$sent_json ) {
+			$sent_json = $args['body'];
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '',
+			);
+		};
+		\add_filter( 'pre_http_request', $callback, 10, 3 );
+
+		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$send_to_inboxes->setAccessible( true );
+		}
+
+		try {
+			$send_to_inboxes->invoke( null, array( 'https://remote.example/inbox' ), $outbox_item->ID );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
+
+		$this->assertNotNull( $sent_json, 'JSON should have been sent' );
+
+		$sent_data = \json_decode( $sent_json, true );
+		$this->assertArrayNotHasKey( 'bto', $sent_data, 'bto must be stripped before delivery' );
+		$this->assertArrayNotHasKey( 'bcc', $sent_data, 'bcc must be stripped before delivery' );
+
+		\remove_filter( 'pre_http_request', $callback );
+	}
+
+	/**
 	 * Test that post_activitypub_add_to_outbox hook triggers send_immediate_accept.
 	 *
 	 * @covers ::send_immediate_accept

--- a/tests/phpunit/tests/includes/class-test-dispatcher.php
+++ b/tests/phpunit/tests/includes/class-test-dispatcher.php
@@ -701,14 +701,14 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 
 		// Capture the JSON that gets sent.
 		$sent_json = null;
-		$callback  = function ( $preempt, $args, $url ) use ( &$sent_json ) {
+		$callback  = function ( $preempt, $args ) use ( &$sent_json ) {
 			$sent_json = $args['body'];
 			return array(
 				'response' => array( 'code' => 200 ),
 				'body'     => '',
 			);
 		};
-		\add_filter( 'pre_http_request', $callback, 10, 3 );
+		\add_filter( 'pre_http_request', $callback, 10, 2 );
 
 		$send_to_inboxes = new \ReflectionMethod( Dispatcher::class, 'send_to_inboxes' );
 		if ( \PHP_VERSION_ID < 80100 ) {


### PR DESCRIPTION
## Proposed changes:

* Strip `bto` and `bcc` fields from activities and their embedded objects before federation delivery, as required by the [ActivityPub spec Section 6.2](https://www.w3.org/TR/activitypub/#delivery). This prevents private recipient lists from being revealed to other recipients.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a post with `bto` or `bcc` addressing in the outbox (e.g. via a C2S client or by manually adding these fields to a stored outbox activity).
* Verify that the delivered JSON payload to remote inboxes does not contain `bto` or `bcc` at either the activity level or the embedded object level.
* Run `npm run env-test -- --filter=Test_Dispatcher` — all 18 tests should pass, including 3 new tests for this change.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security - in case of vulnerabilities

#### Message

Prevent private recipient lists from being shared when sending activities to other servers.

</details>