### PR TITLE
Add rate limiting to OAuth client registration endpoint

### DIFF
--- a/.github/changelog/fix-rate-limit-client-registration
+++ b/.github/changelog/fix-rate-limit-client-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Add rate limiting to app registration to prevent abuse.

--- a/includes/rest/oauth/class-clients-controller.php
+++ b/includes/rest/oauth/class-clients-controller.php
@@ -11,6 +11,8 @@ use Activitypub\OAuth\Client;
 use Activitypub\OAuth\Scope;
 use Activitypub\OAuth\Server as OAuth_Server;
 
+use function Activitypub\get_client_ip;
+
 /**
  * Clients_Controller class for handling OAuth 2.0 client and metadata endpoints.
  *
@@ -112,6 +114,21 @@ class Clients_Controller extends \WP_REST_Controller {
 				array( 'status' => 403 )
 			);
 		}
+
+		// Rate-limit registrations to prevent DB spam (max 10 per minute per IP).
+		$ip            = get_client_ip();
+		$transient_key = 'ap_oauth_reg_' . \md5( $ip );
+		$count         = (int) \get_transient( $transient_key );
+
+		if ( $count >= 10 ) {
+			return new \WP_Error(
+				'activitypub_rate_limited',
+				\__( 'Too many client registration requests. Please try again later.', 'activitypub' ),
+				array( 'status' => 429 )
+			);
+		}
+
+		\set_transient( $transient_key, $count + 1, MINUTE_IN_SECONDS );
 
 		$client_name   = $request->get_param( 'client_name' );
 		$redirect_uris = $request->get_param( 'redirect_uris' );

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
@@ -41,6 +41,10 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 		global $wp_rest_server;
 		$wp_rest_server = null;
 
+		// Clean up rate-limit transient to avoid cross-test pollution.
+		$ip = \Activitypub\get_client_ip();
+		\delete_transient( 'ap_oauth_reg_' . \md5( $ip ) );
+
 		parent::tear_down();
 	}
 
@@ -143,10 +147,10 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 		$request->set_param( 'redirect_uris', array( 'https://limited.example.com/callback' ) );
 
 		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
 
 		$this->assertEquals( 429, $response->get_status() );
-
-		\delete_transient( $transient_key );
+		$this->assertEquals( 'activitypub_rate_limited', $data['code'] );
 	}
 
 	/**
@@ -169,8 +173,6 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 
 		$this->assertEquals( 201, $response->get_status() );
 		$this->assertEquals( 1, (int) \get_transient( $transient_key ) );
-
-		\delete_transient( $transient_key );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
@@ -127,6 +127,53 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the 11th registration request within a minute is rate-limited.
+	 *
+	 * @covers ::register_client
+	 */
+	public function test_register_client_rate_limited() {
+		$ip            = \Activitypub\get_client_ip();
+		$transient_key = 'ap_oauth_reg_' . \md5( $ip );
+
+		// Simulate 10 previous registrations.
+		\set_transient( $transient_key, 10, MINUTE_IN_SECONDS );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/clients' );
+		$request->set_param( 'client_name', 'Rate Limited App' );
+		$request->set_param( 'redirect_uris', array( 'https://limited.example.com/callback' ) );
+
+		$response = \rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 429, $response->get_status() );
+
+		\delete_transient( $transient_key );
+	}
+
+	/**
+	 * Test that registrations below the limit succeed and increment the counter.
+	 *
+	 * @covers ::register_client
+	 */
+	public function test_register_client_increments_rate_limit_counter() {
+		$ip            = \Activitypub\get_client_ip();
+		$transient_key = 'ap_oauth_reg_' . \md5( $ip );
+
+		// Ensure clean state.
+		\delete_transient( $transient_key );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/clients' );
+		$request->set_param( 'client_name', 'Counter App' );
+		$request->set_param( 'redirect_uris', array( 'https://counter.example.com/callback' ) );
+
+		$response = \rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 1, (int) \get_transient( $transient_key ) );
+
+		\delete_transient( $transient_key );
+	}
+
+	/**
 	 * Test getting authorization server metadata.
 	 *
 	 * @covers ::get_metadata


### PR DESCRIPTION
## Proposed changes:
* Add per-IP rate limiting (max 10 per minute) to the `POST /oauth/clients` dynamic client registration endpoint (RFC 7591) to prevent database spam from unrestricted client creation.
* Uses the same transient-based pattern already established in `Client::discover_and_register()`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Send 10 `POST` requests to `/wp-json/activitypub/1.0/oauth/clients` with valid `client_name` and `redirect_uris` parameters — all should return `201`.
* Send an 11th request within the same minute — it should return `429` with an `activitypub_rate_limited` error.
* Wait one minute and try again — it should succeed.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security - in case of vulnerabilities

#### Message

Add rate limiting to app registration to prevent abuse.

</details>