### PR TITLE
Fix fatal error when language property is an array

### DIFF
--- a/.github/changelog/3158-from-description
+++ b/.github/changelog/3158-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a fatal error when receiving activities with a non-string language property.

--- a/includes/rest/trait-language-map.php
+++ b/includes/rest/trait-language-map.php
@@ -97,7 +97,7 @@ trait Language_Map {
 		 * If the object's language matches the site locale,
 		 * the base property is already in the right language.
 		 */
-		if ( $object_lang && \is_string( $value ) ) {
+		if ( $object_lang && \is_string( $object_lang ) && \is_string( $value ) ) {
 			if ( \strtolower( \strtok( $object_lang, '_-' ) ) === $site_lang ) {
 				return $value;
 			}

--- a/tests/phpunit/tests/includes/rest/class-test-trait-language-map.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-language-map.php
@@ -345,6 +345,20 @@ class Test_Trait_Language_Map extends \WP_UnitTestCase {
 				null,
 				'Empty language map in base property should return null.',
 			),
+			'language_as_array'               => array(
+				array(
+					'summary'    => '<img style="max-width:100%" src="https://example.com/image.png"/>',
+					'summaryMap' => array(
+						'en' => 'English summary',
+						'de' => 'Deutsche Zusammenfassung',
+					),
+					'language'   => array( 'en', 'de' ),
+				),
+				'summary',
+				'de_DE',
+				'Deutsche Zusammenfassung',
+				'Array language property should not cause a fatal error, fall through to *Map resolution.',
+			),
 		);
 	}
 }


### PR DESCRIPTION
Fixes a fatal error on wpcom: `strtok(): Argument #1 ($string) must be of type string, array given`.

## Proposed changes:
* Add `is_string()` check for the `language` property before passing it to `strtok()` in the Language_Map trait. Some ActivityPub servers send `language` as an array instead of a string, causing a TypeError.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Send an ActivityPub activity to an inbox where the `language` property is an array (e.g. `["en", "de"]`) instead of a string.
* Verify the request no longer causes a fatal error.
* Verify that the `*Map` resolution still picks the correct locale.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix a fatal error when receiving activities with a non-string language property.

</details>