### PR TITLE
Add OAuth registration endpoint to actor discovery

### DIFF
--- a/.github/changelog/3175-from-description
+++ b/.github/changelog/3175-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add OAuth server metadata and registration endpoint discovery to actor profiles.

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -421,8 +421,10 @@ class Blog extends Actor {
 	public function get_endpoints() {
 		return array(
 			'sharedInbox'                => get_rest_url_by_path( 'inbox' ),
+			'oauthAuthorizationServer'   => \home_url( '/.well-known/oauth-authorization-server' ),
 			'oauthAuthorizationEndpoint' => get_rest_url_by_path( 'oauth/authorize' ),
 			'oauthTokenEndpoint'         => get_rest_url_by_path( 'oauth/token' ),
+			'oauthRegistrationEndpoint'  => get_rest_url_by_path( 'oauth/clients' ),
 			'proxyUrl'                   => get_rest_url_by_path( 'proxy' ),
 			'proxyEventStream'           => get_rest_url_by_path( 'proxy/stream' ),
 		);

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -421,7 +421,6 @@ class Blog extends Actor {
 	public function get_endpoints() {
 		return array(
 			'sharedInbox'                => get_rest_url_by_path( 'inbox' ),
-			'oauthAuthorizationServer'   => \home_url( '/.well-known/oauth-authorization-server' ),
 			'oauthAuthorizationEndpoint' => get_rest_url_by_path( 'oauth/authorize' ),
 			'oauthTokenEndpoint'         => get_rest_url_by_path( 'oauth/token' ),
 			'oauthRegistrationEndpoint'  => get_rest_url_by_path( 'oauth/clients' ),

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -330,8 +330,10 @@ class User extends Actor {
 	public function get_endpoints() {
 		return array(
 			'sharedInbox'                => get_rest_url_by_path( 'inbox' ),
+			'oauthAuthorizationServer'   => \home_url( '/.well-known/oauth-authorization-server' ),
 			'oauthAuthorizationEndpoint' => get_rest_url_by_path( 'oauth/authorize' ),
 			'oauthTokenEndpoint'         => get_rest_url_by_path( 'oauth/token' ),
+			'oauthRegistrationEndpoint'  => get_rest_url_by_path( 'oauth/clients' ),
 			'proxyUrl'                   => get_rest_url_by_path( 'proxy' ),
 			'proxyEventStream'           => get_rest_url_by_path( 'proxy/stream' ),
 		);

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -330,7 +330,6 @@ class User extends Actor {
 	public function get_endpoints() {
 		return array(
 			'sharedInbox'                => get_rest_url_by_path( 'inbox' ),
-			'oauthAuthorizationServer'   => \home_url( '/.well-known/oauth-authorization-server' ),
 			'oauthAuthorizationEndpoint' => get_rest_url_by_path( 'oauth/authorize' ),
 			'oauthTokenEndpoint'         => get_rest_url_by_path( 'oauth/token' ),
 			'oauthRegistrationEndpoint'  => get_rest_url_by_path( 'oauth/clients' ),


### PR DESCRIPTION
## Proposed changes:

* Actor endpoints exposed `oauthAuthorizationEndpoint` and `oauthTokenEndpoint` but not the registration endpoint. Clients discovering OAuth from the actor had no way to know self-registration (RFC 7591) existed, so they fell back to using their URL as `client_id`, triggering CIMD auto-discovery. This fails for localhost clients in Docker environments (e.g. Calypso at `calypso.localhost:3000`).
* Add `oauthRegistrationEndpoint` pointing to `POST /oauth/clients` (RFC 7591) so clients can self-register without needing CIMD auto-discovery.
* Keep existing `oauthAuthorizationEndpoint` and `oauthTokenEndpoint` for backward compatibility.
* Full OAuth server metadata (including registration, revocation, introspection) is already discoverable via `/.well-known/oauth-authorization-server` (RFC 8414).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

No new tests needed. Existing actor model tests pass. The change adds one property to the endpoints object without changing existing ones.

## Testing instructions:

* Fetch a local actor with `curl -H "Accept: application/activity+json" http://localhost:8888/?author=1`
* Verify `endpoints` contains:
  * `oauthRegistrationEndpoint` pointing to `/wp-json/activitypub/1.0/oauth/clients`
  * `oauthAuthorizationEndpoint` still present (backward compat)
  * `oauthTokenEndpoint` still present (backward compat)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Added - for new features

#### Message

Add OAuth registration endpoint discovery to actor profiles.

</details>