### PR TITLE
Add seasonal starter pattern for Fediverse Stats post

### DIFF
--- a/.github/changelog/3160-from-description
+++ b/.github/changelog/3160-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a seasonal starter pattern that suggests sharing Fediverse stats when creating a new post in December and January.

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -232,6 +232,12 @@ class Blocks {
 		if ( '1' === \get_option( 'activitypub_following_ui', '0' ) ) {
 			require ACTIVITYPUB_PLUGIN_DIR . '/patterns/following-page.php';
 		}
+
+		// Only register the Stats post starter pattern in December and January.
+		$month = (int) \gmdate( 'n' );
+		if ( 12 === $month || 1 === $month ) {
+			require ACTIVITYPUB_PLUGIN_DIR . '/patterns/stats-post.php';
+		}
 	}
 
 	/**

--- a/patterns/stats-post.php
+++ b/patterns/stats-post.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Fediverse Stats Post starter pattern.
+ *
+ * This pattern is only registered in December and January, giving users
+ * a seasonal nudge to share their annual Fediverse stats.
+ *
+ * @package Activitypub
+ */
+
+$selected_user = ! \Activitypub\is_user_type_disabled( 'blog' ) ? 'blog' : 'inherit';
+$stats_year    = (int) \gmdate( 'Y' ) - 1;
+
+/*
+ * Skip if a post with the stats block was already published
+ * during the current December–January window.
+ *
+ * The month is re-read here (already checked in class-blocks.php)
+ * because we need to distinguish December from January to build
+ * the correct date range.
+ */
+$month        = (int) \gmdate( 'n' );
+$current_year = (int) \gmdate( 'Y' );
+$window_key   = 12 === $month ? $current_year : ( $current_year - 1 );
+$transient    = 'activitypub_stats_pattern_' . $window_key;
+$cached       = \get_transient( $transient );
+
+if ( 'hide' === $cached ) {
+	return;
+}
+
+if ( false === $cached ) {
+	$after = $window_key . '-12-01';
+
+	global $wpdb;
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+	$has_stats_post = $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT ID FROM {$wpdb->posts} WHERE post_type = 'post' AND post_status = 'publish' AND post_date >= %s AND post_content LIKE %s LIMIT 1",
+			$after,
+			'%<!-- wp:activitypub/stats%'
+		)
+	);
+
+	if ( $has_stats_post ) {
+		\set_transient( $transient, 'hide', MONTH_IN_SECONDS );
+		return;
+	}
+
+	\set_transient( $transient, 'show', DAY_IN_SECONDS );
+}
+
+\register_block_pattern(
+	'activitypub/stats-post',
+	array(
+		'title'         => _x( 'Fediverse Year in Review', 'Block pattern title', 'activitypub' ),
+		'categories'    => array( 'activitypub' ),
+		'keywords'      => array(
+			_x( 'stats', 'Block pattern keyword', 'activitypub' ),
+			_x( 'fediverse', 'Block pattern keyword', 'activitypub' ),
+			_x( 'year in review', 'Block pattern keyword', 'activitypub' ),
+		),
+		'description'   => _x( 'Share your annual Fediverse stats as a post.', 'Block pattern description', 'activitypub' ),
+		'viewportWidth' => 1200,
+		'postTypes'     => array( 'post' ),
+		'blockTypes'    => array( 'core/post-content' ),
+		'content'       => '<!-- wp:activitypub/stats {"selectedUser":"' . $selected_user . '","year":' . $stats_year . '} /-->',
+	)
+);

--- a/patterns/stats-post.php
+++ b/patterns/stats-post.php
@@ -9,7 +9,6 @@
  */
 
 $selected_user = ! \Activitypub\is_user_type_disabled( 'blog' ) ? 'blog' : 'inherit';
-$stats_year    = (int) \gmdate( 'Y' ) - 1;
 
 /*
  * Skip if a post with the stats block was already published
@@ -21,8 +20,8 @@ $stats_year    = (int) \gmdate( 'Y' ) - 1;
  */
 $month        = (int) \gmdate( 'n' );
 $current_year = (int) \gmdate( 'Y' );
-$window_key   = 12 === $month ? $current_year : ( $current_year - 1 );
-$transient    = 'activitypub_stats_pattern_' . $window_key;
+$stats_year   = 12 === $month ? $current_year : ( $current_year - 1 );
+$transient    = 'activitypub_stats_pattern_' . $stats_year;
 $cached       = \get_transient( $transient );
 
 if ( 'hide' === $cached ) {
@@ -30,14 +29,14 @@ if ( 'hide' === $cached ) {
 }
 
 if ( false === $cached ) {
-	$after = $window_key . '-12-01';
+	$after = $stats_year . '-12-01';
 
 	global $wpdb;
 
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 	$has_stats_post = $wpdb->get_var(
 		$wpdb->prepare(
-			"SELECT ID FROM {$wpdb->posts} WHERE post_type = 'post' AND post_status = 'publish' AND post_date >= %s AND post_content LIKE %s LIMIT 1",
+			"SELECT 1 FROM {$wpdb->posts} WHERE post_type = 'post' AND post_status = 'publish' AND post_date_gmt >= %s AND post_content LIKE %s LIMIT 1",
 			$after,
 			'%<!-- wp:activitypub/stats%'
 		)


### PR DESCRIPTION
Fixes Automattic/wordpress-activitypub#3159

## Proposed changes:

* Add a "Fediverse Year in Review" starter pattern that nudges users to share their annual Fediverse stats when creating a new post.
* The pattern only appears in **December and January**, and is automatically hidden once a post with the stats block has already been published during that window.
* Uses a transient to cache the lookup and avoid repeated DB queries on every `init`.

As suggested by @jeherve in [https://github.com/Automattic/wordpress-activitypub/pull/3126#issuecomment-4175989610](<https://github.com/Automattic/wordpress-activitypub/pull/3126#issuecomment-4175989610>).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Temporarily adjust the month check in `includes/class-blocks.php` (line 237) to include the current month, e.g. change `12 === $month || 1 === $month` to `true`.
* Go to **Posts → Add New Post**.
* The "Choose a pattern" modal should appear with the "Fediverse Year in Review" pattern.
* Select the pattern — the stats block should be inserted into the post.
* Publish the post.
* Delete the transient: `wp transient delete activitypub_stats_pattern_YYYY` (replace YYYY with the window key year).
* Create another new post — the pattern should **no longer** appear because a stats post already exists for the window.

### Changelog entry

- [X] Automatically create a changelog entry from the details below.

<details><summary>Changelog Entry Details</summary>

#### Significance

- [X] Patch

#### Type

- [X] Added - for new features

#### Message

Add a seasonal starter pattern that suggests sharing Fediverse stats when creating a new post in December and January.

</details>