### PR TITLE
Fix BuddyPress @mention filter corrupting Followers block

### DIFF
--- a/.github/changelog/3174-from-description
+++ b/.github/changelog/3174-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix BuddyPress @mention filter corrupting Fediverse Followers and Following blocks.

--- a/integration/class-buddypress.php
+++ b/integration/class-buddypress.php
@@ -18,6 +18,29 @@ class Buddypress {
 	 */
 	public static function init() {
 		\add_filter( 'activitypub_json_author_array', array( self::class, 'add_user_metadata' ), 11, 2 );
+		\add_filter( 'render_block_activitypub/followers', array( self::class, 'disable_at_name_filter' ), 0 );
+		\add_filter( 'render_block_activitypub/following', array( self::class, 'disable_at_name_filter' ), 0 );
+	}
+
+	/**
+	 * Disable BuddyPress @mention linking during block rendering.
+	 *
+	 * BuddyPress hooks `bp_activity_at_name_filter` into `the_content` to convert
+	 *
+	 * @username mentions into profile links. This corrupts the JSON in the
+	 * `data-wp-context` attribute of Followers/Following blocks because the handles
+	 * contain @username patterns that get replaced with HTML.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $block_content The block content.
+	 *
+	 * @return string The unmodified block content.
+	 */
+	public static function disable_at_name_filter( $block_content ) {
+		\remove_filter( 'the_content', 'bp_activity_at_name_filter' );
+
+		return $block_content;
 	}
 
 	/**

--- a/integration/class-buddypress.php
+++ b/integration/class-buddypress.php
@@ -31,7 +31,8 @@ class Buddypress {
 	 * contain `@username` patterns that match BuddyPress's regex.
 	 *
 	 * Encoding `@` as `&#x40;` in the HTML attribute makes it invisible to
-	 * BuddyPress's regex while browsers and JSON parsers decode it correctly.
+	 * BuddyPress's regex. The browser decodes the HTML entity before JavaScript
+	 * reads the attribute, so the Interactivity API receives the original `@`.
 	 *
 	 * @since unreleased
 	 *

--- a/integration/class-buddypress.php
+++ b/integration/class-buddypress.php
@@ -16,68 +16,37 @@ class Buddypress {
 	/**
 	 * Initialize the class, registering WordPress hooks.
 	 */
-	/**
-	 * Whether the BuddyPress at-name filter was removed for the current content pass.
-	 *
-	 * @var bool
-	 */
-	private static $at_name_filter_removed = false;
-
-	/**
-	 * Initialize the class, registering WordPress hooks.
-	 */
 	public static function init() {
 		\add_filter( 'activitypub_json_author_array', array( self::class, 'add_user_metadata' ), 11, 2 );
-		\add_filter( 'render_block_activitypub/followers', array( self::class, 'disable_at_name_filter' ), 0 );
-		\add_filter( 'render_block_activitypub/following', array( self::class, 'disable_at_name_filter' ), 0 );
+		\add_filter( 'render_block_activitypub/followers', array( self::class, 'escape_at_signs' ) );
+		\add_filter( 'render_block_activitypub/following', array( self::class, 'escape_at_signs' ) );
 	}
 
 	/**
-	 * Disable BuddyPress `@mention` linking during block rendering.
+	 * Escape `@` signs in block output to prevent BuddyPress mention linking.
 	 *
 	 * BuddyPress hooks `bp_activity_at_name_filter` into `the_content` to convert
 	 * `@username` mentions into profile links. This corrupts the JSON in the
 	 * `data-wp-context` attribute of Followers/Following blocks because the handles
-	 * contain `@username` patterns that get replaced with HTML.
+	 * contain `@username` patterns that match BuddyPress's regex.
 	 *
-	 * The filter is restored after the current `the_content` pass completes so that
-	 * subsequent calls (other posts in a loop, widgets, etc.) still get BuddyPress
-	 * mention linking.
+	 * Encoding `@` as `&#x40;` in the HTML attribute makes it invisible to
+	 * BuddyPress's regex while browsers and JSON parsers decode it correctly.
 	 *
 	 * @since unreleased
 	 *
 	 * @param string $block_content The block content.
 	 *
-	 * @return string The unmodified block content.
+	 * @return string The block content with `@` signs escaped in data attributes.
 	 */
-	public static function disable_at_name_filter( $block_content ) {
-		if ( ! self::$at_name_filter_removed ) {
-			\remove_filter( 'the_content', 'bp_activity_at_name_filter' );
-			\add_filter( 'the_content', array( self::class, 'restore_at_name_filter' ), 999 );
-			self::$at_name_filter_removed = true;
-		}
-
-		return $block_content;
-	}
-
-	/**
-	 * Restore BuddyPress `@mention` filter after the current content pass.
-	 *
-	 * Runs at priority 999 on `the_content` to ensure it executes after all other
-	 * filters, then re-adds the BuddyPress filter for subsequent `the_content` calls.
-	 *
-	 * @since unreleased
-	 *
-	 * @param string $content The post content.
-	 *
-	 * @return string The unmodified content.
-	 */
-	public static function restore_at_name_filter( $content ) {
-		\add_filter( 'the_content', 'bp_activity_at_name_filter' );
-		\remove_filter( 'the_content', array( self::class, 'restore_at_name_filter' ), 999 );
-		self::$at_name_filter_removed = false;
-
-		return $content;
+	public static function escape_at_signs( $block_content ) {
+		return \preg_replace_callback(
+			'/data-wp-context="([^"]*)"/',
+			static function ( $matches ) {
+				return 'data-wp-context="' . \str_replace( '@', '&#x40;', $matches[1] ) . '"';
+			},
+			$block_content
+		);
 	}
 
 	/**

--- a/integration/class-buddypress.php
+++ b/integration/class-buddypress.php
@@ -16,6 +16,16 @@ class Buddypress {
 	/**
 	 * Initialize the class, registering WordPress hooks.
 	 */
+	/**
+	 * Whether the BuddyPress at-name filter was removed for the current content pass.
+	 *
+	 * @var bool
+	 */
+	private static $at_name_filter_removed = false;
+
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
 	public static function init() {
 		\add_filter( 'activitypub_json_author_array', array( self::class, 'add_user_metadata' ), 11, 2 );
 		\add_filter( 'render_block_activitypub/followers', array( self::class, 'disable_at_name_filter' ), 0 );
@@ -23,13 +33,16 @@ class Buddypress {
 	}
 
 	/**
-	 * Disable BuddyPress @mention linking during block rendering.
+	 * Disable BuddyPress `@mention` linking during block rendering.
 	 *
 	 * BuddyPress hooks `bp_activity_at_name_filter` into `the_content` to convert
-	 *
-	 * @username mentions into profile links. This corrupts the JSON in the
+	 * `@username` mentions into profile links. This corrupts the JSON in the
 	 * `data-wp-context` attribute of Followers/Following blocks because the handles
-	 * contain @username patterns that get replaced with HTML.
+	 * contain `@username` patterns that get replaced with HTML.
+	 *
+	 * The filter is restored after the current `the_content` pass completes so that
+	 * subsequent calls (other posts in a loop, widgets, etc.) still get BuddyPress
+	 * mention linking.
 	 *
 	 * @since unreleased
 	 *
@@ -38,9 +51,33 @@ class Buddypress {
 	 * @return string The unmodified block content.
 	 */
 	public static function disable_at_name_filter( $block_content ) {
-		\remove_filter( 'the_content', 'bp_activity_at_name_filter' );
+		if ( ! self::$at_name_filter_removed ) {
+			\remove_filter( 'the_content', 'bp_activity_at_name_filter' );
+			\add_filter( 'the_content', array( self::class, 'restore_at_name_filter' ), 999 );
+			self::$at_name_filter_removed = true;
+		}
 
 		return $block_content;
+	}
+
+	/**
+	 * Restore BuddyPress `@mention` filter after the current content pass.
+	 *
+	 * Runs at priority 999 on `the_content` to ensure it executes after all other
+	 * filters, then re-adds the BuddyPress filter for subsequent `the_content` calls.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $content The post content.
+	 *
+	 * @return string The unmodified content.
+	 */
+	public static function restore_at_name_filter( $content ) {
+		\add_filter( 'the_content', 'bp_activity_at_name_filter' );
+		\remove_filter( 'the_content', array( self::class, 'restore_at_name_filter' ), 999 );
+		self::$at_name_filter_removed = false;
+
+		return $content;
 	}
 
 	/**

--- a/tests/phpunit/tests/integration/class-test-buddypress.php
+++ b/tests/phpunit/tests/integration/class-test-buddypress.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Test BuddyPress integration.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Integration;
+
+use Activitypub\Integration\Buddypress;
+
+/**
+ * Test BuddyPress integration.
+ *
+ * @group integration
+ * @coversDefaultClass \Activitypub\Integration\Buddypress
+ */
+class Test_Buddypress extends \WP_UnitTestCase {
+	/**
+	 * Test that escape_at_signs encodes @ in data-wp-context attributes.
+	 *
+	 * @covers ::escape_at_signs
+	 */
+	public function test_escape_at_signs_in_context() {
+		$input  = '<div data-wp-context="{&quot;handle&quot;:&quot;@alice@mastodon.social&quot;}">';
+		$result = Buddypress::escape_at_signs( $input );
+
+		$this->assertStringNotContainsString( '@', $this->extract_context( $result ) );
+		$this->assertStringContainsString( '&#x40;alice&#x40;mastodon.social', $result );
+	}
+
+	/**
+	 * Test that escape_at_signs does not affect content outside data-wp-context.
+	 *
+	 * @covers ::escape_at_signs
+	 */
+	public function test_escape_at_signs_preserves_other_content() {
+		$input  = '<div data-wp-context="{&quot;handle&quot;:&quot;@bob@pixelfed.social&quot;}"><span>@bob@pixelfed.social</span></div>';
+		$result = Buddypress::escape_at_signs( $input );
+
+		// @ inside data-wp-context should be escaped.
+		$this->assertStringContainsString( '&#x40;bob&#x40;pixelfed.social', $result );
+
+		// @ outside data-wp-context should be untouched.
+		$this->assertStringContainsString( '<span>@bob@pixelfed.social</span>', $result );
+	}
+
+	/**
+	 * Test that escape_at_signs handles content without data-wp-context.
+	 *
+	 * @covers ::escape_at_signs
+	 */
+	public function test_escape_at_signs_no_context() {
+		$input  = '<p>Hello @world</p>';
+		$result = Buddypress::escape_at_signs( $input );
+
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * Test that escape_at_signs handles multiple items in context.
+	 *
+	 * @covers ::escape_at_signs
+	 */
+	public function test_escape_at_signs_multiple_handles() {
+		$context = \wp_json_encode(
+			array(
+				'items' => array(
+					array( 'handle' => '@alice@mastodon.social' ),
+					array( 'handle' => '@bob@pixelfed.social' ),
+				),
+			),
+			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+		);
+
+		$input  = '<div data-wp-context="' . \esc_attr( $context ) . '"></div>';
+		$result = Buddypress::escape_at_signs( $input );
+
+		$this->assertStringNotContainsString( '@alice', $this->extract_context( $result ) );
+		$this->assertStringNotContainsString( '@bob', $this->extract_context( $result ) );
+		$this->assertStringContainsString( '&#x40;alice', $result );
+		$this->assertStringContainsString( '&#x40;bob', $result );
+	}
+
+	/**
+	 * Extract the data-wp-context attribute value from HTML.
+	 *
+	 * @param string $html The HTML to extract from.
+	 *
+	 * @return string The attribute value, or empty string if not found.
+	 */
+	private function extract_context( $html ) {
+		if ( \preg_match( '/data-wp-context="([^"]*)"/', $html, $matches ) ) {
+			return $matches[1];
+		}
+
+		return '';
+	}
+}


### PR DESCRIPTION
Fixes #3171

## Proposed changes:

* BuddyPress hooks `bp_activity_at_name_filter` into `the_content` (priority 10) to convert `@username` mentions into profile links. This corrupts the JSON in the `data-wp-context` attribute of Followers/Following blocks because the handles contain `@username@domain` patterns that match BuddyPress's regex.
* Encode `@` as `&#x40;` in the `data-wp-context` attribute during block rendering. Browsers decode HTML entities in attributes before JavaScript reads them, so the Interactivity API gets the correct `@` characters. BuddyPress's regex no longer matches.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install BuddyPress on a multisite WordPress installation with the ActivityPub plugin.
* Create a local user with a username (e.g. `alice`).
* Have someone from another ActivityPub instance follow you where their username matches (e.g. `alice@mastodon.social`).
* Add the Fediverse Followers block to a post or page.
* Before fix: the follower entry shows mangled HTML because BuddyPress linked the `@alice` part to the local BuddyPress profile.
* After fix: the follower entry displays correctly as `@alice@mastodon.social`.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix BuddyPress @mention filter corrupting Fediverse Followers and Following blocks.

</details>