### PR TITLE
Add WPScan vulnerability tracker link to security-audit agent

### DIFF
--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -10,7 +10,7 @@ You are a security auditor for the WordPress ActivityPub plugin. You check for v
 
 ## Known Vulnerability History
 
-Past CVEs and security fixes inform what patterns to watch for:
+Past CVEs and security fixes inform what patterns to watch for. The full list is tracked on [WPScan](https://wpscan.com/plugin/activitypub/).
 
 1. **Unauthenticated REST API access** (CVE, fixed 1.0.6) — endpoints accessible without auth
 2. **Post title/content disclosure** (CVE, fixed 1.0.0) — low-privilege users accessing unpublished content

--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -10,7 +10,7 @@ You are a security auditor for the WordPress ActivityPub plugin. You check for v
 
 ## Known Vulnerability History
 
-Past CVEs and security fixes inform what patterns to watch for. The full list is tracked on [WPScan](https://wpscan.com/plugin/activitypub/).
+Past CVEs and security fixes inform what patterns to watch for. The full list is tracked on [WPScan](https://wpscan.com/plugin/activitypub/). Check this list periodically to stay current on newly disclosed vulnerabilities and update the entries below accordingly.
 
 1. **Unauthenticated REST API access** (CVE, fixed 1.0.6) — endpoints accessible without auth
 2. **Post title/content disclosure** (CVE, fixed 1.0.0) — low-privilege users accessing unpublished content


### PR DESCRIPTION
## Proposed changes:
* Add a link to the [WPScan ActivityPub vulnerability tracker](https://wpscan.com/plugin/activitypub/) in the security-audit agent's Known Vulnerability History section.
* Add a note for the agent to periodically check the list to stay current on new disclosures.

### Other information:

- [x] No tests needed (documentation-only change)

## Testing instructions:

* Verify the WPScan link in `.claude/agents/security-audit.md` points to the correct page.
* Run the security-audit agent and confirm it references the WPScan list.