### PR TITLE
Move localhost URL allowance to local environment only

### DIFF
--- a/.github/changelog/3076-from-description
+++ b/.github/changelog/3076-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Restrict localhost URL allowance to local development environments only.

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -12,20 +12,6 @@ use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Posts;
 
 /**
- * Allow localhost URLs if WP_DEBUG is true.
- *
- * @param array $parsed_args An array of HTTP request arguments.
- *
- * @return array Array or string of HTTP request arguments.
- */
-function allow_localhost( $parsed_args ) {
-	$parsed_args['reject_unsafe_urls'] = false;
-
-	return $parsed_args;
-}
-\add_filter( 'http_request_args', '\Activitypub\allow_localhost' );
-
-/**
  * Debug the outbox post type.
  *
  * @param array  $args      The arguments for the post type.

--- a/local/load.php
+++ b/local/load.php
@@ -39,23 +39,25 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
  */
 \add_filter( 'activitypub_defer_signature_verification', '__return_true', 20 );
 
-/*
- * Allow localhost URLs in local development.
+/**
+ * Allow unsafe HTTP request URLs (localhost, private IPs, etc.) in local development.
  *
  * Disables WordPress SSRF protection (`reject_unsafe_urls`) so that
  * HTTP requests to localhost, private IPs, etc. are permitted during
  * local development. Must NOT run in production.
  *
+ * @param array $parsed_args HTTP request arguments.
+ *
+ * @return array Filtered HTTP request arguments.
+ *
  * @see wp_http_validate_url()
  */
-\add_filter(
-	'http_request_args',
-	function ( $parsed_args ) {
-		$parsed_args['reject_unsafe_urls'] = false;
+function allow_unsafe_http_request_urls( $parsed_args ) {
+	$parsed_args['reject_unsafe_urls'] = false;
 
-		return $parsed_args;
-	}
-);
+	return $parsed_args;
+}
+\add_filter( 'http_request_args', __NAMESPACE__ . '\allow_unsafe_http_request_urls' );
 
 /*
  * Allow http redirect URIs for OAuth clients in local development.

--- a/local/load.php
+++ b/local/load.php
@@ -40,6 +40,24 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 \add_filter( 'activitypub_defer_signature_verification', '__return_true', 20 );
 
 /*
+ * Allow localhost URLs in local development.
+ *
+ * Disables WordPress SSRF protection (`reject_unsafe_urls`) so that
+ * HTTP requests to localhost, private IPs, etc. are permitted during
+ * local development. Must NOT run in production.
+ *
+ * @see wp_http_validate_url()
+ */
+\add_filter(
+	'http_request_args',
+	function ( $parsed_args ) {
+		$parsed_args['reject_unsafe_urls'] = false;
+
+		return $parsed_args;
+	}
+);
+
+/*
  * Allow http redirect URIs for OAuth clients in local development.
  * In production, only https and custom URI schemes are accepted.
  *


### PR DESCRIPTION
## Proposed changes:

* Move the `allow_localhost` filter (which disables WordPress SSRF protection via `reject_unsafe_urls = false`) from `includes/debug.php` to `local/load.php`.
* `debug.php` loaded whenever `WP_DEBUG` was true, disabling SSRF protection globally for **all** WordPress HTTP requests — not just ActivityPub ones. This affected staging, CI, and misconfigured production sites.
* `local/load.php` is gated behind `wp_get_environment_type() === 'local'`, which is the correct scope for this kind of development convenience.

Props @CrochetFeve0251

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Confirm that with `WP_DEBUG = true` and `WP_ENVIRONMENT_TYPE` unset (or set to `production`/`staging`), `wp_safe_remote_get('http://127.0.0.1/')` returns a "valid URL was not provided" error (SSRF protection active).
* Confirm that with `WP_ENVIRONMENT_TYPE = 'local'`, `wp_safe_remote_get('http://127.0.0.1/')` attempts the connection (SSRF protection correctly disabled for local dev).

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security - in case of vulnerabilities

#### Message

Restrict localhost URL allowance to local development environments only.

</details>