### PR TITLE
Fix blog actor totalItems counting incoming federated comments

### DIFF
--- a/.github/changelog/3136-from-description
+++ b/.github/changelog/3136-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Fediverse profile showing an inflated post count by excluding incoming comments from the total.

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -363,15 +363,17 @@ class Outbox_Controller extends \WP_REST_Controller {
 			)
 		);
 
+		$user_id  = (int) $request->get_param( 'user_id' );
 		$comments = new \WP_Comment_Query(
 			array(
-				'status'        => 'approve',
-				'user_id'       => $request->get_param( 'user_id' ),
+				'status'         => 'approve',
+				'user_id'        => $user_id,
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_key'      => 'activitypub_status',
-				'fields'        => 'ids',
-				'no_found_rows' => false,
-				'number'        => 1,
+				'meta_key'       => 'activitypub_status',
+				'fields'         => 'ids',
+				'no_found_rows'  => false,
+				'number'         => 1,
+				'author__not_in' => array( 0 ),
 			)
 		);
 

--- a/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
@@ -1003,4 +1003,76 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 		// The summary should be used as content fallback.
 		$this->assertNotEmpty( $post->post_content, 'Post should have content from summary fallback.' );
 	}
+
+	/**
+	 * Test that totalItems for the blog actor excludes anonymous comments.
+	 *
+	 * @covers ::overload_total_items
+	 */
+	public function test_blog_actor_total_items_excludes_anonymous_comments() {
+		$original_mode = \get_option( 'activitypub_actor_mode' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$user_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create a federated comment from a local user (should be counted).
+		$local_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'user_id'         => self::$user_id,
+			)
+		);
+		\update_comment_meta( $local_comment_id, 'activitypub_status', 'federated' );
+
+		// Create a federated comment from an anonymous/remote user (should NOT be counted).
+		$remote_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'    => $post_id,
+				'user_id'            => 0,
+				'comment_author'     => 'Remote User',
+				'comment_author_url' => 'https://remote.example/user',
+			)
+		);
+		\update_comment_meta( $remote_comment_id, 'activitypub_status', 'federated' );
+
+		/*
+		 * Query comments the same way overload_total_items does
+		 * to verify the author__not_in filter excludes user_id = 0.
+		 */
+		$with_filter = new \WP_Comment_Query(
+			array(
+				'status'         => 'approve',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'       => 'activitypub_status',
+				'fields'         => 'ids',
+				'no_found_rows'  => false,
+				'number'         => 1,
+				'author__not_in' => array( 0 ),
+			)
+		);
+
+		$without_filter = new \WP_Comment_Query(
+			array(
+				'status'        => 'approve',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'      => 'activitypub_status',
+				'fields'        => 'ids',
+				'no_found_rows' => false,
+				'number'        => 1,
+			)
+		);
+
+		$this->assertGreaterThan(
+			(int) $with_filter->found_comments,
+			(int) $without_filter->found_comments,
+			'Without author__not_in, the count should be higher (includes remote comments).'
+		);
+
+		\update_option( 'activitypub_actor_mode', $original_mode );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
@@ -1010,8 +1010,8 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 	 * @covers ::overload_total_items
 	 */
 	public function test_blog_actor_total_items_excludes_anonymous_comments() {
-		$original_mode = \get_option( 'activitypub_actor_mode' );
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		\wp_set_current_user( 0 );
 
 		$post_id = self::factory()->post->create(
 			array(
@@ -1019,6 +1019,7 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 				'post_status' => 'publish',
 			)
 		);
+		\update_post_meta( $post_id, 'activitypub_status', 'federated' );
 
 		// Create a federated comment from a local user (should be counted).
 		$local_comment_id = self::factory()->comment->create(
@@ -1028,6 +1029,15 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 			)
 		);
 		\update_comment_meta( $local_comment_id, 'activitypub_status', 'federated' );
+
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'totalItems', $data );
+
+		$count_before = $data['totalItems'];
 
 		// Create a federated comment from an anonymous/remote user (should NOT be counted).
 		$remote_comment_id = self::factory()->comment->create(
@@ -1040,39 +1050,9 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 		);
 		\update_comment_meta( $remote_comment_id, 'activitypub_status', 'federated' );
 
-		/*
-		 * Query comments the same way overload_total_items does
-		 * to verify the author__not_in filter excludes user_id = 0.
-		 */
-		$with_filter = new \WP_Comment_Query(
-			array(
-				'status'         => 'approve',
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_key'       => 'activitypub_status',
-				'fields'         => 'ids',
-				'no_found_rows'  => false,
-				'number'         => 1,
-				'author__not_in' => array( 0 ),
-			)
-		);
+		$response2 = \rest_get_server()->dispatch( $request );
+		$data2     = $response2->get_data();
 
-		$without_filter = new \WP_Comment_Query(
-			array(
-				'status'        => 'approve',
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_key'      => 'activitypub_status',
-				'fields'        => 'ids',
-				'no_found_rows' => false,
-				'number'        => 1,
-			)
-		);
-
-		$this->assertGreaterThan(
-			(int) $with_filter->found_comments,
-			(int) $without_filter->found_comments,
-			'Without author__not_in, the count should be higher (includes remote comments).'
-		);
-
-		\update_option( 'activitypub_actor_mode', $original_mode );
+		$this->assertEquals( $count_before, $data2['totalItems'], 'Remote comment should not inflate totalItems.' );
 	}
 }


### PR DESCRIPTION
See https://wordpress.org/support/topic/fediverse-profile-info/

## Proposed changes:
* Fix the blog actor's outbox `totalItems` inflating the post count by including incoming federated comments from remote users.
* The `WP_Comment_Query` used `user_id = 0` which WP treats as "no filter," counting all comments with `activitypub_status` meta — including remote ones. Adding `author__not_in => [0]` excludes anonymous/remote comments so only local user comments are counted.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Set up a site with the blog actor enabled and some incoming federated comments (likes, reposts, or replies from remote users).
* Fetch the blog actor's outbox: `/wp-json/activitypub/1.0/actors/0/outbox`
* Verify `totalItems` reflects only local posts and local user comments, not incoming remote interactions.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix the Fediverse profile showing an inflated post count by excluding incoming comments from the total.

</details>