### PR TITLE
Add activitypub_post_object_type filter wrapping Post::get_type()

### DIFF
--- a/.github/changelog/add-post-object-type-filter
+++ b/.github/changelog/add-post-object-type-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the `activitypub_post_object_type` filter so plugins can override the federated object type (Note, Article, Page) for a post.

--- a/.github/changelog/add-post-object-type-filter
+++ b/.github/changelog/add-post-object-type-filter
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Added the `activitypub_post_object_type` filter so plugins can override the federated object type (Note, Article, Page) for a post.

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -471,8 +471,9 @@ class Post extends Base {
 		 * Allows downstream consumers to override the discriminator that
 		 * decides whether a post federates as Note, Article, or Page.
 		 * The filtered value propagates to all internal callers of
-		 * get_type() (content composition, attachment handling, content
-		 * templates, preview), not only the wire-format type property.
+		 * get_type(), including former_type/tombstone handling,
+		 * summary and title decisions, the content template, and the
+		 * preview guard, not only the wire-format type property.
 		 *
 		 * @since unreleased
 		 *

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -454,25 +454,32 @@ class Post extends Base {
 		$post_format_setting = \get_option( 'activitypub_object_type', ACTIVITYPUB_DEFAULT_OBJECT_TYPE );
 
 		if ( 'wordpress-post-format' !== $post_format_setting ) {
-			return \ucfirst( $post_format_setting );
-		}
-
-		// Check if the post has a title.
-		if ( ! \post_type_supports( $this->item->post_type, 'title' ) || ! $this->item->post_title ) {
-			return 'Note';
-		}
-
-		// Default to Note.
-		$object_type = 'Note';
-		$post_type   = \get_post_type( $this->item );
-
-		if ( 'page' === $post_type ) {
+			$object_type = \ucfirst( $post_format_setting );
+		} elseif ( ! \post_type_supports( $this->item->post_type, 'title' ) || ! $this->item->post_title ) {
+			$object_type = 'Note';
+		} elseif ( 'page' === \get_post_type( $this->item ) ) {
 			$object_type = 'Page';
 		} elseif ( ! \get_post_format( $this->item ) ) {
 			$object_type = 'Article';
+		} else {
+			$object_type = 'Note';
 		}
 
-		return $object_type;
+		/**
+		 * Filters the ActivityPub object type for a post.
+		 *
+		 * Allows downstream consumers to override the discriminator that
+		 * decides whether a post federates as Note, Article, or Page.
+		 * The filtered value propagates to all internal callers of
+		 * get_type() (content composition, attachment handling, content
+		 * templates, preview), not only the wire-format type property.
+		 *
+		 * @since unreleased
+		 *
+		 * @param string   $object_type The computed ActivityPub object type.
+		 * @param \WP_Post $post        The WordPress post being transformed.
+		 */
+		return \apply_filters( 'activitypub_post_object_type', $object_type, $this->item );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -261,10 +261,12 @@ class Test_Post extends \WP_UnitTestCase {
 
 		\add_filter( 'activitypub_post_object_type', $callback, 10, 2 );
 
-		$transformer = new Post( $post );
-		$type        = $this->reflection_method->invoke( $transformer );
-
-		\remove_filter( 'activitypub_post_object_type', $callback, 10 );
+		try {
+			$transformer = new Post( $post );
+			$type        = $this->reflection_method->invoke( $transformer );
+		} finally {
+			\remove_filter( 'activitypub_post_object_type', $callback, 10 );
+		}
 
 		$this->assertSame( 'Article', $received_type, 'Filter should receive the computed default type.' );
 		$this->assertInstanceOf( '\WP_Post', $received_post );

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -234,6 +234,45 @@ class Test_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the activitypub_post_object_type filter overrides the computed type.
+	 *
+	 * Verifies the filter receives the computed default and the post being
+	 * transformed, and that the return value replaces the computed value
+	 * for downstream callers of get_type().
+	 *
+	 * @covers ::get_type
+	 */
+	public function test_get_type_filter_overrides_computed_value() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'A Titled Post With No Format',
+				'post_content' => 'Default behavior here would return Article.',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$received_post = null;
+		$received_type = null;
+		$callback      = function ( $object_type, $filter_post ) use ( &$received_type, &$received_post ) {
+			$received_type = $object_type;
+			$received_post = $filter_post;
+			return 'Note';
+		};
+
+		\add_filter( 'activitypub_post_object_type', $callback, 10, 2 );
+
+		$transformer = new Post( $post );
+		$type        = $this->reflection_method->invoke( $transformer );
+
+		\remove_filter( 'activitypub_post_object_type', $callback, 10 );
+
+		$this->assertSame( 'Article', $received_type, 'Filter should receive the computed default type.' );
+		$this->assertInstanceOf( '\WP_Post', $received_post );
+		$this->assertSame( $post_id, $received_post->ID, 'Filter should receive the post being transformed.' );
+		$this->assertSame( 'Note', $type, 'Filtered value should replace the computed default.' );
+	}
+
+	/**
 	 * Test the to_array method.
 	 *
 	 * @covers ::to_object


### PR DESCRIPTION
## Context

Proposed as part of the FOSSE plugin's design plan for native Bluesky publishing — the design lives at [`Automattic/fosse#18`](https://github.com/Automattic/fosse/pull/18) (see `sdd/bluesky-native-publishing/`). The implementation here is a faithful expression of that plan.

- **If you disagree with WHAT this does** — the filter name, where it wraps, the single-return refactor, scope — the FOSSE SDD is the right place to push back. I'm happy to carry feedback in either direction.
- **Code-level concerns** (style, edge cases, test coverage, whether the refactor should be split out) are perfect for here.

Sibling PR in `Automattic/wordpress-atmosphere` introduces `atmosphere_is_short_form_post` so FOSSE can project a single user-level "always Note" preference onto both networks. Sibling atmosphere PR: https://github.com/Automattic/wordpress-atmosphere/pull/29

## Summary

Adds a new filter, `activitypub_post_object_type`, that wraps the return of [`Activitypub\Transformer\Post::get_type()`](https://github.com/Automattic/wordpress-activitypub/blob/trunk/includes/transformer/class-post.php#L453). Default behavior is unchanged for any consumer that does not hook the filter.

## Why a new filter (and not the existing `activitypub_transform_set_type`)

The existing `activitypub_transform_set_type` filter fires once per property set on the final activity object — it changes the wire-format `type` value going out, but it does not change what `Post::get_type()` returns to internal callers.

`Post::get_type()` is called in five places inside `Post::transform()` to drive downstream decisions:

- `set_former_type()` (tombstone handling, line 116)
- Content composition branching for Note vs Article (lines 538, 567)
- Content template selection (line 1062)
- Preview-generation guard (line 1140)

A downstream filter on `activitypub_transform_set_type` therefore leaves all five of those running with the original computed value, producing an object whose wire `type` says `Note` but whose content/template/preview were computed under `Article` — inconsistent state.

A filter on the discriminator itself is the clean fix: one override, applied uniformly to every caller.

## Changes

- `includes/transformer/class-post.php` — refactor `get_type()` to assign through all branches and return once at the bottom (trivially equivalent to the current early-return shape), then wrap the return value in `apply_filters( 'activitypub_post_object_type', $object_type, $this->item )`. Full PHPDoc on the new filter.
- `tests/phpunit/tests/includes/transformer/class-test-post.php` — new test `test_get_type_filter_overrides_computed_value()` verifying (1) the filter receives the computed default and the post, and (2) the filtered value replaces the computed value.
- `.github/changelog/add-post-object-type-filter` — minor/added entry.

## Test plan

- [x] `composer lint` — the two files I touched are clean (one pre-existing PHPCS error in `includes/cache/class-stats-image.php` is unrelated to this change and exists on trunk).
- [ ] PHPUnit via `wp-env` — I did not run locally (no wp-env set up in my environment). Confident in the change via PHP syntax check and by reading, but please let me know if CI surfaces anything.

Fixes DOTCOM-16839
