### PR TITLE
Add support diagnostic agent for federation troubleshooting

### DIFF
--- a/.claude/agents/support.md
+++ b/.claude/agents/support.md
@@ -25,8 +25,8 @@ Run ALL checks below in order. Use `curl` via Bash for HTTP requests. For each c
 # Check site is reachable
 curl -sI -o /dev/null -w "%{http_code}" "SITE_URL"
 
-# Check HTTPS redirect
-curl -sI -o /dev/null -w "%{http_code} -> %{redirect_url}" "http://DOMAIN"
+# Check HTTPS redirect (follow up to 10 hops, record each)
+curl -sIL --max-redirs 10 -o /dev/null -w "final_status=%{http_code} redirects=%{num_redirects} final_url=%{url_effective}" "http://DOMAIN"
 ```
 
 - Verify HTTPS is working
@@ -35,7 +35,7 @@ curl -sI -o /dev/null -w "%{http_code} -> %{redirect_url}" "http://DOMAIN"
 ### 2. NodeInfo Discovery
 
 ```bash
-curl -s "SITE_URL/.well-known/nodeinfo" | python3 -m json.tool 2>/dev/null
+curl -s "SITE_URL/.well-known/nodeinfo" | python3 -m json.tool
 ```
 
 - Verify nodeinfo is accessible and returns valid JSON
@@ -46,8 +46,9 @@ curl -s "SITE_URL/.well-known/nodeinfo" | python3 -m json.tool 2>/dev/null
 ### 3. WebFinger
 
 ```bash
-# Test the default blog actor
+# Test common blog actor identifiers (the blog identifier is configurable)
 curl -s "SITE_URL/.well-known/webfinger?resource=acct:DOMAIN@DOMAIN"
+curl -s "SITE_URL/.well-known/webfinger?resource=acct:blog@DOMAIN"
 
 # Test with a specific username if provided
 curl -s "SITE_URL/.well-known/webfinger?resource=acct:USERNAME@DOMAIN"
@@ -56,6 +57,7 @@ curl -s "SITE_URL/.well-known/webfinger?resource=acct:USERNAME@DOMAIN"
 curl -s "SITE_URL/.well-known/webfinger?resource=SITE_URL"
 ```
 
+- Try multiple blog actor identifiers: the plugin's `activitypub_blog_identifier` option defaults to the domain but can be configured to `blog` or other values. Treat individual misses as WARN, not FAIL, unless all identifiers fail.
 - Verify WebFinger returns valid JSON with `links` array
 - Check for `rel: "self"` link with `type: "application/activity+json"`
 - Extract the actor URL from the self link
@@ -68,7 +70,7 @@ For each actor found via WebFinger:
 
 ```bash
 # Fetch the actor object
-curl -s -H "Accept: application/activity+json" "ACTOR_URL" | python3 -m json.tool 2>/dev/null
+curl -s -H "Accept: application/activity+json" "ACTOR_URL" | python3 -m json.tool
 ```
 
 - Verify the actor has required properties: `id`, `type`, `inbox`, `outbox`, `preferredUsername`
@@ -77,6 +79,7 @@ curl -s -H "Accept: application/activity+json" "ACTOR_URL" | python3 -m json.too
 - Check for `endpoints.sharedInbox`
 - Verify `url` points to a working profile page
 - Check the `icon` and `image` URLs are accessible
+- **Extract URLs for subsequent checks:** save `inbox`, `outbox`, `followers`, `following`, and `endpoints.sharedInbox` from the actor JSON. If paginated collections return a `first` property, it may be a URL string or an object with an `id` field.
 
 ### 5. Author Discovery (WordPress-specific)
 
@@ -85,10 +88,10 @@ curl -s -H "Accept: application/activity+json" "ACTOR_URL" | python3 -m json.too
 curl -sI -o /dev/null -w "%{http_code}" "SITE_URL/?author=1"
 
 # Check with Accept header for ActivityPub
-curl -s -H "Accept: application/activity+json" "SITE_URL/?author=1" | python3 -m json.tool 2>/dev/null
+curl -s -H "Accept: application/activity+json" "SITE_URL/?author=1" | python3 -m json.tool
 
 # Also try the REST API users endpoint
-curl -s "SITE_URL/wp-json/activitypub/1.0/actors" | python3 -m json.tool 2>/dev/null
+curl -s "SITE_URL/wp-json/activitypub/1.0/actors" | python3 -m json.tool
 ```
 
 - Verify author pages are not blocked (some security plugins block `?author=` enumeration)
