### PR TITLE
Fix stale avatar URLs causing 404s

### DIFF
--- a/.github/changelog/3041-from-description
+++ b/.github/changelog/3041-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix remote actor avatars getting stuck on broken URLs when the original image becomes unavailable.

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -88,18 +88,17 @@ class Avatar extends File {
 	}
 
 	/**
-	 * Clear the cached avatar URL meta when an actor is updated.
+	 * Clear the cached avatar when an actor is updated.
 	 *
-	 * This allows lazy re-caching of the avatar on next access,
-	 * ensuring updated avatars are fetched.
+	 * Invalidates cached files so the avatar is re-downloaded on next access.
 	 *
 	 * @param int $post_id The actor post ID.
 	 */
 	public static function clear_avatar_meta( $post_id ) {
-		// Invalidate cached files.
+		// Invalidate cached files so next access re-downloads.
 		self::invalidate_entity( $post_id );
 
-		// Clear the meta so get_avatar_url() will re-cache on next access.
+		// Clean up legacy meta from previous versions.
 		\delete_post_meta( $post_id, '_activitypub_avatar_url' );
 	}
 
@@ -107,7 +106,7 @@ class Avatar extends File {
 	 * Maybe cache an avatar URL.
 	 *
 	 * Hooked to the activitypub_remote_media_url filter.
-	 * Returns cached URL from meta if available, otherwise downloads and caches.
+	 * Uses filesystem-based caching via get_or_cache() — no persistent meta storage.
 	 *
 	 * @param string     $url       The remote URL.
 	 * @param string     $context   The context ('avatar', 'media', 'emoji', etc.).
@@ -121,24 +120,9 @@ class Avatar extends File {
 			return $url;
 		}
 
-		// Check if we have a cached avatar URL in meta.
-		$cached_url = \get_post_meta( $entity_id, '_activitypub_avatar_url', true );
-		if ( $cached_url ) {
-			return $cached_url;
-		}
+		$cached_url = self::get_or_cache( $url, $entity_id, array( 'max_dimension' => self::MAX_DIMENSION ) );
 
-		// Download and cache the avatar.
-		$local_url = self::cache(
-			$url,
-			$entity_id,
-			array( 'max_dimension' => self::MAX_DIMENSION )
-		);
-
-		// Store the result in meta (local URL if cached, remote URL if not).
-		$avatar_url = $local_url ?: $url;
-		\update_post_meta( $entity_id, '_activitypub_avatar_url', \esc_url_raw( $avatar_url ) );
-
-		return $avatar_url;
+		return $cached_url ?: $url;
 	}
 
 	/**

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -80,8 +80,8 @@ class Avatar extends File {
 		// Hook into the universal remote media URL filter for lazy caching.
 		\add_filter( 'activitypub_remote_media_url', array( self::class, 'maybe_cache' ), 10, 4 );
 
-		// Clear cached avatar URL when actor is updated (allows lazy re-caching).
-		\add_action( 'save_post_' . Remote_Actors::POST_TYPE, array( self::class, 'clear_avatar_meta' ) );
+		// Invalidate cached avatar when actor is updated so it re-downloads on next access.
+		\add_action( 'save_post_' . Remote_Actors::POST_TYPE, array( self::class, 'clear_cached_avatar' ) );
 
 		// Clean up files when actor is deleted.
 		\add_action( 'before_delete_post', array( self::class, 'maybe_cleanup' ) );
@@ -94,7 +94,7 @@ class Avatar extends File {
 	 *
 	 * @param int $post_id The actor post ID.
 	 */
