### PR TITLE
Fix OAuth client metadata fetch for localhost subdomains

### DIFF
--- a/.github/changelog/3169-from-description
+++ b/.github/changelog/3169-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix OAuth authentication failing for local development clients using localhost subdomains.

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -541,7 +541,8 @@ class Client {
 		$host = \strtolower( $host );
 
 		// Match "localhost" and any subdomain of localhost (RFC 6761 Section 6.3).
-		if ( 'localhost' === $host || '.localhost' === \substr( $host, -10 ) ) {
+		$suffix = '.localhost';
+		if ( 'localhost' === $host || $suffix === \substr( $host, -\strlen( $suffix ) ) ) {
 			return true;
 		}
 

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -541,8 +541,7 @@ class Client {
 		$host = \strtolower( $host );
 
 		// Match "localhost" and any subdomain of localhost (RFC 6761 Section 6.3).
-		$suffix = '.localhost';
-		if ( 'localhost' === $host || $suffix === \substr( $host, -\strlen( $suffix ) ) ) {
+		if ( 'localhost' === $host || '.localhost' === \substr( $host, -\strlen( '.localhost' ) ) ) {
 			return true;
 		}
 

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -280,16 +280,26 @@ class Client {
 	 * @return array|\WP_Error Metadata array or error.
 	 */
 	private static function fetch_client_metadata( $url ) {
-		$response = \wp_safe_remote_get(
-			$url,
-			array(
-				'timeout'     => 10,
-				'headers'     => array(
-					'Accept' => 'application/cimd+json, application/json, application/ld+json, application/activity+json',
-				),
-				'redirection' => 0, // CIMDs prohibit following redirects to prevent client impersonation.
-			)
+		$args = array(
+			'timeout'     => 10,
+			'headers'     => array(
+				'Accept' => 'application/cimd+json, application/json, application/ld+json, application/activity+json',
+			),
+			'redirection' => 0, // CIMDs prohibit following redirects to prevent client impersonation.
 		);
+
+		$host = \wp_parse_url( $url, PHP_URL_HOST );
+
+		/*
+		 * Use wp_remote_get for loopback hosts (localhost, *.localhost, 127.x.x.x, ::1).
+		 * wp_safe_remote_get blocks private IPs as SSRF protection, but the OAuth spec
+		 * explicitly allows loopback clients for development (RFC 8252 Section 8.3).
+		 */
+		if ( $host && self::is_loopback( $host ) ) {
+			$response = \wp_remote_get( $url, $args );
+		} else {
+			$response = \wp_safe_remote_get( $url, $args );
+		}
 
 		if ( \is_wp_error( $response ) ) {
 			return new \WP_Error(
@@ -528,7 +538,10 @@ class Client {
 	 * @return bool True if loopback.
 	 */
 	private static function is_loopback( $host ) {
-		if ( 'localhost' === \strtolower( $host ) ) {
+		$host = \strtolower( $host );
+
+		// Match "localhost" and any subdomain of localhost (RFC 6761 Section 6.3).
+		if ( 'localhost' === $host || '.localhost' === \substr( $host, -10 ) ) {
 			return true;
 		}
 

--- a/tests/phpunit/tests/includes/oauth/class-test-client.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-client.php
@@ -232,6 +232,23 @@ class Test_Client extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test register method allows http for localhost subdomains (RFC 6761).
+	 *
+	 * @covers ::register
+	 */
+	public function test_register_allows_http_localhost_subdomain() {
+		$result = $this->create_client(
+			array(
+				'name'          => 'Localhost Subdomain Client',
+				'redirect_uris' => array( 'http://calypso.localhost:3000/callback' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'client_id', $result );
+	}
+
+	/**
 	 * Test register method allows http for non-loopback when filter permits.
 	 *
 	 * @covers ::register


### PR DESCRIPTION
## Proposed changes:

* Fix C2S authentication failing for local development clients (e.g. `http://calypso.localhost:3000`) with error "Could not reach the application: A valid URL was not provided."
* `wp_safe_remote_get` blocks private IPs as SSRF protection, but the OAuth spec explicitly allows loopback clients for development (RFC 8252 Section 8.3). Use `wp_remote_get` when the host is a loopback address.
* Extend `is_loopback()` to match `*.localhost` subdomains per RFC 6761 Section 6.3, which reserves the entire `.localhost` TLD to always resolve to loopback.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Set up a local C2S client running on a `*.localhost` subdomain (e.g. `http://calypso.localhost:3000`).
* Attempt OAuth authentication against the plugin. Before this fix it fails with "Could not reach the application"; after the fix it succeeds.
* Verify that `http://localhost:8080` and `http://127.0.0.1:3000` still work as before.
* Verify that non-loopback `http://` URLs (e.g. `http://example.com`) are still rejected.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix OAuth authentication failing for local development clients using localhost subdomains.

</details>