### PR TITLE
Fix empty error description in WebFinger Site Health check

### DIFF
--- a/.github/changelog/3123-from-description
+++ b/.github/changelog/3123-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Site Health check showing an empty error message when the WebFinger endpoint is not reachable.

--- a/includes/class-http.php
+++ b/includes/class-http.php
@@ -177,6 +177,9 @@ class Http {
 		$code     = \wp_remote_retrieve_response_code( $response );
 
 		if ( \is_wp_error( $response ) || $code >= 400 ) {
+			if ( \is_wp_error( $response ) ) {
+				$code = $response->get_error_code();
+			}
 			$response = new \WP_Error( $code, __( 'Failed HTTP Request', 'activitypub' ), array( 'status' => $code ) );
 
 			/*

--- a/includes/class-http.php
+++ b/includes/class-http.php
@@ -177,8 +177,8 @@ class Http {
 		$code     = \wp_remote_retrieve_response_code( $response );
 
 		if ( \is_wp_error( $response ) || $code >= 400 ) {
-			if ( \is_wp_error( $response ) ) {
-				$code = $response->get_error_code();
+			if ( ! $code ) {
+				$code = 0;
 			}
 			$response = new \WP_Error( $code, __( 'Failed HTTP Request', 'activitypub' ), array( 'status' => $code ) );
 

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -302,14 +302,18 @@ class Health_Check {
 					$author_url
 				),
 				'webfinger_url_invalid_response' => \sprintf(
-					// translators: %s: Author URL.
 					$invalid_response,
 					$author_url
 				),
 			);
-			$message         = null;
+
 			if ( isset( $health_messages[ $url->get_error_code() ] ) ) {
 				$message = $health_messages[ $url->get_error_code() ];
+			} else {
+				$message = \sprintf(
+					$not_accessible,
+					$author_url
+				);
 			}
 
 			return new \WP_Error(

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -316,8 +316,13 @@ class Health_Check {
 				);
 			}
 
+			$error_code = $url->get_error_code();
+			if ( ! $error_code ) {
+				$error_code = 'webfinger_url_not_accessible';
+			}
+
 			return new \WP_Error(
-				$url->get_error_code(),
+				$error_code,
 				$message,
 				$url->get_error_data()
 			);


### PR DESCRIPTION
## Proposed changes:
* Fix the WebFinger Site Health check showing an empty error description (`<p></p>`) when the endpoint is not reachable (e.g. on localhost or other special environments).

The root cause was twofold:
1. `Http::get()` replaced the original `WP_Error` from `wp_safe_remote_get()` with a new one using the HTTP response code as the error code. But `wp_remote_retrieve_response_code()` returns `''` for `WP_Error` responses, and `WP_Error` silently discards messages when the code is empty/falsy.
2. `is_webfinger_endpoint_accessible()` only mapped two specific error codes to user-facing messages, falling through to `null` for any other code.

See #3121

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Set up a local WordPress environment where the WebFinger endpoint is not reachable (e.g. wp-env on `localhost:8888`).
* Go to **Tools → Site Health** and look for the "WebFinger endpoint" test.
* **Before:** The test shows "critical" with a red badge but the description area is completely empty.
* **After:** The test shows a meaningful message like "Your WebFinger endpoint `application@localhost` is not accessible. Please check your WordPress setup or permalink structure."

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix Site Health check showing an empty error message when the WebFinger endpoint is not reachable.

</details>