### PR TITLE
Verify signature keyId host matches activity actor

### DIFF
--- a/.github/changelog/fix-verify-key-id-matches-actor
+++ b/.github/changelog/fix-verify-key-id-matches-actor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Verify that the signing key belongs to the same server as the activity actor.

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -12,6 +12,7 @@ use Activitypub\OAuth\Scope;
 use Activitypub\OAuth\Server as OAuth_Server;
 use Activitypub\Signature;
 
+use function Activitypub\object_to_uri;
 use function Activitypub\use_authorized_fetch;
 
 /**
@@ -65,6 +66,51 @@ trait Verification {
 					array( 'status' => 401 )
 				);
 			}
+
+			// Verify the signing key's host matches the activity actor's host.
+			$key_id_check = $this->verify_key_id( $request );
+			if ( \is_wp_error( $key_id_check ) ) {
+				return $key_id_check;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check that the signature keyId and activity actor share the same host.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return true|\WP_Error True if valid, WP_Error on mismatch.
+	 */
+	private function verify_key_id( $request ) {
+		$sig = $request->get_header( 'signature' );
+		if ( ! $sig || ! \preg_match( '/keyId="([^"]+)"/i', $sig, $m ) ) {
+			// RFC 9421 Signature-Input.
+			$sig = $request->get_header( 'signature-input' );
+			if ( ! $sig || ! \preg_match( '/keyid="([^"]+)"/i', $sig, $m ) ) {
+				return true;
+			}
+		}
+
+		$key_host = \wp_parse_url( $m[1], \PHP_URL_HOST );
+		$json     = $request->get_json_params();
+		$actor    = isset( $json['actor'] ) ? object_to_uri( $json['actor'] ) : null;
+
+		if ( ! $actor || ! $key_host ) {
+			return true;
+		}
+
+		$actor_host = \wp_parse_url( $actor, \PHP_URL_HOST );
+
+		if ( $key_host !== $actor_host ) {
+			return new \WP_Error(
+				'activitypub_key_actor_mismatch',
+				\__( 'Signing key and activity actor must be on the same host.', 'activitypub' ),
+				array( 'status' => 403 )
+			);
 		}
 
 		return true;

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -95,7 +95,7 @@ trait Verification {
 			}
 		}
 
-		$key_host = \wp_parse_url( $m[1], \PHP_URL_HOST );
+		$key_host = \strtolower( (string) \wp_parse_url( $m[1], \PHP_URL_HOST ) );
 		$json     = $request->get_json_params();
 		$actor    = isset( $json['actor'] ) ? object_to_uri( $json['actor'] ) : null;
 
@@ -103,9 +103,9 @@ trait Verification {
 			return true;
 		}
 
-		$actor_host = \wp_parse_url( $actor, \PHP_URL_HOST );
+		$actor_host = \strtolower( (string) \wp_parse_url( $actor, \PHP_URL_HOST ) );
 
-		if ( $key_host !== $actor_host ) {
+		if ( ! $actor_host || $key_host !== $actor_host ) {
 			return new \WP_Error(
 				'activitypub_key_actor_mismatch',
 				\__( 'Signing key and activity actor must be on the same host.', 'activitypub' ),

--- a/tests/phpunit/tests/includes/rest/class-test-actors-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-actors-inbox-controller.php
@@ -298,9 +298,9 @@ class Test_Actors_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controll
 		$activity = new \Activitypub\Activity\Activity();
 		$activity->from_array(
 			array(
-				'id'     => 'https://example.com/activity/1',
+				'id'     => $actor->get_id() . '#activity-1',
 				'type'   => 'Like',
-				'actor'  => 'https://example.com/actor',
+				'actor'  => $actor->get_id(),
 				'object' => $object->get_id(),
 			)
 		);

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -398,6 +398,11 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 				array( 'id' => 'https://remote.example/users/alice' ),
 				false,
 			),
+			'case-insensitive hosts'  => array(
+				'keyId="https://Remote.Example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://remote.example/users/alice',
+				true,
+			),
 		);
 	}
 
