### PR TITLE
Fix double-encoding of comment author names on update

### DIFF
--- a/.github/changelog/fix-update-comment-author-sanitization
+++ b/.github/changelog/fix-update-comment-author-sanitization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed double-encoding of special characters in comment author names on updates.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -108,6 +108,10 @@ class Interactions {
 	public static function update_comment( $activity ) {
 		$meta = get_remote_metadata_by_actor( $activity['actor'] );
 
+		if ( \is_wp_error( $meta ) || ! \is_array( $meta ) ) {
+			return $meta;
+		}
+
 		// Determine comment_ID.
 		$comment      = object_id_to_comment( \esc_url_raw( $activity['object']['id'] ) );
 		$comment_data = \get_comment( $comment, ARRAY_A );

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -117,7 +117,7 @@ class Interactions {
 		}
 
 		// Found a local comment id.
-		$comment_data['comment_author'] = \esc_attr( empty( $meta['name'] ) ? $meta['preferredUsername'] : $meta['name'] );
+		$comment_data['comment_author'] = \sanitize_text_field( empty( $meta['name'] ) ? $meta['preferredUsername'] : $meta['name'] );
 
 		/*
 		 * Wrap emoji in content with blocks for runtime replacement.

--- a/tests/phpunit/tests/includes/collection/class-test-interactions.php
+++ b/tests/phpunit/tests/includes/collection/class-test-interactions.php
@@ -1344,4 +1344,112 @@ class Test_Interactions extends \WP_UnitTestCase {
 		// Clean up.
 		\remove_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter );
 	}
+
+	/**
+	 * Test update_comment does not double-encode special characters in author name.
+	 *
+	 * @covers ::update_comment
+	 */
+	public function test_update_comment_author_no_double_encoding() {
+		// Mock actor with special characters in name.
+		$metadata_filter = static function () {
+			return array(
+				'name'              => "O'Brien & Friends",
+				'preferredUsername' => 'obrien',
+				'id'                => 'https://example.com/users/obrien',
+				'url'               => 'https://example.com/@obrien',
+			);
+		};
+		\add_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter, 1 );
+
+		// First create a comment.
+		$activity = array(
+			'actor'  => 'https://example.com/users/obrien',
+			'id'     => 'https://example.com/activities/comment/' . microtime( true ),
+			'object' => array(
+				'id'        => 'https://example.com/notes/obrien-1',
+				'content'   => 'Original content',
+				'inReplyTo' => self::$post_permalink,
+			),
+		);
+
+		$comment_id = Interactions::add_comment( $activity );
+		$this->assertIsInt( $comment_id );
+
+		// Now update it.
+		$update_activity = array(
+			'actor'  => 'https://example.com/users/obrien',
+			'id'     => 'https://example.com/activities/update/' . microtime( true ),
+			'object' => array(
+				'id'        => 'https://example.com/notes/obrien-1',
+				'content'   => 'Updated content',
+				'inReplyTo' => self::$post_permalink,
+			),
+		);
+
+		$result = Interactions::update_comment( $update_activity );
+		$this->assertNotFalse( $result );
+
+		$comment = \get_comment( $comment_id );
+
+		// Author name should not be entity-encoded in storage.
+		$this->assertEquals( "O'Brien &amp; Friends", $comment->comment_author );
+		$this->assertStringNotContainsString( '&#039;', $comment->comment_author );
+
+		\remove_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter, 1 );
+	}
+
+	/**
+	 * Test update_comment strips HTML tags from author name.
+	 *
+	 * @covers ::update_comment
+	 */
+	public function test_update_comment_author_strips_html() {
+		// Mock actor with HTML in name.
+		$metadata_filter = static function () {
+			return array(
+				'name'              => '<b>Evil</b> Actor',
+				'preferredUsername' => 'evil',
+				'id'                => 'https://example.com/users/evil',
+				'url'               => 'https://example.com/@evil',
+			);
+		};
+		\add_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter, 1 );
+
+		// Create a comment.
+		$activity = array(
+			'actor'  => 'https://example.com/users/evil',
+			'id'     => 'https://example.com/activities/comment/' . microtime( true ),
+			'object' => array(
+				'id'        => 'https://example.com/notes/evil-1',
+				'content'   => 'Original content',
+				'inReplyTo' => self::$post_permalink,
+			),
+		);
+
+		$comment_id = Interactions::add_comment( $activity );
+		$this->assertIsInt( $comment_id );
+
+		// Update it.
+		$update_activity = array(
+			'actor'  => 'https://example.com/users/evil',
+			'id'     => 'https://example.com/activities/update/' . microtime( true ),
+			'object' => array(
+				'id'        => 'https://example.com/notes/evil-1',
+				'content'   => 'Updated content',
+				'inReplyTo' => self::$post_permalink,
+			),
+		);
+
+		$result = Interactions::update_comment( $update_activity );
+		$this->assertNotFalse( $result );
+
+		$comment = \get_comment( $comment_id );
+
+		// HTML tags should be stripped.
+		$this->assertStringNotContainsString( '<b>', $comment->comment_author );
+		$this->assertStringContainsString( 'Evil', $comment->comment_author );
+
+		\remove_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter, 1 );
+	}
 }


### PR DESCRIPTION
## Summary

- Replaces `esc_attr()` with `sanitize_text_field()` in `Interactions::update_comment()` for the `comment_author` field.
- `esc_attr()` is an output escaping function that converts `'`, `"`, `&`, `<`, `>` to HTML entities. When WordPress later applies `esc_html()` at display time, these get double-encoded (e.g., `O'Brien` becomes `O&#039;Brien` in storage, then `O&amp;#039;Brien` on screen).
- `sanitize_text_field()` strips tags and trims whitespace without entity-encoding, matching the behavior of `add_comment()`.

## Test plan

- [ ] Update a comment from a remote actor whose name contains a quote (e.g., `O'Brien`) — the name should display correctly without double-encoding.
- [ ] Verify that HTML tags in actor names are still stripped.