### PR TITLE
Add video poster image federation

### DIFF
--- a/.github/changelog/2982-from-description
+++ b/.github/changelog/2982-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add federation of video poster images set in the WordPress video block.

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -20,6 +20,12 @@ use function Activitypub\object_to_uri;
  *
  * Transformers are responsible for transforming WordPress objects into different ActivityPub
  * Object-Types or Activities.
+ *
+ * @method string|null get_content() Returns the content for the transformed item.
+ * @method array|null  get_icon()    Returns an icon for the transformed item.
+ * @method string|null get_id()      Returns the ID for the transformed item.
+ * @method string|null get_name()    Returns the name for the transformed item.
+ * @method string|null get_summary() Returns the summary for the transformed item.
  */
 abstract class Base {
 	/**
@@ -493,7 +499,7 @@ abstract class Base {
 	/**
 	 * Transforms a WordPress attachment array to ActivityStreams attachment format.
 	 *
-	 * @param array $media The WordPress attachment array with 'id' and optional 'alt'.
+	 * @param array $media The WordPress attachment array with 'id', optional 'alt', and optional 'icon'.
 	 *
 	 * @return array The ActivityStreams attachment array.
 	 */
@@ -557,7 +563,10 @@ abstract class Base {
 					$attachment['height'] = \esc_attr( $meta['height'] );
 				}
 
-				if ( \method_exists( $this, 'get_icon' ) && $this->get_icon() ) {
+				// Use poster image from the block, or fall back to the transformer icon.
+				if ( ! empty( $media['icon'] ) ) {
+					$attachment['icon'] = \esc_url( $media['icon'] );
+				} elseif ( \method_exists( $this, 'get_icon' ) && $this->get_icon() ) {
 					$attachment['icon'] = object_to_uri( $this->get_icon() );
 				}
 				break;

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -22,7 +22,7 @@ use function Activitypub\object_to_uri;
  * Object-Types or Activities.
  *
  * @method string|null get_content() Returns the content for the transformed item.
- * @method array|null  get_icon()    Returns an icon for the transformed item.
+ * @method string|array|null get_icon() Returns an icon for the transformed item.
  * @method string|null get_id()      Returns the ID for the transformed item.
  * @method string|null get_name()    Returns the name for the transformed item.
  * @method string|null get_summary() Returns the summary for the transformed item.
@@ -565,7 +565,7 @@ abstract class Base {
 
 				// Use poster image from the block, or fall back to the transformer icon.
 				if ( ! empty( $media['icon'] ) ) {
-					$attachment['icon'] = \esc_url( $media['icon'] );
+					$attachment['icon'] = \esc_url_raw( $media['icon'] );
 				} elseif ( \method_exists( $this, 'get_icon' ) && $this->get_icon() ) {
 					$attachment['icon'] = object_to_uri( $this->get_icon() );
 				}

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -923,11 +923,10 @@ class Post extends Base {
 				case 'core/image':
 				case 'core/cover':
 					if ( ! empty( $block['attrs']['id'] ) ) {
-						$alt   = '';
-						$check = preg_match( '/<img.*?alt\s*=\s*([\"\'])(.*?)\1.*>/i', $block['innerHTML'], $match );
-
-						if ( $check ) {
-							$alt = $match[2];
+						$alt       = '';
+						$processor = new \WP_HTML_Tag_Processor( $block['innerHTML'] );
+						if ( $processor->next_tag( array( 'tag_name' => 'img' ) ) ) {
+							$alt = $processor->get_attribute( 'alt' ) ?? '';
 						}
 
 						$found = false;

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -955,7 +955,14 @@ class Post extends Base {
 				case 'core/video':
 				case 'videopress/video':
 					if ( ! empty( $block['attrs']['id'] ) ) {
-						$media['video'][] = array( 'id' => $block['attrs']['id'] );
+						$video = array( 'id' => $block['attrs']['id'] );
+
+						// The poster is stored as an HTML attribute on the <video> tag, not in block attrs.
+						if ( preg_match( '/<video[^>]*poster\s*=\s*(["\'])(.*?)\1/i', $block['innerHTML'], $match ) ) {
+							$video['icon'] = \sanitize_url( $match[2] );
+						}
+
+						$media['video'][] = $video;
 					}
 					break;
 				case 'jetpack/slideshow':

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -958,8 +958,12 @@ class Post extends Base {
 						$video = array( 'id' => $block['attrs']['id'] );
 
 						// The poster is stored as an HTML attribute on the <video> tag, not in block attrs.
-						if ( preg_match( '/<video[^>]*poster\s*=\s*(["\'])(.*?)\1/i', $block['innerHTML'], $match ) ) {
-							$video['icon'] = \sanitize_url( $match[2] );
+						$processor = new \WP_HTML_Tag_Processor( $block['innerHTML'] );
+						if ( $processor->next_tag( array( 'tag_name' => 'video' ) ) ) {
+							$poster = $processor->get_attribute( 'poster' );
+							if ( ! empty( $poster ) ) {
+								$video['icon'] = \esc_url_raw( $poster );
+							}
 						}
 
 						$media['video'][] = $video;

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -503,6 +503,74 @@ class Test_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_media_from_blocks extracts poster from video blocks.
+	 *
+	 * @covers ::get_media_from_blocks
+	 */
+	public function test_get_media_from_blocks_extracts_video_poster() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => '<!-- wp:video {"id":789} --><figure class="wp-block-video"><video controls poster="https://example.com/poster.jpg" src="https://example.com/video.mp4"></video></figure><!-- /wp:video -->',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$transformer = new Post( $post );
+		$media       = array(
+			'image' => array(),
+			'audio' => array(),
+			'video' => array(),
+		);
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_media_from_blocks' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$blocks = parse_blocks( $post->post_content );
+		$result = $method->invoke( $transformer, $blocks, $media );
+
+		$this->assertCount( 1, $result['video'] );
+		$this->assertSame( 789, $result['video'][0]['id'] );
+		$this->assertSame( 'https://example.com/poster.jpg', $result['video'][0]['icon'] );
+	}
+
+	/**
+	 * Test get_media_from_blocks handles video blocks without poster.
+	 *
+	 * @covers ::get_media_from_blocks
+	 */
+	public function test_get_media_from_blocks_video_without_poster() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => '<!-- wp:video {"id":789} --><figure class="wp-block-video"><video controls src="https://example.com/video.mp4"></video></figure><!-- /wp:video -->',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$transformer = new Post( $post );
+		$media       = array(
+			'image' => array(),
+			'audio' => array(),
+			'video' => array(),
+		);
+
+		$reflection = new \ReflectionClass( Post::class );
+		$method     = $reflection->getMethod( 'get_media_from_blocks' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$blocks = parse_blocks( $post->post_content );
+		$result = $method->invoke( $transformer, $blocks, $media );
+
+		$this->assertCount( 1, $result['video'] );
+		$this->assertSame( 789, $result['video'][0]['id'] );
+		$this->assertArrayNotHasKey( 'icon', $result['video'][0] );
+	}
+
+	/**
 	 * Test get_icon method.
 	 *
 	 * @covers ::get_icon


### PR DESCRIPTION
Reported in https://wordpress.org/support/topic/videos-poster-image/

## Proposed changes:
* Extract the `poster` attribute from WordPress video block HTML (`<video poster="...">`) and include it as the `icon` property on ActivityPub Video attachments, so Mastodon and other platforms can display video thumbnails.
* Add `@method` PHPDoc tags to the Base transformer class for child-implemented methods (`get_content`, `get_icon`, `get_id`, `get_name`, `get_summary`).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a post with a video block and set a poster image on it.
* Publish the post and check the ActivityPub JSON output (append `?activitypub` to the post URL).
* Verify the video attachment includes an `icon` property with the poster image URL.
* Verify posts without a poster image on the video still federate correctly without an `icon`.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Added - for new features

#### Message

Add federation of video poster images set in the WordPress video block.

</details>