### PR TITLE
Fix reactions buttons inheriting theme background on classic themes

### DIFF
--- a/.github/changelog/fix-reactions-theme-background-override
+++ b/.github/changelog/fix-reactions-theme-background-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix reactions block buttons inheriting theme background color on classic themes.

--- a/build/reactions/render.php
+++ b/build/reactions/render.php
@@ -202,7 +202,7 @@ ob_start();
 	<div class="reaction-group" data-reaction-type="<?php echo esc_attr( $_type ); ?>">
 		<?php if ( $attributes['showActions'] && $intent ) : ?>
 		<button
-			class="reaction-action-button wp-element-button"
+			class="reaction-action-button has-text-color has-background"
 			data-intent="<?php echo esc_attr( $intent ); ?>"
 			data-wp-on--click="actions.openIntentModal"
 			type="button"
@@ -237,7 +237,7 @@ ob_start();
 		</ul>
 		<?php endif; ?>
 		<button
-			class="reaction-label"
+			class="reaction-label has-text-color has-background"
 			data-reaction-type="<?php echo esc_attr( $_type ); ?>"
 			data-wp-on--click="actions.toggleModal"
 			type="button"

--- a/src/reactions/render.php
+++ b/src/reactions/render.php
@@ -202,7 +202,7 @@ ob_start();
 	<div class="reaction-group" data-reaction-type="<?php echo esc_attr( $_type ); ?>">
 		<?php if ( $attributes['showActions'] && $intent ) : ?>
 		<button
-			class="reaction-action-button wp-element-button"
+			class="reaction-action-button has-text-color has-background"
 			data-intent="<?php echo esc_attr( $intent ); ?>"
 			data-wp-on--click="actions.openIntentModal"
 			type="button"
@@ -237,7 +237,7 @@ ob_start();
 		</ul>
 		<?php endif; ?>
 		<button
-			class="reaction-label"
+			class="reaction-label has-text-color has-background"
 			data-reaction-type="<?php echo esc_attr( $_type ); ?>"
 			data-wp-on--click="actions.toggleModal"
 			type="button"


### PR DESCRIPTION
Fixes reaction block buttons picking up aggressive global `button` styles from classic themes like Twenty Twenty-One.

## Proposed changes:
* Add `has-text-color` and `has-background` classes to `.reaction-label` and `.reaction-action-button` so that TT1's `:not(.has-background)` / `:not(.has-text-color)` guards skip them — the same escape hatch WordPress themes use for blocks that manage their own colors.
* Remove `wp-element-button` from `.reaction-action-button` to prevent block themes (TT5) from applying their generated button styles.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Activate Twenty Twenty-One (`wp theme activate twentytwentyone`)
* View a post with the Reactions block that has likes/reposts
* Verify the "2 reposts" / "3 likes" label buttons have **transparent background** (no dark teal fill)
* If action buttons are enabled ("Repost", "Like"), verify they show only an outlined border — no filled background
* Switch to Twenty Twenty-Five and verify no visual regression

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix reactions block buttons inheriting theme background color on classic themes.

</details>