### PR TITLE
Clarify Delete handler signature deferral in security audit agent

### DIFF
--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -52,7 +52,7 @@ Files: `includes/class-signature.php`, `includes/signature/class-http-signature-
 - Verify that missing `date` or `digest` headers cause rejection for POST requests
 - Check algorithm negotiation — are weak algorithms accepted?
 - Verify key fetching does not allow SSRF (fetching actor's `publicKey` URL)
-- Check that the Delete handler's signature deferral (`handler/class-delete.php`) cannot be exploited to forge deletions
+- Note: the Delete handler's signature deferral (`handler/class-delete.php`) is **intentional by design** — the actor's key may already be deleted before the Delete activity arrives. It is mitigated by a Tombstone existence check. Do NOT flag this as a vulnerability.
 
 ### 4. Inbox Input Validation
 

--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -52,7 +52,7 @@ Files: `includes/class-signature.php`, `includes/signature/class-http-signature-
 - Verify that missing `date` or `digest` headers cause rejection for POST requests
 - Check algorithm negotiation — are weak algorithms accepted?
 - Verify key fetching does not allow SSRF (fetching actor's `publicKey` URL)
-- Note: the Delete handler's signature deferral (`handler/class-delete.php`) is **intentional by design** — the actor's key may already be deleted before the Delete activity arrives. It is mitigated by a Tombstone existence check. Do NOT flag this as a vulnerability.
+- Note: the Delete handler's signature deferral (`includes/handler/class-delete.php`) is **intentional by design** — the actor's key may already be deleted before the Delete activity arrives. It is mitigated by a Tombstone existence check. Do NOT flag this as a vulnerability.
 
 ### 4. Inbox Input Validation
 


### PR DESCRIPTION
## Proposed changes:

* Update the security audit agent to note that the Delete handler's signature deferral is intentional by design, not a vulnerability
* The actor's key may already be deleted before the Delete activity arrives, so strict signature verification would reject legitimate deletions
* Mitigated by a Tombstone existence check

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* N/A — agent configuration change only

### Changelog entry

Not applicable (internal tooling).