### PR TITLE
Reject signatures with missing Date header

### DIFF
--- a/.github/changelog/fix-reject-missing-signed-date-header
+++ b/.github/changelog/fix-reject-missing-signed-date-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved HTTP Signature validation for requests with a missing Date header.

--- a/includes/signature/class-http-signature-draft.php
+++ b/includes/signature/class-http-signature-draft.php
@@ -315,7 +315,8 @@ class Http_Signature_Draft implements Http_Signature {
 			}
 			if ( 'date' === $header ) {
 				if ( empty( $headers['date'][0] ) ) {
-					continue;
+					// Date is in the signed headers list but missing from the request.
+					return false;
 				}
 
 				// Allow a bit of leeway for misconfigured clocks.


### PR DESCRIPTION
## Summary

- When `date` is listed in the signed headers but the actual `Date` header is missing or empty, the signature is now rejected instead of silently skipping the time skew check.
- Previously, an attacker could omit the `Date` header while still listing it as signed, bypassing the 3-hour replay window entirely.
- Only affects the legacy HTTP Signature Draft implementation; the HTTP Message Signature path does not have this issue.

## Test plan

- [ ] Send a signed request with a valid `Date` header — should be accepted as before.
- [ ] Send a signed request where `date` is in the signed headers list but the `Date` header is missing — should now be rejected.
- [ ] Send a signed request without `date` in the signed headers list — should be unaffected by this change.