### PR TITLE
Fix performance regression from reply-exclusion filter

### DIFF
--- a/.github/changelog/3153-from-description
+++ b/.github/changelog/3153-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix performance regression from reply-exclusion filter by skipping it for queries targeting non-ActivityPub post types.

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1176,6 +1176,11 @@ class Blocks {
 			return;
 		}
 
+		$query_post_types = (array) $query->get( 'post_type' );
+		if ( $query_post_types && ! array_intersect( $query_post_types, \get_post_types_by_support( 'activitypub' ) ) ) {
+			return;
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$active_tab = isset( $_GET['filter'] ) ? \sanitize_key( $_GET['filter'] ) : 'posts';
 

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1176,9 +1176,14 @@ class Blocks {
 			return;
 		}
 
-		$query_post_types = (array) $query->get( 'post_type' );
-		if ( $query_post_types && ! array_intersect( $query_post_types, \get_post_types_by_support( 'activitypub' ) ) ) {
-			return;
+		// Skip the reply-exclusion filter for queries that only target
+		// non-ActivityPub post types to avoid a full table scan.
+		$query_post_type = $query->get( 'post_type' );
+		if ( ! empty( $query_post_type ) && 'any' !== $query_post_type ) {
+			$query_post_types = (array) $query_post_type;
+			if ( ! array_intersect( $query_post_types, \get_post_types_by_support( 'activitypub' ) ) ) {
+				return;
+			}
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended


### PR DESCRIPTION
## Summary

Follow-up to #3036 — see https://github.com/Automattic/wordpress-activitypub/pull/3036#issuecomment-4206212232

- The `filter_query_loop_vars` method adds a `NOT LIKE '%<!-- wp:activitypub/reply%'` WHERE clause on `post_content` for all main non-singular queries
- This causes a **full table scan** on sites with large `wp_posts` tables, even when the query targets post types that don't support ActivityPub (e.g. the Friends plugin's `friend_post_cache`)
- Fix: skip the filter early when the queried post types don't intersect with ActivityPub-supported post types

## Test plan

- [ ] Visit an author archive page — verify the "Posts" tab still excludes reply posts
- [ ] Click "Posts & Replies" — verify replies appear
- [ ] Visit a page that queries non-ActivityPub post types (e.g. `/friends/`) — verify the `NOT LIKE` clause is not added to the SQL query

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [x] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Fix performance regression from reply-exclusion filter by skipping it for queries targeting non-ActivityPub post types.

</details>