### PR TITLE
Add activitypub_supported_post_types filter

### DIFF
--- a/.github/changelog/add-supported-post-types-filter
+++ b/.github/changelog/add-supported-post-types-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the `activitypub_supported_post_types` filter so integrators can control which post types federate.

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -48,8 +48,42 @@ class Post_Types {
 		\add_filter( 'add_post_metadata', array( self::class, 'prevent_empty_post_meta' ), 10, 4 );
 		\add_filter( 'update_post_metadata', array( self::class, 'prevent_empty_post_meta' ), 10, 4 );
 
-		// Add support for ActivityPub to custom post types.
-		foreach ( \get_option( 'activitypub_support_post_types', array( 'post' ) ) as $post_type ) {
+		self::register_supported_post_type_feature();
+	}
+
+	/**
+	 * Registers the `activitypub` feature for each supported post type.
+	 *
+	 * Reads the admin-selected post types from the `activitypub_support_post_types`
+	 * option and applies the `activitypub_supported_post_types` filter before calling
+	 * `add_post_type_support()`. The admin UI continues to reflect the stored option,
+	 * not the filtered value.
+	 *
+	 * Note: integrations that read the `activitypub_support_post_types` option directly
+	 * (rather than checking `post_type_supports( $type, 'activitypub' )`) are not
+	 * affected by the filter.
+	 *
+	 * @since unreleased
+	 */
+	public static function register_supported_post_type_feature() {
+		$post_types = \get_option( 'activitypub_support_post_types', array( 'post' ) );
+
+		/**
+		 * Filters the post types registered for the `activitypub` post type feature.
+		 *
+		 * Runs before `add_post_type_support()` is called, letting integrators add or
+		 * remove post types regardless of the stored admin selection. The admin UI
+		 * continues to reflect the stored option, not the filtered value. Integrations
+		 * that read the `activitypub_support_post_types` option directly are not
+		 * affected by this filter.
+		 *
+		 * @since unreleased
+		 *
+		 * @param string[] $post_types Array of post type slugs with ActivityPub support.
+		 */
+		$post_types = (array) \apply_filters( 'activitypub_supported_post_types', $post_types );
+
+		foreach ( $post_types as $post_type ) {
 			\add_post_type_support( $post_type, 'activitypub' );
 		}
 	}

--- a/tests/phpunit/tests/includes/class-test-post-types.php
+++ b/tests/phpunit/tests/includes/class-test-post-types.php
@@ -25,6 +25,18 @@ class Test_Post_Types extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down test environment.
+	 *
+	 * Restores the default post-type support state and option value so tests that
+	 * mutate them don't leak into later runs.
+	 */
+	public function tear_down(): void {
+		\delete_option( 'activitypub_support_post_types' );
+		\add_post_type_support( 'post', 'activitypub' );
+		parent::tear_down();
+	}
+
+	/**
 	 * Test prevent_empty_post_meta method.
 	 *
 	 * @covers ::prevent_empty_post_meta
@@ -42,5 +54,117 @@ class Test_Post_Types extends \WP_UnitTestCase {
 		$this->assertEquals( ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS + 3, \get_post_meta( $post_id, 'activitypub_max_image_attachments', true ) );
 
 		\delete_post_meta( $post_id, 'activitypub_max_image_attachments' );
+	}
+
+	/**
+	 * Test that the stored option drives registration when no filter is attached.
+	 *
+	 * @covers ::register_supported_post_type_feature
+	 */
+	public function test_registers_support_from_stored_option() {
+		\register_post_type( 'guide', array( 'public' => true ) );
+		\update_option( 'activitypub_support_post_types', array( 'guide' ) );
+
+		\remove_post_type_support( 'post', 'activitypub' );
+		Post_Types::register_supported_post_type_feature();
+
+		$this->assertTrue( \post_type_supports( 'guide', 'activitypub' ) );
+		$this->assertFalse( \post_type_supports( 'post', 'activitypub' ) );
+
+		\remove_post_type_support( 'guide', 'activitypub' );
+		\unregister_post_type( 'guide' );
+	}
+
+	/**
+	 * Test that the filter receives the stored option value as its first argument.
+	 *
+	 * @covers ::register_supported_post_type_feature
+	 */
+	public function test_filter_receives_stored_option_value() {
+		\update_option( 'activitypub_support_post_types', array( 'post', 'page' ) );
+
+		$received = null;
+		$filter   = static function ( $post_types ) use ( &$received ) {
+			$received = $post_types;
+			return $post_types;
+		};
+		\add_filter( 'activitypub_supported_post_types', $filter );
+
+		Post_Types::register_supported_post_type_feature();
+
+		$this->assertSame( array( 'post', 'page' ), $received );
+
+		\remove_filter( 'activitypub_supported_post_types', $filter );
+	}
+
+	/**
+	 * Test that the activitypub_supported_post_types filter adds post type support.
+	 *
+	 * @covers ::register_supported_post_type_feature
+	 */
+	public function test_supported_post_types_filter_adds_support() {
+		\register_post_type( 'book', array( 'public' => true ) );
+
+		$filter = static function ( $post_types ) {
+			$post_types[] = 'book';
+			return $post_types;
+		};
+		\add_filter( 'activitypub_supported_post_types', $filter );
+
+		Post_Types::register_supported_post_type_feature();
+
+		$this->assertTrue( \post_type_supports( 'book', 'activitypub' ) );
+
+		\remove_filter( 'activitypub_supported_post_types', $filter );
+		\remove_post_type_support( 'book', 'activitypub' );
+		\unregister_post_type( 'book' );
+	}
+
+	/**
+	 * Test that an empty array from the filter prevents support from being registered.
+	 *
+	 * The filter does not strip existing support; it controls what gets (re-)registered
+	 * on the next call to `register_supported_post_type_feature()`.
+	 *
+	 * @covers ::register_supported_post_type_feature
+	 */
+	public function test_supported_post_types_filter_empty_array_skips_registration() {
+		\update_option( 'activitypub_support_post_types', array( 'post' ) );
+
+		$filter = static function () {
+			return array();
+		};
+		\add_filter( 'activitypub_supported_post_types', $filter );
+
+		\remove_post_type_support( 'post', 'activitypub' );
+		Post_Types::register_supported_post_type_feature();
+
+		$this->assertFalse( \post_type_supports( 'post', 'activitypub' ) );
+
+		\remove_filter( 'activitypub_supported_post_types', $filter );
+	}
+
+	/**
+	 * Test that a non-array filter return is coerced safely.
+	 *
+	 * Guards the `(array)` cast that protects against integrators returning null,
+	 * scalars, or other non-array values — in those cases nothing should be registered.
+	 *
+	 * @covers ::register_supported_post_type_feature
+	 */
+	public function test_supported_post_types_filter_non_array_return() {
+		\register_post_type( 'zine', array( 'public' => true ) );
+
+		$filter = static function () {
+			return null;
+		};
+		\add_filter( 'activitypub_supported_post_types', $filter );
+
+		Post_Types::register_supported_post_type_feature();
+
+		$this->assertFalse( \post_type_supports( 'zine', 'activitypub' ) );
+
+		\remove_filter( 'activitypub_supported_post_types', $filter );
+		\unregister_post_type( 'zine' );
 	}
 }


