### PR TITLE
Use wp_safe_remote_request for signature double-knock retry

### DIFF
--- a/.github/changelog/fix-safe-remote-request-double-knock
+++ b/.github/changelog/fix-safe-remote-request-double-knock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use safe HTTP request for signature retry to prevent requests to private IP ranges.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -96,7 +96,7 @@ class Signature {
 			self::rfc9421_add_unsupported_host( $url );
 
 			$args     = ( new Http_Signature_Draft() )->sign( $args, $url );
-			$response = \wp_remote_request( $url, $args );
+			$response = \wp_safe_remote_request( $url, $args );
 		}
 
 		return $response;


### PR DESCRIPTION
## Summary

- The RFC-9421 double-knock fallback retry used `wp_remote_request()` which does not block private IP ranges (loopback, link-local, RFC 1918).
- Switched to `wp_safe_remote_request()` to match the safety guarantees of the initial `wp_safe_remote_post()` call in `Http::post()`.

## Test plan

- [ ] Send an activity to a remote server that rejects RFC-9421 signatures — the fallback retry should still work as before.
- [ ] Verify that the retry does not allow requests to private IP ranges.