### PR TITLE
Fix fatal error when outbox item is missing during delivery

### DIFF
--- a/.github/changelog/3058-from-description
+++ b/.github/changelog/3058-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a fatal error during activity delivery when the outbox item has been deleted.

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -253,16 +253,16 @@ class Dispatcher {
 	private static function send_to_inboxes( $inboxes, $outbox_item_id ) {
 		$outbox_item = \get_post( $outbox_item_id );
 
-		// Strip bto and bcc before delivery per ActivityPub spec Section 6.2.
-		\add_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
 		$activity = Outbox::get_activity( $outbox_item_id );
-		\remove_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
 
 		if ( \is_wp_error( $activity ) ) {
-			return $inboxes;
+			return array();
 		}
 
+		// Strip bto and bcc before delivery per ActivityPub spec Section 6.2.
+		\add_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
 		$json = $activity->to_json();
+		\remove_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
 
 		$retries = array();
 

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -163,9 +163,15 @@ class Dispatcher {
 		}
 
 		$outbox_item = \get_post( $outbox_item_id );
-		$json        = Outbox::get_activity( $outbox_item_id )->to_json();
-		$inboxes     = Followers::get_inboxes_for_activity( $json, $outbox_item->post_author, $batch_size, $offset );
-		$retries     = self::send_to_inboxes( $inboxes, $outbox_item_id );
+		$activity    = Outbox::get_activity( $outbox_item_id );
+
+		if ( \is_wp_error( $activity ) ) {
+			return;
+		}
+
+		$json    = $activity->to_json();
+		$inboxes = Followers::get_inboxes_for_activity( $json, $outbox_item->post_author, $batch_size, $offset );
+		$retries = self::send_to_inboxes( $inboxes, $outbox_item_id );
 
 		// Retry failed inboxes.
 		if ( ! empty( $retries ) ) {
@@ -244,8 +250,14 @@ class Dispatcher {
 
 		// Strip bto and bcc before delivery per ActivityPub spec Section 6.2.
 		\add_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
-		$json = Outbox::get_activity( $outbox_item_id )->to_json();
+		$activity = Outbox::get_activity( $outbox_item_id );
 		\remove_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
+
+		if ( \is_wp_error( $activity ) ) {
+			return $inboxes;
+		}
+
+		$json = $activity->to_json();
 
 		$retries = array();
 

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -163,7 +163,12 @@ class Dispatcher {
 		}
 
 		$outbox_item = \get_post( $outbox_item_id );
-		$activity    = Outbox::get_activity( $outbox_item_id );
+
+		if ( ! $outbox_item ) {
+			return;
+		}
+
+		$activity = Outbox::get_activity( $outbox_item_id );
 
 		if ( \is_wp_error( $activity ) ) {
 			return;

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -328,6 +328,14 @@ class Outbox {
 	public static function get_activity( $outbox_item ) {
 		$outbox_item = \get_post( $outbox_item );
 
+		if ( ! $outbox_item ) {
+			return new \WP_Error(
+				'activitypub_outbox_item_not_found',
+				\__( 'Outbox item not found.', 'activitypub' ),
+				array( 'status' => 404 )
+			);
+		}
+
 		$activity_object = \json_decode( $outbox_item->post_content, true );
 		$type            = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
 

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -230,7 +230,13 @@ class Outbox_Controller extends \WP_REST_Controller {
 				continue;
 			}
 
-			$response['orderedItems'][] = $this->prepare_item_for_response( $outbox_item, $request );
+			$item = $this->prepare_item_for_response( $outbox_item, $request );
+
+			if ( \is_wp_error( $item ) ) {
+				continue;
+			}
+
+			$response['orderedItems'][] = $item;
 		}
 
 		$response = $this->prepare_collection_response( $response, $request );

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -269,6 +269,10 @@ class Outbox_Controller extends \WP_REST_Controller {
 	public function prepare_item_for_response( $item, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$activity = Outbox::get_activity( $item->ID );
 
+		if ( \is_wp_error( $activity ) ) {
+			return $activity;
+		}
+
 		return $activity->to_array( false );
 	}
 


### PR DESCRIPTION
Fixes a fatal error on production: `Call to undefined method WP_Error::to_json()` in `Dispatcher::send_to_inboxes()`.

## Proposed changes:
* Add a null check in `Outbox::get_activity()` when the outbox post no longer exists, returning a `WP_Error` instead of crashing on null property access.
* Add `is_wp_error()` guards in `Dispatcher::send_to_followers()` and `Dispatcher::send_to_inboxes()` before calling `to_json()` on the activity.
* Add a null guard for the outbox post in `send_to_followers()` before accessing `post_author`.
* Add `is_wp_error()` guard in the Outbox REST controller's `prepare_item_for_response()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Delete an outbox post from the database while a retry delivery cron job is pending.
* Verify the cron job completes without a fatal error.
* Verify the Outbox REST endpoint handles missing items gracefully.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix a fatal error during activity delivery when the outbox item has been deleted.

</details>