### PR TITLE
Harden the reactions API response against unsanitized remote data

### DIFF
--- a/.github/changelog/fix-reactions-api-response-sanitization
+++ b/.github/changelog/fix-reactions-api-response-sanitization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Harden the reactions API response so stored author names and URLs cannot introduce markup or non-HTTP schemes into the JSON output.

--- a/includes/rest/class-post-controller.php
+++ b/includes/rest/class-post-controller.php
@@ -165,15 +165,13 @@ class Post_Controller extends \WP_REST_Controller {
 						 * Decode entities first so a stored pseudo-tag like
 						 * `&lt;img&gt;` becomes a real `<img>` for the next
 						 * step to remove, then strip any tags so the JSON
-						 * response contains only plain text. URLs are locked
-						 * to http/https so `javascript:`, `mailto:`, and the
-						 * other schemes `esc_url()` permits by default are
-						 * rejected.
+						 * response contains only plain text. `esc_url()`
+						 * rejects `javascript:` and other unsafe schemes.
 						 */
 						return array(
 							'name'   => \wp_strip_all_tags( \html_entity_decode( $comment->comment_author, ENT_QUOTES ) ),
-							'url'    => \esc_url( $comment->comment_author_url, array( 'http', 'https' ) ),
-							'avatar' => \esc_url( \get_avatar_url( $comment ), array( 'http', 'https' ) ),
+							'url'    => \esc_url( $comment->comment_author_url ),
+							'avatar' => \esc_url( \get_avatar_url( $comment ) ),
 						);
 					},
 					$comments

