### PR TITLE
Consolidate rewrite-rule flushes at end of migration

### DIFF
--- a/.github/changelog/update-consolidate-migration-rewrite-flush
+++ b/.github/changelog/update-consolidate-migration-rewrite-flush
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Always flush rewrite rules at the end of a plugin migration so that users upgrading across multiple versions do not miss a flush.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -213,8 +213,13 @@ class Migration {
 			\wp_schedule_single_event( \time() + HOUR_IN_SECONDS, 'activitypub_backfill_statistics' );
 		}
 
-		// Flush rewrite rules after all migrations are done to ensure any changes to custom endpoints are registered.
-		Activitypub::flush_rewrite_rules();
+		/*
+		 * Defer the flush to late in the `init` cycle (priority 20). Migration::init
+		 * runs at priority 1, which is earlier than most plugins register their
+		 * rewrite rules. Flushing synchronously here would persist a truncated
+		 * ruleset that omits third-party rules added on `init` at priority 10.
+		 */
+		\add_action( 'init', array( Activitypub::class, 'flush_rewrite_rules' ), 20 );
 
 		// Ensure all required cron schedules are registered.
 		Scheduler::register_schedules();

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -160,19 +160,14 @@ class Migration {
 		if ( \version_compare( $version_from_db, '4.7.2', '<' ) ) {
 			self::migrate_to_4_7_2();
 		}
-		if ( \version_compare( $version_from_db, '4.7.3', '<' ) ) {
-			add_action( 'init', 'flush_rewrite_rules', 20 );
-		}
 		if ( \version_compare( $version_from_db, '5.0.0', '<' ) ) {
 			Scheduler::register_schedules();
 			\wp_schedule_single_event( \time(), 'activitypub_create_post_outbox_items' );
 			\wp_schedule_single_event( \time() + 15, 'activitypub_create_comment_outbox_items' );
-			add_action( 'init', 'flush_rewrite_rules', 20 );
 		}
 		if ( \version_compare( $version_from_db, '5.4.0', '<' ) ) {
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'update_actor_json_slashing' ) );
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'update_comment_author_emails' ) );
-			\add_action( 'init', 'flush_rewrite_rules', 20 );
 		}
 		if ( \version_compare( $version_from_db, '5.7.0', '<' ) ) {
 			self::delete_mastodon_api_orphaned_extra_fields();
@@ -180,17 +175,14 @@ class Migration {
 		if ( \version_compare( $version_from_db, '5.8.0', '<' ) ) {
 			self::update_notification_options();
 		}
-
 		if ( \version_compare( $version_from_db, '6.0.0', '<' ) ) {
 			self::migrate_followers_to_ap_actor_cpt();
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'update_actor_json_storage' ) );
 		}
-
 		if ( \version_compare( $version_from_db, '6.0.1', '<' ) ) {
 			self::migrate_followers_to_ap_actor_cpt();
 			\wp_schedule_single_event( \time(), 'activitypub_upgrade', array( 'update_actor_json_storage' ) );
 		}
-
 		if ( \version_compare( $version_from_db, '7.0.0', '<' ) ) {
 			wp_unschedule_hook( 'activitypub_update_followers' );
 			wp_unschedule_hook( 'activitypub_cleanup_followers' );
@@ -203,33 +195,26 @@ class Migration {
 				\wp_schedule_event( time(), 'daily', 'activitypub_cleanup_remote_actors' );
 			}
 		}
-
 		if ( \version_compare( $version_from_db, '7.3.0', '<' ) ) {
 			self::remove_pending_application_user_follow_requests();
 		}
-
 		if ( \version_compare( $version_from_db, '7.5.0', '<' ) ) {
 			self::sync_jetpack_following_meta();
 		}
-
 		if ( \version_compare( $version_from_db, '7.6.0', '<' ) ) {
 			self::clean_up_inbox();
 			\wp_schedule_single_event( \time(), 'activitypub_migrate_avatar_to_remote_actors' );
 		}
-
 		if ( \version_compare( $version_from_db, '7.9.0', '<' ) ) {
 			\wp_schedule_single_event( \time(), 'activitypub_migrate_actor_emoji' );
 		}
 		if ( \version_compare( $version_from_db, '8.1.0', '<' ) ) {
-			// Flush rewrite rules for OAuth Authorization Server Metadata endpoint.
-			\add_action( 'init', 'flush_rewrite_rules', 20 );
 			// Backfill historical statistics data (delay to avoid load immediately after upgrade).
 			\wp_schedule_single_event( \time() + HOUR_IN_SECONDS, 'activitypub_backfill_statistics' );
 		}
 
-		if ( \version_compare( $version_from_db, '8.0.0', '<' ) ) {
-			Activitypub::flush_rewrite_rules();
-		}
+		// Flush rewrite rules after all migrations are done to ensure any changes to custom endpoints are registered.
+		Activitypub::flush_rewrite_rules();
 
 		// Ensure all required cron schedules are registered.
 		Scheduler::register_schedules();
@@ -310,8 +295,6 @@ class Migration {
 				}
 			}
 		}
-
-		Activitypub::flush_rewrite_rules();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes:

Multiple migration steps each scheduled their own \`flush_rewrite_rules()\` via \`add_action( 'init', ..., 20 )\`, with further direct calls sprinkled through the \`maybe_migrate()\` flow. Users who upgrade across several versions in a single step could land in a state where none of the conditional blocks fire, so rewrite rules never flush and endpoints added in intermediate versions fail to resolve until the next manual flush.

* Drop the per-step \`flush_rewrite_rules()\` / \`add_action( 'init', 'flush_rewrite_rules', 20 )\` calls from inside individual version-gated branches.
* Always call \`Activitypub::flush_rewrite_rules()\` unconditionally after all migration steps complete. One flush, every time, regardless of how many versions the user jumped.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No new tests. Existing migration tests continue to pass (the one pre-existing failure in \`test_add_default_extra_field\` is unrelated to this change — confirmed by running tests against trunk without this patch).

## Testing instructions:

* \`npm run env-test -- --filter=Migration\` passes aside from the one pre-existing unrelated failure.
* Manual: set \`activitypub_db_version\` to an older version (e.g. \`4.7.0\`) on a fresh install, trigger a plugin load, confirm rewrite rules are flushed. Repeat for a version jump (e.g. \`4.7.0\` → current) to confirm a single flush is always scheduled.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Changed

#### Message

Always flush rewrite rules at the end of a plugin migration so that users upgrading across multiple versions do not miss a flush.

</details>