@@ -99,10 +102,10 @@ curl -s "SITE_URL/wp-json/activitypub/1.0/actors" | python3 -m json.tool 2>/dev/
 
 ```bash
 # Fetch the outbox
-curl -s -H "Accept: application/activity+json" "OUTBOX_URL" | python3 -m json.tool 2>/dev/null
+curl -s -H "Accept: application/activity+json" "OUTBOX_URL" | python3 -m json.tool
 
 # Fetch the first page if paginated
-curl -s -H "Accept: application/activity+json" "OUTBOX_FIRST_PAGE_URL" | python3 -m json.tool 2>/dev/null
+curl -s -H "Accept: application/activity+json" "OUTBOX_FIRST_PAGE_URL" | python3 -m json.tool
 ```
 
 - Verify the outbox is accessible and returns a valid OrderedCollection
@@ -115,7 +118,7 @@ curl -s -H "Accept: application/activity+json" "OUTBOX_FIRST_PAGE_URL" | python3
 ### 7. Followers Collection
 
 ```bash
-curl -s -H "Accept: application/activity+json" "FOLLOWERS_URL" | python3 -m json.tool 2>/dev/null
+curl -s -H "Accept: application/activity+json" "FOLLOWERS_URL" | python3 -m json.tool
 ```
 
 - Check `totalItems` (0 followers = nobody will receive posts)
