### PR TITLE
Use preg_replace_callback for emoji shortcode wrapping

### DIFF
--- a/.github/changelog/fix-emoji-preg-replace-backreference
+++ b/.github/changelog/fix-emoji-preg-replace-backreference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed emoji shortcode replacement to handle special characters in emoji names correctly.

--- a/includes/class-emoji.php
+++ b/includes/class-emoji.php
@@ -60,7 +60,13 @@ class Emoji {
 
 			// Case-insensitive replacement, avoid already wrapped shortcodes.
 			$pattern = '/(?<!-->)' . \preg_quote( $shortcode, '/' ) . '(?!<!-- \/wp:activitypub\/emoji -->)/i';
-			$content = \preg_replace( $pattern, $wrapped, $content );
+			$content = \preg_replace_callback(
+				$pattern,
+				function () use ( $wrapped ) {
+					return $wrapped;
+				},
+				$content
+			);
 		}
 
 		return $content;

--- a/includes/class-emoji.php
+++ b/includes/class-emoji.php
@@ -62,7 +62,7 @@ class Emoji {
 			$pattern = '/(?<!-->)' . \preg_quote( $shortcode, '/' ) . '(?!<!-- \/wp:activitypub\/emoji -->)/i';
 			$content = \preg_replace_callback(
 				$pattern,
-				function () use ( $wrapped ) {
+				function ( $matches ) use ( $wrapped ) {
 					return $wrapped;
 				},
 				$content

--- a/includes/class-emoji.php
+++ b/includes/class-emoji.php
@@ -62,7 +62,7 @@ class Emoji {
 			$pattern = '/(?<!-->)' . \preg_quote( $shortcode, '/' ) . '(?!<!-- \/wp:activitypub\/emoji -->)/i';
 			$content = \preg_replace_callback(
 				$pattern,
-				function ( $matches ) use ( $wrapped ) {
+				function () use ( $wrapped ) {
 					return $wrapped;
 				},
 				$content

--- a/tests/phpunit/tests/includes/class-test-emoji.php
+++ b/tests/phpunit/tests/includes/class-test-emoji.php
@@ -330,6 +330,63 @@ class Test_Emoji extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test emoji names with preg_replace backreference characters are handled safely.
+	 *
+	 * @covers ::wrap_in_content
+	 */
+	public function test_wrap_emoji_with_backreference_characters() {
+		$text = 'Hello :te$0st: world';
+
+		$activity = array(
+			'tag' => array(
+				array(
+					'type' => 'Emoji',
+					'name' => ':te$0st:',
+					'icon' => array(
+						'type' => 'Image',
+						'url'  => 'https://example.com/emoji/test.png',
+					),
+				),
+			),
+		);
+
+		$result = Emoji::wrap_in_content( $text, $activity );
+
+		// The shortcode must appear literally, not expanded as a backreference.
+		$this->assertStringContainsString( ':te$0st:', $result );
+		$this->assertStringContainsString( '<!-- wp:activitypub/emoji', $result );
+		$this->assertStringContainsString( 'test.png', $result );
+	}
+
+	/**
+	 * Test emoji names with backslash sequences are handled safely.
+	 *
+	 * @covers ::wrap_in_content
+	 */
+	public function test_wrap_emoji_with_backslash_sequences() {
+		$text = 'Hello :te\\1st: world';
+
+		$activity = array(
+			'tag' => array(
+				array(
+					'type' => 'Emoji',
+					'name' => ':te\\1st:',
+					'icon' => array(
+						'type' => 'Image',
+						'url'  => 'https://example.com/emoji/test.png',
+					),
+				),
+			),
+		);
+
+		$result = Emoji::wrap_in_content( $text, $activity );
+
+		// The shortcode must appear literally, not treated as a backreference.
+		$this->assertStringContainsString( ':te\\1st:', $result );
+		$this->assertStringContainsString( '<!-- wp:activitypub/emoji', $result );
+	}
+
+	/**
 	 * Test validate_emoji_src allows local emoji URLs by default.
 	 *
 	 * @covers ::validate_emoji_src


### PR DESCRIPTION
## Summary

- Switches from `preg_replace()` to `preg_replace_callback()` in `Emoji::wrap_in_content()` to prevent PHP backreference expansion (`$0`, `$1`, `\1`) when a remote emoji name contains these characters.
- Without this fix, a remote actor could craft an emoji name like `:te$0st:` and cause the replacement string to be corrupted by PHP's backreference substitution.

## Test plan

- [x] `test_wrap_emoji_with_backreference_characters` — emoji name containing `$0` is preserved literally.
- [x] `test_wrap_emoji_with_backslash_sequences` — emoji name containing `\1` is preserved literally.
- [x] All existing emoji tests continue to pass.