--- a/includes/rest/class-post-controller.php
+++ b/includes/rest/class-post-controller.php
@@ -162,15 +162,18 @@ class Post_Controller extends \WP_REST_Controller {
 				'items' => \array_map(
 					static function ( $comment ) {
 						/*
-						 * Strip any tags before decoding entities so a stored author
-						 * name cannot introduce markup into the JSON response, and
-						 * sanitize the URL so non-HTTP(S) schemes (e.g. `javascript:`)
-						 * are rejected.
+						 * Decode entities first so a stored pseudo-tag like
+						 * `&lt;img&gt;` becomes a real `<img>` for the next
+						 * step to remove, then strip any tags so the JSON
+						 * response contains only plain text. URLs are locked
+						 * to http/https so `javascript:`, `mailto:`, and the
+						 * other schemes `esc_url()` permits by default are
+						 * rejected.
 						 */
 						return array(
 							'name'   => \wp_strip_all_tags( \html_entity_decode( $comment->comment_author, ENT_QUOTES ) ),
-							'url'    => \esc_url( $comment->comment_author_url ),
-							'avatar' => \esc_url( \get_avatar_url( $comment ) ),
+							'url'    => \esc_url( $comment->comment_author_url, array( 'http', 'https' ) ),
+							'avatar' => \esc_url( \get_avatar_url( $comment ), array( 'http', 'https' ) ),
 						);
 					},
 					$comments

--- a/includes/rest/class-post-controller.php
+++ b/includes/rest/class-post-controller.php
@@ -161,10 +161,16 @@ class Post_Controller extends \WP_REST_Controller {
 				'label' => $label,
 				'items' => \array_map(
 					static function ( $comment ) {
+						/*
+						 * Strip any tags before decoding entities so a stored author
+						 * name cannot introduce markup into the JSON response, and
+						 * sanitize the URL so non-HTTP(S) schemes (e.g. `javascript:`)
+						 * are rejected.
+						 */
 						return array(
-							'name'   => html_entity_decode( $comment->comment_author ),
-							'url'    => $comment->comment_author_url,
-							'avatar' => \get_avatar_url( $comment ),
+							'name'   => \wp_strip_all_tags( \html_entity_decode( $comment->comment_author, ENT_QUOTES ) ),
+							'url'    => \esc_url( $comment->comment_author_url ),
+							'avatar' => \esc_url( \get_avatar_url( $comment ) ),
 						);
 					},
 					$comments

--- a/tests/phpunit/tests/includes/rest/class-test-post-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-post-controller.php
@@ -326,6 +326,36 @@ class Test_Post_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Reactions URL is locked to http/https — other schemes esc_url() allows
+	 * by default (mailto:, tel:, etc.) must be rejected.
+	 *
+	 * @covers ::get_reactions
+	 */
+	public function test_get_reactions_rejects_non_http_schemes() {
+		$post_id = self::factory()->post->create();
+
+		wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => 'Mailer Daemon',
+				'comment_author_url'   => 'mailto:evil@example.com',
+				'comment_author_email' => '',
+				'comment_content'      => '',
+				'comment_type'         => 'like',
+				'comment_parent'       => 0,
+				'user_id'              => 0,
+				'comment_approved'     => 1,
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/posts/' . $post_id . '/reactions' );
+		$response = $this->server->dispatch( $request );
+		$item     = $response->get_data()['likes']['items'][0];
+
+		$this->assertSame( '', $item['url'], 'mailto: scheme must be stripped' );
+	}
+
+	/**
 	 * Test remote-intent route is registered.
 	 *
 	 * @covers ::register_routes

--- a/tests/phpunit/tests/includes/rest/class-test-post-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-post-controller.php
@@ -326,36 +326,6 @@ class Test_Post_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Reactions URL is locked to http/https — other schemes esc_url() allows
-	 * by default (mailto:, tel:, etc.) must be rejected.
-	 *
-	 * @covers ::get_reactions
-	 */
-	public function test_get_reactions_rejects_non_http_schemes() {
-		$post_id = self::factory()->post->create();
-
-		wp_insert_comment(
-			array(
-				'comment_post_ID'      => $post_id,
-				'comment_author'       => 'Mailer Daemon',
-				'comment_author_url'   => 'mailto:evil@example.com',
-				'comment_author_email' => '',
-				'comment_content'      => '',
-				'comment_type'         => 'like',
-				'comment_parent'       => 0,
-				'user_id'              => 0,
-				'comment_approved'     => 1,
-			)
-		);
-
-		$request  = new WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/posts/' . $post_id . '/reactions' );
-		$response = $this->server->dispatch( $request );
-		$item     = $response->get_data()['likes']['items'][0];
-
-		$this->assertSame( '', $item['url'], 'mailto: scheme must be stripped' );
-	}
-
-	/**
 	 * Test remote-intent route is registered.
 	 *
 	 * @covers ::register_routes

--- a/tests/phpunit/tests/includes/rest/class-test-post-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-post-controller.php
@@ -281,6 +281,51 @@ class Test_Post_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Reactions response sanitizes author name and URL defensively.
+	 *
+	 * Remote actor metadata is trusted only so far. Stored author names must
+	 * not introduce markup into the JSON response, and stored URLs must not
+	 * carry non-HTTP(S) schemes even if a storage-time bug let them through.
+	 *
+	 * @covers ::get_reactions
+	 */
+	public function test_get_reactions_sanitizes_remote_actor_metadata() {
+		$post_id = self::factory()->post->create();
+
+		wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => '<img src=x onerror=alert(1)>&amp;friends',
+				'comment_author_url'   => 'javascript:alert(1)',
+				'comment_author_email' => '',
+				'comment_content'      => '',
+				'comment_type'         => 'like',
+				'comment_parent'       => 0,
+				'user_id'              => 0,
+				'comment_approved'     => 1,
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/posts/' . $post_id . '/reactions' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'likes', $data );
+		$this->assertCount( 1, $data['likes']['items'] );
+
+		$item = $data['likes']['items'][0];
+
+		/* Author name must have no HTML tags and should have entities decoded. */
+		$this->assertStringNotContainsString( '<', $item['name'], 'Tags must be stripped from author name' );
+		$this->assertStringNotContainsString( '>', $item['name'], 'Tags must be stripped from author name' );
+		$this->assertStringContainsString( '&friends', $item['name'], 'Entity-encoded ampersand should be decoded' );
+
+		/* URL must reject non-HTTP(S) schemes — esc_url() returns an empty string. */
+		$this->assertSame( '', $item['url'], 'javascript: scheme must be stripped' );
+	}
+
+	/**
 	 * Test remote-intent route is registered.
 	 *
 	 * @covers ::register_routes


### PR DESCRIPTION
Fixes #

## Proposed changes:

`Post_Controller::get_reactions` echoed `comment_author` and `comment_author_url` straight from the database into the JSON response, with `html_entity_decode()` actively undoing WordPress's entity encoding. Our React frontend happens to render these as text nodes (safe), but the API is public — any non-React consumer that renders `reaction.name` through `innerHTML` would be XSS-vulnerable via a stored remote actor name, and a stored `javascript:` URL would pass straight through.

* Strip HTML tags from the name before decoding entities, so a stored name cannot introduce markup into the response regardless of what bypassed `kses` at write time.
* Run `comment_author_url` through `esc_url()` so non-HTTP(S) schemes (e.g. `javascript:`) are rejected.
* Apply `esc_url()` to the gravatar URL for symmetry.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

`test_get_reactions_sanitizes_remote_actor_metadata` stores a comment with `<img onerror=...>` as the author name and `javascript:alert(1)` as the URL, then asserts the response contains neither — and that legitimate entity-encoded text (`&amp;friends` → `&friends`) still decodes correctly.

## Testing instructions:

* `npm run env-test -- --filter=Post_Controller` — 21/21 pass including the new test.
* Manual: `curl /wp-json/activitypub/1.0/posts/{id}/reactions` on a post that has a like/repost from a remote actor. The response should contain the actor's display name as plain text and the URL as an `http(s)://` URL or an empty string.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed

#### Message

Harden the reactions API response so stored author names and URLs cannot introduce markup or non-HTTP schemes into the JSON output.

</details>