### PR TITLE
Block non-public posts from ActivityPub content negotiation

### DIFF
--- a/.github/changelog/3045-from-description
+++ b/.github/changelog/3045-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Prevent non-public posts (drafts, scheduled, pending review) from being accessible via ActivityPub.

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -29,10 +29,14 @@ function is_post_disabled( $post ) {
 	$visibility          = \get_post_meta( $post->ID, 'activitypub_content_visibility', true );
 	$is_local_or_private = in_array( $visibility, array( ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE ), true );
 
+	// Only 'publish' is public. 'inherit' is allowed only for attachments.
+	$is_public_status = 'publish' === $post->post_status ||
+		( 'inherit' === $post->post_status && 'attachment' === $post->post_type );
+
 	if (
 		$is_local_or_private ||
 		! \post_type_supports( $post->post_type, 'activitypub' ) ||
-		'private' === $post->post_status ||
+		! $is_public_status ||
 		! empty( $post->post_password )
 	) {
 		$disabled = true;
@@ -40,14 +44,17 @@ function is_post_disabled( $post ) {
 
 	/*
 	 * Check for posts that need special handling.
-	 * Federated posts changed to local/private need Delete activity.
+	 * Federated posts changed to local/private or non-public status need Delete activity.
 	 * Deleted posts restored to public need Create activity.
 	 */
 	$object_state = get_wp_object_state( $post );
 
 	if (
 		ACTIVITYPUB_OBJECT_STATE_DELETED === $object_state ||
-		( $is_local_or_private && ACTIVITYPUB_OBJECT_STATE_FEDERATED === $object_state )
+		(
+			ACTIVITYPUB_OBJECT_STATE_FEDERATED === $object_state &&
+			( $is_local_or_private || ! $is_public_status )
+		)
 	) {
 		$disabled = false;
 	}

--- a/includes/scheduler/class-post.php
+++ b/includes/scheduler/class-post.php
@@ -91,6 +91,7 @@ class Post {
 				break;
 
 			case 'draft':
+			case 'pending':
 				$type = ( 'publish' === $old_status ) ? 'Update' : false;
 				break;
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -359,10 +359,10 @@ class Post extends Base {
 		}
 
 		/*
-		 * Remove attachments from the Fediverse if a post was federated and then set back to draft.
+		 * Remove attachments from the Fediverse if a post was federated and then unpublished.
 		 * Except in preview mode, where we want to show attachments.
 		 */
-		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
+		if ( ! $this->is_preview() && 'publish' !== \get_post_status( $this->item ) ) {
 			$this->attachment = array();
 
 			return $this->attachment;
@@ -543,8 +543,8 @@ class Post extends Base {
 			return $this->summary;
 		}
 
-		// Remove Teaser from drafts.
-		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
+		// Remove Teaser from unpublished posts.
+		if ( ! $this->is_preview() && 'publish' !== \get_post_status( $this->item ) ) {
 			$this->summary = \__( '(This post is being modified)', 'activitypub' );
 
 			return $this->summary;
@@ -593,8 +593,8 @@ class Post extends Base {
 			return $this->content;
 		}
 
-		// Remove Content from drafts.
-		if ( ! $this->is_preview() && 'draft' === \get_post_status( $this->item ) ) {
+		// Remove Content from unpublished posts.
+		if ( ! $this->is_preview() && 'publish' !== \get_post_status( $this->item ) ) {
 			$this->content = \__( '(This post is being modified)', 'activitypub' );
 
 			return $this->content;

--- a/tests/phpunit/tests/includes/class-test-functions-post.php
+++ b/tests/phpunit/tests/includes/class-test-functions-post.php
@@ -60,6 +60,73 @@ class Test_Functions_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_post_disabled with non-public statuses.
+	 *
+	 * @covers \Activitypub\is_post_disabled
+	 */
+	public function test_is_post_disabled_non_public_statuses() {
+		$draft_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+			)
+		);
+		$this->assertTrue( \Activitypub\is_post_disabled( $draft_post_id ), 'Draft posts should be disabled.' );
+
+		$pending_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'pending',
+			)
+		);
+		$this->assertTrue( \Activitypub\is_post_disabled( $pending_post_id ), 'Pending posts should be disabled.' );
+
+		$future_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'future',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+			)
+		);
+		$this->assertTrue( \Activitypub\is_post_disabled( $future_post_id ), 'Future posts should be disabled.' );
+	}
+
+	/**
+	 * Test that previously federated posts with non-public statuses remain enabled.
+	 *
+	 * Federated posts that transition away from publish need to stay accessible
+	 * so the scheduler can determine the correct activity type (Update or Delete).
+	 *
+	 * @covers \Activitypub\is_post_disabled
+	 */
+	public function test_is_post_disabled_federated_non_public_statuses() {
+		// Draft post that was previously federated should NOT be disabled.
+		$draft_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+			)
+		);
+		\update_post_meta( $draft_post_id, 'activitypub_status', ACTIVITYPUB_OBJECT_STATE_FEDERATED );
+		$this->assertFalse( \Activitypub\is_post_disabled( $draft_post_id ), 'Federated draft posts should not be disabled.' );
+
+		// Pending post that was previously federated should NOT be disabled.
+		$pending_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'pending',
+			)
+		);
+		\update_post_meta( $pending_post_id, 'activitypub_status', ACTIVITYPUB_OBJECT_STATE_FEDERATED );
+		$this->assertFalse( \Activitypub\is_post_disabled( $pending_post_id ), 'Federated pending posts should not be disabled.' );
+
+		// Future post that was previously federated should NOT be disabled.
+		$future_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'future',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+			)
+		);
+		\update_post_meta( $future_post_id, 'activitypub_status', ACTIVITYPUB_OBJECT_STATE_FEDERATED );
+		$this->assertFalse( \Activitypub\is_post_disabled( $future_post_id ), 'Federated future posts should not be disabled.' );
+	}
+
+	/**
 	 * Test is_post_disabled with private visibility.
 	 *
 	 * @covers \Activitypub\is_post_disabled

--- a/tests/phpunit/tests/includes/handler/class-test-announce.php
+++ b/tests/phpunit/tests/includes/handler/class-test-announce.php
@@ -50,6 +50,7 @@ class Test_Announce extends \WP_UnitTestCase {
 			array(
 				'post_author'  => $this->user_id,
 				'post_content' => 'test',
+				'post_status'  => 'publish',
 			)
 		);
 		$this->post_permalink = \get_permalink( $this->post_id );

--- a/tests/phpunit/tests/includes/handler/class-test-create.php
+++ b/tests/phpunit/tests/includes/handler/class-test-create.php
@@ -67,6 +67,7 @@ class Test_Create extends \WP_UnitTestCase {
 			array(
 				'post_author'  => $this->user_id,
 				'post_content' => 'test',
+				'post_status'  => 'publish',
 			)
 		);
 		$this->post_permalink = \get_permalink( $this->post_id );

--- a/tests/phpunit/tests/includes/handler/class-test-like.php
+++ b/tests/phpunit/tests/includes/handler/class-test-like.php
@@ -57,6 +57,7 @@ class Test_Like extends \WP_UnitTestCase {
 			array(
 				'post_author'  => $this->user_id,
 				'post_content' => 'test',
+				'post_status'  => 'publish',
 			)
 		);
 		$this->post_permalink = \get_permalink( $this->post_id );

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -273,6 +273,7 @@ class Test_Post extends \WP_UnitTestCase {
 			array(
 				'post_author'  => 1,
 				'post_content' => 'test content visibility',
+				'post_status'  => 'publish',
 			)
 		);
 
@@ -290,7 +291,8 @@ class Test_Post extends \WP_UnitTestCase {
 
 		\update_post_meta( $post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
 
-		$this->assertTrue( \Activitypub\is_post_disabled( $post_id ) );
+		// Post was federated on insert, so is_post_disabled returns false
+		// to allow Delete activity. But visibility settings still apply.
 		$object = Post::transform( get_post( $post_id ) )->to_object();
 		$this->assertEmpty( $object->get_to() );
 		$this->assertEmpty( $object->get_cc() );


### PR DESCRIPTION
## Proposed changes:

* Block draft, pending, future, and trash posts from being served via ActivityPub content negotiation. Previously only `private` status was checked, allowing unauthenticated access to non-public post data via `?p=<id>` with an ActivityPub Accept header.
* Only allow `publish` status (and `inherit` for attachments) through `is_post_disabled()`.
* Previously federated posts that change status remain accessible so the scheduler can create the correct Delete/Update activities.
* Handle `publish → pending` transitions in the scheduler (sends Update with stripped content, like draft).
* Strip content/summary/attachments from all non-published posts in the transformer (previously only drafts).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a post and leave it as draft, pending, or schedule it for the future
* Request `?p=<post_id>` with an `Accept: application/activity+json` header
* Verify you get a 404 / no ActivityPub data instead of the post content
* Publish the post, then move it back to draft or pending
* Verify the post content is stripped (shows "This post is being modified")
* Verify that trashing a previously published post still serves a tombstone correctly

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security - in case of vulnerabilities

#### Message

Prevent non-public posts (drafts, scheduled, pending review) from being accessible via ActivityPub.

</details>