### PR TITLE
Add quotes-as-comments snippet

### DIFF
--- a/snippets/README.md
+++ b/snippets/README.md
@@ -14,6 +14,7 @@ Think of snippets as a testing ground, similar to WordPress' [feature plugin](ht
 | [Blockless ActivityPub](blockless-activitypub/) | Fediverse reactions without all that frontend-rendered but JavaScript-heavy blocks magic. |
 | [Use Jetpack's Site Accelerator CDN (Photon) for Remote Media](photon/) | Rewrites ActivityPub remote media URLs through Jetpack's free image CDN instead of caching files locally. |
 | [ATproto DID for Bridgy Fed](atproto-did-for-bridgy-fed/) | Allows you to serve an ATproto DID from your blog's `.well-known` directory to allow Bridgy Fed to use your blog's hostname as its Bluesky handle. |
+| [Quotes as Comments](quotes-as-comments/) | Displays ActivityPub quotes as regular comments instead of facepile reactions. |
 
 ## How to Use
 

--- a/snippets/quotes-as-comments/README.md
+++ b/snippets/quotes-as-comments/README.md
@@ -1,0 +1,24 @@
+# Quotes as Comments
+
+Displays ActivityPub quotes as regular comments instead of rendering them in the facepile reactions block.
+
+## How It Works
+
+The ActivityPub plugin treats likes, reposts, and quotes as special comment types that are excluded from the normal comment list and displayed as facepiles (avatar rows) instead. Unlike likes and reposts, quotes carry actual content, so it can make more sense to show them as full comments.
+
+This snippet removes `quote` from the excluded comment types list, so quotes appear in the regular comment section alongside replies. Likes and reposts remain as facepiles.
+
+Two hooks are used:
+
+- **`pre_get_comments`** (priority 20) removes `quote` from `type__not_in` in the main comment query, so quotes show up on singular post pages.
+- **`rest_comment_query`** (priority 20) does the same for the WordPress REST API comments endpoint.
+
+## Installation
+
+Copy this folder to `wp-content/plugins/` and activate **Quotes as Comments** from the WordPress admin, or copy `quotes-as-comments.php` to `wp-content/mu-plugins/` for automatic activation.
+
+## Requirements
+
+- WordPress 5.9+
+- PHP 7.4+
+- [ActivityPub](https://wordpress.org/plugins/activitypub/) plugin

--- a/snippets/quotes-as-comments/quotes-as-comments.php
+++ b/snippets/quotes-as-comments/quotes-as-comments.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Plugin Name:       Quotes as Comments
+ * Plugin URI:        https://github.com/Automattic/wordpress-activitypub
+ * Description:       Display ActivityPub quotes as regular comments instead of facepile reactions.
+ * Version:           1.0.0
+ * Requires at least: 5.9
+ * Requires PHP:      7.4
+ * Author:            Matthias Pfefferle
+ * Author URI:        https://notiz.blog/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Requires Plugins:  activitypub
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Snippets;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Remove 'quote' from the list of comment types excluded from the
+ * normal comment query so that quotes appear alongside regular comments.
+ *
+ * The ActivityPub plugin hides likes, reposts, and quotes from the
+ * comment list and renders them as facepiles instead. This filter
+ * keeps likes and reposts as facepiles but lets quotes through as
+ * full comments since they carry meaningful content.
+ */
+\add_action(
+	'pre_get_comments',
+	function ( $query ) {
+		if ( ! $query instanceof \WP_Comment_Query ) {
+			return;
+		}
+
+		if ( empty( $query->query_vars['type__not_in'] ) ) {
+			return;
+		}
+
+		$excluded = $query->query_vars['type__not_in'];
+
+		if ( ! \is_array( $excluded ) ) {
+			return;
+		}
+
+		// Remove 'quote' from the exclusion list.
+		$excluded = \array_diff( $excluded, array( 'quote' ) );
+
+		$query->query_vars['type__not_in'] = \array_values( $excluded );
+	},
+	20
+);
+
+/**
+ * Also remove 'quote' from the REST API comment exclusion so that
+ * quotes appear in the WordPress REST comments endpoint.
+ */
+\add_filter(
+	'rest_comment_query',
+	function ( $prepared_args ) {
+		if ( empty( $prepared_args['type__not_in'] ) || ! \is_array( $prepared_args['type__not_in'] ) ) {
+			return $prepared_args;
+		}
+
+		$prepared_args['type__not_in'] = \array_values(
+			\array_diff( $prepared_args['type__not_in'], array( 'quote' ) )
+		);
+
+		return $prepared_args;
+	},
+	20
+);


### PR DESCRIPTION
## Proposed changes:
* Add a new snippet that displays ActivityPub quotes as regular comments instead of facepile reactions.
* Quotes carry actual content unlike likes and reposts, so it can make more sense to show them alongside replies.
* The snippet removes `quote` from the `type__not_in` exclusion list in both the main comment query and the REST API, while keeping the quote comment type fully registered so storage and handling remain intact.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install and activate the ActivityPub plugin.
* Copy `snippets/quotes-as-comments/` to `wp-content/plugins/` and activate **Quotes as Comments**.
* Create a post and receive a quote from a Fediverse account (or manually insert a comment with `comment_type = 'quote'`).
* Verify the quote appears in the regular comment list on the post, not just in the reactions facepile.
* Verify likes and reposts still appear as facepiles.
* Deactivate the snippet and verify quotes go back to appearing only in the facepile.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.