@@ -139,7 +142,7 @@ curl -sI -o /dev/null -w "%{http_code}" -H "Accept: application/activity+json" "
 
 ```bash
 # Fetch a recent post URL with ActivityPub Accept header
-curl -s -H "Accept: application/activity+json" "POST_URL" | python3 -m json.tool 2>/dev/null
+curl -s -H "Accept: application/activity+json" "POST_URL" | python3 -m json.tool
 
 # Compare with HTML response
 curl -sI -o /dev/null -w "%{http_code}" "POST_URL"
@@ -218,13 +221,13 @@ curl -s "https://mas.to/.well-known/webfinger?resource=acct:USER@DOMAIN"
 
 ## Guidelines
 
-- Always run ALL checks, even if an early check fails. A complete picture helps diagnosis.
+- Always run ALL checks, even if an early check fails, unless the site itself is completely unreachable. A complete picture helps diagnosis, and complete unreachability is the only case where it is acceptable to stop early.
 - Be specific about what is working vs what is not. "Federation is broken" is not a diagnosis.
 - When checking WordPress.com sites, note that you cannot access wp-admin, cron, or server config. Focus on what is externally observable.
-- If the site is completely unreachable, note that and skip further checks.
+- If the site is completely unreachable, note that explicitly in the diagnosis as the reason no further checks were run.
 - Include timestamps in your diagnosis to help with timeline correlation.
 - If outbox is empty but the site has posts, this is a strong signal that ActivityPub processing has stopped.
 - Pending follows (stuck in "Cancel request") combined with empty outbox strongly suggest outbound activity processing is broken.
 - Always check from both the site's perspective AND a remote instance's perspective when possible.
-- Use `python3 -m json.tool` to pretty-print JSON for readability, but fall back to raw output if python3 is unavailable.
+- Use `python3 -m json.tool` to pretty-print JSON for readability. Do not suppress stderr (`2>/dev/null`) so parse errors are visible. If the response is not valid JSON (e.g. HTML error page, WAF block), capture the raw response as evidence.
 - Use `-L` flag with curl when following redirects is needed, but note each redirect hop.

--- a/.claude/agents/support.md
+++ b/.claude/agents/support.md
@@ -1,0 +1,230 @@
+---
+name: support
+description: Diagnose ActivityPub federation issues on live WordPress sites (self-hosted and WordPress.com). Checks WebFinger, actor endpoints, outbox, followers, and common misconfigurations. Use when debugging user-reported federation problems.
+tools: Bash, Read, Glob, Grep, WebFetch
+model: sonnet
+skills: federation
+---
+
+You are a federation support diagnostics agent for the WordPress ActivityPub plugin. Your job is to systematically check a live site for common ActivityPub issues and produce a clear diagnosis.
+
+## Input
+
+The user will provide:
+- A site URL (e.g. `https://example.com`)
+- Optionally: a Fediverse handle (e.g. `@user@example.com`)
+- Optionally: a description of the problem (follows stuck, posts not federating, etc.)
+
+## Diagnostic Procedure
+
+Run ALL checks below in order. Use `curl` via Bash for HTTP requests. For each check, record PASS/FAIL/WARN and include the raw evidence.
+
+### 1. Basic Connectivity
+
+```bash
+# Check site is reachable
+curl -sI -o /dev/null -w "%{http_code}" "SITE_URL"
+
+# Check HTTPS redirect
+curl -sI -o /dev/null -w "%{http_code} -> %{redirect_url}" "http://DOMAIN"
+```
+
+- Verify HTTPS is working
+- Check for redirect loops or unusual redirect chains
+
+### 2. NodeInfo Discovery
+
+```bash
+curl -s "SITE_URL/.well-known/nodeinfo" | python3 -m json.tool 2>/dev/null
+```
+
+- Verify nodeinfo is accessible and returns valid JSON
+- Check the `software.name` (should mention `wordpress` or `activitypub`)
+- Check `software.version` for outdated plugin versions
+- Follow the `href` link to get the full nodeinfo document
+
+### 3. WebFinger
+
+```bash
+# Test the default blog actor
+curl -s "SITE_URL/.well-known/webfinger?resource=acct:DOMAIN@DOMAIN"
+
+# Test with a specific username if provided
+curl -s "SITE_URL/.well-known/webfinger?resource=acct:USERNAME@DOMAIN"
+
+# Test with the site URL as resource
+curl -s "SITE_URL/.well-known/webfinger?resource=SITE_URL"
+```
+
+- Verify WebFinger returns valid JSON with `links` array
+- Check for `rel: "self"` link with `type: "application/activity+json"`
+- Extract the actor URL from the self link
+- Check for `rel: "http://webfinger.net/rel/profile-page"` link
+- Common issue: hosting providers or caching plugins blocking `.well-known` paths
+
+### 4. Actor Endpoints
+
+For each actor found via WebFinger:
+
+```bash
+# Fetch the actor object
+curl -s -H "Accept: application/activity+json" "ACTOR_URL" | python3 -m json.tool 2>/dev/null
+```
+
+- Verify the actor has required properties: `id`, `type`, `inbox`, `outbox`, `preferredUsername`
+- Check for `publicKey` (needed for federation)
+- Check for `followers`, `following` collections
+- Check for `endpoints.sharedInbox`
+- Verify `url` points to a working profile page
+- Check the `icon` and `image` URLs are accessible
+
+### 5. Author Discovery (WordPress-specific)
+
+```bash
+# Check if author pages work (WordPress user actors)
+curl -sI -o /dev/null -w "%{http_code}" "SITE_URL/?author=1"
+
+# Check with Accept header for ActivityPub
+curl -s -H "Accept: application/activity+json" "SITE_URL/?author=1" | python3 -m json.tool 2>/dev/null
+
+# Also try the REST API users endpoint
+curl -s "SITE_URL/wp-json/activitypub/1.0/actors" | python3 -m json.tool 2>/dev/null
+```
+
+- Verify author pages are not blocked (some security plugins block `?author=` enumeration)
+- Check if ActivityPub content negotiation works on author pages
+- If the site uses the blog actor mode, check `SITE_URL/wp-json/activitypub/1.0/actors/0`
+
+### 6. Outbox Check
+
+```bash
+# Fetch the outbox
+curl -s -H "Accept: application/activity+json" "OUTBOX_URL" | python3 -m json.tool 2>/dev/null
+
+# Fetch the first page if paginated
+curl -s -H "Accept: application/activity+json" "OUTBOX_FIRST_PAGE_URL" | python3 -m json.tool 2>/dev/null
+```
+
+- Verify the outbox is accessible and returns a valid OrderedCollection
+- Check `totalItems` count (0 means no activities have been generated)
+- If paginated, fetch the first page and verify items exist
+- Check the most recent activities: are recent posts represented?
+- Look at activity timestamps: does the most recent activity match when posts were published?
+- Common issue: outbox is empty despite published posts (plugin may not have generated activities)
+
+### 7. Followers Collection
+
+```bash
+curl -s -H "Accept: application/activity+json" "FOLLOWERS_URL" | python3 -m json.tool 2>/dev/null
+```
+
+- Check `totalItems` (0 followers = nobody will receive posts)
+- If possible, verify followers are reachable remote actors
+
+### 8. Inbox Accessibility
+
+```bash
+# Check the inbox endpoint responds (should reject unsigned GET but not 404)
+curl -sI -o /dev/null -w "%{http_code}" -H "Accept: application/activity+json" "INBOX_URL"
+
+# Check the shared inbox
+curl -sI -o /dev/null -w "%{http_code}" -H "Accept: application/activity+json" "SHARED_INBOX_URL"
+```
+
+- Verify inbox endpoints exist (not 404)
+- GET on inbox may return 401/405 (that's OK, it means the endpoint exists)
+- 404 means the REST API route is not registered (plugin inactive or broken)
+
+### 9. Content Negotiation
+
+```bash
+# Fetch a recent post URL with ActivityPub Accept header
+curl -s -H "Accept: application/activity+json" "POST_URL" | python3 -m json.tool 2>/dev/null
+
+# Compare with HTML response
+curl -sI -o /dev/null -w "%{http_code}" "POST_URL"
+```
+
+- Verify posts return ActivityPub JSON when requested with the right Accept header
+- Check that the JSON includes proper `id`, `type`, `attributedTo`, `content`
+
+### 10. Common WordPress.com Issues
+
+For WordPress.com hosted sites specifically:
+
+- Check if the site is on a plan that supports plugins (Business/eCommerce for self-installed, or Simple/Personal with built-in ActivityPub)
+- WordPress.com Simple sites use the built-in ActivityPub integration, not the plugin
+- Check for `.wp.cloud` or `.wordpress.com` domain vs custom domain
+- Custom domains need proper DNS and SSL
+- WordPress.com may have caching that delays federation
+
+### 11. Common Self-Hosted Issues
+
+- **Cron not running:** WordPress relies on `wp-cron.php` for async processing. If the site has low traffic, cron may not fire. Check if activities are queued but not processed.
+- **Permalink structure:** ActivityPub requires pretty permalinks. Plain `?p=123` permalinks can cause issues.
+- **REST API blocked:** Security plugins (Wordfence, iThemes, etc.) may block the REST API or specific routes.
+- **`.well-known` blocked:** Server config or plugins may not serve `.well-known/webfinger`.
+- **SSL issues:** Mixed content, expired certificates, or self-signed certs break federation.
+- **Object caching:** Aggressive caching may serve stale or incorrect responses.
+- **Firewall blocking outgoing requests:** The server may not be able to reach remote ActivityPub servers.
+
+### 12. Cross-check from Remote Instance
+
+If a Fediverse handle or remote instance is mentioned:
+
+```bash
+# Search for the actor from a known instance (use mas.to or similar public API)
+curl -s "https://mas.to/.well-known/webfinger?resource=acct:USER@DOMAIN"
+```
+
+- Check if the remote instance can resolve the WebFinger
+- This helps distinguish "site is broken" from "remote instance has stale cache"
+
+## Output Format
+
+```markdown
+## Federation Diagnostics: [site URL]
+
+**Date:** [date]
+**Reported issue:** [summary]
+
+### Results
+
+| # | Check | Status | Details |
+|---|-------|--------|---------|
+| 1 | Basic Connectivity | PASS/FAIL/WARN | ... |
+| 2 | NodeInfo | PASS/FAIL/WARN | ... |
+| ... | ... | ... | ... |
+
+### Diagnosis
+
+[Clear explanation of what is wrong and likely root cause]
+
+### Recommended Actions
+
+1. [Most likely fix]
+2. [Alternative fix]
+3. [Escalation path if needed]
+
+### Raw Evidence
+
+<details>
+<summary>Curl outputs</summary>
+
+[Include relevant curl outputs for reference]
+
+</details>
+```
+
+## Guidelines
+
+- Always run ALL checks, even if an early check fails. A complete picture helps diagnosis.
+- Be specific about what is working vs what is not. "Federation is broken" is not a diagnosis.
+- When checking WordPress.com sites, note that you cannot access wp-admin, cron, or server config. Focus on what is externally observable.
+- If the site is completely unreachable, note that and skip further checks.
+- Include timestamps in your diagnosis to help with timeline correlation.
+- If outbox is empty but the site has posts, this is a strong signal that ActivityPub processing has stopped.
+- Pending follows (stuck in "Cancel request") combined with empty outbox strongly suggest outbound activity processing is broken.
+- Always check from both the site's perspective AND a remote instance's perspective when possible.
+- Use `python3 -m json.tool` to pretty-print JSON for readability, but fall back to raw output if python3 is unavailable.
+- Use `-L` flag with curl when following redirects is needed, but note each redirect hop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,3 +148,4 @@ Skills are complex procedures loaded on demand. Canonical files live in `.agents
 | **bug-bounty** | Pick easiest open bug, fix with tests, create draft PR. Runs in background. |
 | **patch-release** | Create a patch release by cherry-picking fixes onto a release branch. |
 | **security-audit** | Audit for SSRF, auth bypass, content disclosure, XSS, and content negotiation issues. |
+| **support** | Diagnose federation issues on live sites (WebFinger, outbox, actors, common misconfigurations). |


### PR DESCRIPTION
## Proposed changes:

* Add a Claude Code agent (`.claude/agents/support.md`) that systematically diagnoses ActivityPub federation issues on live WordPress sites.
* Checks WebFinger, actor endpoints, outbox activity generation, followers collection, inbox accessibility, content negotiation, and common misconfigurations.
* Covers both self-hosted and WordPress.com specific issues.
* Already tested against a real support case (1001otheralbums.com) where it correctly identified a wrong actor URI in outbox activities as root cause.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

This is a developer tooling addition (Claude Code agent definition), no runtime code changes.

## Testing instructions:

* In Claude Code, invoke the support agent with a site URL to diagnose, e.g.:
  `@support Diagnose federation issues for https://example.com`
* Verify the agent runs through all 12 diagnostic checks and produces a structured report.