### PR TITLE
[C2S] Add Block, Add, and Remove outbox handlers

### DIFF
--- a/.github/changelog/3033-from-description
+++ b/.github/changelog/3033-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add support for Block, Add (pin post), and Remove (unpin post) activities via Client-to-Server API.

--- a/includes/class-handler.php
+++ b/includes/class-handler.php
@@ -48,11 +48,14 @@ class Handler {
 	 * Register outbox handlers.
 	 */
 	public static function register_outbox_handlers() {
+		Handler\Outbox\Add::init();
 		Handler\Outbox\Announce::init();
+		Handler\Outbox\Block::init();
 		Handler\Outbox\Create::init();
 		Handler\Outbox\Delete::init();
 		Handler\Outbox\Follow::init();
 		Handler\Outbox\Like::init();
+		Handler\Outbox\Remove::init();
 		Handler\Outbox\Undo::init();
 		Handler\Outbox\Update::init();
 

--- a/includes/handler/outbox/class-add.php
+++ b/includes/handler/outbox/class-add.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Outbox Add handler file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Handler\Outbox;
+
+use Activitypub\Collection\Actors;
+use Activitypub\Scheduler\Post as Post_Scheduler;
+
+use function Activitypub\add_to_outbox;
+use function Activitypub\object_to_uri;
+
+/**
+ * Handle outgoing Add activities.
+ *
+ * Supports adding objects to an actor's featured collection
+ * by making the corresponding WordPress post sticky.
+ */
+class Add {
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_filter( 'activitypub_outbox_add', array( self::class, 'handle_add' ), 10, 2 );
+	}
+
+	/**
+	 * Handle outgoing "Add" activities from local actors.
+	 *
+	 * When the target is the actor's featured collection, the referenced
+	 * post is made sticky. The activity is then added to the outbox for
+	 * federation.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $data    The activity data array.
+	 * @param int   $user_id The user ID.
+	 *
+	 * @return int|\WP_Error The outbox post ID on success, or WP_Error on failure.
+	 */
+	public static function handle_add( $data, $user_id = null ) {
+		$object_uri = object_to_uri( $data['object'] ?? '' );
+		$target     = object_to_uri( $data['target'] ?? '' );
+
+		if ( empty( $object_uri ) || empty( $target ) ) {
+			return $data;
+		}
+
+		$actor = Actors::get_by_id( $user_id );
+
+		if ( \is_wp_error( $actor ) ) {
+			return $actor;
+		}
+
+		// Only handle featured collection targets.
+		if ( $target !== $actor->get_featured() ) {
+			return $data;
+		}
+
+		$post_id = \url_to_postid( $object_uri );
+
+		if ( ! $post_id ) {
+			return new \WP_Error(
+				'activitypub_object_not_found',
+				\__( 'The referenced object was not found.', 'activitypub' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$post = \get_post( $post_id );
+
+		if ( ! $post ) {
+			return new \WP_Error(
+				'activitypub_object_not_found',
+				\__( 'The referenced object was not found.', 'activitypub' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Verify the user owns this post.
+		if ( $user_id > 0 && (int) $post->post_author !== $user_id ) {
+			return new \WP_Error(
+				'activitypub_forbidden',
+				\__( 'You can only feature your own posts.', 'activitypub' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Temporarily unhook the scheduler to avoid a duplicate outbox entry.
+		\remove_action( 'post_stuck', array( Post_Scheduler::class, 'schedule_featured_add' ) );
+		\stick_post( $post_id );
+		\add_action( 'post_stuck', array( Post_Scheduler::class, 'schedule_featured_add' ) );
+
+		return add_to_outbox( $data, 'Add', $user_id );
+	}
+}

--- a/includes/handler/outbox/class-add.php
+++ b/includes/handler/outbox/class-add.php
@@ -39,7 +39,7 @@ class Add {
 	 * @param array $data    The activity data array.
 	 * @param int   $user_id The user ID.
 	 *
-	 * @return int|\WP_Error The outbox post ID on success, or WP_Error on failure.
+	 * @return array|int|\WP_Error The original data if unhandled, outbox post ID on success, or WP_Error on failure.
 	 */
 	public static function handle_add( $data, $user_id = null ) {
 		$object_uri = object_to_uri( $data['object'] ?? '' );

--- a/includes/handler/outbox/class-add.php
+++ b/includes/handler/outbox/class-add.php
@@ -8,9 +8,7 @@
 namespace Activitypub\Handler\Outbox;
 
 use Activitypub\Collection\Actors;
-use Activitypub\Scheduler\Post as Post_Scheduler;
 
-use function Activitypub\add_to_outbox;
 use function Activitypub\object_to_uri;
 
 /**
@@ -31,15 +29,15 @@ class Add {
 	 * Handle outgoing "Add" activities from local actors.
 	 *
 	 * When the target is the actor's featured collection, the referenced
-	 * post is made sticky. The activity is then added to the outbox for
-	 * federation.
+	 * post is made sticky. The sticky action triggers the scheduler which
+	 * creates the outbox entry automatically.
 	 *
 	 * @since unreleased
 	 *
 	 * @param array $data    The activity data array.
 	 * @param int   $user_id The user ID.
 	 *
-	 * @return array|int|\WP_Error The original data if unhandled, outbox post ID on success, or WP_Error on failure.
+	 * @return \WP_Post|\WP_Error|array The post object on success, WP_Error on failure, or original data if unhandled.
 	 */
 	public static function handle_add( $data, $user_id = null ) {
 		$object_uri = object_to_uri( $data['object'] ?? '' );
@@ -89,11 +87,9 @@ class Add {
 			);
 		}
 
-		// Temporarily unhook the scheduler to avoid a duplicate outbox entry.
-		\remove_action( 'post_stuck', array( Post_Scheduler::class, 'schedule_featured_add' ) );
+		// Making the post sticky triggers the scheduler which adds to outbox.
 		\stick_post( $post_id );
-		\add_action( 'post_stuck', array( Post_Scheduler::class, 'schedule_featured_add' ) );
 
-		return add_to_outbox( $data, 'Add', $user_id );
+		return $post;
 	}
 }

--- a/includes/handler/outbox/class-block.php
+++ b/includes/handler/outbox/class-block.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Outbox Block handler file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Handler\Outbox;
+
+use Activitypub\Moderation;
+
+use function Activitypub\add_to_outbox;
+use function Activitypub\object_to_uri;
+
+/**
+ * Handle outgoing Block activities.
+ */
+class Block {
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_filter( 'activitypub_outbox_block', array( self::class, 'handle_block' ), 10, 2 );
+	}
+
+	/**
+	 * Handle outgoing "Block" activities from local actors.
+	 *
+	 * Blocks a remote actor using the Moderation system, then adds
+	 * the activity to the outbox for federation.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $data    The activity data array.
+	 * @param int   $user_id The user ID.
+	 *
+	 * @return array|int|\WP_Error The original data if unhandled, outbox post ID on success, or WP_Error on failure.
+	 */
+	public static function handle_block( $data, $user_id = null ) {
+		$actor_uri = object_to_uri( $data['object'] ?? '' );
+
+		if ( empty( $actor_uri ) ) {
+			return $data;
+		}
+
+		$result = Moderation::add_user_block( $user_id, Moderation::TYPE_ACTOR, $actor_uri );
+
+		if ( ! $result ) {
+			return new \WP_Error(
+				'activitypub_block_failed',
+				\__( 'Failed to block the actor.', 'activitypub' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		// Block activities should only be sent to the blocked actor.
+		$data['to'] = array( $actor_uri );
+		unset( $data['cc'] );
+
+		return add_to_outbox( $data, 'Block', $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+	}
+}

--- a/includes/handler/outbox/class-remove.php
+++ b/includes/handler/outbox/class-remove.php
@@ -8,9 +8,7 @@
 namespace Activitypub\Handler\Outbox;
 
 use Activitypub\Collection\Actors;
-use Activitypub\Scheduler\Post as Post_Scheduler;
 
-use function Activitypub\add_to_outbox;
 use function Activitypub\object_to_uri;
 
 /**
@@ -31,15 +29,15 @@ class Remove {
 	 * Handle outgoing "Remove" activities from local actors.
 	 *
 	 * When the target is the actor's featured collection, the referenced
-	 * post is unstuck. The activity is then added to the outbox for
-	 * federation.
+	 * post is unstuck. The unstick action triggers the scheduler which
+	 * creates the outbox entry automatically.
 	 *
 	 * @since unreleased
 	 *
 	 * @param array $data    The activity data array.
 	 * @param int   $user_id The user ID.
 	 *
-	 * @return array|int|\WP_Error The original data if unhandled, outbox post ID on success, or WP_Error on failure.
+	 * @return \WP_Post|\WP_Error|array The post object on success, WP_Error on failure, or original data if unhandled.
 	 */
 	public static function handle_remove( $data, $user_id = null ) {
 		$object_uri = object_to_uri( $data['object'] ?? '' );
@@ -89,11 +87,9 @@ class Remove {
 			);
 		}
 
-		// Temporarily unhook the scheduler to avoid a duplicate outbox entry.
-		\remove_action( 'post_unstuck', array( Post_Scheduler::class, 'schedule_featured_remove' ) );
+		// Unsticking the post triggers the scheduler which adds to outbox.
 		\unstick_post( $post_id );
-		\add_action( 'post_unstuck', array( Post_Scheduler::class, 'schedule_featured_remove' ) );
 
-		return add_to_outbox( $data, 'Remove', $user_id );
+		return $post;
 	}
 }

--- a/includes/handler/outbox/class-remove.php
+++ b/includes/handler/outbox/class-remove.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Outbox Remove handler file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Handler\Outbox;
+
+use Activitypub\Collection\Actors;
+use Activitypub\Scheduler\Post as Post_Scheduler;
+
+use function Activitypub\add_to_outbox;
+use function Activitypub\object_to_uri;
+
+/**
+ * Handle outgoing Remove activities.
+ *
+ * Supports removing objects from an actor's featured collection
+ * by unsticking the corresponding WordPress post.
+ */
+class Remove {
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_filter( 'activitypub_outbox_remove', array( self::class, 'handle_remove' ), 10, 2 );
+	}
+
+	/**
+	 * Handle outgoing "Remove" activities from local actors.
+	 *
+	 * When the target is the actor's featured collection, the referenced
+	 * post is unstuck. The activity is then added to the outbox for
+	 * federation.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $data    The activity data array.
+	 * @param int   $user_id The user ID.
+	 *
+	 * @return int|\WP_Error The outbox post ID on success, or WP_Error on failure.
+	 */
+	public static function handle_remove( $data, $user_id = null ) {
+		$object_uri = object_to_uri( $data['object'] ?? '' );
+		$target     = object_to_uri( $data['target'] ?? '' );
+
+		if ( empty( $object_uri ) || empty( $target ) ) {
+			return $data;
+		}
+
+		$actor = Actors::get_by_id( $user_id );
+
+		if ( \is_wp_error( $actor ) ) {
+			return $actor;
+		}
+
+		// Only handle featured collection targets.
+		if ( $target !== $actor->get_featured() ) {
+			return $data;
+		}
+
+		$post_id = \url_to_postid( $object_uri );
+
+		if ( ! $post_id ) {
+			return new \WP_Error(
+				'activitypub_object_not_found',
+				\__( 'The referenced object was not found.', 'activitypub' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$post = \get_post( $post_id );
+
+		if ( ! $post ) {
+			return new \WP_Error(
+				'activitypub_object_not_found',
+				\__( 'The referenced object was not found.', 'activitypub' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Verify the user owns this post.
+		if ( $user_id > 0 && (int) $post->post_author !== $user_id ) {
+			return new \WP_Error(
+				'activitypub_forbidden',
+				\__( 'You can only unfeature your own posts.', 'activitypub' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Temporarily unhook the scheduler to avoid a duplicate outbox entry.
+		\remove_action( 'post_unstuck', array( Post_Scheduler::class, 'schedule_featured_remove' ) );
+		\unstick_post( $post_id );
+		\add_action( 'post_unstuck', array( Post_Scheduler::class, 'schedule_featured_remove' ) );
+
+		return add_to_outbox( $data, 'Remove', $user_id );
+	}
+}

--- a/includes/handler/outbox/class-remove.php
+++ b/includes/handler/outbox/class-remove.php
@@ -39,7 +39,7 @@ class Remove {
 	 * @param array $data    The activity data array.
 	 * @param int   $user_id The user ID.
 	 *
-	 * @return int|\WP_Error The outbox post ID on success, or WP_Error on failure.
+	 * @return array|int|\WP_Error The original data if unhandled, outbox post ID on success, or WP_Error on failure.
 	 */
 	public static function handle_remove( $data, $user_id = null ) {
 		$object_uri = object_to_uri( $data['object'] ?? '' );

--- a/includes/handler/outbox/class-undo.php
+++ b/includes/handler/outbox/class-undo.php
@@ -73,7 +73,7 @@ class Undo {
 
 			case 'Block':
 				$stored    = \json_decode( $outbox_item->post_content, true );
-				$actor_uri = object_to_uri( $stored['object'] ?? '' );
+				$actor_uri = \is_array( $stored ) ? object_to_uri( $stored['object'] ?? '' ) : '';
 
 				if ( $actor_uri ) {
 					Moderation::remove_user_block( $user_id, Moderation::TYPE_ACTOR, $actor_uri );

--- a/includes/handler/outbox/class-undo.php
+++ b/includes/handler/outbox/class-undo.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Handler\Outbox;
 
 use Activitypub\Collection\Outbox as Outbox_Collection;
+use Activitypub\Moderation;
 
 use function Activitypub\object_to_uri;
 use function Activitypub\unfollow;
@@ -69,6 +70,16 @@ class Undo {
 				}
 
 				return $data;
+
+			case 'Block':
+				$stored    = \json_decode( $outbox_item->post_content, true );
+				$actor_uri = object_to_uri( $stored['object'] ?? '' );
+
+				if ( $actor_uri ) {
+					Moderation::remove_user_block( $user_id, Moderation::TYPE_ACTOR, $actor_uri );
+				}
+
+				return Outbox_Collection::undo( $outbox_item );
 
 			default:
 				return Outbox_Collection::undo( $outbox_item );

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-add.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-add.php
@@ -62,9 +62,8 @@ class Test_Add extends \WP_UnitTestCase {
 
 		$result = Add::handle_add( $data, $this->user_id );
 
-		// Should return an outbox post ID.
-		$this->assertIsInt( $result );
-		$this->assertGreaterThan( 0, $result );
+		// Should return the WP_Post object.
+		$this->assertInstanceOf( \WP_Post::class, $result );
 
 		// Verify the post is now sticky.
 		$this->assertTrue(

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-add.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-add.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Test file for Outbox Add Handler.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Handler\Outbox;
+
+use Activitypub\Collection\Actors;
+use Activitypub\Handler\Outbox\Add;
+
+/**
+ * Test class for Outbox Add Handler.
+ *
+ * @coversDefaultClass \Activitypub\Handler\Outbox\Add
+ */
+class Test_Add extends \WP_UnitTestCase {
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	public $user_id;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$user = \get_user_by( 'id', $this->user_id );
+		$user->add_cap( 'activitypub' );
+
+		// Prevent outbox processing from dispatching during tests.
+		\remove_all_actions( 'activitypub_process_outbox' );
+	}
+
+	/**
+	 * Test that handle_add makes a post sticky and adds to outbox.
+	 *
+	 * @covers ::handle_add
+	 */
+	public function test_handle_add_makes_post_sticky() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $this->user_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$actor = Actors::get_by_id( $this->user_id );
+
+		$data = array(
+			'type'   => 'Add',
+			'object' => \get_permalink( $post_id ),
+			'target' => $actor->get_featured(),
+		);
+
+		$result = Add::handle_add( $data, $this->user_id );
+
+		// Should return an outbox post ID.
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		// Verify the post is now sticky.
+		$this->assertTrue(
+			\is_sticky( $post_id ),
+			'Post should be sticky after Add.'
+		);
+	}
+
+	/**
+	 * Test that handle_add returns data for empty object.
+	 *
+	 * @covers ::handle_add
+	 */
+	public function test_handle_add_empty_object() {
+		$data = array(
+			'type'   => 'Add',
+			'object' => '',
+			'target' => 'https://example.com/featured',
+		);
+
+		$result = Add::handle_add( $data, $this->user_id );
+
+		$this->assertSame( $data, $result, 'Should return original data for empty object.' );
+	}
+
+	/**
+	 * Test that handle_add returns data for empty target.
+	 *
+	 * @covers ::handle_add
+	 */
+	public function test_handle_add_empty_target() {
+		$data = array(
+			'type'   => 'Add',
+			'object' => 'https://example.com/post/1',
+			'target' => '',
+		);
+
+		$result = Add::handle_add( $data, $this->user_id );
+
+		$this->assertSame( $data, $result, 'Should return original data for empty target.' );
+	}
+
+	/**
+	 * Test that handle_add ignores non-featured targets.
+	 *
+	 * @covers ::handle_add
+	 */
+	public function test_handle_add_non_featured_target() {
+		$data = array(
+			'type'   => 'Add',
+			'object' => 'https://example.com/post/1',
+			'target' => 'https://example.com/some-other-collection',
+		);
+
+		$result = Add::handle_add( $data, $this->user_id );
+
+		$this->assertSame( $data, $result, 'Should return original data for non-featured target.' );
+	}
+
+	/**
+	 * Test that handle_add rejects other users posts.
+	 *
+	 * @covers ::handle_add
+	 */
+	public function test_handle_add_forbidden_for_other_users_post() {
+		$other_user = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id    = self::factory()->post->create(
+			array(
+				'post_author' => $other_user,
+				'post_status' => 'publish',
+			)
+		);
+
+		$actor = Actors::get_by_id( $this->user_id );
+
+		$data = array(
+			'type'   => 'Add',
+			'object' => \get_permalink( $post_id ),
+			'target' => $actor->get_featured(),
+		);
+
+		$result = Add::handle_add( $data, $this->user_id );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that handle_add returns error for non-existent post.
+	 *
+	 * @covers ::handle_add
+	 */
+	public function test_handle_add_post_not_found() {
+		$actor = Actors::get_by_id( $this->user_id );
+
+		$data = array(
+			'type'   => 'Add',
+			'object' => \home_url( '/non-existent-post/' ),
+			'target' => $actor->get_featured(),
+		);
+
+		$result = Add::handle_add( $data, $this->user_id );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_object_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that init registers the filter.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_registers_filter() {
+		Add::init();
+
+		$this->assertNotFalse(
+			\has_filter( 'activitypub_outbox_add', array( Add::class, 'handle_add' ) ),
+			'Filter should be registered.'
+		);
+	}
+}

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-block.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-block.php
@@ -68,24 +68,26 @@ class Test_Block extends \WP_UnitTestCase {
 		};
 		\add_filter( 'activitypub_pre_http_get_remote_object', $filter );
 
-		$data = array(
-			'type'   => 'Block',
-			'object' => $actor_url,
-		);
+		try {
+			$data = array(
+				'type'   => 'Block',
+				'object' => $actor_url,
+			);
 
-		$result = Block::handle_block( $data, $this->user_id );
+			$result = Block::handle_block( $data, $this->user_id );
 
-		// Should return an outbox post ID.
-		$this->assertIsInt( $result );
-		$this->assertGreaterThan( 0, $result );
+			// Should return an outbox post ID.
+			$this->assertIsInt( $result );
+			$this->assertGreaterThan( 0, $result );
 
-		// Verify the actor is blocked.
-		$this->assertTrue(
-			Moderation::is_actor_blocked( $actor_url, $this->user_id ),
-			'Actor should be blocked.'
-		);
-
-		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+			// Verify the actor is blocked.
+			$this->assertTrue(
+				Moderation::is_actor_blocked( $actor_url, $this->user_id ),
+				'Actor should be blocked.'
+			);
+		} finally {
+			\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+		}
 	}
 
 	/**
@@ -133,21 +135,23 @@ class Test_Block extends \WP_UnitTestCase {
 		};
 		\add_filter( 'activitypub_pre_http_get_remote_object', $filter );
 
-		$data = array(
-			'type'   => 'Block',
-			'object' => $actor_url,
-			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
-			'cc'     => array( 'https://example.com/followers' ),
-		);
+		try {
+			$data = array(
+				'type'   => 'Block',
+				'object' => $actor_url,
+				'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+				'cc'     => array( 'https://example.com/followers' ),
+			);
 
-		$result = Block::handle_block( $data, $this->user_id );
+			$result = Block::handle_block( $data, $this->user_id );
 
-		// Verify the outbox item has private visibility.
-		$this->assertIsInt( $result );
-		$visibility = \get_post_meta( $result, 'activitypub_content_visibility', true );
-		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility );
-
-		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+			// Verify the outbox item has private visibility.
+			$this->assertIsInt( $result );
+			$visibility = \get_post_meta( $result, 'activitypub_content_visibility', true );
+			$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility );
+		} finally {
+			\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-block.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-block.php
@@ -68,26 +68,24 @@ class Test_Block extends \WP_UnitTestCase {
 		};
 		\add_filter( 'activitypub_pre_http_get_remote_object', $filter );
 
-		try {
-			$data = array(
-				'type'   => 'Block',
-				'object' => $actor_url,
-			);
+		$data = array(
+			'type'   => 'Block',
+			'object' => $actor_url,
+		);
 
-			$result = Block::handle_block( $data, $this->user_id );
+		$result = Block::handle_block( $data, $this->user_id );
 
-			// Should return an outbox post ID.
-			$this->assertIsInt( $result );
-			$this->assertGreaterThan( 0, $result );
+		// Should return an outbox post ID.
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
 
-			// Verify the actor is blocked.
-			$this->assertTrue(
-				Moderation::is_actor_blocked( $actor_url, $this->user_id ),
-				'Actor should be blocked.'
-			);
-		} finally {
-			\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
-		}
+		// Verify the actor is blocked.
+		$this->assertTrue(
+			Moderation::is_actor_blocked( $actor_url, $this->user_id ),
+			'Actor should be blocked.'
+		);
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
 	}
 
 	/**
@@ -135,23 +133,21 @@ class Test_Block extends \WP_UnitTestCase {
 		};
 		\add_filter( 'activitypub_pre_http_get_remote_object', $filter );
 
-		try {
-			$data = array(
-				'type'   => 'Block',
-				'object' => $actor_url,
-				'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
-				'cc'     => array( 'https://example.com/followers' ),
-			);
+		$data = array(
+			'type'   => 'Block',
+			'object' => $actor_url,
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'     => array( 'https://example.com/followers' ),
+		);
 
-			$result = Block::handle_block( $data, $this->user_id );
+		$result = Block::handle_block( $data, $this->user_id );
 
-			// Verify the outbox item has private visibility.
-			$this->assertIsInt( $result );
-			$visibility = \get_post_meta( $result, 'activitypub_content_visibility', true );
-			$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility );
-		} finally {
-			\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
-		}
+		// Verify the outbox item has private visibility.
+		$this->assertIsInt( $result );
+		$visibility = \get_post_meta( $result, 'activitypub_content_visibility', true );
+		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-block.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-block.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Test file for Outbox Block Handler.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Handler\Outbox;
+
+use Activitypub\Handler\Outbox\Block;
+use Activitypub\Moderation;
+
+/**
+ * Test class for Outbox Block Handler.
+ *
+ * @coversDefaultClass \Activitypub\Handler\Outbox\Block
+ */
+class Test_Block extends \WP_UnitTestCase {
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	public $user_id;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$user = \get_user_by( 'id', $this->user_id );
+		$user->add_cap( 'activitypub' );
+
+		// Prevent outbox processing from dispatching during tests.
+		\remove_all_actions( 'activitypub_process_outbox' );
+	}
+
+	/**
+	 * Test that handle_block blocks an actor and adds to outbox.
+	 *
+	 * @covers ::handle_block
+	 */
+	public function test_handle_block_blocks_actor() {
+		$actor_url = 'https://example.com/users/spammer';
+
+		$fake_response = array(
+			'type'              => 'Person',
+			'id'                => $actor_url,
+			'name'              => 'Spammer',
+			'preferredUsername' => 'spammer',
+			'inbox'             => $actor_url . '/inbox',
+			'outbox'            => $actor_url . '/outbox',
+			'followers'         => $actor_url . '/followers',
+			'following'         => $actor_url . '/following',
+			'publicKey'         => array(
+				'id'           => $actor_url . '#main-key',
+				'owner'        => $actor_url,
+				'publicKeyPem' => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Rdj53hR4AdsiRcqt1Fd\n-----END PUBLIC KEY-----",
+			),
+		);
+
+		$filter = function () use ( $fake_response ) {
+			return $fake_response;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $filter );
+
+		$data = array(
+			'type'   => 'Block',
+			'object' => $actor_url,
+		);
+
+		$result = Block::handle_block( $data, $this->user_id );
+
+		// Should return an outbox post ID.
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		// Verify the actor is blocked.
+		$this->assertTrue(
+			Moderation::is_actor_blocked( $actor_url, $this->user_id ),
+			'Actor should be blocked.'
+		);
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+	}
+
+	/**
+	 * Test that handle_block returns data for empty object.
+	 *
+	 * @covers ::handle_block
+	 */
+	public function test_handle_block_empty_object() {
+		$data = array(
+			'type'   => 'Block',
+			'object' => '',
+		);
+
+		$result = Block::handle_block( $data, $this->user_id );
+
+		$this->assertSame( $data, $result, 'Should return original data for empty object.' );
+	}
+
+	/**
+	 * Test that handle_block sets private addressing.
+	 *
+	 * @covers ::handle_block
+	 */
+	public function test_handle_block_private_addressing() {
+		$actor_url = 'https://example.com/users/blockme';
+
+		$fake_response = array(
+			'type'              => 'Person',
+			'id'                => $actor_url,
+			'name'              => 'Block Me',
+			'preferredUsername' => 'blockme',
+			'inbox'             => $actor_url . '/inbox',
+			'outbox'            => $actor_url . '/outbox',
+			'followers'         => $actor_url . '/followers',
+			'following'         => $actor_url . '/following',
+			'publicKey'         => array(
+				'id'           => $actor_url . '#main-key',
+				'owner'        => $actor_url,
+				'publicKeyPem' => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Rdj53hR4AdsiRcqt1Fd\n-----END PUBLIC KEY-----",
+			),
+		);
+
+		$filter = function () use ( $fake_response ) {
+			return $fake_response;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $filter );
+
+		$data = array(
+			'type'   => 'Block',
+			'object' => $actor_url,
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'     => array( 'https://example.com/followers' ),
+		);
+
+		$result = Block::handle_block( $data, $this->user_id );
+
+		// Verify the outbox item has private visibility.
+		$this->assertIsInt( $result );
+		$visibility = \get_post_meta( $result, 'activitypub_content_visibility', true );
+		$this->assertEquals( ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE, $visibility );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+	}
+
+	/**
+	 * Test that init registers the filter.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_registers_filter() {
+		Block::init();
+
+		$this->assertNotFalse(
+			\has_filter( 'activitypub_outbox_block', array( Block::class, 'handle_block' ) ),
+			'Filter should be registered.'
+		);
+	}
+}

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-remove.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-remove.php
@@ -66,9 +66,8 @@ class Test_Remove extends \WP_UnitTestCase {
 
 		$result = Remove::handle_remove( $data, $this->user_id );
 
-		// Should return an outbox post ID.
-		$this->assertIsInt( $result );
-		$this->assertGreaterThan( 0, $result );
+		// Should return the WP_Post object.
+		$this->assertInstanceOf( \WP_Post::class, $result );
 
 		// Verify the post is no longer sticky.
 		$this->assertFalse(

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-remove.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-remove.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Test file for Outbox Remove Handler.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Handler\Outbox;
+
+use Activitypub\Collection\Actors;
+use Activitypub\Handler\Outbox\Remove;
+
+/**
+ * Test class for Outbox Remove Handler.
+ *
+ * @coversDefaultClass \Activitypub\Handler\Outbox\Remove
+ */
+class Test_Remove extends \WP_UnitTestCase {
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	public $user_id;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$user = \get_user_by( 'id', $this->user_id );
+		$user->add_cap( 'activitypub' );
+
+		// Prevent outbox processing from dispatching during tests.
+		\remove_all_actions( 'activitypub_process_outbox' );
+	}
+
+	/**
+	 * Test that handle_remove unsticks a post and adds to outbox.
+	 *
+	 * @covers ::handle_remove
+	 */
+	public function test_handle_remove_unsticks_post() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $this->user_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Make the post sticky first.
+		\stick_post( $post_id );
+		$this->assertTrue( \is_sticky( $post_id ), 'Post should be sticky before Remove.' );
+
+		$actor = Actors::get_by_id( $this->user_id );
+
+		$data = array(
+			'type'   => 'Remove',
+			'object' => \get_permalink( $post_id ),
+			'target' => $actor->get_featured(),
+		);
+
+		$result = Remove::handle_remove( $data, $this->user_id );
+
+		// Should return an outbox post ID.
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		// Verify the post is no longer sticky.
+		$this->assertFalse(
+			\is_sticky( $post_id ),
+			'Post should not be sticky after Remove.'
+		);
+	}
+
+	/**
+	 * Test that handle_remove returns data for empty object.
+	 *
+	 * @covers ::handle_remove
+	 */
+	public function test_handle_remove_empty_object() {
+		$data = array(
+			'type'   => 'Remove',
+			'object' => '',
+			'target' => 'https://example.com/featured',
+		);
+
+		$result = Remove::handle_remove( $data, $this->user_id );
+
+		$this->assertSame( $data, $result, 'Should return original data for empty object.' );
+	}
+
+	/**
+	 * Test that handle_remove returns data for empty target.
+	 *
+	 * @covers ::handle_remove
+	 */
+	public function test_handle_remove_empty_target() {
+		$data = array(
+			'type'   => 'Remove',
+			'object' => 'https://example.com/post/1',
+			'target' => '',
+		);
+
+		$result = Remove::handle_remove( $data, $this->user_id );
+
+		$this->assertSame( $data, $result, 'Should return original data for empty target.' );
+	}
+
+	/**
+	 * Test that handle_remove ignores non-featured targets.
+	 *
+	 * @covers ::handle_remove
+	 */
+	public function test_handle_remove_non_featured_target() {
+		$data = array(
+			'type'   => 'Remove',
+			'object' => 'https://example.com/post/1',
+			'target' => 'https://example.com/some-other-collection',
+		);
+
+		$result = Remove::handle_remove( $data, $this->user_id );
+
+		$this->assertSame( $data, $result, 'Should return original data for non-featured target.' );
+	}
+
+	/**
+	 * Test that handle_remove rejects other users posts.
+	 *
+	 * @covers ::handle_remove
+	 */
+	public function test_handle_remove_forbidden_for_other_users_post() {
+		$other_user = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id    = self::factory()->post->create(
+			array(
+				'post_author' => $other_user,
+				'post_status' => 'publish',
+			)
+		);
+
+		\stick_post( $post_id );
+
+		$actor = Actors::get_by_id( $this->user_id );
+
+		$data = array(
+			'type'   => 'Remove',
+			'object' => \get_permalink( $post_id ),
+			'target' => $actor->get_featured(),
+		);
+
+		$result = Remove::handle_remove( $data, $this->user_id );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that handle_remove returns error for non-existent post.
+	 *
+	 * @covers ::handle_remove
+	 */
+	public function test_handle_remove_post_not_found() {
+		$actor = Actors::get_by_id( $this->user_id );
+
+		$data = array(
+			'type'   => 'Remove',
+			'object' => \home_url( '/non-existent-post/' ),
+			'target' => $actor->get_featured(),
+		);
+
+		$result = Remove::handle_remove( $data, $this->user_id );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_object_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that init registers the filter.
+	 *
+	 * @covers ::init
+	 */
+	public function test_init_registers_filter() {
+		Remove::init();
+
+		$this->assertNotFalse(
+			\has_filter( 'activitypub_outbox_remove', array( Remove::class, 'handle_remove' ) ),
+			'Filter should be registered.'
+		);
+	}
+}


### PR DESCRIPTION
## Proposed changes:
* Add C2S outbox handler for **Block** activities — blocks a remote actor via the Moderation system and federates a private Block activity.
* Add C2S outbox handler for **Add** activities — adds a post to the actor's featured collection by making it sticky.
* Add C2S outbox handler for **Remove** activities — removes a post from the actor's featured collection by unsticking it.
* Extend the **Undo** handler to support undoing Block activities (unblocks the actor).

These are the three remaining W3C ActivityPub C2S activity types that were missing after #2851.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Enable C2S support in Settings > ActivityPub > Advanced > "Client-to-Server".
* Connect an ActivityPub client via OAuth.
* **Block:** Send a Block activity targeting a remote actor URI → verify the actor appears in your blocked actors list and the activity is in the outbox.
* **Add to featured:** Send an Add activity with `object` pointing to a local post URL and `target` pointing to the actor's featured collection URL → verify the post becomes sticky.
* **Remove from featured:** Send a Remove activity with the same object/target → verify the post is no longer sticky.
* **Undo Block:** Send an Undo activity referencing the Block outbox entry → verify the actor is unblocked.
* Run the test suite: `npm run env-test -- --filter='Outbox.Test_Block|Outbox.Test_Add|Outbox.Test_Remove'` (18 tests, all passing).

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Added - for new features

#### Message

Add support for Block, Add (pin post), and Remove (unpin post) activities via Client-to-Server API.

</details>