@@ -412,9 +417,6 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 	 * @param bool              $should_pass Whether the check should pass.
 	 */
 	public function test_verify_key_id( $signature, $actor, $should_pass ) {
-		// Defer actual signature crypto so we only test the keyId-actor check.
-		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
-
 		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/inbox' );
 
 		if ( null !== $signature ) {

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -362,6 +362,93 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for verify_key_id tests.
+	 *
+	 * @return array[] Test cases: [ signature_header, actor, expected_pass ].
+	 */
+	public function data_verify_key_id() {
+		return array(
+			'matching hosts'          => array(
+				'keyId="https://remote.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://remote.example/users/alice',
+				true,
+			),
+			'mismatched hosts'        => array(
+				'keyId="https://evil.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://remote.example/users/alice',
+				false,
+			),
+			'no actor in body'        => array(
+				'keyId="https://remote.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				null,
+				true,
+			),
+			'no signature header'     => array(
+				null,
+				'https://remote.example/users/alice',
+				true,
+			),
+			'actor as object with id' => array(
+				'keyId="https://remote.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				array( 'id' => 'https://remote.example/users/alice' ),
+				true,
+			),
+			'actor object mismatch'   => array(
+				'keyId="https://evil.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				array( 'id' => 'https://remote.example/users/alice' ),
+				false,
+			),
+		);
+	}
+
+	/**
+	 * Test that verify_key_id checks keyId host against actor host.
+	 *
+	 * @dataProvider data_verify_key_id
+	 * @covers ::verify_key_id
+	 *
+	 * @param string|null       $signature The Signature header value.
+	 * @param string|array|null $actor     The actor value in the JSON body.
+	 * @param bool              $should_pass Whether the check should pass.
+	 */
+	public function test_verify_key_id( $signature, $actor, $should_pass ) {
+		// Defer actual signature crypto so we only test the keyId-actor check.
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/inbox' );
+
+		if ( null !== $signature ) {
+			$request->set_header( 'Signature', $signature );
+		}
+
+		$body = array(
+			'type' => 'Like',
+			'id'   => 'https://remote.example/activity/1',
+		);
+		if ( null !== $actor ) {
+			$body['actor'] = $actor;
+		}
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( \wp_json_encode( $body ) );
+
+		/*
+		 * verify_key_id is private, so call it via reflection.
+		 * This avoids coupling the test to the full verify_signature flow.
+		 */
+		$method = new \ReflectionMethod( $this->instance, 'verify_key_id' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $this->instance, $request );
+
+		if ( $should_pass ) {
+			$this->assertTrue( $result );
+		} else {
+			$this->assertWPError( $result );
+			$this->assertEquals( 'activitypub_key_actor_mismatch', $result->get_error_code() );
+			$this->assertEquals( 403, $result->get_error_data()['status'] );
+		}
+	}
+
+	/**
 	 * Create a mock OAuth token object.
 	 *
 	 * @param int  $user_id   The user ID the token belongs to.


### PR DESCRIPTION
## Proposed changes:
* Prevent actor spoofing by verifying that the HTTP Signature `keyId` host matches the `actor` field host in incoming activities.
* Without this check, a valid signature from server A could be used to forge activities claiming to be from server B.
* Host-level comparison keeps it simple and avoids breaking implementations that use separate key endpoints on the same domain.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Existing inbox tests continue to pass (the existing signature verification test was updated to use consistent actor/keyId hosts).
* New data-provider test covers: matching hosts, mismatched hosts, missing actor, missing signature, actor-as-object.
* To test manually: send a signed POST to an inbox where the `Signature` header `keyId` host differs from the JSON body `actor` host. Should return 403.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security - in case of vulnerabilities

#### Message

Verify that the signing key belongs to the same server as the activity actor.

</details>