### PR TITLE
Fix reply posts disappearing from front page and admin list

### DIFF
--- a/.github/changelog/fix-posts-and-replies-filter-scope
+++ b/.github/changelog/fix-posts-and-replies-filter-scope
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop hiding posts that contain a federated reply block from the main blog listing and the admin post list on sites that do not use the Posts and Replies block.

--- a/build/posts-and-replies/render.php
+++ b/build/posts-and-replies/render.php
@@ -17,11 +17,15 @@ if ( is_activitypub_request() || \is_feed() ) {
 	return;
 }
 
-// Determine active tab from URL parameter.
+/*
+ * Determine active tab from URL parameter. Default to "Posts & Replies" so
+ * the reply-exclusion filter only attaches on an explicit opt-in via
+ * ?filter=posts (clicked from the tab bar below).
+ */
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$active_tab = isset( $_GET['filter'] ) ? \sanitize_key( $_GET['filter'] ) : 'posts';
+$active_tab = isset( $_GET['filter'] ) ? \sanitize_key( \wp_unslash( $_GET['filter'] ) ) : 'posts-and-replies';
 if ( ! \in_array( $active_tab, array( 'posts', 'posts-and-replies' ), true ) ) {
-	$active_tab = 'posts';
+	$active_tab = 'posts-and-replies';
 }
 
 $current_url = \remove_query_arg( array( 'filter', 'paged' ) );

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1259,15 +1259,16 @@ class Blocks {
 	/**
 	 * Filter the main query to exclude replies.
 	 *
-	 * When the "Posts" tab is active (default), adds a WHERE clause to
-	 * exclude posts containing the `activitypub/reply` block. This
-	 * filters the main query so that Query Loop blocks with
-	 * `inherit: true` also pick up the filter.
+	 * Adds a WHERE clause to exclude posts containing the `activitypub/reply`
+	 * block when the visitor has explicitly requested the "Posts" tab via
+	 * `?filter=posts`. This filters the main query so that Query Loop blocks
+	 * with `inherit: true` also pick up the filter.
 	 *
-	 * The filter is only attached when the current frontend request
-	 * renders the `activitypub/posts-and-replies` tab block. Admin and
-	 * feed queries are never touched, and neither is any frontend
-	 * request whose template does not contain the tab block.
+	 * The filter only attaches on that explicit opt-in. Admin, feed, and any
+	 * regular frontend request (front page, archives, search…) are never
+	 * touched, which is why no block-presence probing is needed: the only
+	 * way `?filter=posts` appears in a URL is from a click on the
+	 * `activitypub/posts-and-replies` tab block.
 	 *
 	 * @since 8.1.0
 	 *
@@ -1293,118 +1294,13 @@ class Blocks {
 			}
 		}
 
-		// Only filter when the current request actually renders the posts-and-replies block.
-		if ( ! self::current_request_has_posts_and_replies_block( $query ) ) {
-			return;
-		}
-
+		// Only filter when the "Posts" tab has been explicitly selected.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$active_tab = isset( $_GET['filter'] ) ? \sanitize_key( $_GET['filter'] ) : 'posts';
-
-		// Only filter when the "Posts" tab is active (default).
-		if ( 'posts-and-replies' === $active_tab ) {
+		if ( ! isset( $_GET['filter'] ) || 'posts' !== \sanitize_key( \wp_unslash( $_GET['filter'] ) ) ) {
 			return;
 		}
 
 		\add_filter( 'posts_where', array( self::class, 'exclude_replies_where' ) );
-	}
-
-	/**
-	 * Best-effort check for whether the current request will render the posts-and-replies block.
-	 *
-	 * Looks at the static front page or posts page (classic / hybrid setups)
-	 * and at the block template the query is most likely to use (block themes).
-	 * Widgets, shortcodes and other embed points are not detected — when in
-	 * doubt, we err on the side of not filtering.
-	 *
-	 * @since unreleased
-	 *
-	 * @param \WP_Query $query The WP_Query instance.
-	 * @return bool Whether the posts-and-replies block is present.
-	 */
-	private static function current_request_has_posts_and_replies_block( $query ) {
-		$block_name = 'activitypub/posts-and-replies';
-
-		if ( $query->is_front_page() ) {
-			$page_on_front = (int) \get_option( 'page_on_front' );
-			if ( $page_on_front && \has_block( $block_name, $page_on_front ) ) {
-				return true;
-			}
-		}
-
-		if ( $query->is_home() ) {
-			$page_for_posts = (int) \get_option( 'page_for_posts' );
-			if ( $page_for_posts && \has_block( $block_name, $page_for_posts ) ) {
-				return true;
-			}
-		}
-
-		if ( \function_exists( 'wp_is_block_theme' ) && \wp_is_block_theme() && \function_exists( 'get_block_template' ) ) {
-			$stylesheet = \get_stylesheet();
-			foreach ( self::candidate_template_slugs( $query ) as $slug ) {
-				/*
-				 * Probe the theme template first so themes can override.
-				 * Fall back to plugin-registered templates (e.g. the
-				 * `activitypub//author` template the plugin itself registers
-				 * for author archives) so the block is detected even when
-				 * the active theme does not ship its own template.
-				 */
-				foreach ( array( $stylesheet, 'activitypub' ) as $namespace ) {
-					$template = \get_block_template( $namespace . '//' . $slug );
-					if ( $template && ! empty( $template->content ) && \has_block( $block_name, $template->content ) ) {
-						return true;
-					}
-				}
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Candidate block template slugs for a query, ordered from most specific to least.
-	 *
-	 * @since unreleased
-	 *
-	 * @param \WP_Query $query The WP_Query instance.
-	 * @return string[] Template slugs to probe.
-	 */
-	private static function candidate_template_slugs( $query ) {
-		if ( $query->is_front_page() ) {
-			return array( 'front-page', 'home', 'index' );
-		}
-		if ( $query->is_home() ) {
-			return array( 'home', 'index' );
-		}
-		if ( $query->is_category() ) {
-			return array( 'category', 'archive', 'index' );
-		}
-		if ( $query->is_tag() ) {
-			return array( 'tag', 'archive', 'index' );
-		}
-		if ( $query->is_tax() ) {
-			return array( 'taxonomy', 'archive', 'index' );
-		}
-		if ( $query->is_author() ) {
-			return array( 'author', 'archive', 'index' );
-		}
-		if ( $query->is_date() ) {
-			return array( 'date', 'archive', 'index' );
-		}
-		if ( $query->is_post_type_archive() ) {
-			$slugs     = array();
-			$post_type = $query->get( 'post_type' );
-			if ( \is_string( $post_type ) && '' !== $post_type ) {
-				$slugs[] = 'archive-' . $post_type;
-			}
-			$slugs[] = 'archive';
-			$slugs[] = 'index';
-			return $slugs;
-		}
-		if ( $query->is_search() ) {
-			return array( 'search', 'index' );
-		}
-		return array( 'index' );
 	}
 
 	/**

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1264,11 +1264,21 @@ class Blocks {
 	 * filters the main query so that Query Loop blocks with
 	 * `inherit: true` also pick up the filter.
 	 *
+	 * The filter is only attached when the current frontend request
+	 * renders the `activitypub/posts-and-replies` tab block. Admin and
+	 * feed queries are never touched, and neither is any frontend
+	 * request whose template does not contain the tab block.
+	 *
 	 * @since 8.1.0
 	 *
 	 * @param WP_Query $query The WP_Query instance.
 	 */
 	public static function filter_query_loop_vars( $query ) {
+		// Never touch admin or feed queries.
+		if ( \is_admin() || $query->is_feed() ) {
+			return;
+		}
+
 		if ( ! $query->is_main_query() || $query->is_singular() ) {
 			return;
 		}
@@ -1283,6 +1293,11 @@ class Blocks {
 			}
 		}
 
+		// Only filter when the current request actually renders the posts-and-replies block.
+		if ( ! self::current_request_has_posts_and_replies_block( $query ) ) {
+			return;
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$active_tab = isset( $_GET['filter'] ) ? \sanitize_key( $_GET['filter'] ) : 'posts';
 
@@ -1292,6 +1307,79 @@ class Blocks {
 		}
 
 		\add_filter( 'posts_where', array( self::class, 'exclude_replies_where' ) );
+	}
+
+	/**
+	 * Best-effort check for whether the current request will render the posts-and-replies block.
+	 *
+	 * Looks at the static front page or posts page (classic / hybrid setups)
+	 * and at the block template the query is most likely to use (block themes).
+	 * Widgets, shortcodes and other embed points are not detected — when in
+	 * doubt, we err on the side of not filtering.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Query $query The WP_Query instance.
+	 * @return bool Whether the posts-and-replies block is present.
+	 */
+	private static function current_request_has_posts_and_replies_block( $query ) {
+		$block_name = 'activitypub/posts-and-replies';
+
+		if ( $query->is_front_page() ) {
+			$page_on_front = (int) \get_option( 'page_on_front' );
+			if ( $page_on_front && \has_block( $block_name, $page_on_front ) ) {
+				return true;
+			}
+		}
+
+		if ( $query->is_home() ) {
+			$page_for_posts = (int) \get_option( 'page_for_posts' );
+			if ( $page_for_posts && \has_block( $block_name, $page_for_posts ) ) {
+				return true;
+			}
+		}
+
+		if ( \function_exists( 'wp_is_block_theme' ) && \wp_is_block_theme() && \function_exists( 'get_block_template' ) ) {
+			$stylesheet = \get_stylesheet();
+			foreach ( self::candidate_template_slugs( $query ) as $slug ) {
+				$template = \get_block_template( $stylesheet . '//' . $slug );
+				if ( $template && ! empty( $template->content ) && \has_block( $block_name, $template->content ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Candidate block template slugs for a query, ordered from most specific to least.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Query $query The WP_Query instance.
+	 * @return string[] Template slugs to probe.
+	 */
+	private static function candidate_template_slugs( $query ) {
+		if ( $query->is_front_page() ) {
+			return array( 'front-page', 'home', 'index' );
+		}
+		if ( $query->is_home() ) {
+			return array( 'home', 'index' );
+		}
+		if ( $query->is_category() || $query->is_tag() || $query->is_tax() ) {
+			return array( 'archive', 'index' );
+		}
+		if ( $query->is_author() ) {
+			return array( 'author', 'archive', 'index' );
+		}
+		if ( $query->is_date() ) {
+			return array( 'date', 'archive', 'index' );
+		}
+		if ( $query->is_search() ) {
+			return array( 'search', 'index' );
+		}
+		return array( 'index' );
 	}
 
 	/**

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1342,9 +1342,18 @@ class Blocks {
 		if ( \function_exists( 'wp_is_block_theme' ) && \wp_is_block_theme() && \function_exists( 'get_block_template' ) ) {
 			$stylesheet = \get_stylesheet();
 			foreach ( self::candidate_template_slugs( $query ) as $slug ) {
-				$template = \get_block_template( $stylesheet . '//' . $slug );
-				if ( $template && ! empty( $template->content ) && \has_block( $block_name, $template->content ) ) {
-					return true;
+				/*
+				 * Probe the theme template first so themes can override.
+				 * Fall back to plugin-registered templates (e.g. the
+				 * `activitypub//author` template the plugin itself registers
+				 * for author archives) so the block is detected even when
+				 * the active theme does not ship its own template.
+				 */
+				foreach ( array( $stylesheet, 'activitypub' ) as $namespace ) {
+					$template = \get_block_template( $namespace . '//' . $slug );
+					if ( $template && ! empty( $template->content ) && \has_block( $block_name, $template->content ) ) {
+						return true;
+					}
 				}
 			}
 		}
@@ -1367,14 +1376,30 @@ class Blocks {
 		if ( $query->is_home() ) {
 			return array( 'home', 'index' );
 		}
-		if ( $query->is_category() || $query->is_tag() || $query->is_tax() ) {
-			return array( 'archive', 'index' );
+		if ( $query->is_category() ) {
+			return array( 'category', 'archive', 'index' );
+		}
+		if ( $query->is_tag() ) {
+			return array( 'tag', 'archive', 'index' );
+		}
+		if ( $query->is_tax() ) {
+			return array( 'taxonomy', 'archive', 'index' );
 		}
 		if ( $query->is_author() ) {
 			return array( 'author', 'archive', 'index' );
 		}
 		if ( $query->is_date() ) {
 			return array( 'date', 'archive', 'index' );
+		}
+		if ( $query->is_post_type_archive() ) {
+			$slugs     = array();
+			$post_type = $query->get( 'post_type' );
+			if ( \is_string( $post_type ) && '' !== $post_type ) {
+				$slugs[] = 'archive-' . $post_type;
+			}
+			$slugs[] = 'archive';
+			$slugs[] = 'index';
+			return $slugs;
 		}
 		if ( $query->is_search() ) {
 			return array( 'search', 'index' );

--- a/src/posts-and-replies/render.php
+++ b/src/posts-and-replies/render.php
@@ -17,11 +17,15 @@ if ( is_activitypub_request() || \is_feed() ) {
 	return;
 }
 
-// Determine active tab from URL parameter.
+/*
+ * Determine active tab from URL parameter. Default to "Posts & Replies" so
+ * the reply-exclusion filter only attaches on an explicit opt-in via
+ * ?filter=posts (clicked from the tab bar below).
+ */
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$active_tab = isset( $_GET['filter'] ) ? \sanitize_key( $_GET['filter'] ) : 'posts';
+$active_tab = isset( $_GET['filter'] ) ? \sanitize_key( \wp_unslash( $_GET['filter'] ) ) : 'posts-and-replies';
 if ( ! \in_array( $active_tab, array( 'posts', 'posts-and-replies' ), true ) ) {
-	$active_tab = 'posts';
+	$active_tab = 'posts-and-replies';
 }
 
 $current_url = \remove_query_arg( array( 'filter', 'paged' ) );

--- a/tests/phpunit/tests/includes/class-test-blocks.php
+++ b/tests/phpunit/tests/includes/class-test-blocks.php
@@ -1227,7 +1227,7 @@ class Test_Blocks extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Admin main queries must not attach the reply-exclusion filter.
+	 * Admin main queries must not attach the reply-exclusion filter, even when ?filter=posts is set.
 	 *
 	 * @covers ::filter_query_loop_vars
 	 */
@@ -1238,7 +1238,7 @@ class Test_Blocks extends \WP_UnitTestCase {
 		$this->go_to( \home_url( '/' ) );
 		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
 
-		// Now pretend we're in wp-admin and re-run the hook on the main query.
+		$_GET['filter'] = 'posts';
 		\set_current_screen( 'edit-post' );
 		$this->assertTrue( \is_admin(), 'Precondition: set_current_screen must make is_admin() true.' );
 
@@ -1246,7 +1246,7 @@ class Test_Blocks extends \WP_UnitTestCase {
 
 		$attached = false !== \has_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
 
-		// Cleanup.
+		unset( $_GET['filter'] );
 		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
 		\set_current_screen( 'front' );
 
@@ -1254,33 +1254,64 @@ class Test_Blocks extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Frontend main queries must not attach the exclusion filter when the tab block is nowhere on the site.
+	 * Feed queries must not attach the reply-exclusion filter.
 	 *
 	 * @covers ::filter_query_loop_vars
-	 * @covers ::current_request_has_posts_and_replies_block
 	 */
-	public function test_filter_query_loop_vars_skips_when_block_not_present() {
+	public function test_filter_query_loop_vars_does_not_touch_feed_queries() {
 		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
 
-		$this->go_to( \home_url( '/' ) );
+		$this->go_to( \home_url( '/?feed=rss2' ) );
 		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		$_GET['filter'] = 'posts';
+
+		$this->assertTrue( $GLOBALS['wp_query']->is_feed(), 'Precondition: the main query must be a feed query.' );
 
 		Blocks::filter_query_loop_vars( $GLOBALS['wp_query'] );
 
 		$attached = false !== \has_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
 
+		unset( $_GET['filter'] );
 		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
 
-		$this->assertFalse( $attached, 'Without the tab block, the exclusion filter must not be attached.' );
+		$this->assertFalse( $attached, 'Feed queries must never attach the posts_where exclusion filter.' );
 	}
 
 	/**
-	 * When the tab block is present on the posts page, the default "Posts" tab still hides reply posts.
+	 * Frontend main queries must not attach the exclusion filter without an explicit ?filter=posts opt-in.
+	 *
+	 * @covers ::filter_query_loop_vars
+	 */
+	public function test_filter_query_loop_vars_skips_without_explicit_filter_param() {
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		$this->go_to( \home_url( '/' ) );
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		unset( $_GET['filter'] );
+		Blocks::filter_query_loop_vars( $GLOBALS['wp_query'] );
+		$attached_default = false !== \has_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		$_GET['filter'] = 'posts-and-replies';
+		Blocks::filter_query_loop_vars( $GLOBALS['wp_query'] );
+		$attached_all = false !== \has_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		unset( $_GET['filter'] );
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		$this->assertFalse( $attached_default, 'Without ?filter the exclusion filter must not be attached.' );
+		$this->assertFalse( $attached_all, 'With ?filter=posts-and-replies the exclusion filter must not be attached.' );
+	}
+
+	/**
+	 * An explicit ?filter=posts opt-in attaches the filter and hides reply-block posts.
 	 *
 	 * @covers ::filter_query_loop_vars
 	 * @covers ::exclude_replies_where
 	 */
-	public function test_filter_query_loop_vars_applies_when_block_present_on_posts_page() {
+	public function test_filter_query_loop_vars_applies_on_explicit_posts_filter() {
 		$reply_post = self::factory()->post->create(
 			array(
 				'post_title'   => 'Reply post',
@@ -1296,43 +1327,15 @@ class Test_Blocks extends \WP_UnitTestCase {
 			)
 		);
 
-		$posts_page = self::factory()->post->create(
-			array(
-				'post_type'    => 'page',
-				'post_status'  => 'publish',
-				'post_title'   => 'Blog',
-				'post_content' => '<!-- wp:activitypub/posts-and-replies /-->',
-			)
-		);
-
-		$original_show_on_front  = \get_option( 'show_on_front' );
-		$original_page_for_posts = \get_option( 'page_for_posts' );
-		$original_page_on_front  = \get_option( 'page_on_front' );
-
-		\update_option( 'show_on_front', 'page' );
-		\update_option( 'page_for_posts', $posts_page );
-		\update_option(
-			'page_on_front',
-			self::factory()->post->create(
-				array(
-					'post_type'   => 'page',
-					'post_status' => 'publish',
-				)
-			)
-		);
-
-		$this->go_to( \get_permalink( $posts_page ) );
+		$this->go_to( \home_url( '/?filter=posts' ) );
 
 		$ids = \wp_list_pluck( $GLOBALS['wp_query']->posts, 'ID' );
 
-		\update_option( 'show_on_front', $original_show_on_front );
-		\update_option( 'page_for_posts', $original_page_for_posts );
-		\update_option( 'page_on_front', $original_page_on_front );
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
 		\wp_delete_post( $reply_post, true );
 		\wp_delete_post( $plain_post, true );
-		\wp_delete_post( $posts_page, true );
 
-		$this->assertContains( $plain_post, $ids, 'Plain posts must stay visible when the tab block is on the posts page.' );
-		$this->assertNotContains( $reply_post, $ids, 'Reply-block posts must be hidden under the default "Posts" tab when the tab block is on the posts page.' );
+		$this->assertContains( $plain_post, $ids, 'Plain posts must stay visible under ?filter=posts.' );
+		$this->assertNotContains( $reply_post, $ids, 'Reply-block posts must be hidden under ?filter=posts.' );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-blocks.php
+++ b/tests/phpunit/tests/includes/class-test-blocks.php
@@ -1225,4 +1225,114 @@ class Test_Blocks extends \WP_UnitTestCase {
 
 		\update_option( 'permalink_structure', $original );
 	}
+
+	/**
+	 * Admin main queries must not attach the reply-exclusion filter.
+	 *
+	 * @covers ::filter_query_loop_vars
+	 */
+	public function test_filter_query_loop_vars_does_not_touch_admin_queries() {
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		// Land on the frontend so $GLOBALS['wp_query'] is a real main query.
+		$this->go_to( \home_url( '/' ) );
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		// Now pretend we're in wp-admin and re-run the hook on the main query.
+		\set_current_screen( 'edit-post' );
+		$this->assertTrue( \is_admin(), 'Precondition: set_current_screen must make is_admin() true.' );
+
+		Blocks::filter_query_loop_vars( $GLOBALS['wp_query'] );
+
+		$attached = false !== \has_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		// Cleanup.
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+		\set_current_screen( 'front' );
+
+		$this->assertFalse( $attached, 'Admin queries must never attach the posts_where exclusion filter.' );
+	}
+
+	/**
+	 * Frontend main queries must not attach the exclusion filter when the tab block is nowhere on the site.
+	 *
+	 * @covers ::filter_query_loop_vars
+	 * @covers ::current_request_has_posts_and_replies_block
+	 */
+	public function test_filter_query_loop_vars_skips_when_block_not_present() {
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		$this->go_to( \home_url( '/' ) );
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		Blocks::filter_query_loop_vars( $GLOBALS['wp_query'] );
+
+		$attached = false !== \has_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		\remove_filter( 'posts_where', array( Blocks::class, 'exclude_replies_where' ) );
+
+		$this->assertFalse( $attached, 'Without the tab block, the exclusion filter must not be attached.' );
+	}
+
+	/**
+	 * When the tab block is present on the posts page, the default "Posts" tab still hides reply posts.
+	 *
+	 * @covers ::filter_query_loop_vars
+	 * @covers ::exclude_replies_where
+	 */
+	public function test_filter_query_loop_vars_applies_when_block_present_on_posts_page() {
+		$reply_post = self::factory()->post->create(
+			array(
+				'post_title'   => 'Reply post',
+				'post_content' => '<!-- wp:activitypub/reply {"url":"https://example.com/c"} /-->',
+				'post_status'  => 'publish',
+			)
+		);
+		$plain_post = self::factory()->post->create(
+			array(
+				'post_title'   => 'Plain post',
+				'post_content' => '<!-- wp:paragraph --><p>Hi.</p><!-- /wp:paragraph -->',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$posts_page = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Blog',
+				'post_content' => '<!-- wp:activitypub/posts-and-replies /-->',
+			)
+		);
+
+		$original_show_on_front  = \get_option( 'show_on_front' );
+		$original_page_for_posts = \get_option( 'page_for_posts' );
+		$original_page_on_front  = \get_option( 'page_on_front' );
+
+		\update_option( 'show_on_front', 'page' );
+		\update_option( 'page_for_posts', $posts_page );
+		\update_option(
+			'page_on_front',
+			self::factory()->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+				)
+			)
+		);
+
+		$this->go_to( \get_permalink( $posts_page ) );
+
+		$ids = \wp_list_pluck( $GLOBALS['wp_query']->posts, 'ID' );
+
+		\update_option( 'show_on_front', $original_show_on_front );
+		\update_option( 'page_for_posts', $original_page_for_posts );
+		\update_option( 'page_on_front', $original_page_on_front );
+		\wp_delete_post( $reply_post, true );
+		\wp_delete_post( $plain_post, true );
+		\wp_delete_post( $posts_page, true );
+
+		$this->assertContains( $plain_post, $ids, 'Plain posts must stay visible when the tab block is on the posts page.' );
+		$this->assertNotContains( $reply_post, $ids, 'Reply-block posts must be hidden under the default "Posts" tab when the tab block is on the posts page.' );
+	}
 }


### PR DESCRIPTION
Fixes #3208.

## Proposed changes:

Hey! This scopes `Blocks::filter_query_loop_vars()` so the `post_content NOT LIKE '%<!-- wp:activitypub/reply%'` clause only gets attached when the current frontend request actually renders the `activitypub/posts-and-replies` tab block.

- Admin and feed queries are now always skipped.
- Block presence is detected via `has_block()` on the static front page / posts page (classic / hybrid setups) and on the likely block template for the current query type (home, front-page, archive, author, date, search, index).
- `candidate_template_slugs()` is a small private helper mapping `WP_Query` conditionals to the block template slugs WordPress would resolve first.

### Why

Shipped in 8.1.0 (#3036) to back the Posts & Replies tab block, the hook runs on every main non-singular `pre_get_posts` and appends the `NOT LIKE` clause via `posts_where`. That hides reply-block posts from both the wp-admin post list view and the front page / archives on sites that don't use the tab block at all — Lord Matt describes it as [Schrödinger's post](https://node.lordmatt.co.uk/2026/04/21/posts/ive-hit-the-wildest-bug-in-wordpress/).

Of note, Friends already worked around the same filter in [akirk/friends@d4639db](https://github.com/akirk/friends/commit/d4639db) after measuring a ~4.7s TTFB regression from the full table scan, so scoping this fixes the performance side of things too.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. On a site running `trunk`, publish a post containing the Federated Reply block. The easiest way is to open the editor with `?in_reply_to=https://mastodon.social/@some/post` in the URL; the reply-intent plugin inserts the block for you.
2. Without this PR, the post disappears from both the front page listing and `wp-admin → Posts`. With this PR, it appears in both places.
3. Drop the "Posts and Replies" tab block onto the page that renders your blog — the `home.html` template in a block theme, or the page assigned as "Posts page" in Settings → Reading. The default "Posts" tab should still hide the reply-block post on the frontend; the "Posts & Replies" tab should show it.
4. `wp-admin → Posts` should list everything regardless of where the tab block is placed.

### Changelog entry

Manually added at `.github/changelog/fix-posts-and-replies-filter-scope`; no need to check the box below.

-   [ ] Automatically create a changelog entry from the details below.