### PR TITLE
Remove fallback for language maps in base properties

### DIFF
--- a/.github/changelog/2979-from-description
+++ b/.github/changelog/2979-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve language map resolution to strictly follow the ActivityStreams spec.

--- a/includes/rest/trait-language-map.php
+++ b/includes/rest/trait-language-map.php
@@ -119,7 +119,7 @@ trait Language_Map {
 
 		/* No base value and no language match: use first map entry. */
 		if ( \is_array( $map ) && ! empty( $map ) ) {
-			return \reset( $map );
+			return \current( $map );
 		}
 
 		return null;

--- a/includes/rest/trait-language-map.php
+++ b/includes/rest/trait-language-map.php
@@ -12,10 +12,9 @@ namespace Activitypub\Rest;
  *
  * Provides methods for resolving ActivityStreams natural language values.
  *
- * Properties like `summary`, `content`, and `name` can be either a plain
- * string or a language map (e.g. `{"en": "Hello"}`). Language maps should
- * use the `*Map` variant (`summaryMap`, `contentMap`, `nameMap`), but some
- * implementations incorrectly send them in the base property.
+ * Properties like `summary`, `content`, and `name` should be plain strings.
+ * Language maps should use the `*Map` variant (`summaryMap`, `contentMap`,
+ * `nameMap`).
  *
  * @since unreleased
  *
@@ -79,14 +78,12 @@ trait Language_Map {
 	 * 1. The base property when the object's language matches the site locale.
 	 * 2. Site locale or English match in the `*Map` variant.
 	 * 3. The base property as a plain string (the default).
-	 * 4. Site locale, English, or first match from a language map incorrectly
-	 *    placed in the base property (e.g. `summary: {"en": "Hello"}`).
 	 *
 	 * @since unreleased
 	 *
-	 * @param string|array|null $value       The base property value.
-	 * @param array|null        $map         The `*Map` variant (e.g. `summaryMap`).
-	 * @param string|null       $object_lang The object's language property.
+	 * @param string|null $value       The base property value.
+	 * @param array|null  $map         The `*Map` variant (e.g. `summaryMap`).
+	 * @param string|null $object_lang The object's language property.
 	 *
 	 * @return string|null The resolved string, or null if empty.
 	 */
@@ -113,22 +110,13 @@ trait Language_Map {
 			}
 		}
 
-		/* Fall back to the base property as a plain string (the default). */
 		if ( \is_string( $value ) ) {
 			return $value;
 		}
 
-		/*
-		 * Handle incorrectly placed language map in the base property:
-		 * same locale resolution, then first available entry.
-		 */
-		if ( \is_array( $value ) ) {
-			$resolved = $this->resolve_language_map( $value, $languages );
-			if ( $resolved ) {
-				return $resolved;
-			}
-
-			return \reset( $value ) ?: null;
+		/* No base value and no language match: use first map entry. */
+		if ( \is_array( $map ) && ! empty( $map ) ) {
+			return \reset( $map );
 		}
 
 		return null;

--- a/includes/rest/trait-language-map.php
+++ b/includes/rest/trait-language-map.php
@@ -78,10 +78,13 @@ trait Language_Map {
 	 * 1. The base property when the object's language matches the site locale.
 	 * 2. Site locale or English match in the `*Map` variant.
 	 * 3. The base property as a plain string (the default).
+	 * 4. First `*Map` entry if no base string and no preferred language match.
+	 *
+	 * Non-string base values (e.g. arrays) are ignored.
 	 *
 	 * @since unreleased
 	 *
-	 * @param string|null $value       The base property value.
+	 * @param mixed       $value       The base property value (only strings are used).
 	 * @param array|null  $map         The `*Map` variant (e.g. `summaryMap`).
 	 * @param string|null $object_lang The object's language property.
 	 *

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -1296,7 +1296,8 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 			'object' => array(
 				'id'         => 'https://remote.example/post/langmap',
 				'type'       => 'Note',
-				'content'    => array(
+				'content'    => 'Hello',
+				'contentMap' => array(
 					'en' => 'Hello',
 					'de' => 'Hallo',
 				),

--- a/tests/phpunit/tests/includes/rest/class-test-trait-language-map.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-language-map.php
@@ -92,7 +92,11 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 					'en' => 'English summary',
 					'de' => 'Deutsche Zusammenfassung',
 				),
-				'content'    => array( 'en' => 'Hello' ),
+				'content'    => 'Hello World',
+				'contentMap' => array(
+					'en' => 'Hello World',
+					'de' => 'Hallo Welt',
+				),
 			),
 		);
 		$result = $this->instance->localize_language_maps( $data );
@@ -100,7 +104,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 		\remove_filter( 'locale', $callback );
 
 		$this->assertSame( 'Deutsche Zusammenfassung', $result['object']['summary'] );
-		$this->assertSame( 'Hello', $result['object']['content'] );
+		$this->assertSame( 'Hallo Welt', $result['object']['content'] );
 	}
 
 	/**
@@ -170,21 +174,21 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 	 */
 	public function data_language_map() {
 		return array(
-			'plain_string'                       => array(
+			'plain_string'                    => array(
 				array( 'summary' => 'Hello World' ),
 				'summary',
 				'en_US',
 				'Hello World',
 				'Plain string should be returned as-is.',
 			),
-			'null_value'                         => array(
+			'null_value'                      => array(
 				array(),
 				'summary',
 				'en_US',
 				null,
 				'Missing property should return null.',
 			),
-			'object_lang_matches_site'           => array(
+			'object_lang_matches_site'        => array(
 				array(
 					'summary'  => 'Hallo Welt',
 					'language' => 'de_DE',
@@ -194,7 +198,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Hallo Welt',
 				'Object language matches site locale: return plain string immediately.',
 			),
-			'object_lang_does_not_match'         => array(
+			'object_lang_does_not_match'      => array(
 				array(
 					'summary'    => 'Bonjour le monde',
 					'summaryMap' => array( 'de' => 'Hallo Welt' ),
@@ -205,7 +209,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Hallo Welt',
 				'Object language differs: prefer *Map locale match over plain string.',
 			),
-			'map_site_locale_match'              => array(
+			'map_site_locale_match'           => array(
 				array(
 					'summary'    => 'Hello World',
 					'summaryMap' => array(
@@ -218,7 +222,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Hallo Welt',
 				'*Map with site locale match should win over plain string.',
 			),
-			'map_english_fallback'               => array(
+			'map_english_fallback'            => array(
 				array(
 					'summary'    => 'Bonjour le monde',
 					'summaryMap' => array(
@@ -231,7 +235,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Hello World',
 				'*Map with no site locale should fall back to English.',
 			),
-			'map_no_match_default_wins'          => array(
+			'map_no_match_default_wins'       => array(
 				array(
 					'summary'    => 'Bonjour le monde',
 					'summaryMap' => array(
@@ -244,7 +248,19 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Bonjour le monde',
 				'*Map with no locale or English match: plain string (default) wins.',
 			),
-			'map_no_match_no_default'            => array(
+			'map_only_no_base_value'          => array(
+				array(
+					'summaryMap' => array(
+						'en' => 'Hello World',
+						'de' => 'Hallo Welt',
+					),
+				),
+				'summary',
+				'de_DE',
+				'Hallo Welt',
+				'*Map with locale match and no base value should resolve from map.',
+			),
+			'map_no_match_no_default'         => array(
 				array(
 					'summaryMap' => array(
 						'fr' => 'Bonjour le monde',
@@ -253,10 +269,10 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				),
 				'summary',
 				'de_DE',
-				null,
-				'*Map with no match and no plain string should return null.',
+				'Bonjour le monde',
+				'*Map with no match and no plain string should return first map entry.',
 			),
-			'value_is_language_map_locale_match' => array(
+			'value_is_language_map_ignored'   => array(
 				array(
 					'summary' => array(
 						'en' => 'Hello World',
@@ -265,34 +281,10 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				),
 				'summary',
 				'de_DE',
-				'Hallo Welt',
-				'Incorrectly placed language map: site locale match.',
+				null,
+				'Language map in base property should return null.',
 			),
-			'value_is_language_map_english'      => array(
-				array(
-					'summary' => array(
-						'en' => 'Hello World',
-						'fr' => 'Bonjour le monde',
-					),
-				),
-				'summary',
-				'de_DE',
-				'Hello World',
-				'Incorrectly placed language map: English fallback.',
-			),
-			'value_is_language_map_first_entry'  => array(
-				array(
-					'summary' => array(
-						'fr' => 'Bonjour le monde',
-						'es' => 'Hola mundo',
-					),
-				),
-				'summary',
-				'de_DE',
-				'Bonjour le monde',
-				'Incorrectly placed language map with no match: first entry.',
-			),
-			'content_key'                        => array(
+			'content_key'                     => array(
 				array(
 					'content'    => 'Default content',
 					'contentMap' => array( 'de' => 'Deutscher Inhalt' ),
@@ -302,7 +294,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Deutscher Inhalt',
 				'Works for content key with contentMap.',
 			),
-			'name_key'                           => array(
+			'name_key'                        => array(
 				array(
 					'name'    => 'Default name',
 					'nameMap' => array( 'de' => 'Deutscher Name' ),
@@ -312,7 +304,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Deutscher Name',
 				'Works for name key with nameMap.',
 			),
-			'english_site_no_double_fallback'    => array(
+			'english_site_no_double_fallback' => array(
 				array(
 					'summary'    => 'Hello World',
 					'summaryMap' => array(
@@ -325,7 +317,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'English from map',
 				'English site: *Map English match is used.',
 			),
-			'object_lang_matches_skips_map'      => array(
+			'object_lang_matches_skips_map'   => array(
 				array(
 					'summary'    => 'Hallo Welt',
 					'summaryMap' => array( 'de' => 'Hallo Welt aus der Map' ),
@@ -336,7 +328,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Hallo Welt',
 				'Object language matches site: plain string returned, *Map skipped.',
 			),
-			'object_lang_partial_match'          => array(
+			'object_lang_partial_match'       => array(
 				array(
 					'summary'  => 'Grüezi',
 					'language' => 'de-CH',
@@ -346,7 +338,7 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				'Grüezi',
 				'Object language de-CH matches site de_DE (both normalize to "de").',
 			),
-			'empty_language_map'                 => array(
+			'empty_language_map'              => array(
 				array( 'summary' => array() ),
 				'summary',
 				'en_US',


### PR DESCRIPTION
## Proposed changes:
* Remove the fallback that resolved language maps incorrectly placed in base properties (e.g. `summary: {"en": "Hello"}` instead of using `summaryMap`). Only `*Map` variants should contain language maps per the ActivityStreams spec.
* When no base string exists and no preferred language matches the `*Map`, fall back to the first map entry instead of returning `null`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run env-test -- --filter='Test_Trait_Language_Map'` — all 36 tests should pass.
* Run `npm run env-test -- --filter='test_language_map_normalization_in_inbox'` — integration test should pass.
* Verify that incoming activities with proper `contentMap`/`summaryMap` resolve correctly.
* Verify that a `*Map` with no matching language and no base string returns the first map entry.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Changed - for changes in existing functionality

#### Message

Improve language map resolution to strictly follow the ActivityStreams spec.

</details>