### PR TITLE
Require signed peer requests on /followers/sync per FEP-8fcf

### DIFF
--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -43,6 +43,19 @@ Files: `includes/rest/`, `includes/rest/trait-verification.php`
 - Verify `verify_authentication()` (OAuth) is applied to all C2S endpoints
 - Check the `activitypub_defer_signature_verification` filter — what hooks it, can third parties disable all auth?
 
+**Signing on GETs — especially with Authorized Fetch off:**
+
+The default `verify_signature()` callback only enforces signatures on GETs when `use_authorized_fetch()` is true. That makes Authorized Fetch the site-wide flag for "are anonymous GETs allowed", and flips the default for every endpoint gated by the shared callback. This is correct for endpoints whose data is genuinely public (actor profiles, `/followers` summary, `/outbox`), but **dangerous for any endpoint that is intended to be peer-only** (FEP-8fcf's `/followers/sync`, anything that encodes a peer-specific authority or identity in the response). For those, Authorized Fetch being off must NOT loosen the signing requirement.
+
+Audit pattern:
+
+1. Enumerate every route registered with `verify_signature` as its permission_callback. Classify each by whether its response is public (anyone can legitimately call it) or peer-only (only a specific authenticated peer should call it).
+2. For each peer-only route, confirm the permission_callback forces signature verification regardless of `use_authorized_fetch()`. The canonical pattern is `verify_signature( $request, true )` via a closure — the `$force_signature` parameter bypasses the Authorized-Fetch-off short-circuit. Any peer-only route that uses the raw `verify_signature` callable is a finding.
+3. For any route that encodes a peer-specific value in its response (an `authority` query parameter, a peer-specific identity in the URL, a filter-by-host selector, etc.), also confirm the handler compares the signer's keyId host against that peer value and rejects mismatches. Signing alone is not enough — FEP-8fcf explicitly requires the authority match so an instance "cannot get tricked into requesting the followers list of a third-party individual". Missing authority check on a peer-only route is a finding even when the signature is verified.
+4. Cross-check: turn Authorized Fetch **off** in a test environment, replay each peer-only route unsigned and confirm 401. Turn Authorized Fetch **on** and confirm public-data routes still respond correctly when signed. Flag any endpoint whose behavior is reachable because of a local `activitypub_defer_signature_verification` filter (some dev environments set `__return_true` site-wide — do not rely on that for the audit; either disable the filter or verify the callbacks run).
+5. Read the `activitypub_defer_signature_verification` filter's hooks on the audited branch — list every site that hooks `__return_true` or a permissive callback, and confirm each is either scoped (e.g., `includes/class-dispatcher.php` wraps a single delivery with it) or intentional (e.g., Delete handler's documented exception). Any unscoped `__return_true` on that filter is an auth-wide bypass and must be flagged.
+6. Report each peer-only route with a one-line pass/fail for: (a) mandatory signing, (b) authority / identity match, (c) graceful rejection of mismatched keyId host, and (d) the signing check runs even when Authorized Fetch is off.
+
 ### 3. HTTP Signature Verification
 
 Files: `includes/class-signature.php`, `includes/signature/class-http-signature-draft.php`, `includes/signature/class-http-message-signature.php`

