### PR TITLE
Validate emoji updated timestamp before storing

### DIFF
--- a/.github/changelog/fix-validate-emoji-updated-timestamp
+++ b/.github/changelog/fix-validate-emoji-updated-timestamp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Validate emoji updated timestamps before storing them.

--- a/includes/class-emoji.php
+++ b/includes/class-emoji.php
@@ -48,8 +48,8 @@ class Emoji {
 			$shortcode   = $tag['name'];
 			$block_attrs = array( 'url' => \esc_url( $url ) );
 
-			if ( ! empty( $tag['updated'] ) ) {
-				$block_attrs['updated'] = $tag['updated'];
+			if ( ! empty( $tag['updated'] ) && \is_string( $tag['updated'] ) && \strtotime( $tag['updated'] ) ) {
+				$block_attrs['updated'] = \sanitize_text_field( $tag['updated'] );
 			}
 
 			$wrapped = \sprintf(

--- a/tests/phpunit/tests/includes/class-test-emoji.php
+++ b/tests/phpunit/tests/includes/class-test-emoji.php
@@ -293,6 +293,36 @@ class Test_Emoji extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wrap_in_content discards invalid updated timestamps.
+	 *
+	 * @covers ::wrap_in_content
+	 */
+	public function test_wrap_discards_invalid_updated_timestamp() {
+		$text = 'Hello :wave:';
+
+		$activity = array(
+			'tag' => array(
+				array(
+					'type'    => 'Emoji',
+					'name'    => ':wave:',
+					'icon'    => array(
+						'type' => 'Image',
+						'url'  => 'https://example.com/emoji/wave.png',
+					),
+					'updated' => 'not-a-date-' . str_repeat( 'x', 500 ),
+				),
+			),
+		);
+
+		$result = Emoji::wrap_in_content( $text, $activity );
+
+		// Invalid timestamp should be discarded.
+		$this->assertStringNotContainsString( 'updated', $result );
+		// Emoji should still be wrapped.
+		$this->assertStringContainsString( '<!-- wp:activitypub/emoji', $result );
+	}
+
+	/**
 	 * Test emoji wrapping is case-insensitive.
 	 *
 	 * @covers ::wrap_in_content


### PR DESCRIPTION
## Summary

- Validates the `updated` field from remote emoji tags with `strtotime()` and `sanitize_text_field()` before storing it in block attributes.
- Previously, any arbitrary string (including very long or malformed values) from a remote actor's emoji definition would be written directly into the block JSON.

## Test plan

- [x] `test_wrap_preserves_updated_timestamp` — valid timestamps are preserved (existing test).
- [x] `test_wrap_omits_updated_when_absent` — missing timestamps are omitted (existing test).
- [x] `test_wrap_discards_invalid_updated_timestamp` — invalid/malformed timestamps are discarded (new test).