### PR TITLE
Add how-to guides for caching, migration, and advanced settings

### DIFF
--- a/docs/how-to/account-migration.md
+++ b/docs/how-to/account-migration.md
@@ -41,7 +41,7 @@ If you want to move away from your WordPress blog to a Mastodon (or other Fedive
 
 ### Step 2: Initiate the move from WordPress
 
-You can trigger the move using WP-CLI:
+There is currently no admin UI for this. You can trigger the move using WP-CLI:
 
 ```bash
 wp activitypub move https://yourblog.com/author/username https://mastodon.social/users/username

--- a/docs/how-to/account-migration.md
+++ b/docs/how-to/account-migration.md
@@ -1,0 +1,93 @@
+# Account Migration
+
+Account migration in the Fediverse allows you to move your identity from one platform to another while bringing your followers with you. When you migrate, your followers are automatically notified and redirected to follow your new account.
+
+The WordPress ActivityPub plugin supports migrating **to** and **from** WordPress, as well as moving between WordPress sites.
+
+## Moving from Mastodon to WordPress
+
+This is the most common migration scenario: you have an existing Mastodon account and want to make your WordPress blog your primary Fediverse identity.
+
+### Step 1: Add your Mastodon account as an alias in WordPress
+
+1. Log in to your WordPress site.
+2. Go to **Users > Profile** (or **Settings > ActivityPub** for the Blog profile).
+3. Scroll down to the **Account Aliases** field.
+4. Enter your Mastodon profile URL (e.g. `https://mastodon.social/@username` or `@username@mastodon.social`).
+5. Save your profile.
+
+This tells the Fediverse that your WordPress account is also known as your Mastodon account, which is required for the migration to be accepted.
+
+### Step 2: Initiate the move on Mastodon
+
+1. Log in to your Mastodon account.
+2. Go to **Preferences > Account > Move to a different account**.
+3. Enter your WordPress ActivityPub handle (e.g. `@username@yourblog.com`) in the "Handle of the new account" field.
+4. Enter your Mastodon password to confirm.
+
+Mastodon will send a `Move` activity to all your followers, telling them to follow your WordPress account instead. Compatible Fediverse servers will automatically transfer the follow.
+
+## Moving from WordPress to Mastodon
+
+If you want to move away from your WordPress blog to a Mastodon (or other Fediverse) account, the process works in reverse.
+
+### Step 1: Add your WordPress account as an alias on Mastodon
+
+1. Log in to your Mastodon account.
+2. Go to **Preferences > Account > Moving from a different account**.
+3. Click **Create an account alias**.
+4. Enter your WordPress ActivityPub handle (e.g. `@username@yourblog.com`).
+5. Save the alias.
+
+### Step 2: Initiate the move from WordPress
+
+You can trigger the move using WP-CLI:
+
+```bash
+wp activitypub move https://yourblog.com/author/username https://mastodon.social/users/username
+```
+
+The plugin will verify that the target account (Mastodon) has your WordPress account listed in its aliases, then send a `Move` activity to all your followers.
+
+After the move, your WordPress ActivityPub profile will display a `movedTo` notice pointing followers to your new Mastodon account.
+
+## Moving between two WordPress sites
+
+If you are migrating from one WordPress site to another (e.g. changing domains or consolidating blogs), the process is the same as any other migration.
+
+### Step 1: Add the old blog as an alias on the new blog
+
+1. On the **new** WordPress site, go to **Users > Profile** (or **Settings > ActivityPub** for the Blog profile).
+2. In the **Account Aliases** field, add the URL of your old blog's ActivityPub profile (e.g. `@you@oldblog.com`).
+3. Save.
+
+### Step 2: Initiate the move from the old blog
+
+On the **old** WordPress site, run:
+
+```bash
+wp activitypub move https://oldblog.com/author/you https://newblog.com/author/you
+```
+
+Your followers will be notified and redirected to your new blog.
+
+## How it works
+
+Account migration uses the ActivityPub `Move` activity type ([FEP-7628](https://codeberg.org/fediverse/fep/src/branch/main/fep/7628/fep-7628.md)). The process relies on two actor properties:
+
+- **`alsoKnownAs`** — A list of other account URLs that belong to the same person. The *target* account must list the *origin* account here before a move can happen. This is the "account aliases" field in the UI.
+- **`movedTo`** — Set on the *origin* account after migration, pointing to the *target*. This tells the Fediverse where the account has moved.
+
+When a Fediverse server receives a `Move` activity, it verifies that:
+
+1. The target account lists the origin in its `alsoKnownAs`.
+2. The origin account has `movedTo` set to the target.
+
+Only if both checks pass will the server transfer followers from the old account to the new one.
+
+## Important notes
+
+- **Migration moves followers, not content.** Your posts, media, and other content stay on the original platform. Only the follower relationships are transferred.
+- **Not all servers support Move.** Most Mastodon-compatible servers do, but some smaller Fediverse platforms may not process `Move` activities.
+- **Migration is essentially one-way.** While you can technically migrate back, followers who already transferred may not automatically follow back to the original account.
+- **Add aliases before initiating the move.** The target account must have the origin listed in its aliases, or the move will be rejected.

--- a/docs/how-to/advanced-settings.md
+++ b/docs/how-to/advanced-settings.md
@@ -1,0 +1,26 @@
+# Advanced Settings
+
+The ActivityPub plugin has an Advanced Settings tab that is hidden by default. It contains options for fine-tuning how the plugin handles content negotiation, the Vary header, authorized fetch, and other technical settings.
+
+## Enabling the Advanced tab
+
+1. Go to **Settings > ActivityPub**.
+2. Click **Screen Options** in the top-right corner of the page.
+3. Check **Advanced Settings**.
+4. Click **Apply**.
+
+An **Advanced** tab will now appear alongside the other tabs on the ActivityPub settings page. This preference is stored per user, so each administrator enables it independently.
+
+You can also reach the Advanced tab directly by navigating to `Settings > ActivityPub > Advanced` or by appending `&tab=advanced` to the settings URL. Visiting the tab directly will make it visible even if you have not enabled it in Screen Options.
+
+## Available settings
+
+The Advanced tab includes the following options:
+
+- **Vary Header** — Sends a `Vary: Accept` HTTP header to help caches distinguish between HTML and JSON responses. Enabled by default. See the [Caching guide](caching.md) for details.
+- **Content Negotiation** — Controls whether the same URL can serve both HTML and ActivityPub JSON based on the `Accept` header. Enabled by default. See the [Caching guide](caching.md) for when and why to disable this.
+- **Authorized Fetch** — Requires remote servers to sign their requests with HTTP Signatures before the plugin serves ActivityPub data. Disabled by default.
+- **Open Registrations** — Advertises in NodeInfo whether the site accepts new user registrations.
+- **Custom Outbox Backfill** — Controls how many existing posts are included in the outbox for new followers.
+- **NodeInfo2** — Enables the NodeInfo2 protocol for enhanced discovery.
+- **Content Warning** — Allows setting a default content warning (summary) for posts.

--- a/docs/how-to/caching.md
+++ b/docs/how-to/caching.md
@@ -1,0 +1,154 @@
+# Caching and Content Negotiation
+
+The ActivityPub plugin uses content negotiation to serve two different responses from the same URL: HTML for browsers and JSON-LD for Fediverse servers. This is elegant and spec-compliant, but it conflicts with most caching setups, which assume one URL equals one response.
+
+This guide explains the problem, how to configure your cache correctly, and when to disable content negotiation entirely.
+
+## The problem
+
+When a Fediverse server like Mastodon fetches one of your posts, it sends an `Accept: application/activity+json` header. The plugin detects this and returns a JSON-LD representation instead of the normal HTML page.
+
+A caching layer that does not account for the `Accept` header will cache whichever response was generated first and serve it to everyone. This leads to one of two symptoms:
+
+- **Browsers see raw JSON** instead of your website, because a Fediverse server requested the page first and the JSON response was cached.
+- **Fediverse servers receive HTML** instead of JSON, because a browser visited first and the HTML response was cached. This breaks federation silently.
+
+## The Vary header
+
+The standard solution is the HTTP `Vary` header. Sending `Vary: Accept` tells caches to store separate versions of the response based on the `Accept` header the client sent.
+
+The plugin sends `Vary: Accept` by default. You can toggle this under **Settings > ActivityPub > [Advanced](advanced-settings.md) > Vary Header**, or force it via `wp-config.php`:
+
+```php
+define( 'ACTIVITYPUB_SEND_VARY_HEADER', true );
+```
+
+Whether this actually works depends on your caching layer respecting the `Vary` header, which many do not.
+
+## Compatible caching plugins
+
+These WordPress caching plugins are known to work with the ActivityPub plugin:
+
+| Plugin | How it works |
+|--------|-------------|
+| **[Surge](https://wordpress.org/plugins/surge/)** | Best option. The ActivityPub plugin automatically configures Surge to cache HTML and JSON as separate variants. This is the only plugin that properly caches both response types. |
+| **WP Super Cache** | Excludes ActivityPub requests from the cache. Federation works, but JSON requests always hit PHP. |
+| **Cachify** | Same as WP Super Cache, excludes ActivityPub requests. |
+| **Cache Enabler** | Same approach, excludes ActivityPub requests. |
+| **WP-Optimize** (v3.3.1+) | Compatible, excludes ActivityPub requests. |
+
+### Incompatible caching plugins
+
+These plugins are known to cause problems:
+
+- **W3 Total Cache** — Ignores the `Vary` header, serves cached HTML to Fediverse servers.
+- **WP Rocket** — Same issue, no support for `Vary: Accept`.
+- **Breeze** — Same issue.
+
+If you must use one of these, consider disabling content negotiation (see below).
+
+## Server-level caches
+
+### Varnish
+
+Varnish does not pass through `Vary: Accept` by default. You need to configure it explicitly. In your VCL:
+
+```vcl
+sub vcl_hash {
+    if (req.http.Accept ~ "application/(ld\+json|activity\+json|json)") {
+        hash_data("activitypub");
+    }
+}
+```
+
+Alternatively, add `Vary: Accept` in your Apache or Nginx config so Varnish sees it from the backend.
+
+### Nginx FastCGI Cache
+
+Add the `Accept` header to your cache key:
+
+```nginx
+fastcgi_cache_key "$scheme$request_method$host$request_uri$http_accept";
+```
+
+Or use a simplified variant that only distinguishes JSON from HTML:
+
+```nginx
+map $http_accept $activitypub_suffix {
+    default        "html";
+    ~application/  "json";
+}
+
+fastcgi_cache_key "$scheme$request_method$host$request_uri$activitypub_suffix";
+```
+
+### Cloudflare
+
+Cloudflare does not vary cache by `Accept` header on most plans. You can work around this by disabling content negotiation and using the `?activitypub` query parameter instead (see below), which gives each response type a distinct URL that Cloudflare can cache separately.
+
+### LiteSpeed / OpenLiteSpeed
+
+The plugin automatically adds `.htaccess` rules when it detects the LiteSpeed Cache plugin. If the automatic setup fails, you can add the rules manually:
+
+```apache
+# BEGIN ActivityPub LiteSpeed Cache
+<IfModule LiteSpeed>
+RewriteEngine On
+RewriteCond %{HTTP:Accept} application
+RewriteRule ^ - [E=Cache-Control:vary=%{ENV:LSCACHE_VARY_VALUE}+isjson]
+</IfModule>
+# END ActivityPub LiteSpeed Cache
+```
+
+Check **Tools > Site Health** to verify the integration is working.
+
+Note that OpenLiteSpeed (the open-source version) may ignore `Vary` headers entirely. If you are on OpenLiteSpeed and still seeing issues, consider disabling content negotiation.
+
+## Disabling content negotiation
+
+If your caching setup cannot handle `Vary: Accept` properly, you can disable content negotiation entirely:
+
+1. Go to **Settings > ActivityPub > [Advanced](advanced-settings.md)**.
+2. Uncheck **Content Negotiation**.
+3. Save.
+
+Or via `wp-config.php` / a plugin:
+
+```php
+add_filter( 'activitypub_should_negotiate_content', '__return_false' );
+```
+
+### What happens when content negotiation is off?
+
+- Your post URLs (`https://example.com/hello-world/`) will always return HTML, regardless of the `Accept` header. Caching works as normal.
+- Fediverse servers will still discover your content through the REST API endpoints (`/wp-json/activitypub/1.0/...`), which are separate URLs and not affected by page caching.
+- The JSON representation is still accessible by appending `?activitypub` to any URL (e.g. `https://example.com/hello-world/?activitypub`). This always triggers content negotiation, even when the global setting is off.
+- The `Link` header with `rel="alternate"` and `type="application/activity+json"` is still sent, so well-behaved clients can discover the JSON endpoint.
+
+Disabling content negotiation is a safe choice if you are primarily concerned with caching. Federation still works, it just uses dedicated API endpoints instead of serving JSON from the same URL as HTML.
+
+## The thundering herd problem
+
+When you publish a post and have many followers (1,000+), hundreds of Fediverse servers may request your new post simultaneously. If your cache does not cache ActivityPub JSON responses (most compatible plugins simply exclude them), every single request hits PHP.
+
+Recommendations for high-follower sites:
+
+- Use **Surge** with the ActivityPub integration, which actually caches both HTML and JSON variants.
+- Use **Nginx FastCGI Cache** or **Varnish** with proper `Vary` support so JSON responses are cached at the server level.
+- Consider a reverse proxy or CDN that supports `Vary: Accept`.
+
+## Checking your setup
+
+The plugin adds checks to **Tools > Site Health** that verify:
+
+- Whether the `Vary` header is enabled.
+- Whether content negotiation is enabled.
+- Whether LiteSpeed Cache or Surge are properly configured (if installed).
+
+You can also test manually by requesting a post URL with an ActivityPub Accept header:
+
+```bash
+curl -H "Accept: application/activity+json" https://example.com/hello-world/
+```
+
+If you get JSON back, content negotiation is working. If you get HTML, either content negotiation is disabled or your cache is serving the wrong variant.

--- a/docs/how-to/caching.md
+++ b/docs/how-to/caching.md
@@ -65,13 +65,7 @@ Alternatively, add `Vary: Accept` in your Apache or Nginx config so Varnish sees
 
 ### Nginx FastCGI Cache
 
-Add the `Accept` header to your cache key:
-
-```nginx
-fastcgi_cache_key "$scheme$request_method$host$request_uri$http_accept";
-```
-
-Or use a simplified variant that only distinguishes JSON from HTML:
+Use a map to distinguish JSON from HTML and add it to your cache key. Avoid using the raw `$http_accept` header directly, as browsers send many different Accept values that would fragment your cache unnecessarily:
 
 ```nginx
 map $http_accept $activitypub_suffix {
@@ -84,7 +78,7 @@ fastcgi_cache_key "$scheme$request_method$host$request_uri$activitypub_suffix";
 
 ### Cloudflare
 
-Cloudflare does not vary cache by `Accept` header on most plans. You can work around this by disabling content negotiation and using the `?activitypub` query parameter instead (see below), which gives each response type a distinct URL that Cloudflare can cache separately.
+Cloudflare does not vary cache by `Accept` header on most plans. The simplest workaround is to disable content negotiation (see below). Federation still works because Fediverse servers discover your content through the REST API endpoints and the `Link` alternate header, which point to distinct URLs that Cloudflare can cache normally.
 
 ### LiteSpeed / OpenLiteSpeed
 

--- a/docs/how-to/readme.md
+++ b/docs/how-to/readme.md
@@ -1,3 +1,13 @@
 # How-To
 
 This folder contains How-To guides for common problems or edge cases. If you miss a guide, please [open an issue](https://github.com/Automattic/wordpress-activitypub/issues/new/choose) or [submit a pull request](https://github.com/Automattic/wordpress-activitypub/pulls).
+
+## Table of Contents
+
+- [Account Migration](account-migration.md) — Moving between Mastodon, WordPress, and other Fediverse platforms.
+- [Advanced Settings](advanced-settings.md) — Enabling and using the hidden Advanced Settings tab.
+- [Caching](caching.md) — Configuring caches and CDNs to work with ActivityPub content negotiation.
+- [Classic Theme Blocks](classic-theme-blocks.md) — Using ActivityPub blocks in classic themes.
+- [Client to Server](client-to-server.md) — Using the OAuth-based Client-to-Server API.
+- [Reverse Proxy](reverse-proxy.md) — Handling reverse proxy setups with Apache.
+- [WordPress in a Subdirectory](wordpress-in-a-subdir.md) — Running WordPress from a subdirectory.


### PR DESCRIPTION
## Proposed changes:

* Add how-to guide for account migration between Mastodon, WordPress, and other Fediverse platforms.
* Add how-to guide for caching and content negotiation, covering compatible/incompatible plugins, server-level caches, Cloudflare, LiteSpeed, and when to disable content negotiation.
* Add how-to guide for enabling and using the hidden Advanced Settings tab.
* Add a table of contents to the how-to readme.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

N/A — documentation only.

## Testing instructions:

* Review the three new files in `docs/how-to/` for accuracy and completeness.
* Verify all internal links between guides work (e.g. caching.md links to advanced-settings.md).
* Check that the table of contents in `docs/how-to/readme.md` lists all existing guides.