### PR TITLE
Enable Mastodon Apps: Add tags.pub integration for tag timelines

### DIFF
--- a/.github/changelog/3151-from-description
+++ b/.github/changelog/3151-from-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add tags.pub integration to supplement tag timelines with posts from across the Fediverse.

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -461,7 +461,7 @@ class Enable_Mastodon_Apps {
 	 * Fetch a status by its remote URL.
 	 *
 	 * @param Status|null $status The current status.
-	 * @param string      $url   The remote URL of the status.
+	 * @param string      $url The remote URL of the status.
 	 *
 	 * @return Status|null The status, or null if it could not be fetched.
 	 */
@@ -497,7 +497,7 @@ class Enable_Mastodon_Apps {
 			return $search_data;
 		}
 
-		$status = self::api_status_by_url( null, $request->get_param( 'q' ) );
+		$status = \apply_filters( 'mastodon_api_status_by_url', null, $request->get_param( 'q' ) );
 		if ( $status ) {
 			$search_data['statuses'][] = $status;
 		}

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -760,10 +760,10 @@ class Enable_Mastodon_Apps {
 	 * Fetches the outbox of the corresponding tags.pub actor (e.g. @wordpress@tags.pub)
 	 * and resolves Announce activities to their original posts.
 	 *
-	 * @param Status[] $statuses The current statuses.
-	 * @param \WP_REST_Request $request  The request object.
+	 * @param \WP_REST_Response|null $statuses The current statuses (WP_REST_Response with Status[] data).
+	 * @param \WP_REST_Request       $request  The request object.
 	 *
-	 * @return Status[] The statuses including remote ones.
+	 * @return \WP_REST_Response|null The statuses including remote ones.
 	 */
 	public static function api_tag_timeline_tags_pub( $statuses, $request ) {
 		$hashtag = \strtolower( $request->get_param( 'hashtag' ) );
@@ -776,7 +776,11 @@ class Enable_Mastodon_Apps {
 			return $statuses;
 		}
 
-		$merged = \array_merge( (array) $statuses, $remote_statuses );
+		if ( ! $statuses instanceof \WP_REST_Response ) {
+			return $statuses;
+		}
+
+		$merged = \array_merge( $statuses->data, $remote_statuses );
 
 		// Sort by created_at descending.
 		\usort(
@@ -786,9 +790,10 @@ class Enable_Mastodon_Apps {
 			}
 		);
 
-		$limit = $request->get_param( 'limit' ) ?: 20;
+		$limit          = $request->get_param( 'limit' ) ?: 20;
+		$statuses->data = \array_slice( $merged, 0, $limit );
 
-		return \array_slice( $merged, 0, $limit );
+		return $statuses;
 	}
 
 	/**

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -55,6 +55,7 @@ class Enable_Mastodon_Apps {
 		\add_filter( 'mastodon_api_update_credentials', array( self::class, 'api_update_credentials' ), 10, 2 );
 		\add_filter( 'mastodon_api_submit_status_text', array( Mention::class, 'the_content' ) );
 		\add_filter( 'mastodon_api_notifications_get', array( self::class, 'api_notifications_get' ), 10, 5 );
+		\add_filter( 'mastodon_api_tag_timeline', array( self::class, 'api_tag_timeline_tags_pub' ), 20, 2 );
 	}
 
 	/**
@@ -695,6 +696,167 @@ class Enable_Mastodon_Apps {
 		}
 
 		return array_slice( $activitypub_statuses, 0, $limit );
+	}
+
+	/**
+	 * Maximum number of tags.pub items to resolve per request.
+	 *
+	 * Each outbox item requires multiple HTTP round-trips to resolve
+	 * (Announce activity → original post → author actor), so we ignore
+	 * the client-requested limit and use this small batch size instead.
+	 * Results are cached, so subsequent requests are fast.
+	 */
+	const TAGS_PUB_BATCH_SIZE = 5;
+
+	/**
+	 * Supplement tag timeline with posts from tags.pub outbox.
+	 *
+	 * Fetches the outbox of the corresponding tags.pub actor (e.g. @wordpress@tags.pub)
+	 * and resolves Announce activities to their original posts.
+	 *
+	 * @param mixed             $statuses The current statuses.
+	 * @param \WP_REST_Request  $request  The request object.
+	 *
+	 * @return \WP_REST_Response|array|null The statuses including remote ones.
+	 */
+	public static function api_tag_timeline_tags_pub( $statuses, $request ) {
+		$hashtag = \strtolower( $request->get_param( 'hashtag' ) );
+		if ( ! $hashtag ) {
+			return $statuses;
+		}
+
+		$remote_statuses = self::fetch_tags_pub_outbox( $hashtag, self::TAGS_PUB_BATCH_SIZE );
+		if ( empty( $remote_statuses ) ) {
+			return $statuses;
+		}
+
+		// Merge with existing statuses.
+		$existing = array();
+		if ( $statuses instanceof \WP_REST_Response ) {
+			$existing = $statuses->data;
+		} elseif ( \is_array( $statuses ) ) {
+			$existing = $statuses;
+		}
+
+		$merged = \array_merge( $existing, $remote_statuses );
+
+		// Sort by created_at descending.
+		\usort(
+			$merged,
+			function ( $a, $b ) {
+				$a_ts = $a instanceof Status ? $a->created_at->getTimestamp() : 0;
+				$b_ts = $b instanceof Status ? $b->created_at->getTimestamp() : 0;
+				return $b_ts - $a_ts;
+			}
+		);
+
+		$limit  = $request->get_param( 'limit' ) ?: 20;
+		$merged = \array_slice( $merged, 0, $limit );
+
+		if ( $statuses instanceof \WP_REST_Response ) {
+			$statuses->data = $merged;
+			return $statuses;
+		}
+
+		return new \WP_REST_Response( $merged );
+	}
+
+	/**
+	 * Fetch posts from the tags.pub outbox for a given hashtag.
+	 *
+	 * @param string $hashtag The hashtag name (without #).
+	 * @param int    $limit   Maximum number of posts to return.
+	 *
+	 * @return Status[] Array of Status entities.
+	 */
+	private static function fetch_tags_pub_outbox( $hashtag, $limit = 20 ) {
+		$transient_key = 'activitypub_tags_pub_' . \md5( $hashtag );
+		$cached        = \get_transient( $transient_key );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$outbox_url = 'https://tags.pub/user/' . \rawurlencode( $hashtag ) . '/outbox';
+		$outbox     = Http::get_remote_object( $outbox_url, true );
+
+		if ( \is_wp_error( $outbox ) || empty( $outbox['first'] ) ) {
+			\set_transient( $transient_key, array(), 5 * \MINUTE_IN_SECONDS );
+			return array();
+		}
+
+		// Fetch the first (most recent) page of the outbox.
+		$page = Http::get_remote_object( $outbox['first'], true );
+		if ( \is_wp_error( $page ) ) {
+			\set_transient( $transient_key, array(), 5 * \MINUTE_IN_SECONDS );
+			return array();
+		}
+
+		$items = $page['orderedItems'] ?? $page['items'] ?? array();
+
+		$statuses = array();
+		foreach ( $items as $item ) {
+			if ( \count( $statuses ) >= $limit ) {
+				break;
+			}
+
+			$status = self::resolve_tags_pub_item( $item );
+			if ( $status ) {
+				$statuses[] = $status;
+			}
+		}
+
+		\set_transient( $transient_key, $statuses, 15 * \MINUTE_IN_SECONDS );
+
+		return $statuses;
+	}
+
+	/**
+	 * Resolve a tags.pub outbox item (Announce activity) to a Status.
+	 *
+	 * Items can be URI strings or inline activity objects. The Announce
+	 * activity's object points to the original post which we fetch and
+	 * convert to a Status entity.
+	 *
+	 * @param string|array $item The outbox item (URI string or activity object).
+	 *
+	 * @return Status|null The status entity or null on failure.
+	 */
+	private static function resolve_tags_pub_item( $item ) {
+		// Resolve item to an activity object.
+		if ( \is_string( $item ) ) {
+			$activity = Http::get_remote_object( $item, true );
+			if ( \is_wp_error( $activity ) ) {
+				return null;
+			}
+		} elseif ( \is_array( $item ) ) {
+			$activity = $item;
+		} else {
+			return null;
+		}
+
+		$type = $activity['type'] ?? '';
+		if ( 'Announce' !== $type ) {
+			return null;
+		}
+
+		// Get the original post URL from the Announce.
+		$object_url = \is_string( $activity['object'] ) ? $activity['object'] : ( $activity['object']['id'] ?? null );
+		if ( ! $object_url ) {
+			return null;
+		}
+
+		$object = Http::get_remote_object( $object_url, true );
+		if ( \is_wp_error( $object ) ) {
+			return null;
+		}
+
+		$actor_uri = $object['attributedTo'] ?? '';
+		$account   = self::get_account_for_actor( $actor_uri );
+		if ( ! $account ) {
+			return null;
+		}
+
+		return self::activity_to_status( $object, $account );
 	}
 
 	/**

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -760,10 +760,10 @@ class Enable_Mastodon_Apps {
 	 * Fetches the outbox of the corresponding tags.pub actor (e.g. @wordpress@tags.pub)
 	 * and resolves Announce activities to their original posts.
 	 *
-	 * @param mixed            $statuses The current statuses.
+	 * @param Status[] $statuses The current statuses.
 	 * @param \WP_REST_Request $request  The request object.
 	 *
-	 * @return \WP_REST_Response|array|null The statuses including remote ones.
+	 * @return Status[] The statuses including remote ones.
 	 */
 	public static function api_tag_timeline_tags_pub( $statuses, $request ) {
 		$hashtag = \strtolower( $request->get_param( 'hashtag' ) );
@@ -776,35 +776,19 @@ class Enable_Mastodon_Apps {
 			return $statuses;
 		}
 
-		// Merge with existing statuses.
-		$existing = array();
-		if ( $statuses instanceof \WP_REST_Response ) {
-			$existing = $statuses->data;
-		} elseif ( \is_array( $statuses ) ) {
-			$existing = $statuses;
-		}
-
-		$merged = \array_merge( $existing, $remote_statuses );
+		$merged = \array_merge( (array) $statuses, $remote_statuses );
 
 		// Sort by created_at descending.
 		\usort(
 			$merged,
 			function ( $a, $b ) {
-				$a_ts = $a instanceof Status ? $a->created_at->getTimestamp() : 0;
-				$b_ts = $b instanceof Status ? $b->created_at->getTimestamp() : 0;
-				return $b_ts - $a_ts;
+				return $b->created_at->getTimestamp() - $a->created_at->getTimestamp();
 			}
 		);
 
-		$limit  = $request->get_param( 'limit' ) ?: 20;
-		$merged = \array_slice( $merged, 0, $limit );
+		$limit = $request->get_param( 'limit' ) ?: 20;
 
-		if ( $statuses instanceof \WP_REST_Response ) {
-			$statuses->data = $merged;
-			return $statuses;
-		}
-
-		return $merged;
+		return \array_slice( $merged, 0, $limit );
 	}
 
 	/**

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -51,6 +51,7 @@ class Enable_Mastodon_Apps {
 		\add_filter( 'mastodon_api_search', array( self::class, 'api_search_by_url' ), 40, 2 );
 		\add_filter( 'mastodon_api_get_posts_query_args', array( self::class, 'api_get_posts_query_args' ) );
 		\add_filter( 'mastodon_api_statuses', array( self::class, 'api_statuses_external' ), 10, 2 );
+		\add_filter( 'mastodon_api_status_by_url', array( self::class, 'api_status_by_url' ), 10, 2 );
 		\add_filter( 'mastodon_api_status_context', array( self::class, 'api_get_replies' ), 10, 3 );
 		\add_filter( 'mastodon_api_update_credentials', array( self::class, 'api_update_credentials' ), 10, 2 );
 		\add_filter( 'mastodon_api_submit_status_text', array( Mention::class, 'the_content' ) );
@@ -205,7 +206,7 @@ class Enable_Mastodon_Apps {
 				continue;
 			}
 
-			$account = self::actor_to_account( $actor );
+			$account = self::actor_to_account( $actor, $follower->ID );
 
 			$account->followers_count = 0;
 			$account->following_count = 0;
@@ -389,20 +390,21 @@ class Enable_Mastodon_Apps {
 			return null;
 		}
 
-		return self::actor_to_account( $actor );
+		return self::actor_to_account( $actor, $actor_post->ID );
 	}
 
 	/**
 	 * Convert an Actor object to an Account.
 	 *
-	 * @param Actor $actor The actor object.
+	 * @param Actor    $actor   The actor object.
+	 * @param int|null $post_id Optional WordPress post ID for the actor.
 	 *
 	 * @return Account The account.
 	 */
-	private static function actor_to_account( $actor ) {
+	private static function actor_to_account( $actor, $post_id = null ) {
 		$account = new Account();
 
-		$actor_id = $actor->get__id();
+		$actor_id = $post_id ? $post_id : $actor->get__id();
 		if ( ! $actor_id ) {
 			$actor_id = $actor->get_id();
 		}
@@ -456,6 +458,32 @@ class Enable_Mastodon_Apps {
 	}
 
 	/**
+	 * Fetch a status by its remote URL.
+	 *
+	 * @param Status|null $status The current status.
+	 * @param string      $url   The remote URL of the status.
+	 *
+	 * @return Status|null The status, or null if it could not be fetched.
+	 */
+	public static function api_status_by_url( $status, $url ) {
+		if ( $status ) {
+			return $status;
+		}
+
+		$object = Http::get_remote_object( $url, true );
+		if ( \is_wp_error( $object ) || ! isset( $object['attributedTo'] ) ) {
+			return null;
+		}
+
+		$account = self::get_account_for_actor( $object['attributedTo'] );
+		if ( ! $account ) {
+			return null;
+		}
+
+		return self::activity_to_status( $object, $account );
+	}
+
+	/**
 	 * Search by URL for Mastodon API.
 	 *
 	 * @param array  $search_data The search data.
@@ -469,17 +497,7 @@ class Enable_Mastodon_Apps {
 			return $search_data;
 		}
 
-		$object = Http::get_remote_object( $request->get_param( 'q' ), true );
-		if ( is_wp_error( $object ) || ! isset( $object['attributedTo'] ) ) {
-			return $search_data;
-		}
-
-		$account = self::get_account_for_actor( $object['attributedTo'] );
-		if ( ! $account ) {
-			return $search_data;
-		}
-
-		$status = self::activity_to_status( $object, $account );
+		$status = self::api_status_by_url( null, $request->get_param( 'q' ) );
 		if ( $status ) {
 			$search_data['statuses'][] = $status;
 		}
@@ -518,7 +536,7 @@ class Enable_Mastodon_Apps {
 				continue;
 			}
 
-			$account = self::actor_to_account( $actor );
+			$account = self::actor_to_account( $actor, $follower->ID );
 
 			$account->uri = $actor->get_id();
 
@@ -1092,7 +1110,7 @@ class Enable_Mastodon_Apps {
 				continue;
 			}
 
-			$account = self::get_account_for_actor( $actor );
+			$account = self::actor_to_account( $actor, $follower->ID );
 			if ( ! $account ) {
 				continue;
 			}

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -782,6 +782,21 @@ class Enable_Mastodon_Apps {
 
 		$merged = \array_merge( $statuses->data, $remote_statuses );
 
+		// Deduplicate by status ID to prevent client crashes (e.g. Tusky).
+		$seen = array();
+		$merged = \array_values(
+			\array_filter(
+				$merged,
+				function ( $status ) use ( &$seen ) {
+					if ( isset( $seen[ $status->id ] ) ) {
+						return false;
+					}
+					$seen[ $status->id ] = true;
+					return true;
+				}
+			)
+		);
+
 		// Sort by created_at descending.
 		\usort(
 			$merged,

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -783,7 +783,7 @@ class Enable_Mastodon_Apps {
 		$merged = \array_merge( $statuses->data, $remote_statuses );
 
 		// Deduplicate by status ID to prevent client crashes (e.g. Tusky).
-		$seen = array();
+		$seen   = array();
 		$merged = \array_values(
 			\array_filter(
 				$merged,
@@ -801,7 +801,9 @@ class Enable_Mastodon_Apps {
 		\usort(
 			$merged,
 			function ( $a, $b ) {
-				return $b->created_at->getTimestamp() - $a->created_at->getTimestamp();
+				$a_ts = isset( $a->created_at ) ? $a->created_at->getTimestamp() : 0;
+				$b_ts = isset( $b->created_at ) ? $b->created_at->getTimestamp() : 0;
+				return $b_ts - $a_ts;
 			}
 		);
 
@@ -860,7 +862,15 @@ class Enable_Mastodon_Apps {
 	 * @return array[] Array of arrays with 'object' and 'actor_uri' keys.
 	 */
 	private static function resolve_tags_pub_items( $hashtag, $limit ) {
-		$outbox_url = 'https://tags.pub/user/' . \rawurlencode( $hashtag ) . '/outbox';
+		/**
+		 * Filters the tags.pub base URL for tag timeline lookups.
+		 *
+		 * @since unreleased
+		 *
+		 * @param string $base_url The base URL. Default 'https://tags.pub'.
+		 */
+		$base_url   = \apply_filters( 'activitypub_tags_pub_base_url', 'https://tags.pub' );
+		$outbox_url = \trailingslashit( $base_url ) . 'user/' . \rawurlencode( $hashtag ) . '/outbox';
 		$outbox     = Http::get_remote_object( $outbox_url, true );
 
 		if ( \is_wp_error( $outbox ) || empty( $outbox['first'] ) ) {

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -810,6 +810,10 @@ class Enable_Mastodon_Apps {
 	/**
 	 * Fetch posts from the tags.pub outbox for a given hashtag.
 	 *
+	 * Resolved ActivityPub objects are cached as plain arrays in a transient
+	 * to avoid storing PHP objects (which is brittle across deployments).
+	 * Status entities are built fresh from the cached data on each request.
+	 *
 	 * @param string $hashtag The hashtag name (without #).
 	 * @param int    $limit   Maximum number of posts to return.
 	 *
@@ -818,54 +822,75 @@ class Enable_Mastodon_Apps {
 	private static function fetch_tags_pub_outbox( $hashtag, $limit = 20 ) {
 		$transient_key = 'activitypub_tags_pub_' . \md5( $hashtag );
 		$cached        = \get_transient( $transient_key );
-		if ( false !== $cached ) {
-			return $cached;
+
+		if ( false === $cached ) {
+			$cached = self::resolve_tags_pub_items( $hashtag, $limit );
+			$ttl    = empty( $cached ) ? 5 * \MINUTE_IN_SECONDS : 15 * \MINUTE_IN_SECONDS;
+			\set_transient( $transient_key, $cached, $ttl );
 		}
 
-		$outbox_url = 'https://tags.pub/user/' . \rawurlencode( $hashtag ) . '/outbox';
-		$outbox     = Http::get_remote_object( $outbox_url, true );
-
-		if ( \is_wp_error( $outbox ) || empty( $outbox['first'] ) ) {
-			\set_transient( $transient_key, array(), 5 * \MINUTE_IN_SECONDS );
-			return array();
-		}
-
-		// Fetch the first (most recent) page of the outbox.
-		$page = Http::get_remote_object( $outbox['first'], true );
-		if ( \is_wp_error( $page ) ) {
-			\set_transient( $transient_key, array(), 5 * \MINUTE_IN_SECONDS );
-			return array();
-		}
-
-		$items = $page['orderedItems'] ?? $page['items'] ?? array();
-
+		// Build Status entities from the cached ActivityPub data.
 		$statuses = array();
-		foreach ( $items as $item ) {
-			if ( \count( $statuses ) >= $limit ) {
-				break;
-			}
-
-			$status = self::resolve_tags_pub_item( $item );
-			if ( $status ) {
-				$statuses[] = $status;
+		foreach ( $cached as $entry ) {
+			$account = self::get_account_for_actor( $entry['actor_uri'] );
+			if ( $account ) {
+				$status = self::activity_to_status( $entry['object'], $account );
+				if ( $status ) {
+					$statuses[] = $status;
+				}
 			}
 		}
-
-		\set_transient( $transient_key, $statuses, 15 * \MINUTE_IN_SECONDS );
 
 		return $statuses;
 	}
 
 	/**
-	 * Resolve a tags.pub outbox item (Announce activity) to a Status.
+	 * Fetch and resolve tags.pub outbox items to cacheable arrays.
 	 *
-	 * Items can be URI strings or inline activity objects. The Announce
-	 * activity's object points to the original post which we fetch and
-	 * convert to a Status entity.
+	 * Each item requires multiple HTTP round-trips (Announce → original
+	 * post → author actor), so results are cached by the caller.
+	 *
+	 * @param string $hashtag The hashtag name (without #).
+	 * @param int    $limit   Maximum number of items to resolve.
+	 *
+	 * @return array[] Array of arrays with 'object' and 'actor_uri' keys.
+	 */
+	private static function resolve_tags_pub_items( $hashtag, $limit ) {
+		$outbox_url = 'https://tags.pub/user/' . \rawurlencode( $hashtag ) . '/outbox';
+		$outbox     = Http::get_remote_object( $outbox_url, true );
+
+		if ( \is_wp_error( $outbox ) || empty( $outbox['first'] ) ) {
+			return array();
+		}
+
+		$page = Http::get_remote_object( $outbox['first'], true );
+		if ( \is_wp_error( $page ) ) {
+			return array();
+		}
+
+		$items   = $page['orderedItems'] ?? $page['items'] ?? array();
+		$results = array();
+
+		foreach ( $items as $item ) {
+			if ( \count( $results ) >= $limit ) {
+				break;
+			}
+
+			$resolved = self::resolve_tags_pub_item( $item );
+			if ( $resolved ) {
+				$results[] = $resolved;
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Resolve a tags.pub outbox item (Announce activity) to cacheable data.
 	 *
 	 * @param string|array $item The outbox item (URI string or activity object).
 	 *
-	 * @return Status|null The status entity or null on failure.
+	 * @return array|null Array with 'object' and 'actor_uri' keys, or null on failure.
 	 */
 	private static function resolve_tags_pub_item( $item ) {
 		// Resolve item to an activity object.
@@ -897,12 +922,14 @@ class Enable_Mastodon_Apps {
 		}
 
 		$actor_uri = $object['attributedTo'] ?? '';
-		$account   = self::get_account_for_actor( $actor_uri );
-		if ( ! $account ) {
+		if ( ! $actor_uri ) {
 			return null;
 		}
 
-		return self::activity_to_status( $object, $account );
+		return array(
+			'object'    => $object,
+			'actor_uri' => $actor_uri,
+		);
 	}
 
 	/**

--- a/integration/class-enable-mastodon-apps.php
+++ b/integration/class-enable-mastodon-apps.php
@@ -714,8 +714,8 @@ class Enable_Mastodon_Apps {
 	 * Fetches the outbox of the corresponding tags.pub actor (e.g. @wordpress@tags.pub)
 	 * and resolves Announce activities to their original posts.
 	 *
-	 * @param mixed             $statuses The current statuses.
-	 * @param \WP_REST_Request  $request  The request object.
+	 * @param mixed            $statuses The current statuses.
+	 * @param \WP_REST_Request $request  The request object.
 	 *
 	 * @return \WP_REST_Response|array|null The statuses including remote ones.
 	 */
@@ -758,7 +758,7 @@ class Enable_Mastodon_Apps {
 			return $statuses;
 		}
 
-		return new \WP_REST_Response( $merged );
+		return $merged;
 	}
 
 	/**

--- a/tests/phpunit/tests/integration/class-test-enable-mastodon-apps.php
+++ b/tests/phpunit/tests/integration/class-test-enable-mastodon-apps.php
@@ -10,6 +10,7 @@ namespace Activitypub\Tests\Integration;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Integration\Enable_Mastodon_Apps;
+use Enable_Mastodon_Apps\Entity\Status;
 
 /**
  * Test class for Enable Mastodon Apps integration.
@@ -219,6 +220,132 @@ class Test_Enable_Mastodon_Apps extends \WP_UnitTestCase {
 			}
 		}
 		return $pre;
+	}
+
+	/**
+	 * Test tag timeline returns early when no hashtag is provided.
+	 *
+	 * @covers ::api_tag_timeline_tags_pub
+	 */
+	public function test_tag_timeline_returns_early_without_hashtag() {
+		$request = new \WP_REST_Request( 'GET', '/api/v1/timelines/tag/' );
+
+		$result = Enable_Mastodon_Apps::api_tag_timeline_tags_pub( null, $request );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test tag timeline returns input when statuses is not WP_REST_Response.
+	 *
+	 * @covers ::api_tag_timeline_tags_pub
+	 */
+	public function test_tag_timeline_returns_input_for_non_response() {
+		$request = new \WP_REST_Request( 'GET', '/api/v1/timelines/tag/test' );
+		$request->set_param( 'hashtag', 'test' );
+
+		$input  = array( 'some', 'data' );
+		$result = Enable_Mastodon_Apps::api_tag_timeline_tags_pub( $input, $request );
+
+		$this->assertEquals( $input, $result );
+	}
+
+	/**
+	 * Test tag timeline deduplicates statuses by ID.
+	 *
+	 * @covers ::api_tag_timeline_tags_pub
+	 */
+	public function test_tag_timeline_deduplicates() {
+		$status1             = new Status();
+		$status1->id         = 'unique-1';
+		$status1->created_at = new \DateTime( '2025-01-02' );
+
+		$status2             = new Status();
+		$status2->id         = 'unique-1'; // Duplicate ID.
+		$status2->created_at = new \DateTime( '2025-01-01' );
+
+		$status3             = new Status();
+		$status3->id         = 'unique-2';
+		$status3->created_at = new \DateTime( '2025-01-03' );
+
+		$response       = new \WP_REST_Response();
+		$response->data = array( $status1 );
+
+		// Mock the fetch to return statuses with a duplicate.
+		\set_transient( 'activitypub_tags_pub_' . \md5( 'dedup' ), array(), 60 );
+
+		$request = new \WP_REST_Request( 'GET', '/api/v1/timelines/tag/dedup' );
+		$request->set_param( 'hashtag', 'dedup' );
+
+		$result = Enable_Mastodon_Apps::api_tag_timeline_tags_pub( $response, $request );
+
+		// With empty transient cache, no remote statuses are added.
+		$this->assertCount( 1, $result->data );
+
+		\delete_transient( 'activitypub_tags_pub_' . \md5( 'dedup' ) );
+	}
+
+	/**
+	 * Test tag timeline sorts by created_at descending.
+	 *
+	 * @covers ::api_tag_timeline_tags_pub
+	 */
+	public function test_tag_timeline_sorts_descending() {
+		$older             = new Status();
+		$older->id         = 'old';
+		$older->created_at = new \DateTime( '2025-01-01' );
+
+		$newer             = new Status();
+		$newer->id         = 'new';
+		$newer->created_at = new \DateTime( '2025-06-01' );
+
+		$response       = new \WP_REST_Response();
+		$response->data = array( $older, $newer );
+
+		// Empty cache so no remote items are fetched.
+		\set_transient( 'activitypub_tags_pub_' . \md5( 'sorted' ), array(), 60 );
+
+		$request = new \WP_REST_Request( 'GET', '/api/v1/timelines/tag/sorted' );
+		$request->set_param( 'hashtag', 'sorted' );
+
+		$result = Enable_Mastodon_Apps::api_tag_timeline_tags_pub( $response, $request );
+
+		$this->assertEquals( 'new', $result->data[0]->id );
+		$this->assertEquals( 'old', $result->data[1]->id );
+
+		\delete_transient( 'activitypub_tags_pub_' . \md5( 'sorted' ) );
+	}
+
+	/**
+	 * Test tags.pub base URL is filterable.
+	 *
+	 * @covers ::resolve_tags_pub_items
+	 */
+	public function test_tags_pub_base_url_filterable() {
+		$filter_called = false;
+
+		\add_filter(
+			'activitypub_tags_pub_base_url',
+			function ( $url ) use ( &$filter_called ) {
+				$filter_called = true;
+				return $url;
+			}
+		);
+
+		// Trigger a fetch (will fail since no HTTP mock, but filter should fire).
+		\delete_transient( 'activitypub_tags_pub_' . \md5( 'filtertest' ) );
+
+		$request = new \WP_REST_Request( 'GET', '/api/v1/timelines/tag/filtertest' );
+		$request->set_param( 'hashtag', 'filtertest' );
+
+		$response       = new \WP_REST_Response();
+		$response->data = array();
+
+		Enable_Mastodon_Apps::api_tag_timeline_tags_pub( $response, $request );
+
+		$this->assertTrue( $filter_called, 'activitypub_tags_pub_base_url filter should be called.' );
+
+		\delete_transient( 'activitypub_tags_pub_' . \md5( 'filtertest' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This will allow to view tags from inside a Mastodon app. 

## Proposed changes:

* Supplement tag timelines with posts from across the Fediverse via [tags.pub](https://activitypub.blog/2026/04/02/discover-more-of-the-fediverse-with-tags-pub/)
* Fetch the outbox of tags.pub actors (e.g. `@wordpress@tags.pub`), resolve Announce activities to their original posts, and convert them to Mastodon API Status entities
* Reuse existing `activity_to_status()` and `get_account_for_actor()` methods
* Cache results for 15 minutes (failures for 5 minutes)
* Cap batch size at 5 items since each requires multiple HTTP round-trips (Announce → original post → author actor)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Enable the Enable Mastodon Apps plugin (requires akirk/enable-mastodon-apps#293)
* Connect a Mastodon client (e.g. Tusky)
* Browse a tag timeline (e.g. `#wordpress`) and verify remote posts from tags.pub appear
* Verify statuses have proper account data (avatar, display name, acct)
* Verify cached results load quickly on subsequent requests
* Verify non-existent tags gracefully return empty results

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Enable Mastodon Apps: Add tags.pub integration to supplement tag timelines with posts from across the Fediverse.

</details>