### PR TITLE
Add support for Mastodon FeaturedCollection import

### DIFF
--- a/.github/changelog/3168-from-description
+++ b/.github/changelog/3168-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add support for importing Starter Packs in both the Pixelfed and Mastodon formats.

--- a/includes/functions-activity.php
+++ b/includes/functions-activity.php
@@ -212,6 +212,10 @@ function object_to_uri( $data ) {
 			$data = $data['href'];
 			break;
 
+		case 'FeaturedItem': // See https://github.com/mastodon/featured_collections/pull/1.
+			$data = object_to_uri( $data['featuredObject'] ?? null );
+			break;
+
 		default:
 			$data = $data['id'];
 			break;

--- a/includes/functions-activity.php
+++ b/includes/functions-activity.php
@@ -217,7 +217,15 @@ function object_to_uri( $data ) {
 			break;
 
 		default:
-			$data = $data['id'];
+			if ( isset( $data['id'] ) ) {
+				$data = $data['id'];
+			} elseif ( isset( $data['url'] ) ) {
+				$data = object_to_uri( $data['url'] );
+			} elseif ( isset( $data['href'] ) ) {
+				$data = $data['href'];
+			} else {
+				$data = null;
+			}
 			break;
 	}
 

--- a/includes/wp-admin/import/class-starter-kit.php
+++ b/includes/wp-admin/import/class-starter-kit.php
@@ -385,7 +385,7 @@ class Starter_Kit {
 				\printf(
 					'<img src="%s" style="max-width: 500px;" alt="%s" />',
 					\esc_url( $image_url ),
-					\esc_attr( self::$starter_kit['name'] ?? '' )
+					\esc_attr( $name )
 				);
 			}
 		}

