### PR TITLE
Fix double-encoded HTML entities in stats top posts titles

### DIFF
--- a/.github/changelog/fix-stats-title-encoding
+++ b/.github/changelog/fix-stats-title-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix double-encoded HTML entities in post titles on the Fediverse Stats dashboard.

--- a/includes/class-statistics.php
+++ b/includes/class-statistics.php
@@ -420,7 +420,7 @@ class Statistics {
 			if ( $post ) {
 				$top_posts[] = array(
 					'post_id'          => $result['post_id'],
-					'title'            => \get_the_title( $post ),
+					'title'            => \html_entity_decode( \get_the_title( $post ), ENT_QUOTES, 'UTF-8' ),
 					'url'              => \get_permalink( $post ),
 					'edit_url'         => \get_edit_post_link( $post, 'raw' ),
 					'engagement_count' => (int) $result['engagement_count'],


### PR DESCRIPTION
Fixes #3161

## Proposed changes:
* Fix post titles in the Fediverse Stats dashboard widget (and email report) displaying raw HTML entities like `&#8217;` instead of the intended characters.
* `get_the_title()` returns text already processed by `wptexturize()`, which encodes characters as HTML entities. When the render template applies `esc_html()`, the `&` gets re-encoded, causing double-encoding. This wraps the title in `html_entity_decode()` at the data source so downstream `esc_html()` calls encode only once.

**Before**

<img width="550" height="107" alt="Screenshot 2026-04-10 at 15 32 06" src="https://github.com/user-attachments/assets/8cc7047a-9f22-4424-ad6a-87eb8abbd337" />


**After**

<img width="563" height="107" alt="Screenshot 2026-04-10 at 16 01 06" src="https://github.com/user-attachments/assets/35ab5b7e-d9ad-4cd2-bee7-c62ba3736d54" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a post with an apostrophe in the title (e.g. "Kagi's homepage looks great today!").
* Publish the post and ensure it has some fediverse engagement (likes, boosts, replies).
* Go to the WordPress dashboard and view the Fediverse Stats widget's "Top Posts" section.
* Verify that the post title displays correctly with proper curly quotes, not raw `&#8217;` entities.
* Also check the stats email report to confirm titles render correctly there as well.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix double-encoded HTML entities in post titles on the Fediverse Stats dashboard.

</details>