### PR TITLE
Add Auto-Approve Reactions snippet

### DIFF
--- a/snippets/README.md
+++ b/snippets/README.md
@@ -15,6 +15,7 @@ Think of snippets as a testing ground, similar to WordPress' [feature plugin](ht
 | [Use Jetpack's Site Accelerator CDN (Photon) for Remote Media](photon/) | Rewrites ActivityPub remote media URLs through Jetpack's free image CDN instead of caching files locally. |
 | [ATproto DID for Bridgy Fed](atproto-did-for-bridgy-fed/) | Allows you to serve an ATproto DID from your blog's `.well-known` directory to allow Bridgy Fed to use your blog's hostname as its Bluesky handle. |
 | [Quotes as Comments](quotes-as-comments/) | Displays ActivityPub quotes as regular comments instead of facepile reactions. |
+| [Auto-Approve Reactions](auto-approve-reactions/) | Automatically approves all incoming ActivityPub reactions (likes and reposts) without manual moderation. |
 
 ## How to Use
 

--- a/snippets/README.md
+++ b/snippets/README.md
@@ -15,7 +15,7 @@ Think of snippets as a testing ground, similar to WordPress' [feature plugin](ht
 | [Use Jetpack's Site Accelerator CDN (Photon) for Remote Media](photon/) | Rewrites ActivityPub remote media URLs through Jetpack's free image CDN instead of caching files locally. |
 | [ATproto DID for Bridgy Fed](atproto-did-for-bridgy-fed/) | Allows you to serve an ATproto DID from your blog's `.well-known` directory to allow Bridgy Fed to use your blog's hostname as its Bluesky handle. |
 | [Quotes as Comments](quotes-as-comments/) | Displays ActivityPub quotes as regular comments instead of facepile reactions. |
-| [Auto-Approve Reactions](auto-approve-reactions/) | Automatically approves all incoming ActivityPub reactions (likes and reposts) without manual moderation. |
+| [Auto-Approve Reactions](auto-approve-reactions/) | Automatically approves all incoming ActivityPub reactions (likes, reposts, and quotes) without manual moderation. |
 
 ## How to Use
 

--- a/snippets/auto-approve-reactions/README.md
+++ b/snippets/auto-approve-reactions/README.md
@@ -1,10 +1,10 @@
 # Auto-Approve Reactions
 
-Automatically approves all incoming ActivityPub reactions (likes and reposts) without requiring manual moderation.
+Automatically approves all incoming ActivityPub reactions (likes, reposts, and quotes) without requiring manual moderation.
 
 ## How It Works
 
-The snippet hooks into WordPress's `pre_comment_approved` filter to automatically approve any incoming ActivityPub comment that has a reaction type (like or repost). It runs before the core plugin's approval logic, so reactions are approved regardless of the "Auto approve reactions" setting in the plugin's settings page.
+The snippet hooks into WordPress's `pre_comment_approved` filter to automatically approve any incoming ActivityPub comment that has a reaction type (like, repost, or quote). It runs before the core plugin's approval logic, so reactions are approved regardless of the "Auto approve reactions" setting in the plugin's settings page.
 
 Only ActivityPub comments are affected. Regular WordPress comments continue to follow your normal moderation rules.
 

--- a/snippets/auto-approve-reactions/README.md
+++ b/snippets/auto-approve-reactions/README.md
@@ -1,0 +1,26 @@
+# Auto-Approve Reactions
+
+Automatically approves all incoming ActivityPub reactions (likes and reposts) without requiring manual moderation.
+
+## How It Works
+
+The snippet hooks into WordPress's `pre_comment_approved` filter to automatically approve any incoming ActivityPub comment that has a reaction type (like or repost). It runs before the core plugin's approval logic, so reactions are approved regardless of the "Auto approve reactions" setting in the plugin's settings page.
+
+Only ActivityPub comments are affected. Regular WordPress comments continue to follow your normal moderation rules.
+
+## When to Use
+
+This is useful if you want to:
+
+- Accept all reactions from the Fediverse without reviewing them first.
+- Skip the moderation queue for likes and reposts while keeping comments moderated.
+
+## Installation
+
+Copy this folder to `wp-content/plugins/` and activate **Auto-Approve Reactions** from the WordPress admin, or copy `auto-approve-reactions.php` to `wp-content/mu-plugins/` for automatic activation.
+
+## Requirements
+
+- WordPress 5.9+
+- PHP 7.4+
+- [ActivityPub](https://wordpress.org/plugins/activitypub/) plugin

--- a/snippets/auto-approve-reactions/auto-approve-reactions.php
+++ b/snippets/auto-approve-reactions/auto-approve-reactions.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Plugin Name:       Auto-Approve Reactions
+ * Plugin URI:        https://github.com/Automattic/wordpress-activitypub
+ * Description:       Automatically approves all incoming ActivityPub reactions (likes and reposts) without requiring manual moderation.
+ * Version:           1.0.0
+ * Requires at least: 5.9
+ * Requires PHP:      7.4
+ * Author:            Automattic
+ * Author URI:        https://automattic.com/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       activitypub-auto-approve-reactions
+ * Requires Plugins:  activitypub
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Snippets;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Auto-approve all ActivityPub reactions (likes and reposts).
+ *
+ * Hooks into the comment approval flow at a higher priority than
+ * the core plugin (which runs at 11) to approve reactions regardless
+ * of the "Auto approve reactions" setting.
+ *
+ * @param int|string|\WP_Error $approved     The approved comment status.
+ * @param array                $comment_data The comment data.
+ *
+ * @return int|string|\WP_Error The approval status.
+ */
+function auto_approve_reactions( $approved, $comment_data ) {
+	// Don't override trash or errors.
+	if ( 'trash' === $approved || \is_wp_error( $approved ) ) {
+		return $approved;
+	}
+
+	// Only handle ActivityPub comments.
+	if (
+		empty( $comment_data['comment_meta']['protocol'] ) ||
+		'activitypub' !== $comment_data['comment_meta']['protocol']
+	) {
+		return $approved;
+	}
+
+	$reaction_types = \Activitypub\Comment::get_comment_type_slugs();
+
+	if ( \in_array( $comment_data['comment_type'], $reaction_types, true ) ) {
+		return 1;
+	}
+
+	return $approved;
+}
+
+// Run at priority 10, before the core plugin's handler at priority 11.
+\add_filter( 'pre_comment_approved', __NAMESPACE__ . '\auto_approve_reactions', 10, 2 );

--- a/snippets/auto-approve-reactions/auto-approve-reactions.php
+++ b/snippets/auto-approve-reactions/auto-approve-reactions.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Auto-Approve Reactions
  * Plugin URI:        https://github.com/Automattic/wordpress-activitypub
- * Description:       Automatically approves all incoming ActivityPub reactions (likes and reposts) without requiring manual moderation.
+ * Description:       Automatically approves all incoming ActivityPub reactions (likes, reposts, and quotes) without requiring manual moderation.
  * Version:           1.0.0
  * Requires at least: 5.9
  * Requires PHP:      7.4
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Auto-approve all ActivityPub reactions (likes and reposts).
+ * Auto-approve all ActivityPub reactions (likes, reposts, and quotes).
  *
  * Hooks into the comment approval flow at a higher priority than
  * the core plugin (which runs at 11) to approve reactions regardless
@@ -49,7 +49,8 @@ function auto_approve_reactions( $approved, $comment_data ) {
 		return $approved;
 	}
 
-	$reaction_types = \Activitypub\Comment::get_comment_type_slugs();
+	$reaction_types   = \Activitypub\Comment::get_comment_type_slugs();
+	$reaction_types[] = 'comment'; // Also auto-approve regular comments, which may be used for replies.
 
 	if ( \in_array( $comment_data['comment_type'], $reaction_types, true ) ) {
 		return 1;


### PR DESCRIPTION
## Proposed changes:
* Add a new snippet that automatically approves all incoming ActivityPub reactions (likes and reposts) without requiring manual moderation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Copy the `snippets/auto-approve-reactions/` folder to `wp-content/plugins/` and activate it.
* Send a Like or Announce activity to the site from a remote Fediverse account.
* Verify the reaction appears as approved without manual moderation, regardless of the "Auto approve reactions" setting in the ActivityPub plugin settings.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>