### PR TITLE
Fix blog actor Joined date showing oldest post date

### DIFF
--- a/.github/changelog/3137-from-description
+++ b/.github/changelog/3137-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Fediverse profile "Joined" date showing the oldest post date instead of when the site started federating.

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -307,7 +307,7 @@ class Blog extends Actor {
 
 		$published = \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $time );
 
-		\update_option( 'activitypub_blog_published', $published, true );
+		\update_option( 'activitypub_blog_published', $published, false );
 
 		return $published;
 	}

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -285,12 +285,16 @@ class Blog extends Actor {
 		// Backfill from the first federated post.
 		$first_federated = new \WP_Query(
 			array(
-				'orderby'        => 'date',
-				'order'          => 'ASC',
-				'posts_per_page' => 1,
-				'post_status'    => 'publish',
+				'orderby'                => 'date',
+				'order'                  => 'ASC',
+				'posts_per_page'         => 1,
+				'post_status'            => 'publish',
+				'no_found_rows'          => true,
+				'ignore_sticky_posts'    => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				'meta_query'     => array(
+				'meta_query'             => array(
 					array(
 						'key'     => 'activitypub_status',
 						'compare' => 'EXISTS',

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -276,21 +276,40 @@ class Blog extends Actor {
 	 * @return string The published date.
 	 */
 	public function get_published() {
-		$first_post = new \WP_Query(
+		$published = \get_option( 'activitypub_blog_published' );
+
+		if ( $published ) {
+			return $published;
+		}
+
+		// Backfill from the first federated post.
+		$first_federated = new \WP_Query(
 			array(
-				'orderby' => 'date',
-				'order'   => 'ASC',
-				'number'  => 1,
+				'orderby'        => 'date',
+				'order'          => 'ASC',
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'     => array(
+					array(
+						'key'     => 'activitypub_status',
+						'compare' => 'EXISTS',
+					),
+				),
 			)
 		);
 
-		if ( ! empty( $first_post->posts[0] ) ) {
-			$time = \strtotime( $first_post->posts[0]->post_date_gmt );
+		if ( ! empty( $first_federated->posts[0] ) ) {
+			$time = \strtotime( $first_federated->posts[0]->post_date_gmt );
 		} else {
 			$time = \time();
 		}
 
-		return \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $time );
+		$published = \gmdate( ACTIVITYPUB_DATE_TIME_RFC3339, $time );
+
+		\update_option( 'activitypub_blog_published', $published, true );
+
+		return $published;
 	}
 
 	/**


### PR DESCRIPTION
See https://wordpress.org/support/topic/fediverse-profile-info/

## Proposed changes:
* The blog actor's `published` date (shown as "Joined" on Mastodon) was using the oldest post on the site, which could be a "Hello World" from years ago or imported content.
* Now uses the date of the first federated post instead, which accurately reflects when the site joined the Fediverse.
* Caches the result in the `activitypub_blog_published` option to avoid a DB query on every actor profile request.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Fetch the blog actor profile: `/wp-json/activitypub/1.0/actors/0`
* Verify `published` reflects the date of the first federated post, not the oldest post on the site.
* On a fresh install with no federated posts, the date should be the current time.
* Check the `activitypub_blog_published` option is created after the first request.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix the Fediverse profile "Joined" date showing the oldest post date instead of when the site started federating.

</details>