--- a/includes/wp-admin/import/class-starter-kit.php
+++ b/includes/wp-admin/import/class-starter-kit.php
@@ -378,12 +378,16 @@ class Starter_Kit {
 
 		echo '<h3>' . \esc_html( $name ) . '</h3>';
 
-		if ( ! empty( self::$starter_kit['image']['url'] ) ) {
-			\printf(
-				'<img src="%s" style="max-width: 500px;" alt="%s" />',
-				\esc_url( self::$starter_kit['image']['url'] ),
-				\esc_attr( self::$starter_kit['image']['summary'] ?? '' )
-			);
+		if ( ! empty( self::$starter_kit['image'] ) ) {
+			$image_url = object_to_uri( self::$starter_kit['image'] );
+
+			if ( $image_url ) {
+				\printf(
+					'<img src="%s" style="max-width: 500px;" alt="%s" />',
+					\esc_url( $image_url ),
+					\esc_attr( self::$starter_kit['name'] ?? '' )
+				);
+			}
 		}
 
 		if ( ! empty( self::$starter_kit['summary'] ) ) {
@@ -440,11 +444,18 @@ class Starter_Kit {
 				if ( ! self::is_valid_actor( $actor_uri ) ) {
 					continue;
 				}
+
+				$actor_name = \is_array( $actor ) ? ( $actor['name'] ?? '' ) : '';
 				?>
 				<li>
 					<label>
 						<input type="checkbox" name="actors[]" value="<?php echo \esc_attr( $actor_uri ); ?>" checked />
-						<?php echo \esc_html( $actor_uri ); ?>
+						<?php if ( $actor_name ) : ?>
+							<strong><?php echo \esc_html( $actor_name ); ?></strong>
+							(<?php echo \esc_html( $actor_uri ); ?>)
+						<?php else : ?>
+							<?php echo \esc_html( $actor_uri ); ?>
+						<?php endif; ?>
 					</label>
 				</li>
 			<?php endforeach; ?>
@@ -610,6 +621,18 @@ class Starter_Kit {
 		self::$starter_kit = \json_decode( $file_contents, true );
 		if ( null === self::$starter_kit ) {
 			return new \WP_Error( 'invalid_json', \esc_html__( 'Invalid JSON format in the uploaded file.', 'activitypub' ) );
+		}
+
+		/*
+		 * Validate that the type is a Collection-like type.
+		 * FeaturedCollection is from the Mastodon FEP draft:
+		 * https://github.com/mastodon/featured_collections/pull/1
+		 */
+		$type        = (array) ( self::$starter_kit['type'] ?? array() );
+		$valid_types = array( 'Collection', 'OrderedCollection', 'FeaturedCollection' );
+
+		if ( ! \array_intersect( $type, $valid_types ) ) {
+			return new \WP_Error( 'invalid_type', \esc_html__( 'The file does not contain a valid Starter Kit Collection.', 'activitypub' ) );
 		}
 
 		$actors = self::$starter_kit['items'] ?? self::$starter_kit['orderedItems'] ?? array();

--- a/tests/phpunit/tests/includes/class-test-functions-activity.php
+++ b/tests/phpunit/tests/includes/class-test-functions-activity.php
@@ -93,6 +93,20 @@ class Test_Functions_Activity extends \WP_UnitTestCase {
 				),
 				'https://example.com',
 			),
+			array(
+				array(
+					'type'                 => 'FeaturedItem',
+					'featuredObject'       => 'https://example.com/users/alice',
+					'featureAuthorization' => 'https://example.com/users/alice/stamps/1',
+				),
+				'https://example.com/users/alice',
+			),
+			array(
+				array(
+					'type' => 'FeaturedItem',
+				),
+				null,
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/includes/class-test-functions-activity.php
+++ b/tests/phpunit/tests/includes/class-test-functions-activity.php
@@ -107,6 +107,29 @@ class Test_Functions_Activity extends \WP_UnitTestCase {
 				),
 				null,
 			),
+			// Default fallback: object with url but no id.
+			array(
+				array(
+					'type' => 'Unknown',
+					'url'  => 'https://example.com/image.jpg',
+				),
+				'https://example.com/image.jpg',
+			),
+			// Default fallback: object with href but no id or url.
+			array(
+				array(
+					'type' => 'Unknown',
+					'href' => 'https://example.com/link',
+				),
+				'https://example.com/link',
+			),
+			// Default fallback: object with no id, url, or href.
+			array(
+				array(
+					'type' => 'Unknown',
+				),
+				null,
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/includes/class-test-moderation.php
+++ b/tests/phpunit/tests/includes/class-test-moderation.php
@@ -507,23 +507,8 @@ class Test_Moderation extends \WP_UnitTestCase {
 			)
 		);
 
-		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
-		\set_error_handler(
-			static function ( $errno, $errstr ) {
-				throw new \Exception( \esc_html( $errstr ), \esc_html( $errno ) );
-			},
-			E_NOTICE | E_WARNING
-		);
-
-		// PHP 7.x uses "Undefined index", PHP 8+ uses "Undefined array key".
-		if ( version_compare( PHP_VERSION, '8.0.0', '>=' ) ) {
-			$this->expectExceptionMessage( 'Undefined array key &quot;id&quot;' );
-		} else {
-			$this->expectExceptionMessage( 'Undefined index: id' );
-		}
+		// A malformed actor with no 'id' should gracefully return false, not trigger a PHP notice.
 		$this->assertFalse( Moderation::activity_is_blocked( $activity ) );
-
-		\restore_error_handler();
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* Add `FeaturedItem` type handling to `object_to_uri()` so the Starter Kit importer transparently supports both the [Pixelfed starter-kit format](https://github.com/pixelfed/starter-kits/issues/1) and the [Mastodon FEP FeaturedCollection format](https://github.com/mastodon/featured_collections/pull/1).
* Validate collection `type` on import (accepts `Collection`, `OrderedCollection`, and `FeaturedCollection`, including multi-type arrays).
* Resolve images via `object_to_uri()` for format-agnostic URL extraction (handles both `{ "url": "..." }` and `{ "url": { "type": "Link", "href": "..." } }`).
* Show actor display names when available in the import selection UI.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Import a Pixelfed-format starter kit JSON (with `type: Collection` and `Person` items) — should work as before.
* Import a Mastodon FEP-format starter kit JSON (with `type: FeaturedCollection` and `FeaturedItem` entries containing `featuredObject`) — actors should be correctly extracted and listed.
* Try importing a JSON file with an invalid `type` (e.g. `Note`) — should show an error message.
* Verify actor names display as **Name** (URI) when available, and as plain URIs when not.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Added - for new features

#### Message

Add support for importing Starter Packs in both the Pixelfed and Mastodon formats.

</details>