--- a/.github/changelog/fix-followers-sync-auth
+++ b/.github/changelog/fix-followers-sync-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Require signed peer requests for the followers synchronization endpoint per FEP-8fcf.

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -91,7 +91,15 @@ class Followers_Controller extends Actors_Controller {
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_partial_followers' ),
-					'permission_callback' => array( $this, 'verify_signature' ),
+
+					/*
+					 * FEP-8fcf requires that the partial followers collection only be
+					 * disclosed to an authenticated peer. Force signature verification
+					 * even when Authorized Fetch is globally disabled.
+					 */
+					'permission_callback' => function ( $request ) {
+						return $this->verify_signature( $request, true );
+					},
 					'args'                => array(
 						'authority' => array(
 							'description' => 'The host to filter followers by.',
@@ -198,7 +206,22 @@ class Followers_Controller extends Actors_Controller {
 		$user_id   = $request->get_param( 'user_id' );
 		$authority = $request->get_param( 'authority' );
 
-		// Get partial followers filtered by authority.
+		/*
+		 * FEP-8fcf: the responding server MUST ensure the requested authority
+		 * matches the signing peer, so that instances cannot "get tricked
+		 * into requesting the followers list of a third-party individual".
+		 */
+		$signer_host = self::get_signer_host( $request );
+		$asked_host  = \strtolower( (string) \wp_parse_url( (string) $authority, \PHP_URL_HOST ) );
+
+		if ( ! $signer_host || ! $asked_host || $signer_host !== $asked_host ) {
+			return new \WP_Error(
+				'activitypub_authority_mismatch',
+				\__( 'The authority parameter must match the signing peer.', 'activitypub' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$followers = Followers::get_by_authority( $user_id, $authority );
 		$followers = \wp_list_pluck( $followers, 'guid' );
 
@@ -225,6 +248,38 @@ class Followers_Controller extends Actors_Controller {
 		$response->header( 'Content-Type', 'application/activity+json; charset=' . \get_option( 'blog_charset' ) );
 
 		return $response;
+	}
+
+	/**
+	 * Resolve the signing peer's host from the request's HTTP Signature header.
+	 *
+	 * Supports both Cavage-style `Signature: keyId="…"` and RFC 9421's
+	 * `Signature-Input: …keyid="…"`. Returns the host component of the key
+	 * ID URI, lowercased, or an empty string when none is present.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return string The signer's host, or an empty string.
+	 */
+	private static function get_signer_host( $request ) {
+		$signature = $request->get_header( 'signature' );
+		$key_id    = null;
+
+		if ( $signature && \preg_match( '/keyId="([^"]+)"/i', $signature, $matches ) ) {
+			$key_id = $matches[1];
+		} else {
+			$signature_input = $request->get_header( 'signature-input' );
+			if ( $signature_input && \preg_match( '/keyid="([^"]+)"/i', $signature_input, $matches ) ) {
+				$key_id = $matches[1];
+			}
+		}
+
+		if ( ! $key_id ) {
+			return '';
+		}
+
+		return \strtolower( (string) \wp_parse_url( $key_id, \PHP_URL_HOST ) );
 	}
 
 	/**

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -32,10 +32,14 @@ trait Verification {
 	 * @see https://www.w3.org/wiki/SocialCG/ActivityPub/Primer/Authentication_Authorization#Authorized_fetch
 	 * @see https://swicg.github.io/activitypub-http-signature/#authorized-fetch
 	 *
-	 * @param \WP_REST_Request $request The request object.
+	 * @param \WP_REST_Request $request         The request object.
+	 * @param bool             $force_signature Optional. When true, GET requests also require a
+	 *                                          valid signature even with Authorized Fetch
+	 *                                          disabled. Use for endpoints that are peer-only
+	 *                                          (e.g. FEP-8fcf's `/followers/sync`). Default false.
 	 * @return bool|\WP_Error True if authorized, WP_Error otherwise.
 	 */
-	public function verify_signature( $request ) {
+	public function verify_signature( $request, $force_signature = false ) {
 		if ( 'HEAD' === $request->get_method() ) {
 			return true;
 		}
@@ -44,20 +48,25 @@ trait Verification {
 		 * Filter to defer signature verification.
 		 *
 		 * Skip signature verification for debugging purposes or to reduce load for
-		 * certain Activity-Types, like "Delete".
+		 * certain Activity-Types, like "Delete". Callers that want to preserve
+		 * mandatory signing for endpoints passing `$force_signature = true`
+		 * (e.g. FEP-8fcf's `/followers/sync`) should inspect the third argument
+		 * and return `false` in that case.
 		 *
-		 * @param bool             $defer   Whether to defer signature verification.
-		 * @param \WP_REST_Request $request The request used to generate the response.
+		 * @param bool             $defer           Whether to defer signature verification.
+		 * @param \WP_REST_Request $request         The request used to generate the response.
+		 * @param bool             $force_signature Whether the caller has forced signature
+		 *                                          verification for this endpoint.
 		 * @return bool Whether to defer signature verification.
 		 */
-		$defer = \apply_filters( 'activitypub_defer_signature_verification', false, $request );
+		$defer = \apply_filters( 'activitypub_defer_signature_verification', false, $request, $force_signature );
 
 		if ( $defer ) {
 			return true;
 		}
 
-		// POST-Requests always have to be signed, GET-Requests only require a signature in secure mode.
-		if ( 'GET' !== $request->get_method() || use_authorized_fetch() ) {
+		// POST-Requests always have to be signed, GET-Requests only require a signature in secure mode or when forced.
+		if ( 'GET' !== $request->get_method() || use_authorized_fetch() || $force_signature ) {
 			$verified_request = Signature::verify_http_signature( $request );
 			if ( \is_wp_error( $verified_request ) ) {
 				return new \WP_Error(

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -205,4 +205,190 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 	public function test_get_item() {
 		// Controller does not implement get_item().
 	}
+
+	/**
+	 * Seed one follower from a given authority against the blog actor.
+	 *
+	 * @param string $host Remote actor host (bare hostname).
+	 * @return int The remote_actors post ID.
+	 */
+	private function seed_follower_on_host( $host ) {
+		$actor_id = 'https://' . $host . '/users/alice';
+		$post_id  = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Actors::POST_TYPE,
+				'guid'         => $actor_id,
+				'post_content' => \wp_slash(
+					\wp_json_encode(
+						array(
+							'id'                => $actor_id,
+							'type'              => 'Person',
+							'preferredUsername' => 'alice',
+							'name'              => 'Alice',
+							'inbox'             => $actor_id . '/inbox',
+						)
+					)
+				),
+				'meta_input'   => array( Followers::FOLLOWER_META_KEY => '0' ),
+			)
+		);
+
+		return $post_id;
+	}
+
+	/**
+	 * Unsigned anonymous requests to the sync endpoint must be rejected
+	 * because the route is not on the unsigned-GET allowlist.
+	 *
+	 * @covers \Activitypub\Rest\Verification::verify_signature
+	 */
+	public function test_sync_rejects_unsigned_request() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
+		$request->set_param( 'authority', 'https://evil.example' );
+		$request->set_param( 'page', 1 );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertErrorResponse( 'activitypub_signature_verification', $response, 401 );
+	}
+
+	/**
+	 * Build a request ready for direct dispatch to `get_partial_followers`.
+	 *
+	 * The permission_callback on `/followers/sync` forces signature
+	 * verification, so these handler-level tests bypass the callback and
+	 * call the method directly to cover the authority-match logic without
+	 * generating real HTTP signatures.
+	 *
+	 * @param int    $user_id    The user ID.
+	 * @param string $authority  The authority query parameter value.
+	 * @param string $signer_url The URI used in the fake Signature keyId.
+	 * @return \WP_REST_Request Prepared request.
+	 */
+	private function build_sync_request( $user_id, $authority, $signer_url ) {
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
+		$request->set_param( 'user_id', $user_id );
+		$request->set_param( 'authority', $authority );
+		$request->set_param( 'page', 1 );
+		$request->set_header( 'Signature', 'keyId="' . $signer_url . '#main-key",algorithm="rsa-sha256",headers="(request-target) host date",signature="x"' );
+
+		return $request;
+	}
+
+	/**
+	 * A signed peer requesting an authority it does not own must be rejected.
+	 *
+	 * @covers ::get_partial_followers
+	 */
+	public function test_sync_rejects_authority_mismatch() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$request    = $this->build_sync_request( $user_id, 'https://evil.example', 'https://other.example/users/bob' );
+		$controller = new \Activitypub\Rest\Followers_Controller();
+		$response   = $controller->get_partial_followers( $request );
+
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'activitypub_authority_mismatch', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * The hide-social-graph setting governs public disclosure, not peer
+	 * reconciliation. A properly signed peer whose authority matches still
+	 * receives the partial collection even when the owner has hidden the
+	 * graph — the peer already has the relationship on its own side.
+	 *
+	 * @covers ::get_partial_followers
+	 */
+	public function test_sync_still_syncs_when_social_graph_is_hidden() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		\update_user_option( $user_id, 'activitypub_hide_social_graph', '1' );
+
+		$post_id = $this->seed_follower_on_host( 'peer.example' );
+		Followers::add( $user_id, 'https://peer.example/users/alice' );
+
+		$request    = $this->build_sync_request( $user_id, 'https://peer.example', 'https://peer.example/users/peer' );
+		$controller = new \Activitypub\Rest\Followers_Controller();
+		$response   = $controller->get_partial_followers( $request );
+
+		\wp_delete_post( $post_id, true );
+		\delete_user_option( $user_id, 'activitypub_hide_social_graph' );
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertNotWPError( $response );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'orderedItems', $data );
+		$this->assertContains( 'https://peer.example/users/alice', $data['orderedItems'] );
+	}
+
+	/**
+	 * A signed peer whose authority matches and whose target has a public
+	 * social graph receives the partial follower collection.
+	 *
+	 * @covers ::get_partial_followers
+	 */
+	public function test_sync_returns_items_for_matching_authority() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		\delete_user_option( $user_id, 'activitypub_hide_social_graph' );
+
+		$post_id = $this->seed_follower_on_host( 'peer.example' );
+		Followers::add( $user_id, 'https://peer.example/users/alice' );
+
+		$request    = $this->build_sync_request( $user_id, 'https://peer.example', 'https://peer.example/users/peer' );
+		$controller = new \Activitypub\Rest\Followers_Controller();
+		$response   = $controller->get_partial_followers( $request );
+
+		\wp_delete_post( $post_id, true );
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertNotWPError( $response );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'orderedItems', $data );
+		$this->assertContains( 'https://peer.example/users/alice', $data['orderedItems'] );
+	}
+
+	/**
+	 * The defer-signature filter receives `$force_signature` as a third
+	 * argument so hooks can preserve mandatory signing on peer-only
+	 * endpoints like `/followers/sync` without touching unrelated requests.
+	 *
+	 * @covers \Activitypub\Rest\Verification::verify_signature
+	 */
+	public function test_sync_defer_filter_receives_force_signature_flag() {
+		$captured_force = null;
+		\add_filter(
+			'activitypub_defer_signature_verification',
+			static function ( $defer, $request, $force = false ) use ( &$captured_force ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				$captured_force = $force;
+				return $force ? false : true;
+			},
+			10,
+			3
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
+		$request->set_param( 'authority', 'https://peer.example' );
+		$request->set_param( 'page', 1 );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		\remove_all_filters( 'activitypub_defer_signature_verification' );
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertTrue( $captured_force, 'Filter must receive $force_signature = true for /followers/sync.' );
+		$this->assertErrorResponse( 'activitypub_signature_verification', $response, 401 );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -516,4 +516,22 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 		$property->setAccessible( true );
 		$property->setValue( null, $token );
 	}
+
+	/**
+	 * Test that `$force_signature = true` makes a GET require a signature even
+	 * when Authorized Fetch is disabled.
+	 *
+	 * @covers ::verify_signature
+	 */
+	public function test_verify_signature_force_requires_signature_on_get() {
+		\delete_option( 'activitypub_authorized_fetch' );
+
+		$request = new \WP_REST_Request( 'GET', '/activitypub/1.0/actors/1/followers/sync' );
+
+		$result = $this->instance->verify_signature( $request, true );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_signature_verification', $result->get_error_code() );
+		$this->assertEquals( 401, $result->get_error_data()['status'] );
+	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Require HTTP Signatures on `GET /followers/sync`, regardless of the site's Authorized Fetch setting. Previously the endpoint was unsigned, allowing anyone to enumerate a site's followers; FEP-8fcf specifies this endpoint is peer-to-peer only.
* Add an optional `$force_signature` parameter to `Rest\Verification::verify_signature()`. When `true`, GET requests verify signatures even when Authorized Fetch is disabled. Default remains `false`, so every other endpoint is untouched.
* Pass `$force_signature` as a third argument to the `activitypub_defer_signature_verification` filter, so local-dev / test environments can still defer when they want to, and filter consumers can inspect the forced-flag to make an informed decision.
* In `get_partial_followers()`, compare the signer's `keyId` host to the `authority` query parameter. Mismatch returns 403 to satisfy FEP-8fcf's rule against third-party lookups.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New coverage in `class-test-followers-controller.php` and `class-test-trait-verification.php`:
- Unsigned request → 401
- Signed with mismatched authority → 403
- Signed with matching authority → 200
- Defer filter receives the forced flag
- `$force_signature` parameter round-trip on `verify_signature()`

Also extends `.claude/agents/security-audit.md` with a checklist item for signed/authority-matched endpoints so future audits catch regressions.

## Testing instructions:

* `npm run env-test` — new tests pass
* Manual: `curl` the `/followers/sync` endpoint without a signature → expect 401
* Manual: sign the request with a keyId on a different host than the `authority` query param → expect 403
* Manual: sign the request with a matching host → expect 200 and the expected partial collection
* Verify the rest of the REST surface (outbox, actor, etc.) is unchanged — signature verification is only forced on `/followers/sync`.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed

#### Message

Require signed peer requests for the followers synchronization endpoint per FEP-8fcf.

</details>