### PR TITLE
Remove plain PKCE support, only allow S256

### DIFF
--- a/.github/changelog/fix-remove-plain-pkce
+++ b/.github/changelog/fix-remove-plain-pkce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only allow S256 as PKCE code challenge method for OAuth authorization.

--- a/includes/oauth/class-authorization-code.php
+++ b/includes/oauth/class-authorization-code.php
@@ -34,7 +34,7 @@ class Authorization_Code {
 	 * @param string $redirect_uri          The redirect URI.
 	 * @param array  $scopes                Requested scopes.
 	 * @param string $code_challenge        PKCE code challenge.
-	 * @param string $code_challenge_method PKCE method (S256 or plain).
+	 * @param string $code_challenge_method PKCE method (only S256 is supported).
 	 * @return string|\WP_Error The authorization code or error.
 	 */
 	public static function create(
@@ -204,7 +204,7 @@ class Authorization_Code {
 	 *
 	 * @param string $code_verifier  The PKCE code verifier.
 	 * @param string $code_challenge The stored code challenge.
-	 * @param string $method         The challenge method (S256 or plain).
+	 * @param string $method         The challenge method (only S256 is supported).
 	 * @return bool True if valid.
 	 */
 	public static function verify_pkce( $code_verifier, $code_challenge, $method = 'S256' ) {
@@ -218,8 +218,9 @@ class Authorization_Code {
 			return false;
 		}
 
-		if ( 'plain' === $method ) {
-			return hash_equals( $code_challenge, $code_verifier );
+		// Only S256 is supported; reject anything else.
+		if ( 'S256' !== $method ) {
+			return false;
 		}
 
 		// S256: BASE64URL(SHA256(code_verifier)) == code_challenge.

--- a/includes/oauth/class-server.php
+++ b/includes/oauth/class-server.php
@@ -162,7 +162,7 @@ class Server {
 	 *
 	 * @param string $code_verifier  The PKCE code verifier.
 	 * @param string $code_challenge The stored code challenge.
-	 * @param string $method         The challenge method (S256 or plain).
+	 * @param string $method         The challenge method (only S256 is supported).
 	 * @return bool True if valid.
 	 */
 	public static function verify_pkce( $code_verifier, $code_challenge, $method = 'S256' ) {
@@ -365,6 +365,15 @@ class Server {
 		$code_challenge_method = isset( $_POST['code_challenge_method'] ) ? \sanitize_text_field( \wp_unslash( $_POST['code_challenge_method'] ) ) : 'S256';
 		$approve               = isset( $_POST['approve'] );
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		// Only S256 is supported; normalize empty/missing values and reject anything else.
+		if ( empty( $code_challenge_method ) ) {
+			$code_challenge_method = 'S256';
+		} elseif ( 'S256' !== $code_challenge_method ) {
+			$error_message = \__( 'Only S256 is supported as PKCE code challenge method.', 'activitypub' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in template.
+			include ACTIVITYPUB_PLUGIN_DIR . 'templates/oauth-error.php';
+			exit;
+		}
 
 		// Re-validate client and redirect URI (form fields could be tampered with).
 		$client = Client::get( $client_id );

--- a/includes/oauth/class-server.php
+++ b/includes/oauth/class-server.php
@@ -366,10 +366,6 @@ class Server {
 		$approve               = isset( $_POST['approve'] );
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-		if ( 'S256' !== $code_challenge_method ) {
-			$code_challenge_method = 'S256';
-		}
-
 		// Re-validate client and redirect URI (form fields could be tampered with).
 		$client = Client::get( $client_id );
 

--- a/includes/rest/oauth/class-authorization-controller.php
+++ b/includes/rest/oauth/class-authorization-controller.php
@@ -81,7 +81,7 @@ class Authorization_Controller extends \WP_REST_Controller {
 						'code_challenge_method' => array(
 							'description' => 'PKCE code challenge method.',
 							'type'        => 'string',
-							'enum'        => array( 'S256', 'plain' ),
+							'enum'        => array( 'S256' ),
 							'default'     => 'S256',
 						),
 					),
@@ -122,7 +122,7 @@ class Authorization_Controller extends \WP_REST_Controller {
 						'code_challenge_method' => array(
 							'description' => 'PKCE code challenge method.',
 							'type'        => 'string',
-							'enum'        => array( 'S256', 'plain' ),
+							'enum'        => array( 'S256' ),
 							'default'     => 'S256',
 						),
 						'approve'               => array(

--- a/tests/phpunit/tests/includes/oauth/class-test-authorization-code.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-authorization-code.php
@@ -121,14 +121,15 @@ class Test_Authorization_Code extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test verify_pkce method with plain.
+	 * Test verify_pkce method rejects plain method.
 	 *
 	 * @covers ::verify_pkce
 	 */
-	public function test_verify_pkce_plain() {
+	public function test_verify_pkce_plain_rejected() {
 		$verifier = $this->generate_code_verifier();
 
-		$this->assertTrue( Authorization_Code::verify_pkce( $verifier, $verifier, 'plain' ) );
+		// Plain PKCE is no longer supported; both cases should fail.
+		$this->assertFalse( Authorization_Code::verify_pkce( $verifier, $verifier, 'plain' ) );
 		$this->assertFalse( Authorization_Code::verify_pkce( 'wrong_verifier', $verifier, 'plain' ) );
 	}
 


### PR DESCRIPTION
## Summary

- Removes `plain` from the `code_challenge_method` enum in both GET and POST OAuth authorize endpoint schemas.
- Rejects any non-S256 method in `verify_pkce()` instead of falling through to a plain string comparison.
- Removes the now-unnecessary force-override in `Server::process_authorize_form()` that silently converted `plain` to `S256`.
- The server metadata already only advertised `S256`, so compliant clients are unaffected.

## Test plan

- [ ] OAuth flow with `code_challenge_method=S256` works as before.
- [ ] OAuth flow with `code_challenge_method=plain` is rejected at the schema level (400 response).
- [ ] OAuth flow without PKCE (no `code_challenge`) continues to work for backward compatibility.