### PR TITLE
Fix Update handler using stale local actor data instead of activity payload

### DIFF
--- a/.github/changelog/3110-from-description
+++ b/.github/changelog/3110-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Update handler using stale local actor data instead of the activity payload

--- a/includes/handler/class-update.php
+++ b/includes/handler/class-update.php
@@ -139,18 +139,17 @@ class Update {
 		if ( ! \is_array( $actor ) || ! isset( $actor['id'] ) ) {
 			$object = Http::get_remote_object( $activity['actor'], false );
 
-			if ( \is_wp_error( $object ) || ! \is_array( $object ) ) {
-				$state = new \WP_Error( 'activitypub_update_failed', 'Update failed: missing or invalid actor object in Update activity' );
-				$actor = array();
-
-				\do_action( 'activitypub_handled_update', $activity, (array) $user_ids, $state, $actor );
-				return;
+			if ( ! \is_wp_error( $object ) && \is_array( $object ) ) {
+				$actor = $object;
 			}
-
-			$actor = $object;
 		}
 
-		$state = Remote_Actors::upsert( $actor );
+		if ( \is_array( $actor ) && isset( $actor['id'] ) ) {
+			$state = Remote_Actors::upsert( $actor );
+		} else {
+			$state = new \WP_Error( 'activitypub_update_failed', 'Update failed: missing or invalid actor object in Update activity' );
+			$actor = array();
+		}
 
 		/**
 		 * Fires after an ActivityPub Update activity has been handled.

--- a/includes/handler/class-update.php
+++ b/includes/handler/class-update.php
@@ -10,8 +10,8 @@ namespace Activitypub\Handler;
 use Activitypub\Collection\Interactions;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Collection\Remote_Posts;
+use Activitypub\Http;
 
-use function Activitypub\get_remote_metadata_by_actor;
 use function Activitypub\is_activity_reply;
 
 /**
@@ -127,17 +127,30 @@ class Update {
 	 * @param int[]|null $user_ids The user IDs. Always null for Update activities.
 	 */
 	public static function update_actor( $activity, $user_ids ) {
-		// Use the actor data from the activity object directly, as it contains
-		// the fresh data. Fetching via get_remote_metadata_by_actor() would return
-		// the stale locally cached copy because fetch_by_uri() short-circuits
-		// when the actor already exists locally.
-		$actor = $activity['object'] ?? array();
+		// Prefer the actor data embedded in the activity object, as it contains
+		// the fresh data sent by the remote server.
+		$actor = $activity['object'] ?? null;
 
-		if ( ! $actor || ! isset( $actor['id'] ) ) {
-			$state = new \WP_Error( 'activitypub_update_failed', 'Update failed: could not fetch actor data' );
-		} else {
-			$state = Remote_Actors::upsert( $actor );
+		// The object may be a string IRI instead of an embedded object,
+		// in which case we need to fetch the actor data remotely.
+		// We use Http::get_remote_object() directly instead of
+		// get_remote_metadata_by_actor() because the latter returns the
+		// stale locally cached copy via fetch_by_uri().
+		if ( ! \is_array( $actor ) || ! isset( $actor['id'] ) ) {
+			$object = Http::get_remote_object( $activity['actor'], false );
+
+			if ( \is_wp_error( $object ) || ! \is_array( $object ) ) {
+				$state = new \WP_Error( 'activitypub_update_failed', 'Update failed: missing or invalid actor object in Update activity' );
+				$actor = array();
+
+				\do_action( 'activitypub_handled_update', $activity, (array) $user_ids, $state, $actor );
+				return;
+			}
+
+			$actor = $object;
 		}
+
+		$state = Remote_Actors::upsert( $actor );
 
 		/**
 		 * Fires after an ActivityPub Update activity has been handled.

--- a/includes/handler/class-update.php
+++ b/includes/handler/class-update.php
@@ -127,15 +127,19 @@ class Update {
 	 * @param int[]|null $user_ids The user IDs. Always null for Update activities.
 	 */
 	public static function update_actor( $activity, $user_ids ) {
-		// Prefer the actor data embedded in the activity object, as it contains
-		// the fresh data sent by the remote server.
+		/*
+		 * Prefer the actor data embedded in the activity object, as it contains
+		 * the fresh data sent by the remote server.
+		 */
 		$actor = $activity['object'] ?? null;
 
-		// The object may be a string IRI instead of an embedded object,
-		// in which case we need to fetch the actor data remotely.
-		// We use Http::get_remote_object() directly instead of
-		// get_remote_metadata_by_actor() because the latter returns the
-		// stale locally cached copy via fetch_by_uri().
+		/*
+		 * The object may be a string IRI instead of an embedded object,
+		 * in which case we need to fetch the actor data remotely.
+		 * We use Http::get_remote_object() directly instead of
+		 * get_remote_metadata_by_actor() because the latter returns the
+		 * stale locally cached copy via fetch_by_uri().
+		 */
 		if ( ! \is_array( $actor ) || ! isset( $actor['id'] ) ) {
 			$object = Http::get_remote_object( $activity['actor'], false );
 

--- a/includes/handler/class-update.php
+++ b/includes/handler/class-update.php
@@ -127,10 +127,13 @@ class Update {
 	 * @param int[]|null $user_ids The user IDs. Always null for Update activities.
 	 */
 	public static function update_actor( $activity, $user_ids ) {
-		// Update cache.
-		$actor = get_remote_metadata_by_actor( $activity['actor'], false );
+		// Use the actor data from the activity object directly, as it contains
+		// the fresh data. Fetching via get_remote_metadata_by_actor() would return
+		// the stale locally cached copy because fetch_by_uri() short-circuits
+		// when the actor already exists locally.
+		$actor = $activity['object'] ?? array();
 
-		if ( ! $actor || \is_wp_error( $actor ) || ! isset( $actor['id'] ) ) {
+		if ( ! $actor || ! isset( $actor['id'] ) ) {
 			$state = new \WP_Error( 'activitypub_update_failed', 'Update failed: could not fetch actor data' );
 		} else {
 			$state = Remote_Actors::upsert( $actor );

--- a/tests/phpunit/tests/includes/handler/class-test-update.php
+++ b/tests/phpunit/tests/includes/handler/class-test-update.php
@@ -127,6 +127,199 @@ class Test_Update extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that update_actor uses embedded object data instead of stale cached data.
+	 *
+	 * @covers ::update_actor
+	 */
+	public function test_update_actor_uses_embedded_object_data() {
+		$actor_url = 'https://example.com/users/embedded';
+
+		$original_actor = array(
+			'type'              => 'Person',
+			'id'                => $actor_url,
+			'name'              => 'Original Name',
+			'preferredUsername' => 'embedded',
+			'inbox'             => $actor_url . '/inbox',
+			'outbox'            => $actor_url . '/outbox',
+			'followers'         => $actor_url . '/followers',
+			'following'         => $actor_url . '/following',
+			'publicKey'         => array(
+				'id'           => $actor_url . '#main-key',
+				'owner'        => $actor_url,
+				'publicKeyPem' => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQE\n-----END PUBLIC KEY-----",
+			),
+		);
+
+		// Store the actor locally first, simulating a cached copy.
+		Remote_Actors::upsert( $original_actor );
+
+		$post = Remote_Actors::get_by_uri( $actor_url );
+		$this->assertNotWPError( $post, 'Actor should be stored locally.' );
+
+		// Build an Update activity with fresh embedded data.
+		$updated_actor = array_merge( $original_actor, array( 'name' => 'Updated Name' ) );
+
+		$activity = array(
+			'type'   => 'Update',
+			'actor'  => $actor_url,
+			'object' => $updated_actor,
+		);
+
+		/*
+		 * Mock HTTP to return stale data — if the handler incorrectly
+		 * fetches remotely, we'll catch it.
+		 */
+		$stale_response = function () use ( $original_actor ) {
+			return $original_actor;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $stale_response );
+
+		Update::update_actor( $activity, array( $this->user_id ) );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $stale_response );
+
+		// Verify the embedded (fresh) data was used.
+		$post  = Remote_Actors::get_by_uri( $actor_url );
+		$actor = Remote_Actors::get_actor( $post );
+		$this->assertEquals( 'Updated Name', $actor->get_name(), 'Should use embedded object data, not stale cached data.' );
+	}
+
+	/**
+	 * Test that update_actor falls back to remote fetch when object is a string IRI.
+	 *
+	 * @covers ::update_actor
+	 */
+	public function test_update_actor_fetches_remotely_for_string_iri() {
+		$actor_url = 'https://example.com/users/iri-test';
+
+		$remote_actor = array(
+			'type'              => 'Person',
+			'id'                => $actor_url,
+			'name'              => 'Fetched Remotely',
+			'preferredUsername' => 'iritest',
+			'inbox'             => $actor_url . '/inbox',
+			'outbox'            => $actor_url . '/outbox',
+			'followers'         => $actor_url . '/followers',
+			'following'         => $actor_url . '/following',
+			'publicKey'         => array(
+				'id'           => $actor_url . '#main-key',
+				'owner'        => $actor_url,
+				'publicKeyPem' => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQE\n-----END PUBLIC KEY-----",
+			),
+		);
+
+		// Activity with string IRI instead of embedded object.
+		$activity = array(
+			'type'   => 'Update',
+			'actor'  => $actor_url,
+			'object' => $actor_url,
+		);
+
+		// Mock HTTP to return valid actor data.
+		$mock_response = function () use ( $remote_actor ) {
+			return $remote_actor;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_response );
+
+		Update::update_actor( $activity, array( $this->user_id ) );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_response );
+
+		$post  = Remote_Actors::get_by_uri( $actor_url );
+		$actor = Remote_Actors::get_actor( $post );
+		$this->assertEquals( 'Fetched Remotely', $actor->get_name(), 'Should fetch remotely when object is a string IRI.' );
+	}
+
+	/**
+	 * Test that update_actor fires activitypub_handled_update with WP_Error when fetch fails.
+	 *
+	 * @covers ::update_actor
+	 */
+	public function test_update_actor_fires_error_on_failed_fetch() {
+		$activity = array(
+			'type'   => 'Update',
+			'actor'  => 'https://example.com/users/missing',
+			'object' => 'https://example.com/users/missing',
+		);
+
+		// Mock HTTP to return an error.
+		$mock_error = function () {
+			return new \WP_Error( 'http_error', 'Could not fetch' );
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_error );
+
+		$state    = null;
+		$listener = function ( $act, $uids, $s ) use ( &$state ) {
+			$state = $s;
+		};
+		\add_action( 'activitypub_handled_update', $listener, 10, 3 );
+
+		Update::update_actor( $activity, array( $this->user_id ) );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_error );
+		\remove_action( 'activitypub_handled_update', $listener );
+
+		$this->assertWPError( $state, 'Should fire activitypub_handled_update with WP_Error when remote fetch fails.' );
+		$this->assertEquals( 'activitypub_update_failed', $state->get_error_code() );
+	}
+
+	/**
+	 * Test that update_actor always fires activitypub_handled_update exactly once.
+	 *
+	 * @covers ::update_actor
+	 */
+	public function test_update_actor_fires_action_exactly_once() {
+		$actor_url = 'https://example.com/users/action-count';
+
+		$actor_data = array(
+			'type'              => 'Person',
+			'id'                => $actor_url,
+			'name'              => 'Action Counter',
+			'preferredUsername' => 'actioncount',
+			'inbox'             => $actor_url . '/inbox',
+			'outbox'            => $actor_url . '/outbox',
+			'followers'         => $actor_url . '/followers',
+			'following'         => $actor_url . '/following',
+			'publicKey'         => array(
+				'id'           => $actor_url . '#main-key',
+				'owner'        => $actor_url,
+				'publicKeyPem' => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQE\n-----END PUBLIC KEY-----",
+			),
+		);
+
+		$fire_count = 0;
+		$listener   = function () use ( &$fire_count ) {
+			++$fire_count;
+		};
+		\add_action( 'activitypub_handled_update', $listener );
+
+		// Test with embedded object (success path).
+		$activity = array(
+			'type'   => 'Update',
+			'actor'  => $actor_url,
+			'object' => $actor_data,
+		);
+
+		Update::update_actor( $activity, array( $this->user_id ) );
+		$this->assertSame( 1, $fire_count, 'Action should fire exactly once on success.' );
+
+		// Test with failed fetch (error path).
+		$fire_count = 0;
+		$mock_error = function () {
+			return new \WP_Error( 'http_error', 'fail' );
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_error );
+
+		$activity['object'] = 'https://example.com/users/nonexistent';
+		Update::update_actor( $activity, array( $this->user_id ) );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_error );
+		\remove_action( 'activitypub_handled_update', $listener );
+
+		$this->assertSame( 1, $fire_count, 'Action should fire exactly once on error.' );
+	}
+
+	/**
 	 * Data provider for update_actor tests.
 	 *
 	 * @return array Test cases with activity data, HTTP response, expected outcome, and description.


### PR DESCRIPTION
## Proposed changes:

I noticed that a friend's avatar on my Friends plugin timeline was stale — the `ap_actor` still had their old Mastodon avatar URL (`37df032a5951b96c.jpg`) while Mastodon had already switched to a new one (`388649acb2026701.webp`). 

The Friends plugin had the correct avatar because it updates it when receiving an `Update` Person activity. But the `ap_actor` post in the ActivityPub plugin was never updated, even though the same `Update` activity was delivered.

The root cause is in `update_actor()`: it calls `get_remote_metadata_by_actor()` which calls `fetch_by_uri()`, which **returns the stale locally cached copy** when the actor already exists locally (line 262-265 of `class-remote-actors.php`). The `$cached = false` parameter is not passed down the call chain and is thus ignored.

The `Update` activity already contains the fresh actor data in `$activity['object']` — so this PR uses it directly instead of re-fetching.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Have a remote actor (e.g. a Mastodon user) already stored locally as an `ap_actor`
2. Have that user change their avatar on Mastodon
3. Mastodon sends an `Update` Person activity
4. **Before this fix:** the `ap_actor` post_content and avatar remain stale
5. **After this fix:** the `ap_actor` is updated with the fresh data from the activity

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix Update handler using stale local actor data instead of the activity payload

</details>