### PR TITLE
Fix Move activity losing target when sent to followers

### DIFF
--- a/.github/changelog/fix-move-activity-target
+++ b/.github/changelog/fix-move-activity-target
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix account migration (Move) not working when moving back to an external account.

--- a/includes/handler/class-move.php
+++ b/includes/handler/class-move.php
@@ -170,8 +170,9 @@ class Move {
 			return false;
 		}
 
-		// Check if the target has an alsoKnownAs property.
-		if ( empty( $target_object['alsoKnownAs'] ) ) {
+		// Normalize alsoKnownAs to an array (some JSON-LD payloads may use a string).
+		$also_known_as = (array) ( $target_object['alsoKnownAs'] ?? array() );
+		if ( empty( $also_known_as ) ) {
 			return false;
 		}
 
@@ -185,7 +186,7 @@ class Move {
 		);
 
 		// Check if any origin identifier is in the alsoKnownAs property of the target.
-		if ( ! array_intersect( $origin_ids, $target_object['alsoKnownAs'] ) ) {
+		if ( ! array_intersect( $origin_ids, $also_known_as ) ) {
 			return false;
 		}
 

--- a/includes/handler/class-move.php
+++ b/includes/handler/class-move.php
@@ -26,7 +26,6 @@ class Move {
 	 */
 	public static function init() {
 		\add_action( 'activitypub_inbox_move', array( self::class, 'handle_move' ), 10, 2 );
-		\add_filter( 'activitypub_get_outbox_activity', array( self::class, 'outbox_activity' ) );
 	}
 
 	/**
@@ -102,22 +101,6 @@ class Move {
 	}
 
 	/**
-	 * Convert the object and origin to the correct format.
-	 *
-	 * @param \Activitypub\Activity\Activity $activity The Activity object.
-	 * @return \Activitypub\Activity\Activity The filtered Activity object.
-	 */
-	public static function outbox_activity( $activity ) {
-		if ( 'Move' === $activity->get_type() ) {
-			$activity->set_object( object_to_uri( $activity->get_object() ) );
-			$activity->set_origin( $activity->get_actor() );
-			$activity->set_target( $activity->get_object() );
-		}
-
-		return $activity;
-	}
-
-	/**
 	 * Extract the target from the activity.
 	 *
 	 * The ActivityStreams spec define the `target` attribute as the
@@ -188,12 +171,21 @@ class Move {
 		}
 
 		// Check if the target has an alsoKnownAs property.
-		if ( empty( $target_object['also_known_as'] ) ) {
+		if ( empty( $target_object['alsoKnownAs'] ) ) {
 			return false;
 		}
 
-		// Check if the origin is in the alsoKnownAs property of the target.
-		if ( ! in_array( $origin_object['id'], $target_object['also_known_as'], true ) ) {
+		// Collect all possible origin identifiers (id, url, webfinger).
+		$origin_ids = array_filter(
+			array(
+				$origin_object['id'] ?? null,
+				$origin_object['url'] ?? null,
+				$origin_object['webfinger'] ?? null,
+			)
+		);
+
+		// Check if any origin identifier is in the alsoKnownAs property of the target.
+		if ( ! array_intersect( $origin_ids, $target_object['alsoKnownAs'] ) ) {
 			return false;
 		}
 

--- a/tests/phpunit/tests/includes/class-test-move.php
+++ b/tests/phpunit/tests/includes/class-test-move.php
@@ -97,7 +97,7 @@ class Test_Move extends \WP_UnitTestCase {
 
 		$filter = function () use ( $from ) {
 			return array(
-				'body'     => wp_json_encode( array( 'also_known_as' => array( $from ) ) ),
+				'body'     => wp_json_encode( array( 'alsoKnownAs' => array( $from ) ) ),
 				'response' => array( 'code' => 200 ),
 			);
 		};

--- a/tests/phpunit/tests/includes/handler/class-test-move.php
+++ b/tests/phpunit/tests/includes/handler/class-test-move.php
@@ -62,12 +62,12 @@ class Test_Move extends \WP_UnitTestCase {
 
 		// Mock the HTTP response for the target object.
 		$target_object = array(
-			'type'          => 'Person',
-			'id'            => $target,
-			'url'           => $target,
-			'name'          => 'New Profile',
-			'inbox'         => 'https://example.com/new-profile/inbox',
-			'also_known_as' => array(
+			'type'        => 'Person',
+			'id'          => $target,
+			'url'         => $target,
+			'name'        => 'New Profile',
+			'inbox'       => 'https://example.com/new-profile/inbox',
+			'alsoKnownAs' => array(
 				$origin,
 			),
 		);
@@ -234,12 +234,12 @@ class Test_Move extends \WP_UnitTestCase {
 				return array(
 					'body'     => \wp_json_encode(
 						array(
-							'type'          => 'Person',
-							'id'            => $target,
-							'url'           => $target,
-							'name'          => 'New Profile',
-							'inbox'         => 'https://example.com/new-profile/inbox',
-							'also_known_as' => array( $origin ),
+							'type'        => 'Person',
+							'id'          => $target,
+							'url'         => $target,
+							'name'        => 'New Profile',
+							'inbox'       => 'https://example.com/new-profile/inbox',
+							'alsoKnownAs' => array( $origin ),
 						)
 					),
 					'response' => array( 'code' => 200 ),
@@ -322,12 +322,12 @@ class Test_Move extends \WP_UnitTestCase {
 
 			if ( $url === $target ) {
 				return array(
-					'type'          => 'Person',
-					'id'            => $target,
-					'url'           => $target,
-					'name'          => 'New Profile',
-					'inbox'         => 'https://example.com/new-profile/inbox',
-					'also_known_as' => array(
+					'type'        => 'Person',
+					'id'          => $target,
+					'url'         => $target,
+					'name'        => 'New Profile',
+					'inbox'       => 'https://example.com/new-profile/inbox',
+					'alsoKnownAs' => array(
 						$origin,
 					),
 				);
@@ -366,6 +366,125 @@ class Test_Move extends \WP_UnitTestCase {
 
 		// Check if the origin follower was deleted.
 		$this->assertWPError( Remote_Actors::get_by_uri( $origin ) );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+	}
+
+	/**
+	 * Test that verify_move matches origin by url when id is not in alsoKnownAs.
+	 */
+	public function test_handle_move_matches_origin_by_url() {
+		$target = 'https://example.com/new-profile';
+		$origin = 'https://example.com/old-profile';
+
+		$origin_object = array(
+			'type'    => 'Person',
+			'id'      => $origin,
+			'url'     => 'https://example.com/@oldprofile',
+			'name'    => 'Old Profile',
+			'inbox'   => 'https://example.com/old-profile/inbox',
+			'movedTo' => $target,
+		);
+
+		// Target's alsoKnownAs contains the origin's url, not its id.
+		$target_object = array(
+			'type'        => 'Person',
+			'id'          => $target,
+			'url'         => $target,
+			'name'        => 'New Profile',
+			'inbox'       => 'https://example.com/new-profile/inbox',
+			'alsoKnownAs' => array(
+				'https://example.com/@oldprofile',
+			),
+		);
+
+		$id = Remote_Actors::upsert( $origin_object );
+		\add_post_meta( $id, Followers::FOLLOWER_META_KEY, $this->user_id );
+
+		$filter = function ( $pre, $url_or_object ) use ( $target, $target_object, $origin, $origin_object ) {
+			$url = object_to_uri( $url_or_object );
+			if ( $url === $target ) {
+				return $target_object;
+			}
+			if ( $url === $origin ) {
+				return $origin_object;
+			}
+			return $pre;
+		};
+
+		\add_filter( 'activitypub_pre_http_get_remote_object', $filter, 10, 2 );
+
+		$activity = array(
+			'type'   => 'Move',
+			'actor'  => $origin,
+			'object' => $target,
+		);
+
+		Move::handle_move( $activity, 1 );
+
+		$updated_follower = Remote_Actors::get_by_uri( $target );
+		$this->assertNotNull( $updated_follower );
+		$this->assertEquals( $target, $updated_follower->guid );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+	}
+
+	/**
+	 * Test that verify_move matches origin by webfinger when id is not in alsoKnownAs.
+	 */
+	public function test_handle_move_matches_origin_by_webfinger() {
+		$target = 'https://example.com/new-profile2';
+		$origin = 'https://example.com/old-profile2';
+
+		$origin_object = array(
+			'type'      => 'Person',
+			'id'        => $origin,
+			'url'       => $origin,
+			'name'      => 'Old Profile',
+			'inbox'     => 'https://example.com/old-profile2/inbox',
+			'movedTo'   => $target,
+			'webfinger' => 'olduser@example.com',
+		);
+
+		// Target's alsoKnownAs contains the origin's webfinger, not its id.
+		$target_object = array(
+			'type'        => 'Person',
+			'id'          => $target,
+			'url'         => $target,
+			'name'        => 'New Profile',
+			'inbox'       => 'https://example.com/new-profile2/inbox',
+			'alsoKnownAs' => array(
+				'olduser@example.com',
+			),
+		);
+
+		$id = Remote_Actors::upsert( $origin_object );
+		\add_post_meta( $id, Followers::FOLLOWER_META_KEY, $this->user_id );
+
+		$filter = function ( $pre, $url_or_object ) use ( $target, $target_object, $origin, $origin_object ) {
+			$url = object_to_uri( $url_or_object );
+			if ( $url === $target ) {
+				return $target_object;
+			}
+			if ( $url === $origin ) {
+				return $origin_object;
+			}
+			return $pre;
+		};
+
+		\add_filter( 'activitypub_pre_http_get_remote_object', $filter, 10, 2 );
+
+		$activity = array(
+			'type'   => 'Move',
+			'actor'  => $origin,
+			'object' => $target,
+		);
+
+		Move::handle_move( $activity, 1 );
+
+		$updated_follower = Remote_Actors::get_by_uri( $target );
+		$this->assertNotNull( $updated_follower );
+		$this->assertEquals( $target, $updated_follower->guid );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
 	}


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/unmigrate-followers/

## Proposed changes:

* Remove the buggy `outbox_activity` filter for Move activities that was overwriting the `target` with the `object` value. This caused all outgoing Move activities to have `origin == target`, so remote instances correctly ignored them as no-ops. The stored outbox JSON already has the correct values, making the filter unnecessary.
* Fix `verify_move` to use camelCase JSON keys (`alsoKnownAs`) matching raw HTTP responses from `Http::get_remote_object()`, which returns `json_decode`'d data without key transformation.
* Broaden origin matching in `verify_move` to check `id`, `url`, and `webfinger` identifiers against the target's `alsoKnownAs` array.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Set up two accounts: a local WordPress site with ActivityPub and an external account (e.g. Mastodon).
* Configure account aliases so both accounts reference each other via `alsoKnownAs`.
* Run `wp activitypub move <local-actor-url> <remote-actor-url>` to trigger an external Move.
* Verify the outbox contains a Move activity where `target` points to the remote account (not the local one).
* Verify followers on remote instances receive the Move and migrate accordingly.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix account migration (Move) not working when moving back to an external account.

</details>