### PR TITLE
Sync version number and changelog from 8.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.2] - 2026-03-17
+### Security
+- Prevent non-public posts (drafts, scheduled, pending review) from being accessible via ActivityPub. [#3045]
+
 ## [8.0.1] - 2026-03-11
 ### Changed
 - Simplify the follow page block pattern to avoid duplicate headings and improve accessibility. [#3029]
@@ -1742,6 +1746,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - initial
 
+[8.0.2]: https://github.com/Automattic/wordpress-activitypub/compare/8.0.1...8.0.2
 [8.0.1]: https://github.com/Automattic/wordpress-activitypub/compare/8.0.0...8.0.1
 [8.0.0]: https://github.com/Automattic/wordpress-activitypub/compare/7.9.1...8.0.0
 [7.9.1]: https://github.com/Automattic/wordpress-activitypub/compare/7.9.0...7.9.1

--- a/activitypub.php
+++ b/activitypub.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActivityPub
  * Plugin URI: https://github.com/Automattic/wordpress-activitypub
  * Description: The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
- * Version: 8.0.1
+ * Version: 8.0.2
  * Author: Matthias Pfefferle & Automattic
  * Author URI: https://automattic.com/
  * License: MIT
@@ -17,7 +17,7 @@
 
 namespace Activitypub;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '8.0.1' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '8.0.2' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaf
 Tags: fediverse, activitypub, indieweb, activitystream, social web
 Requires at least: 6.5
 Tested up to: 6.9
-Stable tag: 8.0.1
+Stable tag: 8.0.2
 Requires PHP: 7.4
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -110,6 +110,10 @@ For reasons of data protection, it is not possible to see the followers of other
 5. A Blog-Profile on Mastodon
 
 == Changelog ==
+
+### 8.0.2 - 2026-03-17
+#### Security
+- Prevent non-public posts (drafts, scheduled, pending review) from being accessible via ActivityPub.
 
 ### 8.0.1 - 2026-03-11
 #### Changed


### PR DESCRIPTION
## Proposed changes:

* The 8.0.2 patch release was created on a release branch but the version bump and changelog entry were never merged back to trunk.
* Updates `Version` header and `ACTIVITYPUB_PLUGIN_VERSION` constant to 8.0.2.
* Updates `Stable tag` in readme.txt to 8.0.2.
* Adds the 8.0.2 security changelog entry to both `CHANGELOG.md` and `readme.txt`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No code changes, version/changelog sync only.

## Testing instructions:

* Verify `activitypub.php` shows `Version: 8.0.2` and `ACTIVITYPUB_PLUGIN_VERSION` is `'8.0.2'`.
* Verify `readme.txt` shows `Stable tag: 8.0.2` and includes the 8.0.2 changelog section.
* Verify `CHANGELOG.md` includes the 8.0.2 entry and comparison link.

### Changelog entry

No changelog entry needed — this syncs an already-released version.