### PR TITLE
Fix soft-deleted posts generating spurious activities on re-save

### DIFF
--- a/.github/changelog/2991-from-description
+++ b/.github/changelog/2991-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix soft-deleted posts being served instead of a tombstone when the post is re-saved.

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -63,14 +63,23 @@ class Post {
 			return;
 		}
 
+		$object_status = get_wp_object_state( $post );
+
+		// If the post is already soft-deleted, do not create any more activities.
+		if (
+			ACTIVITYPUB_OBJECT_STATE_DELETED === $object_status &&
+			in_array( get_content_visibility( $post ), array( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE ), true )
+		) {
+			return;
+		}
+
 		// Bail on bulk edits, unless post author or post status changed.
 		if ( isset( $_REQUEST['bulk_edit'] ) && ( ! isset( $_REQUEST['post_author'] ) || -1 === (int) $_REQUEST['post_author'] ) && -1 === (int) $_REQUEST['_status'] ) { // phpcs:ignore WordPress
 			return;
 		}
 
-		$new_status    = get_post_status( $post );
-		$old_status    = $post_before ? get_post_status( $post_before ) : null;
-		$object_status = get_wp_object_state( $post );
+		$new_status = get_post_status( $post );
+		$old_status = $post_before ? get_post_status( $post_before ) : null;
 
 		switch ( $new_status ) {
 			case 'publish':

--- a/tests/phpunit/tests/includes/scheduler/class-test-post.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-post.php
@@ -454,7 +454,6 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	 * a subsequent wp_update_post (e.g. from a plugin re-saving) should not
 	 * create a spurious Update activity that undoes the tombstone.
 	 *
-	 * @ticket https://github.com/Automattic/wordpress-activitypub/issues/2990
 	 * @covers ::triage
 	 */
 	public function test_resave_soft_deleted_post_no_new_activity() {

--- a/tests/phpunit/tests/includes/scheduler/class-test-post.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-post.php
@@ -446,4 +446,70 @@ class Test_Post extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		$this->assertEmpty( $outbox_items, 'Should not create a Delete activity when visibility changes to public' );
 	}
+
+	/**
+	 * Test that re-saving a soft-deleted post does not create a new outbox activity.
+	 *
+	 * When a post has already been soft-deleted (state=deleted, visibility=local/private),
+	 * a subsequent wp_update_post (e.g. from a plugin re-saving) should not
+	 * create a spurious Update activity that undoes the tombstone.
+	 *
+	 * @ticket https://github.com/Automattic/wordpress-activitypub/issues/2990
+	 * @covers ::triage
+	 */
+	public function test_resave_soft_deleted_post_no_new_activity() {
+		// Create a post (will be federated).
+		$post_id        = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$activitypub_id = \add_query_arg( 'p', $post_id, \home_url( '/' ) );
+
+		// Verify the post was federated (Create activity exists).
+		$create_item = $this->get_latest_outbox_item( $activitypub_id );
+		$this->assertNotNull( $create_item );
+		$this->assertSame( 'Create', \get_post_meta( $create_item->ID, '_activitypub_activity_type', true ) );
+
+		// Simulate the post being soft-deleted: state=deleted, visibility=local.
+		\update_post_meta( $post_id, 'activitypub_status', ACTIVITYPUB_OBJECT_STATE_DELETED );
+		\update_post_meta( $post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
+
+		// Count existing outbox items before re-save.
+		$before_count = count(
+			\get_posts(
+				array(
+					'post_type'   => 'ap_outbox',
+					'post_status' => 'pending',
+					'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						array(
+							'key'   => '_activitypub_object_id',
+							'value' => $activitypub_id,
+						),
+					),
+					'numberposts' => -1,
+				)
+			)
+		);
+
+		$this->assertGreaterThan( 0, $before_count, 'Sanity check: post should have at least one outbox item before re-save.' );
+
+		// Re-save the post (simulates a plugin re-saving during save_post).
+		\wp_update_post( array( 'ID' => $post_id ) );
+
+		// Count outbox items after re-save.
+		$after_count = count(
+			\get_posts(
+				array(
+					'post_type'   => 'ap_outbox',
+					'post_status' => 'pending',
+					'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						array(
+							'key'   => '_activitypub_object_id',
+							'value' => $activitypub_id,
+						),
+					),
+					'numberposts' => -1,
+				)
+			)
+		);
+
+		$this->assertSame( $before_count, $after_count, 'Re-saving a soft-deleted post should not create any new outbox activities.' );
+	}
 }


### PR DESCRIPTION
Fixes #2990

## Proposed changes:
* Add an early return guard in `Post::triage()` that skips posts already in `deleted` state with local/private visibility. This prevents any re-save — whether from a plugin or the user editing the post again — from creating a spurious Update activity that undoes the tombstone.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create and publish a post — confirm it federates normally.
* Edit the post and change its ActivityPub visibility to **Local** (do not federate).
* Save the post.
* Verify that only a single `Delete` outbox item is created (no spurious `Update` after it).
* Edit and save the post again — verify no new outbox item is created.
* Request the post URL with `Accept: application/activity+json` and confirm a tombstone response is returned.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix soft-deleted posts being served instead of a tombstone when the post is re-saved.

</details>