### PR TITLE
Show OAuth errors as styled WordPress login page

### DIFF
--- a/.github/changelog/3043-from-description
+++ b/.github/changelog/3043-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show a styled error page instead of raw technical output when an OAuth application cannot be reached during authorization.

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -282,7 +282,12 @@ class Client {
 		if ( \is_wp_error( $response ) ) {
 			return new \WP_Error(
 				'activitypub_client_fetch_failed',
-				\__( 'Failed to fetch client metadata.', 'activitypub' ),
+				\sprintf(
+					/* translators: 1: The client metadata URL, 2: The error message from the HTTP request */
+					\__( 'Could not reach the application at %1$s: %2$s', 'activitypub' ),
+					\esc_url( $url ),
+					\esc_html( $response->get_error_message() )
+				),
 				array( 'status' => 502 )
 			);
 		}
@@ -291,8 +296,12 @@ class Client {
 		if ( 200 !== $code ) {
 			return new \WP_Error(
 				'activitypub_client_fetch_failed',
-				/* translators: %d: HTTP status code */
-				sprintf( \__( 'Client metadata returned HTTP %d.', 'activitypub' ), $code ),
+				\sprintf(
+					/* translators: 1: The client metadata URL, 2: HTTP status code */
+					\__( 'The application at %1$s returned an unexpected response (HTTP %2$d).', 'activitypub' ),
+					\esc_url( $url ),
+					$code
+				),
 				array( 'status' => 502 )
 			);
 		}

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -285,8 +285,8 @@ class Client {
 				\sprintf(
 					/* translators: 1: The client metadata URL, 2: The error message from the HTTP request */
 					\__( 'Could not reach the application at %1$s: %2$s', 'activitypub' ),
-					\esc_url( $url ),
-					\esc_html( $response->get_error_message() )
+					$url,
+					$response->get_error_message()
 				),
 				array( 'status' => 502 )
 			);
@@ -299,7 +299,7 @@ class Client {
 				\sprintf(
 					/* translators: 1: The client metadata URL, 2: HTTP status code */
 					\__( 'The application at %1$s returned an unexpected response (HTTP %2$d).', 'activitypub' ),
-					\esc_url( $url ),
+					$url,
 					$code
 				),
 				array( 'status' => 502 )

--- a/includes/oauth/class-server.php
+++ b/includes/oauth/class-server.php
@@ -287,6 +287,14 @@ class Server {
 	 */
 	private static function render_authorize_form() {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Initial form display, nonce checked on POST.
+
+		// Check for error parameter (redirected from REST authorization endpoint).
+		if ( isset( $_GET['auth_error'] ) ) {
+			$error_message = \sanitize_text_field( \wp_unslash( $_GET['auth_error'] ) ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			include ACTIVITYPUB_PLUGIN_DIR . 'templates/oauth-error.php';
+			return;
+		}
+
 		$authorize_params = array(
 			'client_id'             => isset( $_GET['client_id'] ) ? \sanitize_text_field( \wp_unslash( $_GET['client_id'] ) ) : '',
 			'redirect_uri'          => isset( $_GET['redirect_uri'] ) ? Sanitize::redirect_uri( \wp_unslash( $_GET['redirect_uri'] ) ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized via Sanitize::redirect_uri().
@@ -300,20 +308,16 @@ class Server {
 		// Validate client.
 		$client = Client::get( $authorize_params['client_id'] );
 		if ( \is_wp_error( $client ) ) {
-			\wp_die(
-				\esc_html( $client->get_error_message() ),
-				\esc_html__( 'Authorization Error', 'activitypub' ),
-				array( 'response' => 404 )
-			);
+			$error_message = $client->get_error_message(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			include ACTIVITYPUB_PLUGIN_DIR . 'templates/oauth-error.php';
+			return;
 		}
 
 		// Validate redirect URI.
 		if ( ! $client->is_valid_redirect_uri( $authorize_params['redirect_uri'] ) ) {
-			\wp_die(
-				\esc_html__( 'Invalid redirect URI for this client.', 'activitypub' ),
-				\esc_html__( 'Authorization Error', 'activitypub' ),
-				array( 'response' => 400 )
-			);
+			$error_message = \__( 'Invalid redirect URI for this client.', 'activitypub' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			include ACTIVITYPUB_PLUGIN_DIR . 'templates/oauth-error.php';
+			return;
 		}
 
 		// Use the canonical client ID (may differ from the raw input for discovered clients).
@@ -340,11 +344,9 @@ class Server {
 	private static function process_authorize_form() {
 		// Verify nonce.
 		if ( ! isset( $_POST['_wpnonce'] ) || ! \wp_verify_nonce( \sanitize_text_field( \wp_unslash( $_POST['_wpnonce'] ) ), 'activitypub_oauth_authorize' ) ) {
-			\wp_die(
-				\esc_html__( 'Security check failed. Please try again.', 'activitypub' ),
-				\esc_html__( 'Authorization Error', 'activitypub' ),
-				array( 'response' => 403 )
-			);
+			$error_message = \__( 'Security check failed. Please try again.', 'activitypub' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			include ACTIVITYPUB_PLUGIN_DIR . 'templates/oauth-error.php';
+			exit;
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above.
@@ -365,19 +367,15 @@ class Server {
 		$client = Client::get( $client_id );
 
 		if ( \is_wp_error( $client ) ) {
-			\wp_die(
-				\esc_html( $client->get_error_message() ),
-				\esc_html__( 'Authorization Error', 'activitypub' ),
-				array( 'response' => 404 )
-			);
+			$error_message = $client->get_error_message(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			include ACTIVITYPUB_PLUGIN_DIR . 'templates/oauth-error.php';
+			exit;
 		}
 
 		if ( ! $client->is_valid_redirect_uri( $redirect_uri ) ) {
-			\wp_die(
-				\esc_html__( 'Invalid redirect URI for this client.', 'activitypub' ),
-				\esc_html__( 'Authorization Error', 'activitypub' ),
-				array( 'response' => 400 )
-			);
+			$error_message = \__( 'Invalid redirect URI for this client.', 'activitypub' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			include ACTIVITYPUB_PLUGIN_DIR . 'templates/oauth-error.php';
+			exit;
 		}
 
 		// User denied authorization.

--- a/includes/oauth/class-server.php
+++ b/includes/oauth/class-server.php
@@ -288,9 +288,16 @@ class Server {
 	private static function render_authorize_form() {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Initial form display, nonce checked on POST.
 
-		// Check for error parameter (redirected from REST authorization endpoint).
+		// Check for error token (redirected from REST authorization endpoint).
 		if ( isset( $_GET['auth_error'] ) ) {
-			$error_message = \sanitize_text_field( \wp_unslash( $_GET['auth_error'] ) ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			$token         = \sanitize_text_field( \wp_unslash( $_GET['auth_error'] ) );
+			$error_message = \get_transient( 'ap_oauth_err_' . $token ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			\delete_transient( 'ap_oauth_err_' . $token );
+
+			if ( ! $error_message ) {
+				$error_message = \__( 'An authorization error occurred. Please try again.', 'activitypub' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			}
+
 			include ACTIVITYPUB_PLUGIN_DIR . 'templates/oauth-error.php';
 			return;
 		}

--- a/includes/rest/oauth/class-authorization-controller.php
+++ b/includes/rest/oauth/class-authorization-controller.php
@@ -340,16 +340,24 @@ class Authorization_Controller extends \WP_REST_Controller {
 	 * wp-login.php where the error is rendered using login_header/login_footer
 	 * for a consistent, user-friendly appearance.
 	 *
+	 * The error message is stored in a short-lived transient (5 minutes)
+	 * keyed by a random token. Only the opaque token is passed in the URL,
+	 * preventing social-engineering attacks where an attacker crafts a URL
+	 * with arbitrary error text displayed inside WordPress login chrome.
+	 *
 	 * @since unreleased
 	 *
 	 * @param \WP_Error $error The error to display.
 	 * @return \WP_REST_Response Redirect response to wp-login.php.
 	 */
 	private function error_page( $error ) {
+		$token = \wp_generate_password( 20, false );
+		\set_transient( 'ap_oauth_err_' . $token, $error->get_error_message(), 5 * MINUTE_IN_SECONDS );
+
 		$login_url = \add_query_arg(
 			array(
 				'action'     => 'activitypub_authorize',
-				'auth_error' => $error->get_error_message(),
+				'auth_error' => $token,
 			),
 			\wp_login_url()
 		);

--- a/includes/rest/oauth/class-authorization-controller.php
+++ b/includes/rest/oauth/class-authorization-controller.php
@@ -174,15 +174,17 @@ class Authorization_Controller extends \WP_REST_Controller {
 		// Validate client.
 		$client = Client::get( $client_id );
 		if ( \is_wp_error( $client ) ) {
-			return $client;
+			return $this->error_page( $client );
 		}
 
 		// Validate redirect URI.
 		if ( ! $client->is_valid_redirect_uri( $redirect_uri ) ) {
-			return new \WP_Error(
-				'activitypub_invalid_redirect_uri',
-				\__( 'Invalid redirect URI for this client.', 'activitypub' ),
-				array( 'status' => 400 )
+			return $this->error_page(
+				new \WP_Error(
+					'activitypub_invalid_redirect_uri',
+					\__( 'Invalid redirect URI for this client.', 'activitypub' ),
+					array( 'status' => 400 )
+				)
 			);
 		}
 
@@ -243,14 +245,16 @@ class Authorization_Controller extends \WP_REST_Controller {
 		// Re-validate client and redirect URI (form fields could be tampered with).
 		$client = Client::get( $client_id );
 		if ( \is_wp_error( $client ) ) {
-			return $client;
+			return $this->error_page( $client );
 		}
 
 		if ( ! $client->is_valid_redirect_uri( $redirect_uri ) ) {
-			return new \WP_Error(
-				'activitypub_invalid_redirect_uri',
-				\__( 'Invalid redirect URI for this client.', 'activitypub' ),
-				array( 'status' => 400 )
+			return $this->error_page(
+				new \WP_Error(
+					'activitypub_invalid_redirect_uri',
+					\__( 'Invalid redirect URI for this client.', 'activitypub' ),
+					array( 'status' => 400 )
+				)
 			);
 		}
 
@@ -326,6 +330,35 @@ class Authorization_Controller extends \WP_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Redirect to wp-login.php with a styled error message.
+	 *
+	 * These errors occur before a valid redirect URI is confirmed, so we
+	 * cannot safely redirect back to the client. Instead, redirect to
+	 * wp-login.php where the error is rendered using login_header/login_footer
+	 * for a consistent, user-friendly appearance.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Error $error The error to display.
+	 * @return \WP_REST_Response Redirect response to wp-login.php.
+	 */
+	private function error_page( $error ) {
+		$login_url = \add_query_arg(
+			array(
+				'action'     => 'activitypub_authorize',
+				'auth_error' => $error->get_error_message(),
+			),
+			\wp_login_url()
+		);
+
+		return new \WP_REST_Response(
+			null,
+			302,
+			array( 'Location' => $login_url )
+		);
 	}
 
 	/**

--- a/templates/oauth-error.php
+++ b/templates/oauth-error.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * OAuth Authorization Error Template.
+ *
+ * Renders a styled error page using WordPress login page chrome,
+ * consistent with the consent form in oauth-authorize.php.
+ *
+ * @package Activitypub
+ *
+ * Variables available (passed via include from class-server.php):
+ * @var string $error_message The error message to display.
+ */
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- Variables passed via include.
+
+$login_errors = new WP_Error(
+	'oauth_error',
+	esc_html( $error_message )
+);
+
+login_header(
+	esc_html__( 'Authorization Error', 'activitypub' ),
+	'',
+	$login_errors
+);
+?>
+
+<p style="margin-top: 20px; text-align: center;">
+	<a href="<?php echo esc_url( home_url() ); ?>"><?php esc_html_e( 'Go to homepage', 'activitypub' ); ?></a>
+</p>
+
+<?php
+login_footer();

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
@@ -147,6 +147,10 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 		$location = $response->get_headers()['Location'];
 		$this->assertStringContainsString( 'action=activitypub_authorize', $location );
 		$this->assertStringContainsString( 'auth_error=', $location );
+
+		// Verify the error token resolves to a stored message.
+		\parse_str( \wp_parse_url( $location, PHP_URL_QUERY ), $query );
+		$this->assertNotEmpty( \get_transient( 'ap_oauth_err_' . $query['auth_error'] ) );
 	}
 
 	/**
@@ -166,6 +170,10 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 		$location = $response->get_headers()['Location'];
 		$this->assertStringContainsString( 'action=activitypub_authorize', $location );
 		$this->assertStringContainsString( 'auth_error=', $location );
+
+		// Verify the error token resolves to a stored message.
+		\parse_str( \wp_parse_url( $location, PHP_URL_QUERY ), $query );
+		$this->assertNotEmpty( \get_transient( 'ap_oauth_err_' . $query['auth_error'] ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
@@ -131,7 +131,7 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that GET authorize returns error for unknown client.
+	 * Test that GET authorize redirects to wp-login.php error page for unknown client.
 	 *
 	 * @covers ::authorize
 	 */
@@ -143,11 +143,14 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 
 		$response = \rest_get_server()->dispatch( $request );
 
-		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+		$this->assertEquals( 302, $response->get_status() );
+		$location = $response->get_headers()['Location'];
+		$this->assertStringContainsString( 'action=activitypub_authorize', $location );
+		$this->assertStringContainsString( 'auth_error=', $location );
 	}
 
 	/**
-	 * Test that GET authorize returns error for mismatched redirect URI.
+	 * Test that GET authorize redirects to wp-login.php error page for mismatched redirect URI.
 	 *
 	 * @covers ::authorize
 	 */
@@ -159,7 +162,10 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 
 		$response = \rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 302, $response->get_status() );
+		$location = $response->get_headers()['Location'];
+		$this->assertStringContainsString( 'action=activitypub_authorize', $location );
+		$this->assertStringContainsString( 'auth_error=', $location );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
* When a C2S client starts the OAuth flow and client metadata fetch fails, show a styled WordPress login page error instead of raw JSON or `wp_die()`.
* The REST `/oauth/authorize` endpoint now redirects errors to `wp-login.php?action=activitypub_authorize&auth_error=...` where they render using `login_header()`/`login_footer()`, consistent with the consent form.
* Sanitize attacker-controlled URLs with `esc_url()` and error messages with `esc_html()` at the point of construction in error strings.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Start wp-env: `npm run env-start`
* Visit: `/wp-json/activitypub/1.0/oauth/authorize?response_type=code&client_id=https://bogus.example/metadata.json&redirect_uri=https://example.com/callback`
* Should redirect to `wp-login.php`, then after login show a styled error page saying the application couldn't be reached (instead of raw JSON)
* Run OAuth tests: `npm run env-test -- --group=oauth` — all 126 tests should pass

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Show a styled error page instead of raw technical output when an OAuth application cannot be reached during authorization.

</details>