### PR TITLE
Add ActivityPub options to Jetpack sync allow list

### DIFF
--- a/.github/changelog/3176-from-description
+++ b/.github/changelog/3176-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync ActivityPub blog actor settings via Jetpack.

--- a/integration/class-jetpack.php
+++ b/integration/class-jetpack.php
@@ -24,6 +24,7 @@ class Jetpack {
 	 */
 	public static function init() {
 		if ( ! \defined( 'IS_WPCOM' ) ) {
+			\add_filter( 'jetpack_sync_options_whitelist', array( self::class, 'add_sync_options' ) );
 			\add_filter( 'jetpack_sync_post_meta_whitelist', array( self::class, 'add_sync_meta' ) );
 			\add_filter( 'jetpack_sync_comment_meta_whitelist', array( self::class, 'add_sync_comment_meta' ) );
 			\add_filter( 'jetpack_sync_whitelisted_comment_types', array( self::class, 'add_comment_types' ) );
@@ -40,6 +41,24 @@ class Jetpack {
 		}
 
 		\add_action( 'load-post-new.php', array( self::class, 'adapt_post_share' ) );
+	}
+
+	/**
+	 * Add ActivityPub options to the Jetpack sync allow list.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $allow_list The Jetpack sync options allow list.
+	 *
+	 * @return array The allow list with ActivityPub options.
+	 */
+	public static function add_sync_options( $allow_list ) {
+		$allow_list[] = 'activitypub_blog_identifier';
+		$allow_list[] = 'activitypub_blog_description';
+		$allow_list[] = 'activitypub_header_image';
+		$allow_list[] = 'activitypub_actor_mode';
+
+		return $allow_list;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* ActivityPub options like `activitypub_blog_identifier` were not synced via Jetpack, meaning changes on WordPress.com wouldn't propagate to the self-hosted site and vice versa.
* Add key blog actor options to the `jetpack_sync_options_whitelist` filter:
  * `activitypub_blog_identifier` — the blog actor's username/handle
  * `activitypub_blog_description` — the blog actor's bio
  * `activitypub_header_image` — the blog actor's header image
  * `activitypub_actor_mode` — which actor types are enabled

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Existing Jetpack integration tests pass. The sync allowlist is a simple array addition that doesn't need dedicated tests.

## Testing instructions:

* On a Jetpack-connected site, change the blog actor identifier in ActivityPub settings.
* Verify the option change is picked up by Jetpack sync (check Jetpack debug tools or sync status).
* Verify the same option value appears on the WordPress.com side.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Sync ActivityPub blog actor settings via Jetpack.

</details>