### PR TITLE
Pass $url to http_headers_useragent filter

### DIFF
--- a/.github/changelog/3179-from-description
+++ b/.github/changelog/3179-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix fatal error when other plugins hook into the user agent filter expecting two arguments.

--- a/includes/class-http.php
+++ b/includes/class-http.php
@@ -38,8 +38,9 @@ class Http {
 		 * Filters the HTTP headers user agent string.
 		 *
 		 * @param string $user_agent The user agent string.
+		 * @param string $url        The request URL.
 		 */
-		$user_agent = \apply_filters( 'http_headers_useragent', 'WordPress/' . get_masked_wp_version() . '; ' . \get_bloginfo( 'url' ) );
+		$user_agent = \apply_filters( 'http_headers_useragent', 'WordPress/' . get_masked_wp_version() . '; ' . \get_bloginfo( 'url' ), $url );
 
 		/**
 		 * Filters the timeout duration for remote POST requests in ActivityPub.
@@ -142,12 +143,10 @@ class Http {
 		/**
 		 * Filters the HTTP headers user agent string.
 		 *
-		 * This filter allows developers to modify the user agent string that is
-		 * sent with HTTP requests.
-		 *
 		 * @param string $user_agent The user agent string.
+		 * @param string $url        The request URL.
 		 */
-		$user_agent = \apply_filters( 'http_headers_useragent', 'WordPress/' . get_masked_wp_version() . '; ' . \get_bloginfo( 'url' ) );
+		$user_agent = \apply_filters( 'http_headers_useragent', 'WordPress/' . get_masked_wp_version() . '; ' . \get_bloginfo( 'url' ), $url );
 
 		/**
 		 * Filters the timeout duration for remote GET requests in ActivityPub.


### PR DESCRIPTION
Fixes #3177

## Proposed changes:

* Since WordPress 5.1, the `http_headers_useragent` filter expects a second `$url` argument. The plugin was not passing it, causing fatal errors when other plugins hook into the filter expecting both arguments.
* Add the `$url` parameter to both `apply_filters` calls in `Http::post()` and `Http::get()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Install a plugin that hooks into `http_headers_useragent` with two parameters (e.g. `add_filter( 'http_headers_useragent', function( $ua, $url ) { return $ua; }, 10, 2 );`).
* Trigger any ActivityPub HTTP request (e.g. follow a remote account).
* Before fix: fatal error "Too few arguments to function".
* After fix: no error.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix fatal error when other plugins hook into the user agent filter expecting two arguments.

</details>