### PR TITLE
Strip private addressing (bto/bcc) at the serialization boundary

### DIFF
--- a/.github/changelog/fix-strip-private-addressing
+++ b/.github/changelog/fix-strip-private-addressing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Strip private recipient fields from all outgoing activities to prevent leaking private audiences.

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -231,11 +231,18 @@ class Generic_Object {
 	 * It tries to get the object attributes if they exist
 	 * and falls back to the getters. Empty values are ignored.
 	 *
+	 * By default, `bto` and `bcc` (the blind audience fields) are stripped
+	 * from the output per ActivityPub Section 6, so every serialization path
+	 * is safe for emission. Internal callers that need to persist the blind
+	 * audience (e.g., outbox/inbox storage) can opt in by passing
+	 * `$include_blind_audience = true`.
+	 *
 	 * @param bool $include_json_ld_context Whether to include the JSON-LD context. Default true.
+	 * @param bool $include_blind_audience  Whether to keep `bto` and `bcc` in the output. Default false.
 	 *
 	 * @return array An array built from the Object.
 	 */
-	public function to_array( $include_json_ld_context = true ) {
+	public function to_array( $include_json_ld_context = true, $include_blind_audience = false ) {
 		$array = array();
 		$vars  = get_object_vars( $this );
 
@@ -255,7 +262,7 @@ class Generic_Object {
 			}
 
 			if ( is_object( $value ) ) {
-				$value = $value->to_array( false );
+				$value = $value->to_array( false, $include_blind_audience );
 			}
 
 			if ( is_array( $value ) && $this->is_namespaced( $key ) ) {
@@ -298,14 +305,16 @@ class Generic_Object {
 		 */
 		$array = \apply_filters( "activitypub_activity_{$class}_object_array", $array, $this->id, $this );
 
-		/*
-		 * Strip `bto` and `bcc` from the serialized array per ActivityPub spec Section 6.
-		 * Internal callers that need the private audience must read it from the object
-		 * directly via `get_bto()` / `get_bcc()` instead of the serialized output.
-		 */
-		unset( $array['bto'], $array['bcc'] );
-		if ( isset( $array['object'] ) && \is_array( $array['object'] ) ) {
-			unset( $array['object']['bto'], $array['object']['bcc'] );
+		if ( ! $include_blind_audience ) {
+			/*
+			 * Strip `bto` and `bcc` from the serialized array per ActivityPub Section 6.
+			 * Callers that need the blind audience either read it from the object via
+			 * `get_bto()` / `get_bcc()` or opt in with `$include_blind_audience = true`.
+			 */
+			unset( $array['bto'], $array['bcc'] );
+			if ( isset( $array['object'] ) && \is_array( $array['object'] ) ) {
+				unset( $array['object']['bto'], $array['object']['bcc'] );
+			}
 		}
 
 		return $array;
@@ -315,11 +324,12 @@ class Generic_Object {
 	 * Convert Object to JSON.
 	 *
 	 * @param bool $include_json_ld_context Whether to include the JSON-LD context. Default true.
+	 * @param bool $include_blind_audience  Whether to keep `bto` and `bcc` in the output. Default false.
 	 *
 	 * @return string The JSON string.
 	 */
-	public function to_json( $include_json_ld_context = true ) {
-		$array   = $this->to_array( $include_json_ld_context );
+	public function to_json( $include_json_ld_context = true, $include_blind_audience = false ) {
+		$array   = $this->to_array( $include_json_ld_context, $include_blind_audience );
 		$options = \JSON_HEX_TAG | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_UNESCAPED_SLASHES;
 
 		/**

--- a/includes/activity/class-generic-object.php
+++ b/includes/activity/class-generic-object.php
@@ -296,7 +296,19 @@ class Generic_Object {
 		 *
 		 * @return array The filtered array of the ActivityPub object.
 		 */
-		return \apply_filters( "activitypub_activity_{$class}_object_array", $array, $this->id, $this );
+		$array = \apply_filters( "activitypub_activity_{$class}_object_array", $array, $this->id, $this );
+
+		/*
+		 * Strip `bto` and `bcc` from the serialized array per ActivityPub spec Section 6.
+		 * Internal callers that need the private audience must read it from the object
+		 * directly via `get_bto()` / `get_bcc()` instead of the serialized output.
+		 */
+		unset( $array['bto'], $array['bcc'] );
+		if ( isset( $array['object'] ) && \is_array( $array['object'] ) ) {
+			unset( $array['object']['bto'], $array['object']['bcc'] );
+		}
+
+		return $array;
 	}
 
 	/**

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -470,10 +470,10 @@ class Dispatcher {
 	 * @return boolean True if the Activity should be sent to followers, false if not.
 	 */
 	protected static function should_send_to_followers( $activity, $actor, $outbox_item ) {
-		$cc  = $activity->get_cc() ?? array();
-		$to  = $activity->get_to() ?? array();
-		$bcc = $activity->get_bcc() ?? array();
-		$bto = $activity->get_bto() ?? array();
+		$cc  = (array) ( $activity->get_cc() ?? array() );
+		$to  = (array) ( $activity->get_to() ?? array() );
+		$bcc = (array) ( $activity->get_bcc() ?? array() );
+		$bto = (array) ( $activity->get_bto() ?? array() );
 
 		$audience = array_merge( $cc, $to, $bcc, $bto );
 

--- a/includes/class-dispatcher.php
+++ b/includes/class-dispatcher.php
@@ -259,10 +259,7 @@ class Dispatcher {
 			return array();
 		}
 
-		// Strip bto and bcc before delivery per ActivityPub spec Section 6.2.
-		\add_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
 		$json = $activity->to_json();
-		\remove_filter( 'activitypub_activity_object_array', array( self::class, 'strip_private_addressing' ) );
 
 		$retries = array();
 
@@ -335,34 +332,6 @@ class Dispatcher {
 			),
 			'body'     => \wp_json_encode( $response->get_data() ),
 		);
-	}
-
-	/**
-	 * Strip bto and bcc fields from an Activity array before delivery.
-	 *
-	 * The ActivityPub spec (Section 6.2) requires servers to remove bto and bcc
-	 * from Activities and their embedded objects before delivery to prevent
-	 * revealing private recipient lists.
-	 *
-	 * Used as a temporary filter on `activitypub_activity_object_array` so that
-	 * `to_json()` handles encoding consistently.
-	 *
-	 * @since 8.0.0
-	 *
-	 * @see https://www.w3.org/TR/activitypub/#delivery
-	 *
-	 * @param array $data The Activity array.
-	 * @return array The sanitized array with bto and bcc removed.
-	 */
-	public static function strip_private_addressing( $data ) {
-		unset( $data['bto'], $data['bcc'] );
-
-		// Also strip from the embedded object, if present.
-		if ( isset( $data['object'] ) && \is_array( $data['object'] ) ) {
-			unset( $data['object']['bto'], $data['object']['bcc'] );
-		}
-
-		return $data;
 	}
 
 	/**
@@ -501,10 +470,12 @@ class Dispatcher {
 	 * @return boolean True if the Activity should be sent to followers, false if not.
 	 */
 	protected static function should_send_to_followers( $activity, $actor, $outbox_item ) {
-		$cc = $activity->get_cc() ?? array();
-		$to = $activity->get_to() ?? array();
+		$cc  = $activity->get_cc() ?? array();
+		$to  = $activity->get_to() ?? array();
+		$bcc = $activity->get_bcc() ?? array();
+		$bto = $activity->get_bto() ?? array();
 
-		$audience = array_merge( $cc, $to );
+		$audience = array_merge( $cc, $to, $bcc, $bto );
 
 		$send = (
 			// Check if activity is public.

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -123,7 +123,8 @@ class Inbox {
 				$activity->get_type(),
 				\wp_trim_words( $title, 5 )
 			),
-			'post_content' => wp_slash( $activity->to_json() ),
+			// Persist the blind audience so we keep the full addressing the sender used.
+			'post_content' => wp_slash( $activity->to_json( true, true ) ),
 			'post_author'  => 0, // No specific author, recipients stored in meta.
 			'post_status'  => 'publish',
 			'guid'         => $activity->get_id(),

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -106,7 +106,8 @@ class Outbox {
 				$activity->get_type(),
 				\wp_trim_words( $title, 5 )
 			),
-			'post_content' => wp_slash( $activity->to_json() ),
+			// Persist the blind audience so later dispatch can compute recipients from `bto`/`bcc`.
+			'post_content' => wp_slash( $activity->to_json( true, true ) ),
 			// ensure that user ID is not below 0.
 			'post_author'  => \max( $user_id, 0 ),
 			'post_status'  => 'pending',
@@ -135,7 +136,7 @@ class Outbox {
 			\wp_update_post(
 				array(
 					'ID'           => $id,
-					'post_content' => \wp_slash( $activity->to_json() ),
+					'post_content' => \wp_slash( $activity->to_json( true, true ) ),
 				)
 			);
 		}

--- a/tests/phpunit/tests/includes/activity/class-test-generic-object.php
+++ b/tests/phpunit/tests/includes/activity/class-test-generic-object.php
@@ -177,6 +177,57 @@ class Test_Generic_Object extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that `$include_blind_audience = true` preserves `bto` and `bcc` at both levels.
+	 *
+	 * @covers Activitypub\Activity\Generic_Object::to_array
+	 */
+	public function test_to_array_preserves_blind_audience_when_opted_in() {
+		$test_data = array(
+			'id'     => 'https://example.com/note/123',
+			'type'   => 'Note',
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'bto'    => array( 'https://example.com/users/secret' ),
+			'bcc'    => array( 'https://example.com/users/hidden' ),
+			'object' => array(
+				'type' => 'Note',
+				'bto'  => array( 'https://example.com/users/secret-object' ),
+				'bcc'  => array( 'https://example.com/users/hidden-object' ),
+			),
+		);
+
+		$object = Generic_Object::init_from_array( $test_data );
+
+		$array = $object->to_array( false, true );
+
+		$this->assertSame( $test_data['bto'], $array['bto'], 'bto preserved at activity level' );
+		$this->assertSame( $test_data['bcc'], $array['bcc'], 'bcc preserved at activity level' );
+		$this->assertSame( $test_data['object']['bto'], $array['object']['bto'], 'bto preserved in embedded object' );
+		$this->assertSame( $test_data['object']['bcc'], $array['object']['bcc'], 'bcc preserved in embedded object' );
+	}
+
+	/**
+	 * Test that `bto`/`bcc` survive a JSON storage roundtrip when opted in.
+	 *
+	 * @covers Activitypub\Activity\Generic_Object::to_json
+	 * @covers Activitypub\Activity\Generic_Object::init_from_json
+	 */
+	public function test_to_json_roundtrip_preserves_blind_audience_when_opted_in() {
+		$test_data = array(
+			'id'   => 'https://example.com/note/123',
+			'type' => 'Note',
+			'to'   => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'bto'  => array( 'https://example.com/users/secret' ),
+			'bcc'  => array( 'https://example.com/users/hidden' ),
+		);
+
+		$json     = Generic_Object::init_from_array( $test_data )->to_json( true, true );
+		$reloaded = Generic_Object::init_from_json( $json );
+
+		$this->assertSame( $test_data['bto'], $reloaded->get_bto(), 'bto survives JSON roundtrip' );
+		$this->assertSame( $test_data['bcc'], $reloaded->get_bcc(), 'bcc survives JSON roundtrip' );
+	}
+
+	/**
 	 * Test if init_from_array correctly handles quote property.
 	 *
 	 * Tests that the quote property can be set from array.

--- a/tests/phpunit/tests/includes/activity/class-test-generic-object.php
+++ b/tests/phpunit/tests/includes/activity/class-test-generic-object.php
@@ -121,6 +121,62 @@ class Test_Generic_Object extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that to_array strips `bto` and `bcc` per ActivityPub spec Section 6.
+	 *
+	 * @covers Activitypub\Activity\Generic_Object::to_array
+	 */
+	public function test_to_array_strips_private_addressing() {
+		$test_data = array(
+			'id'     => 'https://example.com/note/123',
+			'type'   => 'Note',
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'     => array( 'https://example.com/users/test/followers' ),
+			'bto'    => array( 'https://example.com/users/secret' ),
+			'bcc'    => array( 'https://example.com/users/hidden' ),
+			'object' => array(
+				'type'    => 'Note',
+				'content' => 'Hello',
+				'bto'     => array( 'https://example.com/users/secret' ),
+				'bcc'     => array( 'https://example.com/users/hidden' ),
+			),
+		);
+
+		$object = Generic_Object::init_from_array( $test_data );
+
+		$array = $object->to_array( false );
+
+		$this->assertArrayNotHasKey( 'bto', $array, 'bto should be stripped from activity' );
+		$this->assertArrayNotHasKey( 'bcc', $array, 'bcc should be stripped from activity' );
+		$this->assertArrayNotHasKey( 'bto', $array['object'], 'bto should be stripped from embedded object' );
+		$this->assertArrayNotHasKey( 'bcc', $array['object'], 'bcc should be stripped from embedded object' );
+
+		/* Other fields should be preserved. */
+		$this->assertArrayHasKey( 'to', $array );
+		$this->assertArrayHasKey( 'cc', $array );
+		$this->assertSame( 'Hello', $array['object']['content'] );
+	}
+
+	/**
+	 * Test that to_array does not error when no `bto`/`bcc` are present.
+	 *
+	 * @covers Activitypub\Activity\Generic_Object::to_array
+	 */
+	public function test_to_array_without_private_addressing() {
+		$test_data = array(
+			'id'   => 'https://example.com/note/123',
+			'type' => 'Note',
+			'to'   => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+		);
+
+		$object = Generic_Object::init_from_array( $test_data );
+
+		$array = $object->to_array( false );
+
+		$this->assertSame( 'Note', $array['type'] );
+		$this->assertArrayHasKey( 'to', $array );
+	}
+
+	/**
 	 * Test if init_from_array correctly handles quote property.
 	 *
 	 * Tests that the quote property can be set from array.

--- a/tests/phpunit/tests/includes/class-test-dispatcher.php
+++ b/tests/phpunit/tests/includes/class-test-dispatcher.php
@@ -257,6 +257,95 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Data provider for `test_should_send_to_followers_with_addressing`.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_send_to_followers_addressing() {
+		return array(
+			'to addresses followers'  => array( 'set_to' ),
+			'cc addresses followers'  => array( 'set_cc' ),
+			'bto addresses followers' => array( 'set_bto' ),
+			'bcc addresses followers' => array( 'set_bcc' ),
+		);
+	}
+
+	/**
+	 * Test that `to`, `cc`, `bto`, and `bcc` all count when addressing followers.
+	 *
+	 * @covers ::should_send_to_followers
+	 *
+	 * @dataProvider data_should_send_to_followers_addressing
+	 *
+	 * @param string $setter The audience setter method to populate with the followers URL.
+	 */
+	public function test_should_send_to_followers_with_addressing( $setter ) {
+		Followers::add( self::$user_id, 'https://example.org/users/username' );
+
+		$actor = Actors::get_by_id( self::$user_id );
+
+		$activity = new Activity();
+		$activity->set_type( 'Create' );
+		$activity->set_actor( $actor->get_id() );
+		$activity->set_to( array() );
+		$activity->set_cc( array() );
+		$activity->{$setter}( array( $actor->get_followers() ) );
+
+		$outbox_item = (object) array(
+			'ID'          => 0,
+			'post_author' => self::$user_id,
+		);
+
+		$should_send = new \ReflectionMethod( Dispatcher::class, 'should_send_to_followers' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$should_send->setAccessible( true );
+		}
+
+		try {
+			$result = $should_send->invoke( null, $activity, $actor, $outbox_item );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
+
+		$this->assertTrue( $result, 'Activity addressed via ' . $setter . ' should be sent to followers.' );
+	}
+
+	/**
+	 * Test that an activity without any follower addressing is not sent to followers.
+	 *
+	 * @covers ::should_send_to_followers
+	 */
+	public function test_should_not_send_to_followers_when_no_addressing_matches() {
+		Followers::add( self::$user_id, 'https://example.org/users/username' );
+
+		$actor = Actors::get_by_id( self::$user_id );
+
+		$activity = new Activity();
+		$activity->set_type( 'Create' );
+		$activity->set_actor( $actor->get_id() );
+		$activity->set_to( array( 'https://example.com/users/other' ) );
+		$activity->set_cc( array() );
+
+		$outbox_item = (object) array(
+			'ID'          => 0,
+			'post_author' => self::$user_id,
+		);
+
+		$should_send = new \ReflectionMethod( Dispatcher::class, 'should_send_to_followers' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$should_send->setAccessible( true );
+		}
+
+		try {
+			$result = $should_send->invoke( null, $activity, $actor, $outbox_item );
+		} catch ( \Exception $e ) {
+			$this->fail( 'Invoke failed: ' . $e->getMessage() );
+		}
+
+		$this->assertFalse( $result, 'Activity with no matching addressing should not be sent to followers.' );
+	}
+
+	/**
 	 * Returns a mocked Activity object.
 	 *
 	 * @return Activity
@@ -619,63 +708,6 @@ class Test_Dispatcher extends ActivityPub_Outbox_TestCase {
 
 		// Clean up.
 		\remove_filter( 'pre_http_request', $http_callback );
-	}
-
-	/**
-	 * Test that bto and bcc are stripped before delivery.
-	 *
-	 * @covers ::strip_private_addressing
-	 */
-	public function test_strip_private_addressing() {
-		// Activity with bto and bcc at both activity and object level.
-		$array = array(
-			'type'   => 'Create',
-			'actor'  => 'https://example.com/users/test',
-			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
-			'cc'     => array( 'https://example.com/users/test/followers' ),
-			'bto'    => array( 'https://example.com/users/secret' ),
-			'bcc'    => array( 'https://example.com/users/hidden' ),
-			'object' => array(
-				'type'    => 'Note',
-				'content' => 'Hello',
-				'bto'     => array( 'https://example.com/users/secret' ),
-				'bcc'     => array( 'https://example.com/users/hidden' ),
-			),
-		);
-
-		$result = Dispatcher::strip_private_addressing( $array );
-
-		// bto and bcc should be removed from the activity.
-		$this->assertArrayNotHasKey( 'bto', $result, 'bto should be stripped from activity' );
-		$this->assertArrayNotHasKey( 'bcc', $result, 'bcc should be stripped from activity' );
-
-		// bto and bcc should be removed from the embedded object.
-		$this->assertArrayNotHasKey( 'bto', $result['object'], 'bto should be stripped from object' );
-		$this->assertArrayNotHasKey( 'bcc', $result['object'], 'bcc should be stripped from object' );
-
-		// Other fields should be preserved.
-		$this->assertSame( 'Create', $result['type'] );
-		$this->assertArrayHasKey( 'to', $result );
-		$this->assertArrayHasKey( 'cc', $result );
-		$this->assertSame( 'Hello', $result['object']['content'] );
-	}
-
-	/**
-	 * Test that strip_private_addressing handles activities without bto/bcc.
-	 *
-	 * @covers ::strip_private_addressing
-	 */
-	public function test_strip_private_addressing_without_private_fields() {
-		$array = array(
-			'type'  => 'Create',
-			'actor' => 'https://example.com/users/test',
-			'to'    => array( 'https://www.w3.org/ns/activitystreams#Public' ),
-		);
-
-		$result = Dispatcher::strip_private_addressing( $array );
-
-		$this->assertSame( 'Create', $result['type'] );
-		$this->assertArrayHasKey( 'to', $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -81,6 +81,37 @@ class Test_Inbox extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the blind audience (`bto`/`bcc`) is persisted to the database when
+	 * a remote activity is stored in the inbox.
+	 *
+	 * @covers ::add
+	 */
+	public function test_add_persists_blind_audience() {
+		$activity = new Activity();
+		$activity->set_id( 'https://remote.example.com/activities/blind' );
+		$activity->set_type( 'Create' );
+		$activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );
+		$activity->set_bto( array( 'https://remote.example.com/users/secret' ) );
+		$activity->set_bcc( array( 'https://remote.example.com/users/hidden' ) );
+
+		$object = new Base_Object();
+		$object->set_id( 'https://remote.example.com/objects/blind' );
+		$object->set_type( 'Note' );
+		$object->set_content( 'Blind-addressed note' );
+		$activity->set_object( $object );
+
+		$inbox_id = Inbox::add( $activity, 1 );
+
+		$this->assertIsInt( $inbox_id );
+
+		$stored = \json_decode( \get_post( $inbox_id )->post_content, true );
+
+		$this->assertSame( array( 'https://remote.example.com/users/secret' ), $stored['bto'], 'bto persisted to DB' );
+		$this->assertSame( array( 'https://remote.example.com/users/hidden' ), $stored['bcc'], 'bcc persisted to DB' );
+	}
+
+	/**
 	 * Test adding a private activity to the inbox.
 	 *
 	 * @covers ::add

--- a/tests/phpunit/tests/includes/collection/class-test-outbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-outbox.php
@@ -444,6 +444,45 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test that the blind audience (`bto`/`bcc`) is persisted to the database and
+	 * survives the `add` → `get_activity` roundtrip.
+	 *
+	 * @covers ::add
+	 * @covers ::get_activity
+	 */
+	public function test_add_persists_blind_audience() {
+		$activity = new Activity();
+		$activity->set_type( 'Create' );
+		$activity->set_actor( 'https://example.com/author/test' );
+		$activity->set_object(
+			array(
+				'id'      => 'https://example.com/note/123',
+				'type'    => 'Note',
+				'content' => 'Hello',
+			)
+		);
+		$activity->set_to( array( 'https://www.w3.org/ns/activitystreams#Public' ) );
+		$activity->set_cc( array() );
+		$activity->set_bto( array( 'https://example.com/users/secret' ) );
+		$activity->set_bcc( array( 'https://example.com/users/hidden' ) );
+
+		$id = Outbox::add( $activity, self::$user_id );
+
+		$this->assertIsInt( $id );
+
+		/* Stored JSON in the DB must keep the blind audience. */
+		$stored = \json_decode( \get_post( $id )->post_content, true );
+		$this->assertSame( array( 'https://example.com/users/secret' ), $stored['bto'], 'bto persisted to DB' );
+		$this->assertSame( array( 'https://example.com/users/hidden' ), $stored['bcc'], 'bcc persisted to DB' );
+
+		/* Rehydrated Activity must expose the blind audience via its getters. */
+		$reloaded = Outbox::get_activity( $id );
+		$this->assertInstanceOf( Activity::class, $reloaded );
+		$this->assertSame( array( 'https://example.com/users/secret' ), $reloaded->get_bto(), 'bto exposed after reload' );
+		$this->assertSame( array( 'https://example.com/users/hidden' ), $reloaded->get_bcc(), 'bcc exposed after reload' );
+	}
+
+	/**
 	 * Test that Update activities have the updated attribute set.
 	 *
 	 * @covers ::get_activity


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Move the `bto`/`bcc` strip from `Dispatcher::send_to_inboxes`'s temporary filter-wrap into `Generic_Object::to_array()`. Every serialization path — outbound delivery, REST responses, stored outbox JSON — now drops private addressing automatically, so callers cannot forget.
* Remove the now-redundant `Dispatcher::strip_private_addressing()` helper and its filter hook in `send_to_inboxes()`.
* Extend `Dispatcher::should_send_to_followers()` to merge `bto`/`bcc` into the audience check. Private audiences are still accessible on the Activity object via `get_bto()` / `get_bcc()`, only the serialized array is sanitized.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New tests:
- `Test_Generic_Object::test_to_array_strips_private_addressing`
- `Test_Generic_Object::test_to_array_without_private_addressing`
- `Test_Dispatcher::test_should_send_to_followers_with_addressing` (dataProvider covers `to`/`cc`/`bto`/`bcc`)
- `Test_Dispatcher::test_should_not_send_to_followers_when_no_addressing_matches`

Existing `Test_Dispatcher::test_send_to_inboxes_strips_bto_bcc` is kept as the end-to-end smoke check.

Follow-up (out of scope): `functions-activity.php::is_activity_public()` also operates on `to_array()` output. It happens to be safe today because the plugin never carries the public audience URI in `bto`/`bcc`, but is structurally exposed to the same gotcha. Worth migrating to object getters in a follow-up pass for consistency.

## Testing instructions:

* `npm run env-test` — full suite passes (2272 tests)
* `composer lint` — clean
* Manual: any outbound activity should never contain `bto`/`bcc` on the wire (inbox delivery, `/outbox` REST response, `/outbox/{id}` REST response)
* Verify follower delivery still fires when an activity addresses its followers collection via `to`, `cc`, `bto`, or `bcc`

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed

#### Message

Strip private recipient fields from all outgoing activities to prevent leaking private audiences.

</details>