-	public static function clear_avatar_meta( $post_id ) {
+	public static function clear_cached_avatar( $post_id ) {
 		// Invalidate cached files so next access re-downloads.
 		self::invalidate_entity( $post_id );
 

--- a/includes/cli/class-cache-command.php
+++ b/includes/cli/class-cache-command.php
@@ -210,7 +210,7 @@ class Cache_Command extends \WP_CLI_Command {
 			File::delete_directory( $subdir );
 		}
 
-		// Also clear avatar URL meta for avatar cache.
+		// Clean up legacy avatar URL meta from previous versions.
 		if ( 'avatar' === $type ) {
 			\delete_metadata( 'post', 0, '_activitypub_avatar_url', '', true );
 		}

--- a/tests/phpunit/tests/includes/cache/class-test-avatar.php
+++ b/tests/phpunit/tests/includes/cache/class-test-avatar.php
@@ -91,6 +91,78 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test maybe_cache caches a valid avatar URL via filesystem.
+	 */
+	public function test_maybe_cache_caches_valid_url() {
+		$post_id = self::factory()->post->create();
+		$url     = 'https://example.com/avatar.jpg';
+
+		// Mock the file download to return a local fixture.
+		$mock_download = function ( $result, $download_url ) use ( $url ) {
+			if ( $download_url === $url ) {
+				$tmp_file = \wp_tempnam( 'test-avatar.jpg' );
+				copy( AP_TESTS_DIR . '/data/assets/test.jpg', $tmp_file );
+
+				return array(
+					'file'      => $tmp_file,
+					'mime_type' => 'image/jpeg',
+				);
+			}
+
+			return $result;
+		};
+
+		\add_filter( 'activitypub_pre_download_url', $mock_download, 10, 2 );
+
+		// First call should download and cache.
+		$result = Avatar::maybe_cache( $url, 'avatar', $post_id );
+		$this->assertNotEquals( $url, $result, 'Should return a local cached URL, not the original' );
+		$this->assertStringContainsString( '/activitypub/actors/', $result );
+
+		// No meta should be stored (the old bug).
+		$meta = \get_post_meta( $post_id, '_activitypub_avatar_url', true );
+		$this->assertEmpty( $meta, 'Should not store avatar URL in post meta' );
+
+		// Second call should return the same cached URL from filesystem.
+		$result2 = Avatar::maybe_cache( $url, 'avatar', $post_id );
+		$this->assertEquals( $result, $result2, 'Subsequent calls should return the same cached URL' );
+
+		// Clean up.
+		\remove_filter( 'activitypub_pre_download_url', $mock_download );
+		Avatar::invalidate_entity( $post_id );
+	}
+
+	/**
+	 * Test maybe_cache returns original URL when download fails.
+	 */
+	public function test_maybe_cache_returns_original_url_on_failure() {
+		$post_id = self::factory()->post->create();
+		$url     = 'https://example.com/broken-avatar.jpg';
+
+		// Mock the download to fail by returning false.
+		$mock_download = function ( $result, $download_url ) use ( $url ) {
+			if ( $download_url === $url ) {
+				return false;
+			}
+
+			return $result;
+		};
+
+		\add_filter( 'activitypub_pre_download_url', $mock_download, 10, 2 );
+
+		// Should return the original URL as fallback.
+		$result = Avatar::maybe_cache( $url, 'avatar', $post_id );
+		$this->assertEquals( $url, $result, 'Should fall back to the original URL on download failure' );
+
+		// No meta should be stored (this was the root cause of #3038).
+		$meta = \get_post_meta( $post_id, '_activitypub_avatar_url', true );
+		$this->assertEmpty( $meta, 'Should not persist a broken URL in post meta' );
+
+		// Clean up.
+		\remove_filter( 'activitypub_pre_download_url', $mock_download );
+	}
+
+	/**
 	 * Test save returns false for invalid actor_id.
 	 */
 	public function test_save_invalid_actor_id() {

--- a/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
+++ b/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
@@ -1321,25 +1321,17 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 		$remote_actor_id = Remote_Actors::upsert( $actor_data );
 		$this->assertIsInt( $remote_actor_id );
 
-		// Avatar is NOT cached eagerly - meta should be empty after upsert.
-		$avatar_url = get_post_meta( $remote_actor_id, '_activitypub_avatar_url', true );
-		$this->assertEmpty( $avatar_url, 'Avatar should not be eagerly cached on upsert' );
-
-		// Calling get_avatar_url() triggers lazy caching.
+		// Calling get_avatar_url() returns the avatar URL from the actor JSON.
 		$retrieved_avatar = Remote_Actors::get_avatar_url( $remote_actor_id );
 		$this->assertEquals( 'https://example.com/avatar-test.jpg', $retrieved_avatar );
-
-		// Now meta should be populated for subsequent calls.
-		$cached_avatar = get_post_meta( $remote_actor_id, '_activitypub_avatar_url', true );
-		$this->assertEquals( 'https://example.com/avatar-test.jpg', $cached_avatar );
 	}
 
 	/**
-	 * Test get_avatar_url fallback to JSON when meta is empty.
+	 * Test get_avatar_url extracts URL from actor JSON.
 	 *
 	 * @covers ::get_avatar_url
 	 */
-	public function test_get_avatar_url_fallback_to_json() {
+	public function test_get_avatar_url_from_json() {
 		// Create a remote actor.
 		$actor_data = array(
 			'id'                => 'https://example.com/users/json-avatar',
@@ -1356,22 +1348,9 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 		$remote_actor_id = Remote_Actors::upsert( $actor_data );
 		$this->assertIsInt( $remote_actor_id );
 
-		// Delete the avatar meta to simulate old data.
-		delete_post_meta( $remote_actor_id, '_activitypub_avatar_url' );
-
-		// Verify meta is empty.
-		$avatar_meta = get_post_meta( $remote_actor_id, '_activitypub_avatar_url', true );
-		$this->assertEmpty( $avatar_meta );
-
-		// Test get_avatar_url extracts from JSON and caches it.
+		// Test get_avatar_url extracts from JSON.
 		$retrieved_avatar = Remote_Actors::get_avatar_url( $remote_actor_id );
 		$this->assertEquals( 'https://example.com/json-avatar.jpg', $retrieved_avatar );
-
-		// Verify it was cached in meta.
-		$cached_avatar = get_post_meta( $remote_actor_id, '_activitypub_avatar_url', true );
-		$this->assertEquals( 'https://example.com/json-avatar.jpg', $cached_avatar );
-
-		// Clean up.
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3038

## Proposed changes:
* Refactor `Avatar::maybe_cache()` to use the existing `File::get_or_cache()` filesystem-based cache infrastructure instead of a custom `_activitypub_avatar_url` post meta shortcut.
* The old approach permanently cached broken remote URLs in meta when downloads failed, causing persistent 404s until the actor was manually updated. With 21,500+ actors and only 5-50 processed per cron hour, stale avatars could persist for days/weeks.
* The new approach matches how `Media::maybe_cache()` already works: check filesystem for cached file, download if not found, return original URL on failure. No broken URL gets persisted, so the next access retries.
* Legacy `_activitypub_avatar_url` meta is cleaned up on actor update for backwards compatibility.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Verify avatar caching still works: visit a post with federated comments — remote actor avatars should display correctly.
* Verify that a failed avatar download does NOT permanently cache a broken URL — the original remote URL should be returned as fallback, and the next page load retries.
* Verify that updating an actor (e.g., via the cron or manually) clears the cached avatar files so re-download happens on next access.
* Run `npm run env-test -- --filter=Avatar` — all 26 tests should pass.
* Run `npm run env-test -- --filter=Remote_Actors` — all 33 tests should pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix remote actor avatars getting stuck on broken URLs when the original image becomes unavailable.

</details>