### PR TITLE
Remove changelog entry already released in 8.0.2

### DIFF
--- a/.github/changelog/3045-from-description
+++ b/.github/changelog/3045-from-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Prevent non-public posts (drafts, scheduled, pending review) from being accessible via ActivityPub.


### PR DESCRIPTION
## Summary
- Remove `.github/changelog/3045-from-description` which was already included in the 8.0.2 patch release.
- Prevents the entry from being duplicated in the next major/minor release changelog.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.