### PR TITLE
Add Arrive outbox handler for check-in activities

### DIFF
--- a/.github/changelog/3120-from-description
+++ b/.github/changelog/3120-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add support for check-in activities posted via compatible apps.

--- a/includes/class-handler.php
+++ b/includes/class-handler.php
@@ -50,6 +50,7 @@ class Handler {
 	public static function register_outbox_handlers() {
 		Handler\Outbox\Add::init();
 		Handler\Outbox\Announce::init();
+		Handler\Outbox\Arrive::init();
 		Handler\Outbox\Block::init();
 		Handler\Outbox\Create::init();
 		Handler\Outbox\Delete::init();

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -434,7 +434,7 @@ class Outbox {
 			return new \WP_Error( 'private_outbox_item', 'Not a public Outbox item.' );
 		}
 
-		$activity_types = \apply_filters( 'rest_activitypub_outbox_activity_types', array( 'Announce', 'Create', 'Like', 'Update' ) );
+		$activity_types = \apply_filters( 'rest_activitypub_outbox_activity_types', array( 'Announce', 'Arrive', 'Create', 'Like', 'Update' ) );
 		$activity_type  = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
 
 		if ( ! in_array( $activity_type, $activity_types, true ) ) {

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -39,6 +39,14 @@ class Outbox {
 	const MAX_ITEMS = 5000;
 
 	/**
+	 * Activity types included in the outbox collection listing.
+	 *
+	 * @var string[]
+	 */
+	const ACTIVITY_TYPES = array( 'Announce', 'Arrive', 'Create', 'Like', 'Update' );
+
+
+	/**
 	 * Number of items to process per batch during purge.
 	 *
 	 * @var int
@@ -434,7 +442,7 @@ class Outbox {
 			return new \WP_Error( 'private_outbox_item', 'Not a public Outbox item.' );
 		}
 
-		$activity_types = \apply_filters( 'rest_activitypub_outbox_activity_types', array( 'Announce', 'Arrive', 'Create', 'Like', 'Update' ) );
+		$activity_types = \apply_filters( 'rest_activitypub_outbox_activity_types', self::ACTIVITY_TYPES );
 		$activity_type  = \get_post_meta( $outbox_item->ID, '_activitypub_activity_type', true );
 
 		if ( ! in_array( $activity_type, $activity_types, true ) ) {

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -8,7 +8,6 @@
 namespace Activitypub\Handler\Outbox;
 
 use Activitypub\Collection\Posts;
-use Activitypub\Scheduler\Post;
 
 use function Activitypub\add_to_outbox;
 use function Activitypub\is_activity_public;
@@ -159,18 +158,7 @@ class Arrive {
 			'cc'     => $data['cc'] ?? array(),
 		);
 
-		/*
-		 * Suppress the Post scheduler so wp_insert_post() does not
-		 * trigger a separate Create activity for the blog post.
-		 * Only the Arrive activity should be federated.
-		 */
-		\remove_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33 );
-
-		$post = Posts::create( $activity, $user_id, $visibility );
-
-		\add_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33, 4 );
-
-		return $post;
+		return Posts::create( $activity, $user_id, $visibility );
 	}
 
 	/**

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -9,6 +9,7 @@ namespace Activitypub\Handler\Outbox;
 
 use Activitypub\Collection\Posts;
 
+use function Activitypub\add_to_outbox;
 use function Activitypub\is_activity_public;
 
 /**
@@ -24,16 +25,18 @@ class Arrive {
 	 */
 	public static function init() {
 		\add_filter( 'activitypub_outbox_arrive', array( self::class, 'handle_arrive' ), 10, 3 );
-		\add_action( 'activitypub_outbox_arrive_sent', array( self::class, 'save_location' ), 10, 4 );
 	}
 
 	/**
 	 * Handle outgoing "Arrive" activities from local actors.
 	 *
-	 * Arrive is an intransitive activity indicating that the actor
-	 * has arrived at a location. Creates a WordPress post so the
-	 * check-in appears on the blog. Location geodata is saved via
-	 * the `activitypub_outbox_arrive_sent` action.
+	 * Arrive is an intransitive activity (no object) indicating that
+	 * the actor has arrived at a location. Per the ActivityPub spec,
+	 * the server must preserve the original activity type, so this
+	 * handler adds the Arrive directly to the outbox as-is.
+	 *
+	 * As a local side effect, a WordPress post is created so the
+	 * check-in appears on the blog with location geodata.
 	 *
 	 * @since unreleased
 	 *
@@ -41,13 +44,59 @@ class Arrive {
 	 * @param int         $user_id    The user ID.
 	 * @param string|null $visibility Content visibility.
 	 *
-	 * @return \WP_Post|\WP_Error|false The created post, error, or false.
+	 * @return int|\WP_Error|false The outbox post ID, error, or false.
 	 */
 	public static function handle_arrive( $data, $user_id = null, $visibility = null ) {
 		if ( ! is_activity_public( $data ) ) {
 			return false;
 		}
 
+		// Create a local blog post as a side effect for on-site display.
+		$post = self::create_checkin_post( $data, $user_id, $visibility );
+
+		if ( $post && ! \is_wp_error( $post ) ) {
+			self::save_location( $post->ID, $data['location'] ?? null );
+
+			/*
+			 * Add a link to the blog post so remote servers can find
+			 * the rendered check-in from the Arrive activity.
+			 */
+			$data['url'] = \get_permalink( $post );
+		}
+
+		/*
+		 * Add the original Arrive activity to the outbox directly.
+		 * This preserves the intransitive activity type per the
+		 * ActivityPub spec (Section 6) instead of wrapping it in Create.
+		 */
+		$outbox_id = add_to_outbox( $data, null, $user_id, $visibility );
+
+		if ( ! $outbox_id ) {
+			return new \WP_Error(
+				'activitypub_outbox_error',
+				\__( 'Failed to add Arrive activity to outbox.', 'activitypub' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return $outbox_id;
+	}
+
+	/**
+	 * Create a WordPress post from the Arrive activity.
+	 *
+	 * Synthesizes a Create-style payload from the intransitive
+	 * Arrive data so the check-in is visible on the blog.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array       $data       The activity data.
+	 * @param int         $user_id    The user ID.
+	 * @param string|null $visibility Content visibility.
+	 *
+	 * @return \WP_Post|\WP_Error|false The created post, error, or false.
+	 */
+	private static function create_checkin_post( $data, $user_id, $visibility ) {
 		$location_name = self::get_location_name( $data['location'] ?? null );
 
 		$title = $location_name
@@ -58,11 +107,6 @@ class Arrive {
 			)
 			: \__( 'Check-in', 'activitypub' );
 
-		/*
-		 * Synthesize a Create-style activity for Posts::create().
-		 * Arrive is intransitive (no object), so we build a Note
-		 * from the activity-level content/summary.
-		 */
 		$activity = array(
 			'object' => array(
 				'type'    => 'Note',
@@ -73,40 +117,21 @@ class Arrive {
 			'cc'     => $data['cc'] ?? array(),
 		);
 
-		$post = Posts::create( $activity, $user_id, $visibility );
-
-		if ( \is_wp_error( $post ) ) {
-			return $post;
-		}
-
-		/**
-		 * Fires after an outgoing Arrive activity has created a post.
-		 *
-		 * @param int        $post_id    The created post ID.
-		 * @param array|null $location   The location data from the activity.
-		 * @param array      $data       The activity data.
-		 * @param int        $user_id    The user ID.
-		 */
-		\do_action( 'activitypub_outbox_arrive_sent', $post->ID, $data['location'] ?? null, $data, $user_id );
-
-		return $post;
+		return Posts::create( $activity, $user_id, $visibility );
 	}
 
 	/**
-	 * Save location geodata on the created post.
+	 * Save location geodata on a post.
 	 *
-	 * Hooked to `activitypub_outbox_arrive_sent`. Uses the standard
-	 * `geo_*` meta keys that the Post transformer reads back when
-	 * converting to ActivityPub Place objects.
+	 * Uses the standard `geo_*` meta keys that the Post transformer
+	 * reads back when converting to ActivityPub Place objects.
 	 *
 	 * @since unreleased
 	 *
 	 * @param int        $post_id  The post ID.
 	 * @param array|null $location The ActivityPub location data.
-	 * @param array      $data     The activity data.
-	 * @param int        $user_id  The user ID.
 	 */
-	public static function save_location( $post_id, $location, $data, $user_id ) {
+	private static function save_location( $post_id, $location ) {
 		if ( ! \is_array( $location ) ) {
 			return;
 		}

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -149,7 +149,7 @@ class Arrive {
 			'object' => array(
 				'type'    => 'Note',
 				'name'    => $title,
-				'content' => $data['content'] ?? self::get_summary( $data ),
+				'content' => $data['content'] ?? $data['summary'] ?? '',
 			),
 			'to'     => $data['to'] ?? array(),
 			'cc'     => $data['cc'] ?? array(),
@@ -200,28 +200,6 @@ class Arrive {
 		if ( ! empty( $location['name'] ) || ( isset( $location['latitude'] ) && isset( $location['longitude'] ) ) ) {
 			\update_post_meta( $post_id, 'geo_public', '1' );
 		}
-	}
-
-	/**
-	 * Extract the summary string from an Arrive activity.
-	 *
-	 * Supports both `summary` (string) and `summaryMap` (language map).
-	 *
-	 * @param array $data The activity data.
-	 *
-	 * @return string The summary text.
-	 */
-	private static function get_summary( $data ) {
-		if ( ! empty( $data['summary'] ) ) {
-			return $data['summary'];
-		}
-
-		if ( ! empty( $data['summaryMap'] ) && \is_array( $data['summaryMap'] ) ) {
-			$summary_map = $data['summaryMap'];
-			return (string) \reset( $summary_map );
-		}
-
-		return '';
 	}
 
 	/**

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -77,7 +77,17 @@ class Arrive {
 		// Create a local blog post as a side effect for on-site display.
 		$post = self::create_checkin_post( $data, $user_id, $visibility );
 
-		if ( $post && ! \is_wp_error( $post ) ) {
+		if ( \is_wp_error( $post ) ) {
+			\error_log(
+				\sprintf(
+					'[ActivityPub] Arrive: blog post creation failed for user %d: %s',
+					$user_id,
+					$post->get_error_message()
+				)
+			);
+		}
+
+		if ( $post instanceof \WP_Post ) {
 			self::save_location( $post->ID, $data['location'] ?? null );
 
 			/*

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -78,13 +78,7 @@ class Arrive {
 		$post = self::create_checkin_post( $data, $user_id, $visibility );
 
 		if ( \is_wp_error( $post ) ) {
-			\error_log(
-				\sprintf(
-					'[ActivityPub] Arrive: blog post creation failed for user %d: %s',
-					$user_id,
-					$post->get_error_message()
-				)
-			);
+			return $post;
 		}
 
 		if ( $post instanceof \WP_Post ) {

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -47,37 +47,13 @@ class Arrive {
 	 * @return int|\WP_Error|false The outbox post ID, error, or false.
 	 */
 	public static function handle_arrive( $data, $user_id = null, $visibility = null ) {
-		if ( ! is_activity_public( $data ) ) {
-			return false;
-		}
+		// Create a blog post for public check-ins so they appear on the site.
+		if ( is_activity_public( $data ) ) {
+			$post = self::create_checkin_post( $data, $user_id, $visibility );
 
-		// Create a local blog post as a side effect for on-site display.
-		$post = self::create_checkin_post( $data, $user_id, $visibility );
-
-		if ( \is_wp_error( $post ) ) {
-			return $post;
-		}
-
-		if ( $post instanceof \WP_Post ) {
-			self::save_location( $post->ID, $data['location'] ?? null );
-
-			/*
-			 * Add a link to the blog post so remote servers can find
-			 * the rendered check-in from the Arrive activity.
-			 */
-			$data['url'] = \get_permalink( $post );
-
-			/**
-			 * Fires after an Arrive activity has created a local blog post.
-			 *
-			 * @since unreleased
-			 *
-			 * @param int        $post_id  The created post ID.
-			 * @param array|null $location The location data from the activity.
-			 * @param array      $data     The activity data.
-			 * @param int        $user_id  The user ID.
-			 */
-			\do_action( 'activitypub_outbox_arrive_sent', $post->ID, $data['location'] ?? null, $data, $user_id );
+			if ( ! \is_wp_error( $post ) ) {
+				$data['url'] = \get_permalink( $post );
+			}
 		}
 
 		/*
@@ -101,11 +77,8 @@ class Arrive {
 	/**
 	 * Create a WordPress post from the Arrive activity.
 	 *
-	 * Synthesizes a Create-style payload from the intransitive
-	 * Arrive data so the check-in is visible on the blog.
-	 *
-	 * Temporarily suppresses the Post scheduler to prevent a
-	 * duplicate Create activity from being added to the outbox.
+	 * Creates a blog post with the check-in content and saves
+	 * location geodata so it can be displayed on the site.
 	 *
 	 * @since unreleased
 	 *
@@ -113,10 +86,11 @@ class Arrive {
 	 * @param int         $user_id    The user ID.
 	 * @param string|null $visibility Content visibility.
 	 *
-	 * @return \WP_Post|\WP_Error|false The created post, error, or false.
+	 * @return \WP_Post|\WP_Error The created post or error.
 	 */
 	private static function create_checkin_post( $data, $user_id, $visibility ) {
-		$location_name = self::get_location_name( $data['location'] ?? null );
+		$location      = $data['location'] ?? null;
+		$location_name = self::get_location_name( $location );
 
 		$title = $location_name
 			? sprintf(
@@ -136,7 +110,27 @@ class Arrive {
 			'cc'     => $data['cc'] ?? array(),
 		);
 
-		return Posts::create( $activity, $user_id, $visibility );
+		$post = Posts::create( $activity, $user_id, $visibility );
+
+		if ( \is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		self::save_location( $post->ID, $location );
+
+		/**
+		 * Fires after an Arrive activity has created a local blog post.
+		 *
+		 * @since unreleased
+		 *
+		 * @param int        $post_id  The created post ID.
+		 * @param array|null $location The location data from the activity.
+		 * @param array      $data     The activity data.
+		 * @param int        $user_id  The user ID.
+		 */
+		\do_action( 'activitypub_outbox_arrive_sent', $post->ID, $location, $data, $user_id );
+
+		return $post;
 	}
 
 	/**

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -25,28 +25,6 @@ class Arrive {
 	 */
 	public static function init() {
 		\add_filter( 'activitypub_outbox_arrive', array( self::class, 'handle_arrive' ), 10, 3 );
-		\add_filter( 'activitypub_outbox_activity_types', array( self::class, 'register_activity_type' ) );
-		\add_filter( 'rest_activitypub_outbox_activity_types', array( self::class, 'register_activity_type' ) );
-	}
-
-	/**
-	 * Add Arrive to the outbox activity type allowlists.
-	 *
-	 * Without this, Arrive activities would be excluded from
-	 * the public outbox collection and REST API responses.
-	 *
-	 * @since unreleased
-	 *
-	 * @param array $types The existing activity types.
-	 *
-	 * @return array The filtered activity types.
-	 */
-	public static function register_activity_type( $types ) {
-		if ( ! \in_array( 'Arrive', $types, true ) ) {
-			$types[] = 'Arrive';
-		}
-
-		return $types;
 	}
 
 	/**

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Outbox Arrive handler file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Handler\Outbox;
+
+use Activitypub\Collection\Posts;
+
+use function Activitypub\is_activity_public;
+
+/**
+ * Handle outgoing Arrive activities.
+ *
+ * @since unreleased
+ */
+class Arrive {
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 *
+	 * @since unreleased
+	 */
+	public static function init() {
+		\add_filter( 'activitypub_outbox_arrive', array( self::class, 'handle_arrive' ), 10, 3 );
+		\add_action( 'activitypub_outbox_arrive_sent', array( self::class, 'save_location' ), 10, 4 );
+	}
+
+	/**
+	 * Handle outgoing "Arrive" activities from local actors.
+	 *
+	 * Arrive is an intransitive activity indicating that the actor
+	 * has arrived at a location. Creates a WordPress post so the
+	 * check-in appears on the blog. Location geodata is saved via
+	 * the `activitypub_outbox_arrive_sent` action.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array       $data       The activity data array.
+	 * @param int         $user_id    The user ID.
+	 * @param string|null $visibility Content visibility.
+	 *
+	 * @return \WP_Post|\WP_Error|false The created post, error, or false.
+	 */
+	public static function handle_arrive( $data, $user_id = null, $visibility = null ) {
+		if ( ! is_activity_public( $data ) ) {
+			return false;
+		}
+
+		$location_name = self::get_location_name( $data['location'] ?? null );
+
+		$title = $location_name
+			? sprintf(
+				/* translators: %s: location name */
+				\__( 'Checked in at %s', 'activitypub' ),
+				$location_name
+			)
+			: \__( 'Check-in', 'activitypub' );
+
+		/*
+		 * Synthesize a Create-style activity for Posts::create().
+		 * Arrive is intransitive (no object), so we build a Note
+		 * from the activity-level content/summary.
+		 */
+		$activity = array(
+			'object' => array(
+				'type'    => 'Note',
+				'name'    => $title,
+				'content' => $data['content'] ?? self::get_summary( $data ),
+			),
+			'to'     => $data['to'] ?? array(),
+			'cc'     => $data['cc'] ?? array(),
+		);
+
+		$post = Posts::create( $activity, $user_id, $visibility );
+
+		if ( \is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		/**
+		 * Fires after an outgoing Arrive activity has created a post.
+		 *
+		 * @param int        $post_id    The created post ID.
+		 * @param array|null $location   The location data from the activity.
+		 * @param array      $data       The activity data.
+		 * @param int        $user_id    The user ID.
+		 */
+		\do_action( 'activitypub_outbox_arrive_sent', $post->ID, $data['location'] ?? null, $data, $user_id );
+
+		return $post;
+	}
+
+	/**
+	 * Save location geodata on the created post.
+	 *
+	 * Hooked to `activitypub_outbox_arrive_sent`. Uses the standard
+	 * `geo_*` meta keys that the Post transformer reads back when
+	 * converting to ActivityPub Place objects.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int        $post_id  The post ID.
+	 * @param array|null $location The ActivityPub location data.
+	 * @param array      $data     The activity data.
+	 * @param int        $user_id  The user ID.
+	 */
+	public static function save_location( $post_id, $location, $data, $user_id ) {
+		if ( ! \is_array( $location ) ) {
+			return;
+		}
+
+		if ( ! empty( $location['name'] ) ) {
+			\update_post_meta( $post_id, 'geo_address', \sanitize_text_field( $location['name'] ) );
+		}
+
+		if ( isset( $location['latitude'] ) && \is_numeric( $location['latitude'] ) ) {
+			\update_post_meta( $post_id, 'geo_latitude', (float) $location['latitude'] );
+		}
+
+		if ( isset( $location['longitude'] ) && \is_numeric( $location['longitude'] ) ) {
+			\update_post_meta( $post_id, 'geo_longitude', (float) $location['longitude'] );
+		}
+
+		if ( ! empty( $location['name'] ) || ( isset( $location['latitude'] ) && isset( $location['longitude'] ) ) ) {
+			\update_post_meta( $post_id, 'geo_public', '1' );
+		}
+	}
+
+	/**
+	 * Extract the summary string from an Arrive activity.
+	 *
+	 * Supports both `summary` (string) and `summaryMap` (language map).
+	 *
+	 * @param array $data The activity data.
+	 *
+	 * @return string The summary text.
+	 */
+	private static function get_summary( $data ) {
+		if ( ! empty( $data['summary'] ) ) {
+			return $data['summary'];
+		}
+
+		if ( ! empty( $data['summaryMap'] ) && \is_array( $data['summaryMap'] ) ) {
+			return \reset( $data['summaryMap'] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract a human-readable name from an ActivityPub location.
+	 *
+	 * @param mixed $location The location data (array or string).
+	 *
+	 * @return string|null The location name or null.
+	 */
+	private static function get_location_name( $location ) {
+		if ( \is_array( $location ) && ! empty( $location['name'] ) ) {
+			return \sanitize_text_field( $location['name'] );
+		}
+
+		if ( \is_string( $location ) && ! empty( $location ) ) {
+			return \sanitize_text_field( $location );
+		}
+
+		return null;
+	}
+}

--- a/includes/handler/outbox/class-arrive.php
+++ b/includes/handler/outbox/class-arrive.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Handler\Outbox;
 
 use Activitypub\Collection\Posts;
+use Activitypub\Scheduler\Post;
 
 use function Activitypub\add_to_outbox;
 use function Activitypub\is_activity_public;
@@ -25,6 +26,28 @@ class Arrive {
 	 */
 	public static function init() {
 		\add_filter( 'activitypub_outbox_arrive', array( self::class, 'handle_arrive' ), 10, 3 );
+		\add_filter( 'activitypub_outbox_activity_types', array( self::class, 'register_activity_type' ) );
+		\add_filter( 'rest_activitypub_outbox_activity_types', array( self::class, 'register_activity_type' ) );
+	}
+
+	/**
+	 * Add Arrive to the outbox activity type allowlists.
+	 *
+	 * Without this, Arrive activities would be excluded from
+	 * the public outbox collection and REST API responses.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $types The existing activity types.
+	 *
+	 * @return array The filtered activity types.
+	 */
+	public static function register_activity_type( $types ) {
+		if ( ! \in_array( 'Arrive', $types, true ) ) {
+			$types[] = 'Arrive';
+		}
+
+		return $types;
 	}
 
 	/**
@@ -62,6 +85,18 @@ class Arrive {
 			 * the rendered check-in from the Arrive activity.
 			 */
 			$data['url'] = \get_permalink( $post );
+
+			/**
+			 * Fires after an Arrive activity has created a local blog post.
+			 *
+			 * @since unreleased
+			 *
+			 * @param int        $post_id  The created post ID.
+			 * @param array|null $location The location data from the activity.
+			 * @param array      $data     The activity data.
+			 * @param int        $user_id  The user ID.
+			 */
+			\do_action( 'activitypub_outbox_arrive_sent', $post->ID, $data['location'] ?? null, $data, $user_id );
 		}
 
 		/*
@@ -87,6 +122,9 @@ class Arrive {
 	 *
 	 * Synthesizes a Create-style payload from the intransitive
 	 * Arrive data so the check-in is visible on the blog.
+	 *
+	 * Temporarily suppresses the Post scheduler to prevent a
+	 * duplicate Create activity from being added to the outbox.
 	 *
 	 * @since unreleased
 	 *
@@ -117,7 +155,18 @@ class Arrive {
 			'cc'     => $data['cc'] ?? array(),
 		);
 
-		return Posts::create( $activity, $user_id, $visibility );
+		/*
+		 * Suppress the Post scheduler so wp_insert_post() does not
+		 * trigger a separate Create activity for the blog post.
+		 * Only the Arrive activity should be federated.
+		 */
+		\remove_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33 );
+
+		$post = Posts::create( $activity, $user_id, $visibility );
+
+		\add_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33, 4 );
+
+		return $post;
 	}
 
 	/**
@@ -168,7 +217,8 @@ class Arrive {
 		}
 
 		if ( ! empty( $data['summaryMap'] ) && \is_array( $data['summaryMap'] ) ) {
-			return \reset( $data['summaryMap'] );
+			$summary_map = $data['summaryMap'];
+			return (string) \reset( $summary_map );
 		}
 
 		return '';

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -254,7 +254,7 @@ class Client {
 					'_activitypub_client_id'          => $client_id,
 					'_activitypub_client_secret_hash' => '', // Public client.
 					'_activitypub_redirect_uris'      => array_map( array( Sanitize::class, 'redirect_uri' ), $redirect_uris ),
-					'_activitypub_allowed_scopes'     => Scope::DEFAULT_SCOPES,
+					'_activitypub_allowed_scopes'     => Scope::ALL,
 					'_activitypub_is_public'          => true,
 					'_activitypub_discovered'         => true,
 					'_activitypub_logo_uri'           => ! empty( $metadata['logo_uri'] ) ? \sanitize_url( $metadata['logo_uri'] ) : '',

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -149,7 +149,19 @@ class Client {
 		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 
 		if ( ! empty( $posts ) ) {
-			return new self( $posts[0]->ID );
+			$client = new self( $posts[0]->ID );
+
+			/*
+			 * Re-discover stale auto-discovered clients that have no redirect URIs.
+			 * This can happen when a previous discovery failed to parse the metadata
+			 * correctly (e.g. before ActivityStreams vocabulary support was added).
+			 */
+			if ( $client->is_discovered() && empty( $client->get_redirect_uris() ) && \filter_var( $client_id, FILTER_VALIDATE_URL ) ) {
+				\wp_delete_post( $posts[0]->ID, true );
+				return self::discover_and_register( $client_id );
+			}
+
+			return $client;
 		}
 
 		// If client_id is a URL, try auto-discovery.

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -357,38 +357,40 @@ class Client {
 		}
 
 		/*
-		 * ActivityPub actor format fields (Application, Person, Service, etc.).
+		 * ActivityStreams vocabulary fallbacks.
 		 *
-		 * Only used as fallback when the document doesn't contain CIMD fields.
-		 * If a client_id is already set from CIMD data, skip actor conversion
-		 * to prevent mixup/impersonation attacks.
+		 * Client ID Metadata Documents may use ActivityStreams context
+		 * (e.g. "id" instead of "client_id", "name" instead of "client_name",
+		 * "redirectURI" instead of "redirect_uris"). These are used as
+		 * fallbacks when the CIMD-specific fields are not present.
 		 */
-		$actor_types = array( 'Application', 'Person', 'Service', 'Group', 'Organization' );
-		if ( ! empty( $data['type'] ) && in_array( $data['type'], $actor_types, true ) && empty( $metadata['client_id'] ) ) {
-			if ( ! empty( $data['id'] ) ) {
-				$metadata['client_id'] = $data['id'];
-			}
+		if ( empty( $metadata['client_id'] ) && ! empty( $data['id'] ) ) {
+			$metadata['client_id'] = $data['id'];
+		}
+		if ( empty( $metadata['client_name'] ) ) {
 			if ( ! empty( $data['name'] ) ) {
 				$metadata['client_name'] = $data['name'];
 			} elseif ( ! empty( $data['preferredUsername'] ) ) {
 				$metadata['client_name'] = $data['preferredUsername'];
 			}
-			// Handle redirectURI (singular) as used by ap CLI.
-			if ( ! empty( $data['redirectURI'] ) ) {
-				$metadata['redirect_uris'] = (array) $data['redirectURI'];
+		}
+		if ( empty( $metadata['redirect_uris'] ) && ! empty( $data['redirectURI'] ) ) {
+			$metadata['redirect_uris'] = (array) $data['redirectURI'];
+		}
+		if ( empty( $metadata['logo_uri'] ) && ! empty( $data['icon'] ) ) {
+			if ( is_string( $data['icon'] ) ) {
+				$metadata['logo_uri'] = $data['icon'];
+			} elseif ( is_array( $data['icon'] ) && ! empty( $data['icon']['url'] ) ) {
+				$metadata['logo_uri'] = $data['icon']['url'];
 			}
-			// Handle icon object.
-			if ( ! empty( $data['icon'] ) ) {
-				if ( is_string( $data['icon'] ) ) {
-					$metadata['logo_uri'] = $data['icon'];
-				} elseif ( is_array( $data['icon'] ) && ! empty( $data['icon']['url'] ) ) {
-					$metadata['logo_uri'] = $data['icon']['url'];
-				}
-			}
-			if ( ! empty( $data['url'] ) ) {
-				$metadata['client_uri'] = is_array( $data['url'] ) ? $data['url'][0] : $data['url'];
-			}
-			// Mark as actor-based client for lenient redirect validation.
+		}
+		if ( empty( $metadata['client_uri'] ) && ! empty( $data['url'] ) ) {
+			$metadata['client_uri'] = is_array( $data['url'] ) ? $data['url'][0] : $data['url'];
+		}
+
+		// Mark ActivityPub actor-typed clients for lenient redirect validation.
+		$actor_types = array( 'Application', 'Person', 'Service', 'Group', 'Organization' );
+		if ( ! empty( $data['type'] ) && in_array( $data['type'], $actor_types, true ) ) {
 			$metadata['is_actor'] = true;
 		}
 

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -461,18 +461,9 @@ class Outbox_Controller extends \WP_REST_Controller {
 		$object_id = get_object_id( $result );
 
 		if ( $object_id ) {
-			/*
-			 * Handler returned a WP_Post or WP_Comment; look up its outbox entry.
-			 * Fall back to Create if the specific type isn't found, because the
-			 * Post scheduler wraps new posts in Create activities regardless of
-			 * the original C2S activity type (e.g. Arrive → Create).
-			 */
+			// Handler returned a WP_Post or WP_Comment; look up its outbox entry.
 			$activity_type = \ucfirst( $data['type'] ?? 'Create' );
 			$outbox_item   = Outbox::get_by_object_id( $object_id, $activity_type );
-
-			if ( ! $outbox_item && 'Create' !== $activity_type ) {
-				$outbox_item = Outbox::get_by_object_id( $object_id, 'Create' );
-			}
 		} elseif ( \is_int( $result ) && $result > 0 ) {
 			// Handler returned an outbox post ID directly.
 			$outbox_item = \get_post( $result );

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -28,6 +28,9 @@ use function Activitypub\object_to_uri;
  */
 class Outbox_Controller extends \WP_REST_Controller {
 	use Collection;
+	use Event_Stream;
+	use Language_Map;
+	use Verification;
 
 	/**
 	 * Activity types accessible as individual outbox items via REST.
@@ -35,10 +38,6 @@ class Outbox_Controller extends \WP_REST_Controller {
 	 * @var string[]
 	 */
 	const PUBLIC_ACTIVITY_TYPES = array( 'Announce', 'Arrive', 'Create', 'Like', 'Update' );
-
-	use Event_Stream;
-	use Language_Map;
-	use Verification;
 
 	/**
 	 * The namespace of this controller's route.

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -29,6 +29,7 @@ use function Activitypub\object_to_uri;
 class Outbox_Controller extends \WP_REST_Controller {
 	use Collection;
 	use Event_Stream;
+	use Language_Map;
 	use Verification;
 
 	/**
@@ -413,6 +414,9 @@ class Outbox_Controller extends \WP_REST_Controller {
 		if ( ! $is_activity ) {
 			$data = $this->wrap_in_create( $data, $user );
 		}
+
+		// Resolve language maps (summaryMap, contentMap, nameMap) to plain strings.
+		$data = $this->localize_language_maps( $data );
 
 		// Default to public addressing if client omits recipients.
 		$data = $this->ensure_addressing( $data, $user );

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -28,6 +28,14 @@ use function Activitypub\object_to_uri;
  */
 class Outbox_Controller extends \WP_REST_Controller {
 	use Collection;
+
+	/**
+	 * Activity types accessible as individual outbox items via REST.
+	 *
+	 * @var string[]
+	 */
+	const PUBLIC_ACTIVITY_TYPES = array( 'Announce', 'Arrive', 'Create', 'Like', 'Update' );
+
 	use Event_Stream;
 	use Language_Map;
 	use Verification;
@@ -149,11 +157,11 @@ class Outbox_Controller extends \WP_REST_Controller {
 		\do_action( 'activitypub_rest_outbox_pre', $request );
 
 		/**
-		 * Filters the list of activity types to include in the outbox.
+		 * Filters the activity types included in the outbox collection.
 		 *
-		 * @param string[] $activity_types The list of activity types.
+		 * @param string[] $activity_types The activity types.
 		 */
-		$activity_types = \apply_filters( 'activitypub_outbox_activity_types', array( 'Announce', 'Arrive', 'Create', 'Like', 'Update' ) );
+		$activity_types = \apply_filters( 'activitypub_outbox_activity_types', self::PUBLIC_ACTIVITY_TYPES );
 
 		$args = array(
 			'posts_per_page' => $request->get_param( 'per_page' ),

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -153,7 +153,7 @@ class Outbox_Controller extends \WP_REST_Controller {
 		 *
 		 * @param string[] $activity_types The list of activity types.
 		 */
-		$activity_types = \apply_filters( 'activitypub_outbox_activity_types', array( 'Announce', 'Create', 'Like', 'Update' ) );
+		$activity_types = \apply_filters( 'activitypub_outbox_activity_types', array( 'Announce', 'Arrive', 'Create', 'Like', 'Update' ) );
 
 		$args = array(
 			'posts_per_page' => $request->get_param( 'per_page' ),

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -461,9 +461,18 @@ class Outbox_Controller extends \WP_REST_Controller {
 		$object_id = get_object_id( $result );
 
 		if ( $object_id ) {
-			// Handler returned a WP_Post or WP_Comment; look up its outbox entry.
+			/*
+			 * Handler returned a WP_Post or WP_Comment; look up its outbox entry.
+			 * Fall back to Create if the specific type isn't found, because the
+			 * Post scheduler wraps new posts in Create activities regardless of
+			 * the original C2S activity type (e.g. Arrive → Create).
+			 */
 			$activity_type = \ucfirst( $data['type'] ?? 'Create' );
 			$outbox_item   = Outbox::get_by_object_id( $object_id, $activity_type );
+
+			if ( ! $outbox_item && 'Create' !== $activity_type ) {
+				$outbox_item = Outbox::get_by_object_id( $object_id, 'Create' );
+			}
 		} elseif ( \is_int( $result ) && $result > 0 ) {
 			// Handler returned an outbox post ID directly.
 			$outbox_item = \get_post( $result );

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-arrive.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-arrive.php
@@ -213,11 +213,13 @@ class Test_Arrive extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test Arrive with non-public activity returns false.
+	 * Test Arrive with non-public activity still creates outbox entry but no blog post.
 	 *
 	 * @covers ::handle_arrive
 	 */
-	public function test_arrive_non_public_returns_false() {
+	public function test_arrive_non_public_creates_outbox_but_no_post() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
 		$data = array(
 			'type'     => 'Arrive',
 			'actor'    => 'https://example.com/users/test',
@@ -226,9 +228,23 @@ class Test_Arrive extends \WP_UnitTestCase {
 			'to'       => array( 'https://example.com/users/friend' ),
 		);
 
-		$result = Arrive::handle_arrive( $data, 1 );
+		$result = Arrive::handle_arrive( $data, $user_id );
 
-		$this->assertFalse( $result );
+		$this->assertIsInt( $result, 'Non-public Arrive should still create an outbox entry.' );
+		$this->assertGreaterThan( 0, $result );
+
+		// No blog post should be created for non-public activities.
+		$posts = \get_posts(
+			array(
+				'author'         => $user_id,
+				'posts_per_page' => 1,
+				'orderby'        => 'ID',
+				'order'          => 'DESC',
+				'post_type'      => 'post',
+			)
+		);
+
+		$this->assertEmpty( $posts, 'Non-public Arrive should not create a blog post.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-arrive.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-arrive.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Test file for Outbox Arrive Handler.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Handler\Outbox;
+
+use Activitypub\Handler\Outbox\Arrive;
+use Activitypub\Scheduler\Post;
+
+/**
+ * Test class for Outbox Arrive Handler.
+ *
+ * @coversDefaultClass \Activitypub\Handler\Outbox\Arrive
+ */
+class Test_Arrive extends \WP_UnitTestCase {
+
+	/**
+	 * Test Arrive creates a blog post and returns an outbox ID.
+	 *
+	 * @covers ::handle_arrive
+	 */
+	public function test_arrive_creates_post_and_returns_outbox_id() {
+		\remove_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33 );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$data = array(
+			'type'     => 'Arrive',
+			'actor'    => 'https://example.com/users/test',
+			'location' => array(
+				'type'      => 'Place',
+				'name'      => 'Berlin',
+				'latitude'  => 52.52,
+				'longitude' => 13.405,
+			),
+			'content'  => 'Just arrived!',
+			'to'       => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'       => array( 'https://example.com/users/test/followers' ),
+		);
+
+		$result = Arrive::handle_arrive( $data, $user_id );
+
+		$this->assertIsInt( $result, 'Handler should return an outbox post ID.' );
+		$this->assertGreaterThan( 0, $result );
+
+		\add_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33, 4 );
+	}
+
+	/**
+	 * Test Arrive saves location geodata on the blog post.
+	 *
+	 * @covers ::handle_arrive
+	 */
+	public function test_arrive_saves_geodata() {
+		\remove_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33 );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$data = array(
+			'type'     => 'Arrive',
+			'actor'    => 'https://example.com/users/test',
+			'location' => array(
+				'type'      => 'Place',
+				'name'      => 'Ettlingen',
+				'latitude'  => 48.9408,
+				'longitude' => 8.4075,
+			),
+			'content'  => 'Checked in.',
+			'to'       => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+		);
+
+		Arrive::handle_arrive( $data, $user_id );
+
+		// Find the most recent post by this user.
+		$posts = \get_posts(
+			array(
+				'author'         => $user_id,
+				'posts_per_page' => 1,
+				'orderby'        => 'ID',
+				'order'          => 'DESC',
+			)
+		);
+
+		$this->assertNotEmpty( $posts, 'A blog post should be created.' );
+
+		$post_id = $posts[0]->ID;
+
+		$this->assertSame( 'Ettlingen', \get_post_meta( $post_id, 'geo_address', true ) );
+		$this->assertEquals( 48.9408, (float) \get_post_meta( $post_id, 'geo_latitude', true ) );
+		$this->assertEquals( 8.4075, (float) \get_post_meta( $post_id, 'geo_longitude', true ) );
+		$this->assertSame( '1', \get_post_meta( $post_id, 'geo_public', true ) );
+
+		\add_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33, 4 );
+	}
+
+	/**
+	 * Test Arrive with name-only location (no coordinates).
+	 *
+	 * @covers ::handle_arrive
+	 */
+	public function test_arrive_with_name_only_location() {
+		\remove_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33 );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$data = array(
+			'type'     => 'Arrive',
+			'actor'    => 'https://example.com/users/test',
+			'location' => array(
+				'id'   => 'https://places.pub/relation/123',
+				'name' => 'Karlsruhe',
+			),
+			'content'  => 'Hello!',
+			'to'       => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+		);
+
+		Arrive::handle_arrive( $data, $user_id );
+
+		$posts = \get_posts(
+			array(
+				'author'         => $user_id,
+				'posts_per_page' => 1,
+				'orderby'        => 'ID',
+				'order'          => 'DESC',
+			)
+		);
+
+		$this->assertNotEmpty( $posts );
+
+		$post_id = $posts[0]->ID;
+
+		$this->assertSame( 'Karlsruhe', \get_post_meta( $post_id, 'geo_address', true ) );
+		$this->assertEmpty( \get_post_meta( $post_id, 'geo_latitude', true ) );
+		$this->assertEmpty( \get_post_meta( $post_id, 'geo_longitude', true ) );
+		$this->assertSame( '1', \get_post_meta( $post_id, 'geo_public', true ) );
+
+		\add_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33, 4 );
+	}
+
+	/**
+	 * Test Arrive without location still creates a post.
+	 *
+	 * @covers ::handle_arrive
+	 */
+	public function test_arrive_without_location() {
+		\remove_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33 );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$data = array(
+			'type'    => 'Arrive',
+			'actor'   => 'https://example.com/users/test',
+			'content' => 'Somewhere!',
+			'to'      => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+		);
+
+		$result = Arrive::handle_arrive( $data, $user_id );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$posts = \get_posts(
+			array(
+				'author'         => $user_id,
+				'posts_per_page' => 1,
+				'orderby'        => 'ID',
+				'order'          => 'DESC',
+			)
+		);
+
+		$this->assertNotEmpty( $posts );
+		$this->assertStringContainsString( 'Check-in', $posts[0]->post_title );
+
+		\add_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33, 4 );
+	}
+
+	/**
+	 * Test Arrive uses summary when content is missing.
+	 *
+	 * @covers ::handle_arrive
+	 */
+	public function test_arrive_uses_summary_fallback() {
+		\remove_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33 );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$data = array(
+			'type'       => 'Arrive',
+			'actor'      => 'https://example.com/users/test',
+			'location'   => array( 'name' => 'Munich' ),
+			'summaryMap' => array( 'en' => 'Arrived at Munich' ),
+			'to'         => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+		);
+
+		Arrive::handle_arrive( $data, $user_id );
+
+		$posts = \get_posts(
+			array(
+				'author'         => $user_id,
+				'posts_per_page' => 1,
+				'orderby'        => 'ID',
+				'order'          => 'DESC',
+			)
+		);
+
+		$this->assertNotEmpty( $posts );
+		$this->assertStringContainsString( 'Arrived at Munich', $posts[0]->post_content );
+
+		\add_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33, 4 );
+	}
+
+	/**
+	 * Test Arrive with non-public activity returns false.
+	 *
+	 * @covers ::handle_arrive
+	 */
+	public function test_arrive_non_public_returns_false() {
+		$data = array(
+			'type'     => 'Arrive',
+			'actor'    => 'https://example.com/users/test',
+			'location' => array( 'name' => 'Secret Place' ),
+			'content'  => 'Private check-in.',
+			'to'       => array( 'https://example.com/users/friend' ),
+		);
+
+		$result = Arrive::handle_arrive( $data, 1 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test Arrive sets status post format on the blog post.
+	 *
+	 * @covers ::handle_arrive
+	 */
+	public function test_arrive_sets_status_post_format() {
+		\remove_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33 );
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$data = array(
+			'type'     => 'Arrive',
+			'actor'    => 'https://example.com/users/test',
+			'location' => array( 'name' => 'Hamburg' ),
+			'content'  => 'Arrived.',
+			'to'       => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+		);
+
+		Arrive::handle_arrive( $data, $user_id );
+
+		$posts = \get_posts(
+			array(
+				'author'         => $user_id,
+				'posts_per_page' => 1,
+				'orderby'        => 'ID',
+				'order'          => 'DESC',
+			)
+		);
+
+		$this->assertNotEmpty( $posts );
+		$this->assertSame( 'status', \get_post_format( $posts[0]->ID ) );
+
+		\add_action( 'wp_after_insert_post', array( Post::class, 'triage' ), 33, 4 );
+	}
+}

--- a/tests/phpunit/tests/includes/handler/outbox/class-test-arrive.php
+++ b/tests/phpunit/tests/includes/handler/outbox/class-test-arrive.php
@@ -188,11 +188,11 @@ class Test_Arrive extends \WP_UnitTestCase {
 		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 
 		$data = array(
-			'type'       => 'Arrive',
-			'actor'      => 'https://example.com/users/test',
-			'location'   => array( 'name' => 'Munich' ),
-			'summaryMap' => array( 'en' => 'Arrived at Munich' ),
-			'to'         => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'type'     => 'Arrive',
+			'actor'    => 'https://example.com/users/test',
+			'location' => array( 'name' => 'Munich' ),
+			'summary'  => 'Arrived at Munich',
+			'to'       => array( 'https://www.w3.org/ns/activitystreams#Public' ),
 		);
 
 		Arrive::handle_arrive( $data, $user_id );

--- a/tests/phpunit/tests/includes/oauth/class-test-client.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-client.php
@@ -665,4 +665,113 @@ class Test_Client extends \WP_UnitTestCase {
 
 		$this->assertEquals( $result['client_id'], $client->get_client_id() );
 	}
+
+	/**
+	 * Test normalize_client_metadata with CIMD format.
+	 *
+	 * @covers ::normalize_client_metadata
+	 */
+	public function test_normalize_client_metadata_cimd_format() {
+		$data = array(
+			'client_id'     => 'https://example.com/client',
+			'client_name'   => 'CIMD Client',
+			'redirect_uris' => array( 'https://example.com/callback' ),
+			'logo_uri'      => 'https://example.com/logo.png',
+			'client_uri'    => 'https://example.com/',
+		);
+
+		$metadata = $this->call_normalize_client_metadata( $data );
+
+		$this->assertEquals( 'https://example.com/client', $metadata['client_id'] );
+		$this->assertEquals( 'CIMD Client', $metadata['client_name'] );
+		$this->assertEquals( array( 'https://example.com/callback' ), $metadata['redirect_uris'] );
+		$this->assertEquals( 'https://example.com/logo.png', $metadata['logo_uri'] );
+		$this->assertEquals( 'https://example.com/', $metadata['client_uri'] );
+		$this->assertArrayNotHasKey( 'is_actor', $metadata );
+	}
+
+	/**
+	 * Test normalize_client_metadata with ActivityStreams vocabulary (no type).
+	 *
+	 * Client ID Metadata Documents may use ActivityStreams context with
+	 * fields like "id", "name", and "redirectURI" instead of CIMD fields.
+	 *
+	 * @covers ::normalize_client_metadata
+	 */
+	public function test_normalize_client_metadata_activitystreams_vocabulary() {
+		$data = array(
+			'id'          => 'https://checkin.example.com/client.jsonld',
+			'name'        => 'Checkin Sample App',
+			'summary'     => 'A sample client for geosocial activities',
+			'redirectURI' => 'https://checkin.example.com/',
+		);
+
+		$metadata = $this->call_normalize_client_metadata( $data );
+
+		$this->assertEquals( 'https://checkin.example.com/client.jsonld', $metadata['client_id'] );
+		$this->assertEquals( 'Checkin Sample App', $metadata['client_name'] );
+		$this->assertEquals( array( 'https://checkin.example.com/' ), $metadata['redirect_uris'] );
+		$this->assertArrayNotHasKey( 'is_actor', $metadata );
+	}
+
+	/**
+	 * Test normalize_client_metadata with ActivityPub actor format.
+	 *
+	 * @covers ::normalize_client_metadata
+	 */
+	public function test_normalize_client_metadata_actor_format() {
+		$data = array(
+			'type'              => 'Application',
+			'id'                => 'https://app.example.com/actor',
+			'name'              => 'AP App',
+			'preferredUsername' => 'app',
+			'redirectURI'       => 'https://app.example.com/callback',
+			'icon'              => array( 'url' => 'https://app.example.com/icon.png' ),
+			'url'               => 'https://app.example.com/',
+		);
+
+		$metadata = $this->call_normalize_client_metadata( $data );
+
+		$this->assertEquals( 'https://app.example.com/actor', $metadata['client_id'] );
+		$this->assertEquals( 'AP App', $metadata['client_name'] );
+		$this->assertEquals( array( 'https://app.example.com/callback' ), $metadata['redirect_uris'] );
+		$this->assertEquals( 'https://app.example.com/icon.png', $metadata['logo_uri'] );
+		$this->assertEquals( 'https://app.example.com/', $metadata['client_uri'] );
+		$this->assertTrue( $metadata['is_actor'] );
+	}
+
+	/**
+	 * Test CIMD fields take precedence over ActivityStreams fields.
+	 *
+	 * @covers ::normalize_client_metadata
+	 */
+	public function test_normalize_client_metadata_cimd_takes_precedence() {
+		$data = array(
+			'client_id'     => 'https://example.com/cimd-client',
+			'client_name'   => 'CIMD Name',
+			'redirect_uris' => array( 'https://example.com/cimd-callback' ),
+			'id'            => 'https://example.com/as-id',
+			'name'          => 'AS Name',
+			'redirectURI'   => 'https://example.com/as-callback',
+		);
+
+		$metadata = $this->call_normalize_client_metadata( $data );
+
+		$this->assertEquals( 'https://example.com/cimd-client', $metadata['client_id'] );
+		$this->assertEquals( 'CIMD Name', $metadata['client_name'] );
+		$this->assertEquals( array( 'https://example.com/cimd-callback' ), $metadata['redirect_uris'] );
+	}
+
+	/**
+	 * Helper to call the private normalize_client_metadata method.
+	 *
+	 * @param array $data The raw metadata.
+	 * @return array Normalized metadata.
+	 */
+	private function call_normalize_client_metadata( $data ) {
+		$method = new \ReflectionMethod( Client::class, 'normalize_client_metadata' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $data );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
@@ -897,4 +897,110 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 		$this->assertEmpty( \get_post_meta( $post_id, 'geo_longitude', true ), 'No longitude when not provided.' );
 		$this->assertSame( '1', \get_post_meta( $post_id, 'geo_public', true ), 'geo_public set when name is present.' );
 	}
+
+	/**
+	 * Test C2S POST with exact checkin.swf.pub payload.
+	 *
+	 * The checkin app sends inline actor objects, string to/cc,
+	 * summaryMap without summary, and content. This test verifies
+	 * that Posts::create receives all required fields after the
+	 * outbox controller transforms the data.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_c2s_arrive_with_checkin_app_payload() {
+		$user = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
+
+		$data = array(
+			'@context'   => 'https://www.w3.org/ns/activitystreams',
+			'actor'      => array(
+				'id'   => $user->get_id(),
+				'name' => $user->get_name(),
+				'url'  => $user->get_url(),
+			),
+			'type'       => 'Arrive',
+			'location'   => array(
+				'id'   => 'https://places.pub/relation/659839',
+				'name' => 'Ettlingen',
+				'url'  => 'https://places.pub/relation/659839',
+			),
+			'content'    => 'Great coffee here!',
+			'to'         => 'https://www.w3.org/ns/activitystreams#Public',
+			'cc'         => $user->get_followers(),
+			'summaryMap' => array(
+				'en' => $user->get_name() . ' arrived at Ettlingen',
+			),
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . self::$user_id . '/outbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $data ) );
+
+		\wp_set_current_user( self::$user_id );
+
+		$response = \rest_get_server()->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status(), 'Outbox POST should return 201.' );
+
+		$response_data = $response->get_data();
+		$this->assertSame( 'Arrive', $response_data['type'] );
+		$this->assertArrayHasKey( 'url', $response_data, 'Arrive should have a url pointing to the blog post.' );
+
+		// Blog post should exist with correct content.
+		$post_id = \url_to_postid( $response_data['url'] );
+		$this->assertGreaterThan( 0, $post_id, 'Blog post should be created.' );
+
+		$post = \get_post( $post_id );
+		$this->assertStringContainsString( 'Ettlingen', $post->post_title );
+		$this->assertNotEmpty( $post->post_content, 'Post content should not be empty.' );
+		$this->assertSame( 'status', \get_post_format( $post_id ) );
+
+		// Geodata should be saved.
+		$this->assertSame( 'Ettlingen', \get_post_meta( $post_id, 'geo_address', true ) );
+		$this->assertSame( '1', \get_post_meta( $post_id, 'geo_public', true ) );
+	}
+
+	/**
+	 * Test C2S POST with Arrive without content uses summary fallback.
+	 *
+	 * When the checkin app omits content but provides summaryMap,
+	 * the localized summary should be used as post content.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_c2s_arrive_without_content_uses_summary() {
+		$user = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
+
+		$data = array(
+			'@context'   => 'https://www.w3.org/ns/activitystreams',
+			'type'       => 'Arrive',
+			'actor'      => $user->get_id(),
+			'location'   => array(
+				'id'   => 'https://places.pub/relation/123',
+				'name' => 'Berlin',
+			),
+			'summaryMap' => array(
+				'en' => $user->get_name() . ' arrived at Berlin',
+			),
+			'to'         => 'https://www.w3.org/ns/activitystreams#Public',
+			'cc'         => $user->get_followers(),
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . self::$user_id . '/outbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $data ) );
+
+		\wp_set_current_user( self::$user_id );
+
+		$response = \rest_get_server()->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$post_id       = \url_to_postid( $response_data['url'] );
+		$this->assertGreaterThan( 0, $post_id, 'Blog post should be created even without content.' );
+
+		$post = \get_post( $post_id );
+		$this->assertStringContainsString( 'Berlin', $post->post_title );
+		// The summary should be used as content fallback.
+		$this->assertNotEmpty( $post->post_content, 'Post should have content from summary fallback.' );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
@@ -831,12 +831,12 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 		$this->assertEquals( 201, $response->get_status() );
 
 		$response_data = $response->get_data();
-		$this->assertSame( 'Create', $response_data['type'] );
+		$this->assertSame( 'Arrive', $response_data['type'], 'Activity type should be preserved as Arrive.' );
+		$this->assertArrayHasKey( 'url', $response_data, 'Arrive should include a url to the blog post.' );
 
-		// Find the created post from the response object ID.
-		$object  = $response_data['object'];
-		$post_id = \url_to_postid( $object['id'] );
-		$this->assertGreaterThan( 0, $post_id, 'Arrive should create a WordPress post.' );
+		// Find the blog post created as a side effect.
+		$post_id = \url_to_postid( $response_data['url'] );
+		$this->assertGreaterThan( 0, $post_id, 'Arrive should create a WordPress post as side effect.' );
 
 		$this->assertSame( 'status', \get_post_format( $post_id ), 'Arrive post should have status format.' );
 		$this->assertStringContainsString( 'Ettlingen', \get_the_title( $post_id ), 'Post title should contain location name.' );
@@ -884,10 +884,12 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 		$response = \rest_get_server()->dispatch( $request );
 		$this->assertEquals( 201, $response->get_status() );
 
-		// Find the created post from the response object ID.
+		// Find the blog post created as a side effect.
 		$response_data = $response->get_data();
-		$post_id       = \url_to_postid( $response_data['object']['id'] );
-		$this->assertGreaterThan( 0, $post_id, 'Arrive should create a WordPress post.' );
+		$this->assertSame( 'Arrive', $response_data['type'], 'Activity type should be preserved as Arrive.' );
+
+		$post_id = \url_to_postid( $response_data['url'] );
+		$this->assertGreaterThan( 0, $post_id, 'Arrive should create a WordPress post as side effect.' );
 
 		// Verify geodata - address saved but no coordinates.
 		$this->assertSame( 'Ettlingen', \get_post_meta( $post_id, 'geo_address', true ) );

--- a/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
@@ -791,14 +791,14 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 * Test C2S POST with an intransitive activity and object actor payload.
+	 * Test C2S POST with an Arrive activity creates a WordPress post.
 	 *
-	 * Ensures activities like Arrive do not trigger object-ID resolution errors
-	 * when the actor is provided as an object and no explicit object is present.
+	 * Ensures the Arrive handler creates a check-in post with location
+	 * geodata and stores the activity in the outbox.
 	 *
 	 * @covers ::create_item
 	 */
-	public function test_c2s_arrive_with_actor_object() {
+	public function test_c2s_arrive_creates_post_with_geodata() {
 		$user = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
 
 		$data = array(
@@ -810,8 +810,11 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 				'url'  => $user->get_url(),
 			),
 			'location' => array(
-				'id'   => 'https://places.pub/relation/659839',
-				'name' => 'Ettlingen',
+				'type'      => 'Place',
+				'id'        => 'https://places.pub/relation/659839',
+				'name'      => 'Ettlingen',
+				'latitude'  => 48.9408,
+				'longitude' => 8.4075,
 			),
 			'content'  => 'Arrived.',
 			'to'       => 'https://www.w3.org/ns/activitystreams#Public',
@@ -828,27 +831,68 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 		$this->assertEquals( 201, $response->get_status() );
 
 		$response_data = $response->get_data();
-		$this->assertSame( 'Arrive', $response_data['type'] );
+		$this->assertSame( 'Create', $response_data['type'] );
 
-		$outbox_items = \get_posts(
-			array(
-				'post_type'      => Outbox::POST_TYPE,
-				'post_status'    => 'any',
-				'author'         => self::$user_id,
-				'posts_per_page' => 1,
-				'orderby'        => 'ID',
-				'order'          => 'DESC',
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				'meta_query'     => array(
-					array(
-						'key'   => '_activitypub_activity_type',
-						'value' => 'Arrive',
-					),
-				),
-			)
+		// Find the created post from the response object ID.
+		$object  = $response_data['object'];
+		$post_id = \url_to_postid( $object['id'] );
+		$this->assertGreaterThan( 0, $post_id, 'Arrive should create a WordPress post.' );
+
+		$this->assertSame( 'status', \get_post_format( $post_id ), 'Arrive post should have status format.' );
+		$this->assertStringContainsString( 'Ettlingen', \get_the_title( $post_id ), 'Post title should contain location name.' );
+
+		// Verify geodata meta.
+		$this->assertSame( 'Ettlingen', \get_post_meta( $post_id, 'geo_address', true ) );
+		$this->assertEquals( 48.9408, (float) \get_post_meta( $post_id, 'geo_latitude', true ) );
+		$this->assertEquals( 8.4075, (float) \get_post_meta( $post_id, 'geo_longitude', true ) );
+		$this->assertSame( '1', \get_post_meta( $post_id, 'geo_public', true ) );
+	}
+
+	/**
+	 * Test C2S POST with Arrive activity without coordinates.
+	 *
+	 * Ensures the handler works when the location only has a name
+	 * but no latitude/longitude, as is common with checkin.swf.pub.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_c2s_arrive_with_name_only_location() {
+		$user = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
+
+		$data = array(
+			'@context'   => 'https://www.w3.org/ns/activitystreams',
+			'type'       => 'Arrive',
+			'actor'      => $user->get_id(),
+			'location'   => array(
+				'id'   => 'https://places.pub/relation/659839',
+				'name' => 'Ettlingen',
+			),
+			'content'    => 'Hello!',
+			'summaryMap' => array(
+				'en' => 'Arrived at Ettlingen',
+			),
+			'to'         => 'https://www.w3.org/ns/activitystreams#Public',
+			'cc'         => $user->get_followers(),
 		);
 
-		$this->assertNotEmpty( $outbox_items );
-		$this->assertSame( $user->get_id(), \get_post_meta( $outbox_items[0]->ID, '_activitypub_object_id', true ) );
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . self::$user_id . '/outbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $data ) );
+
+		\wp_set_current_user( self::$user_id );
+
+		$response = \rest_get_server()->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+
+		// Find the created post from the response object ID.
+		$response_data = $response->get_data();
+		$post_id       = \url_to_postid( $response_data['object']['id'] );
+		$this->assertGreaterThan( 0, $post_id, 'Arrive should create a WordPress post.' );
+
+		// Verify geodata - address saved but no coordinates.
+		$this->assertSame( 'Ettlingen', \get_post_meta( $post_id, 'geo_address', true ) );
+		$this->assertEmpty( \get_post_meta( $post_id, 'geo_latitude', true ), 'No latitude when not provided.' );
+		$this->assertEmpty( \get_post_meta( $post_id, 'geo_longitude', true ), 'No longitude when not provided.' );
+		$this->assertSame( '1', \get_post_meta( $post_id, 'geo_public', true ), 'geo_public set when name is present.' );
 	}
 }


### PR DESCRIPTION
Supersedes #2977 (rebased cleanly onto current trunk).

## Proposed changes:
* Add an `Arrive` outbox handler that creates WordPress posts from C2S check-in activities (e.g. from [checkin.swf.pub](https://checkin.swf.pub)).
* The handler synthesizes a Note from the intransitive Arrive activity, creates a post via `Posts::create()`, and saves location geodata (`geo_address`, `geo_latitude`, `geo_longitude`, `geo_public`) via the `activitypub_outbox_arrive_sent` action hook.
* Fix the outbox controller to fall back to `Create` when looking up outbox entries, since the Post scheduler wraps new posts in Create activities regardless of the original C2S activity type (e.g. Arrive → Create).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Start wp-env with `npm run env-start`
* Run `npm run env-test -- --filter=test_c2s_arrive` — both tests should pass
* Alternatively, use a C2S client like checkin.swf.pub to POST an Arrive activity to the outbox endpoint and verify a WordPress post is created with geodata meta

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Add support for check-in activities posted via compatible apps.

</details>