### PR DESCRIPTION
See DOTCOM-16875.

## Proposed changes:

* Extracts the `activitypub` post-type support registration from `Post_Types::init()` into a dedicated `register_supported_post_type_feature()` method.
* Adds a new `activitypub_supported_post_types` filter that runs after the `activitypub_support_post_types` option is read and before `add_post_type_support()` is called, letting integrators augment or replace the stored admin selection.
* Casts the filter return to an array so a misbehaving integrator returning `null`/scalar does not fatal.

The admin UI at Settings → ActivityPub → "Post Types" continues to reflect the stored option, not the filtered value. Integrations that read `activitypub_support_post_types` directly (Yoast SEO, Enable Mastodon Apps, REST cache, Statistics) are intentionally left alone — this filter governs `post_type_supports( …, 'activitypub' )` registration only, which is the path every federation decision already uses.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Five new PHPUnit tests in `Test_Post_Types` cover: default registration from the stored option (no filter), the filter receiving the stored option value, the filter adding a post type, an empty array skipping registration, and the `(array)` cast guarding non-array returns. A shared `tear_down()` restores the option and `post` support to prevent cross-test leakage.

## Testing instructions:

* Check out this branch and run `npm run env-test -- --filter=Test_Post_Types` — all tests pass.
* Sanity-check with WP-CLI:
  ```bash
  wp shell
  >>> add_filter( 'activitypub_supported_post_types', fn( $t ) => array_merge( $t, [ 'page' ] ) );
  >>> \Activitypub\Post_Types::register_supported_post_type_feature();
  >>> var_dump( post_type_supports( 'page', 'activitypub' ) ); // bool(true)
  ```
* Confirm Settings → ActivityPub → "Post Types" checkboxes still reflect the stored option only (filter additions are not shown as checked).

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Minor

#### Type

- [x] Added - for new features

#### Message

Added the `activitypub_supported_post_types` filter so integrators can control which post types federate.

</details>