### PR TITLE
Add activitypub_pre_get_by_id filter to Actors::get_by_id()

### DIFF
--- a/.github/changelog/3073-from-description
+++ b/.github/changelog/3073-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added `activitypub_pre_get_by_id` filter to allow plugins to register custom virtual actors resolved by ID.

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -51,6 +51,23 @@ class Actors {
 			$user_id = (int) $user_id;
 		}
 
+		/**
+		 * Filter the actor before resolving by ID.
+		 *
+		 * Allows third-party plugins to register custom virtual actors
+		 * resolved by ID, mirroring the `activitypub_pre_get_by_username`
+		 * filter for username lookups.
+		 *
+		 * @since unreleased
+		 *
+		 * @param null $pre     The pre-existing value.
+		 * @param int  $user_id The user ID.
+		 */
+		$pre = \apply_filters( 'activitypub_pre_get_by_id', null, $user_id );
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
 		if ( ! user_can_activitypub( $user_id ) ) {
 			return new \WP_Error(
 				'activitypub_user_not_found',

--- a/tests/phpunit/tests/includes/collection/class-test-actors.php
+++ b/tests/phpunit/tests/includes/collection/class-test-actors.php
@@ -273,6 +273,37 @@ class Test_Actors extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test activitypub_pre_get_by_id filter.
+	 *
+	 * @covers ::get_by_id
+	 */
+	public function test_pre_get_by_id_filter() {
+		$custom_id = -1000001;
+
+		// Without filter, the custom ID should return a WP_Error.
+		$result = Actors::get_by_id( $custom_id );
+		$this->assertWPError( $result );
+
+		// With filter, we can return a custom actor.
+		$filter = function ( $pre, $user_id ) use ( $custom_id ) {
+			if ( $custom_id === $user_id ) {
+				return new \Activitypub\Model\Blog();
+			}
+			return $pre;
+		};
+		\add_filter( 'activitypub_pre_get_by_id', $filter, 10, 2 );
+
+		$result = Actors::get_by_id( $custom_id );
+		$this->assertInstanceOf( 'Activitypub\Model\Blog', $result );
+
+		// Ensure non-matching IDs still work normally.
+		$result = Actors::get_by_id( Actors::BLOG_USER_ID );
+		$this->assertInstanceOf( 'Activitypub\Model\Blog', $result );
+
+		\remove_filter( 'activitypub_pre_get_by_id', $filter );
+	}
+
+	/**
 	 * Test show_social_graph for blog user.
 	 *
 	 * @covers ::show_social_graph


### PR DESCRIPTION
Fixes #3073

## Proposed changes:
* Add `activitypub_pre_get_by_id` filter to `Actors::get_by_id()`, allowing third-party plugins to register custom virtual actors resolved by ID.
* Mirrors the existing `activitypub_pre_get_by_username` filter pattern for username lookups.
* Enables use cases like WapuuGotchi where virtual actors use negative IDs and need to be resolvable by ID for federation to work.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Register a filter on `activitypub_pre_get_by_id` that returns a custom actor for a specific ID (e.g., a negative integer).
* Verify that `Actors::get_by_id()` returns the custom actor for the filtered ID.
* Verify that existing actor lookups (Blog, Application, WP users) continue to work normally.
* Run `npm run env-test -- --filter=test_pre_get_by_id_filter` to confirm the new test passes.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Added - for new features

#### Message

Added a filter to allow plugins to register custom virtual actors resolved by ID.

</details>