### PR TITLE
Fix array_keys(null) fatal in get_comment_type_slugs()

### DIFF
--- a/.github/changelog/3196-from-description
+++ b/.github/changelog/3196-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a fatal `array_keys(null)` in `Comment::get_comment_type_slugs()` that could take down any request where a third-party plugin transitioned a custom comment type before `add_comment_type()` had been called.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -581,7 +581,7 @@ class Comment {
 	public static function get_comment_types() {
 		global $activitypub_comment_types;
 
-		return $activitypub_comment_types;
+		return (array) $activitypub_comment_types;
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -553,9 +553,10 @@ class Test_Comment extends \WP_UnitTestCase {
 	/**
 	 * Regression: get_comment_types() must coerce null to an empty array.
 	 *
-	 * $activitypub_comment_types is null until add_comment_type() runs at
-	 * least once, which isn't guaranteed on every request. array_keys( null )
-	 * fatals under PHP 8+, so callers must see an array either way.
+	 * $activitypub_comment_types can be null until comment types are registered
+	 * (for example via Comment::register_comment_types()), which isn't
+	 * guaranteed on every request. array_keys( null ) fatals under PHP 8+,
+	 * so callers must see an array either way.
 	 *
 	 * @covers ::get_comment_types
 	 * @covers ::get_comment_type_slugs

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -551,6 +551,36 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression: get_comment_types() must coerce null to an empty array.
+	 *
+	 * $activitypub_comment_types is null until add_comment_type() runs at
+	 * least once, which isn't guaranteed on every request. array_keys( null )
+	 * fatals under PHP 8+, so callers must see an array either way.
+	 *
+	 * @covers ::get_comment_types
+	 * @covers ::get_comment_type_slugs
+	 */
+	public function test_get_comment_types_returns_array_when_global_is_null() {
+		global $activitypub_comment_types;
+
+		$backup                    = $activitypub_comment_types;
+		$activitypub_comment_types = null;
+
+		try {
+			$result = Comment::get_comment_types();
+			$this->assertIsArray( $result );
+			$this->assertSame( array(), $result );
+
+			// And the downstream call that triggered the original crash.
+			$slugs = Comment::get_comment_type_slugs();
+			$this->assertIsArray( $slugs );
+			$this->assertSame( array(), $slugs );
+		} finally {
+			$activitypub_comment_types = $backup;
+		}
+	}
+
+	/**
 	 * Test object_id_to_comment method.
 	 *
 	 * @covers ::object_id_to_comment


### PR DESCRIPTION
Fixes #3195

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Coerce `Comment::get_comment_types()`'s return to an `array` so callers never see the raw `$activitypub_comment_types` global when it's still `null`. Before this change, `Comment::get_comment_type_slugs()` passed that `null` straight to `array_keys()`, which is a `TypeError` under PHP 8+ and takes down any request that reaches it. The `did_action( 'init' )` guard in `get_comment_type_slugs()` covers the "called too early" case but does nothing when `init` has run and no one has registered a comment type — which is the state on every request until `add_comment_type()` is first called.
* The crash is reachable from any plugin that fires `wp_transition_comment_status` on a custom comment type. In our case (GatherPress) a magic-link email verifies an RSVP by transitioning a `gatherpress_rsvp`-typed comment from `hold` → `approve`, and the first click on the link 500s. A one-line `(array)` cast on the global — as suggested in the issue — fixes both `get_comment_types()` and its downstream callers (`get_comment_type_slugs()`, `is_registered_comment_type()`, `get_comment_type()`), which already handled an empty-array return correctly but assumed the value was ever an array in the first place.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Added `Test_Comment::test_get_comment_types_returns_array_when_global_is_null` — backs up `$activitypub_comment_types`, sets it to `null`, and asserts both `get_comment_types()` and `get_comment_type_slugs()` return `array()` instead of fataling. Restores the global in a `finally` so the rest of the test suite is unaffected. Without a test anchored on the `null` case, a future "simplify" refactor could easily drop the cast and reintroduce the fatal.

## Testing instructions:

1. With a clean environment where no plugin has called `add_comment_type()` yet, insert a comment whose `comment_type` is anything custom (e.g. `'custom_type'`) and then call `wp_set_comment_status( $comment_id, 'approve' )`. Without this PR, the transition fires `wp_transition_comment_status`, hits `Activitypub\Scheduler\Comment::schedule_comment_activity()`, and fatals on `array_keys( null )`. With this PR, the transition completes cleanly.
2. Run the PHPUnit suite:
   ```
   composer test
   ```
   The new `test_get_comment_types_returns_array_when_global_is_null` case should pass. Reverting just the one-line change in `includes/class-comment.php` should make it fail with a `TypeError`, confirming the test actually guards the regression.
3. Sanity-check that sites where comment types *do* get registered still behave identically. Load a site in a browser where your theme/plugin stack calls `Activitypub\add_comment_type()` during `init`; every ActivityPub feature that depended on `get_comment_types()` / `get_comment_type_slugs()` should render exactly as before because `(array) $already_an_array === $already_an_array`.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix a fatal `array_keys(null)` in `Comment::get_comment_type_slugs()` that could take down any request where a third-party plugin transitioned a custom comment type before `add_comment_type()` had been called.

</details>