### PR TITLE
Fix infinite recursion in Outbox::add() causing OOM

### DIFF
--- a/.github/changelog/fix-outbox-add-infinite-recursion
+++ b/.github/changelog/fix-outbox-add-infinite-recursion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an infinite loop when saving activities to the outbox on sites where the outbox post type passes through content filters.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -126,6 +126,13 @@ class Outbox {
 			\kses_remove_filters();
 		}
 
+		// Prevent infinite recursion: wp_insert_post fires wp_after_insert_post,
+		// which would re-enter Post::triage() -> add_to_outbox() -> Outbox::add().
+		$has_triage = false !== \has_action( 'wp_after_insert_post', array( Scheduler\Post::class, 'triage' ) );
+		if ( $has_triage ) {
+			\remove_action( 'wp_after_insert_post', array( Scheduler\Post::class, 'triage' ), 33 );
+		}
+
 		$id = \wp_insert_post( $outbox_item, true );
 
 		// Update the activity ID if the post was inserted successfully.
@@ -138,6 +145,10 @@ class Outbox {
 					'post_content' => \wp_slash( $activity->to_json() ),
 				)
 			);
+		}
+
+		if ( $has_triage ) {
+			\add_action( 'wp_after_insert_post', array( Scheduler\Post::class, 'triage' ), 33, 4 );
 		}
 
 		if ( $has_kses ) {

--- a/tests/phpunit/tests/includes/collection/class-test-outbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-outbox.php
@@ -430,6 +430,70 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test that Outbox::add() does not cause infinite recursion via Post::triage().
+	 *
+	 * When wp_insert_post() fires inside Outbox::add(), it triggers wp_after_insert_post,
+	 * which could re-enter Post::triage() → add_to_outbox() → Outbox::add() in an infinite
+	 * loop if the triage hook is not temporarily removed.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_does_not_recurse_via_post_triage() {
+		// Ensure the triage hook is registered as a baseline.
+		\add_action( 'wp_after_insert_post', array( \Activitypub\Scheduler\Post::class, 'triage' ), 33, 4 );
+
+		$triage_hooked_during_insert = null;
+
+		// Check whether Post::triage is hooked when wp_after_insert_post fires
+		// during the outbox insert.
+		\add_action(
+			'wp_after_insert_post',
+			function ( $post_id ) use ( &$triage_hooked_during_insert ) {
+				if ( Outbox::POST_TYPE === \get_post_type( $post_id ) ) {
+					$triage_hooked_during_insert = \has_action(
+						'wp_after_insert_post',
+						array( \Activitypub\Scheduler\Post::class, 'triage' )
+					);
+				}
+			},
+			0 // Run before priority 33 to inspect hook state.
+		);
+
+		$object = new Base_Object();
+		$object->set_id( 'https://example.com/recursion-test' );
+		$object->set_type( 'Note' );
+		$object->set_content( '<p>Recursion test</p>' );
+
+		$id = \Activitypub\add_to_outbox( $object, 'Create', self::$user_id );
+
+		$this->assertIsInt( $id );
+		$this->assertFalse( $triage_hooked_during_insert, 'Post::triage should be unhooked during Outbox::add() to prevent recursion.' );
+	}
+
+	/**
+	 * Test that Outbox::add() restores the Post::triage hook after inserting.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_restores_triage_hook() {
+		// Ensure the triage hook is registered as a baseline.
+		\add_action( 'wp_after_insert_post', array( \Activitypub\Scheduler\Post::class, 'triage' ), 33, 4 );
+
+		$object = new Base_Object();
+		$object->set_id( 'https://example.com/restore-hook-test' );
+		$object->set_type( 'Note' );
+		$object->set_content( '<p>Hook restore test</p>' );
+
+		\Activitypub\add_to_outbox( $object, 'Create', self::$user_id );
+
+		// After add_to_outbox completes, the triage hook should be restored.
+		$this->assertNotFalse(
+			\has_action( 'wp_after_insert_post', array( \Activitypub\Scheduler\Post::class, 'triage' ) ),
+			'Post::triage hook should be restored after Outbox::add() completes.'
+		);
+	}
+
+	/**
 	 * Helper method to create a dummy activity object for testing.
 	 *
 	 * @return Activity


### PR DESCRIPTION
Fixes #3145

## Proposed changes:
* Temporarily unhook `Post::triage` from `wp_after_insert_post` before `Outbox::add()` calls `wp_insert_post()` and `wp_update_post()`, preventing an infinite recursion loop that exhausts memory.
* Uses a conditional guard (`$has_triage`) mirroring the existing `$has_kses` pattern in the same method, so the hook is only removed/restored if it was registered in the first place.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Confirm that publishing a new post still creates an outbox entry (check `ap_outbox` posts in the database or via the REST API).
* Confirm that updating a published post creates an Update activity in the outbox.
* If possible, test on a site where a plugin or filter adds `activitypub` support to the `ap_outbox` post type, or overrides `activitypub_is_post_disabled` to return `false` for outbox posts — this was the scenario that triggered the infinite loop.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix an infinite loop when saving activities to the outbox on sites where the outbox post type passes through content filters.

</details>