### PR TITLE
Sanitize SSE access token query parameter

### DIFF
--- a/.github/changelog/fix-sanitize-sse-access-token
+++ b/.github/changelog/fix-sanitize-sse-access-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added validation for SSE access tokens passed via query parameter.

--- a/includes/rest/trait-event-stream.php
+++ b/includes/rest/trait-event-stream.php
@@ -102,6 +102,11 @@ trait Event_Stream {
 		$token_string = \wp_unslash( $_GET['access_token'] );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
+		// Reject tokens that are too long or contain unexpected characters.
+		if ( \strlen( $token_string ) > 512 || \preg_match( '/[^A-Za-z0-9._~+\/-]/', $token_string ) ) {
+			return;
+		}
+
 		// Inject as Authorization header so the OAuth server can find it.
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token_string;
 


### PR DESCRIPTION
## Summary

- Adds a length cap (512 characters) and character allowlist for the `access_token` query parameter before injecting it into `$_SERVER['HTTP_AUTHORIZATION']`.
- The SSE EventSource API requires passing tokens via query params since it cannot set custom headers. This change ensures only well-formed tokens are accepted.

## Test plan

- [ ] Connect to an SSE endpoint with a valid OAuth token via `?access_token=<token>` — should authenticate as before.
- [ ] Send a token longer than 512 characters — should be silently ignored (no authentication).
- [ ] Send a token with special characters (e.g., `<script>`, null bytes) — should be silently ignored.