### PR TITLE
Enforce caller ownership on OAuth token revocation

### DIFF
--- a/.github/changelog/fix-oauth-token-revocation-ownership
+++ b/.github/changelog/fix-oauth-token-revocation-ownership
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+OAuth token revocation now verifies the caller owns the token being revoked.

--- a/includes/oauth/class-token.php
+++ b/includes/oauth/class-token.php
@@ -436,6 +436,11 @@ class Token {
 			return true;
 		}
 
+		/*
+		 * Require a real client_id on the token. An empty string on both
+		 * sides would otherwise match and let an un-attributed token be
+		 * revoked by any caller presenting an empty client claim.
+		 */
 		if ( null !== $caller_client_id && '' !== $token_client_id && $token_client_id === $caller_client_id ) {
 			return true;
 		}

--- a/includes/oauth/class-token.php
+++ b/includes/oauth/class-token.php
@@ -385,7 +385,6 @@ class Token {
 			$user_id     = (int) $user_id;
 			$access_hash = \get_user_meta( $user_id, $refresh_index_key, true );
 			$client_id   = '';
-			$token_data  = null;
 
 			if ( $access_hash ) {
 				$token_data = \get_user_meta( $user_id, self::META_PREFIX . $access_hash, true );

--- a/includes/oauth/class-token.php
+++ b/includes/oauth/class-token.php
@@ -324,10 +324,19 @@ class Token {
 	/**
 	 * Revoke a token.
 	 *
-	 * @param string $token The token to revoke (access or refresh).
+	 * When `$caller_user_id` or `$caller_client_id` is provided, the token
+	 * is only deleted if it was issued to that user or that client, per
+	 * RFC 7009 Section 2.1. A mismatch is treated as a successful no-op so
+	 * the caller cannot probe for token existence belonging to others.
+	 *
+	 * @since unreleased The `$caller_user_id` and `$caller_client_id` parameters were added.
+	 *
+	 * @param string      $token            The token to revoke (access or refresh).
+	 * @param int|null    $caller_user_id   Optional. User ID of the caller. Null disables the user check.
+	 * @param string|null $caller_client_id Optional. OAuth client ID of the caller. Null disables the client check.
 	 * @return bool True on success (always returns true per RFC 7009).
 	 */
-	public static function revoke( $token ) {
+	public static function revoke( $token, $caller_user_id = null, $caller_client_id = null ) {
 		global $wpdb;
 
 		$token_hash = self::hash_token( $token );
@@ -345,6 +354,10 @@ class Token {
 			$user_id    = (int) $user_id;
 			$token_data = \get_user_meta( $user_id, $access_meta_key, true );
 			$client_id  = is_array( $token_data ) ? ( $token_data['client_id'] ?? '' ) : '';
+
+			if ( ! self::caller_owns_token( $user_id, $client_id, $caller_user_id, $caller_client_id ) ) {
+				return true;
+			}
 
 			// Delete the token.
 			\delete_user_meta( $user_id, $access_meta_key );
@@ -372,11 +385,18 @@ class Token {
 			$user_id     = (int) $user_id;
 			$access_hash = \get_user_meta( $user_id, $refresh_index_key, true );
 			$client_id   = '';
+			$token_data  = null;
 
-			// Delete the token and index.
 			if ( $access_hash ) {
 				$token_data = \get_user_meta( $user_id, self::META_PREFIX . $access_hash, true );
 				$client_id  = is_array( $token_data ) ? ( $token_data['client_id'] ?? '' ) : '';
+			}
+
+			if ( ! self::caller_owns_token( $user_id, $client_id, $caller_user_id, $caller_client_id ) ) {
+				return true;
+			}
+
+			if ( $access_hash ) {
 				\delete_user_meta( $user_id, self::META_PREFIX . $access_hash );
 			}
 			\delete_user_meta( $user_id, $refresh_index_key );
@@ -387,6 +407,40 @@ class Token {
 
 		// Token doesn't exist or already revoked - that's fine per RFC 7009.
 		return true;
+	}
+
+	/**
+	 * Decide whether a caller is permitted to revoke a specific token.
+	 *
+	 * A null caller user and null caller client disable the check entirely,
+	 * preserving the pre-RFC-7009-enforcement behavior for internal callers
+	 * that already know they have authority (admin unlink, uninstall, etc.).
+	 *
+	 * When either caller parameter is provided, the token is considered
+	 * owned if it matches the caller user OR the caller client. Matching
+	 * client alone is enough to let an OAuth client clean up any token it
+	 * issued, regardless of which user granted consent.
+	 *
+	 * @param int         $token_user_id    User ID the token was issued to.
+	 * @param string      $token_client_id  OAuth client ID the token was issued to.
+	 * @param int|null    $caller_user_id   Caller user ID, or null to skip the user check.
+	 * @param string|null $caller_client_id Caller client ID, or null to skip the client check.
+	 * @return bool True if the caller may revoke, false otherwise.
+	 */
+	private static function caller_owns_token( $token_user_id, $token_client_id, $caller_user_id, $caller_client_id ) {
+		if ( null === $caller_user_id && null === $caller_client_id ) {
+			return true;
+		}
+
+		if ( null !== $caller_user_id && $token_user_id === $caller_user_id ) {
+			return true;
+		}
+
+		if ( null !== $caller_client_id && '' !== $token_client_id && $token_client_id === $caller_client_id ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/rest/oauth/class-token-controller.php
+++ b/includes/rest/oauth/class-token-controller.php
@@ -277,16 +277,19 @@ class Token_Controller extends \WP_REST_Controller {
 		} else {
 			/*
 			 * RFC 7009 §2.1: the server must verify the token was issued to
-			 * the requesting client. Scope the revocation to either the
-			 * logged-in user or the OAuth client whose bearer token
-			 * authenticated this request. `$caller_client_id` is null for
-			 * pure cookie-authenticated callers; the user check still
-			 * applies in that case.
+			 * the requesting client. When the caller authenticated with a
+			 * bearer token we know the calling client, so require a client
+			 * match and ignore the user — otherwise a low-trust client
+			 * could revoke tokens the user had granted to a different
+			 * client. For pure cookie-authenticated callers there is no
+			 * client context, so user match is the only available check.
 			 */
-			$caller_token     = OAuth_Server::get_current_token();
-			$caller_client_id = $caller_token ? $caller_token->get_client_id() : null;
-
-			Token::revoke( $token, \get_current_user_id(), $caller_client_id );
+			$caller_token = OAuth_Server::get_current_token();
+			if ( $caller_token ) {
+				Token::revoke( $token, null, $caller_token->get_client_id() );
+			} else {
+				Token::revoke( $token, \get_current_user_id(), null );
+			}
 		}
 
 		// Per RFC 7009, always return 200 even if the token doesn't exist or was not owned.

--- a/includes/rest/oauth/class-token-controller.php
+++ b/includes/rest/oauth/class-token-controller.php
@@ -271,9 +271,23 @@ class Token_Controller extends \WP_REST_Controller {
 	public function revoke( \WP_REST_Request $request ) {
 		$token = $request->get_param( 'token' );
 
-		// Per RFC 7009, always return 200 even if token doesn't exist.
-		Token::revoke( $token );
+		if ( \current_user_can( 'manage_options' ) ) {
+			// Site admins may revoke any token.
+			Token::revoke( $token );
+		} else {
+			/*
+			 * RFC 7009 §2.1: the server must verify the token was issued to
+			 * the requesting client. Scope the revocation to either the
+			 * logged-in user or the OAuth client whose bearer token
+			 * authenticated this request.
+			 */
+			$caller_token     = OAuth_Server::get_current_token();
+			$caller_client_id = $caller_token ? $caller_token->get_client_id() : null;
 
+			Token::revoke( $token, \get_current_user_id(), $caller_client_id );
+		}
+
+		// Per RFC 7009, always return 200 even if the token doesn't exist or was not owned.
 		return new \WP_REST_Response( null, 200 );
 	}
 

--- a/includes/rest/oauth/class-token-controller.php
+++ b/includes/rest/oauth/class-token-controller.php
@@ -272,14 +272,16 @@ class Token_Controller extends \WP_REST_Controller {
 		$token = $request->get_param( 'token' );
 
 		if ( \current_user_can( 'manage_options' ) ) {
-			// Site admins may revoke any token.
+			// Site admins may revoke any token. Null-null disables the ownership check.
 			Token::revoke( $token );
 		} else {
 			/*
 			 * RFC 7009 §2.1: the server must verify the token was issued to
 			 * the requesting client. Scope the revocation to either the
 			 * logged-in user or the OAuth client whose bearer token
-			 * authenticated this request.
+			 * authenticated this request. `$caller_client_id` is null for
+			 * pure cookie-authenticated callers; the user check still
+			 * applies in that case.
 			 */
 			$caller_token     = OAuth_Server::get_current_token();
 			$caller_client_id = $caller_token ? $caller_token->get_client_id() : null;

--- a/tests/phpunit/tests/includes/oauth/class-test-token.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-token.php
@@ -380,17 +380,19 @@ class Test_Token extends \WP_UnitTestCase {
 		);
 		$other_client_id     = $other_client_result['client_id'];
 
-		$token = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+		try {
+			$token = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
 
-		// Different user AND different client — both checks must fail.
-		$other_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
-		$result        = Token::revoke( $token['access_token'], $other_user_id, $other_client_id );
-		$this->assertTrue( $result );
+			// Different user AND different client — both checks must fail.
+			$other_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+			$result        = Token::revoke( $token['access_token'], $other_user_id, $other_client_id );
+			$this->assertTrue( $result );
 
-		$validation = Token::validate( $token['access_token'] );
-		$this->assertNotWPError( $validation, 'Cross-client revoke must not delete.' );
-
-		Client::delete( $other_client_id );
+			$validation = Token::validate( $token['access_token'] );
+			$this->assertNotWPError( $validation, 'Cross-client revoke must not delete.' );
+		} finally {
+			Client::delete( $other_client_id );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/oauth/class-test-token.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-token.php
@@ -320,6 +320,112 @@ class Test_Token extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A mismatched caller user must not be able to revoke another user's token.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_rejects_mismatched_caller_user() {
+		$other_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$token         = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		// Different user, no client context — must not delete.
+		$result = Token::revoke( $token['access_token'], $other_user_id );
+		$this->assertTrue( $result, 'Revoke must return true per RFC 7009 even when it skipped the delete.' );
+
+		$validation = Token::validate( $token['access_token'] );
+		$this->assertNotWPError( $validation, 'Token must survive a cross-user revoke attempt.' );
+	}
+
+	/**
+	 * A matching caller user may revoke.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_allows_matching_caller_user() {
+		$token = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		$result = Token::revoke( $token['access_token'], $this->user_id );
+		$this->assertTrue( $result );
+
+		$this->assertInstanceOf( \WP_Error::class, Token::validate( $token['access_token'] ) );
+	}
+
+	/**
+	 * A matching caller client may revoke even when the user differs (same client, other user's token).
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_allows_matching_caller_client() {
+		$other_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$token         = Token::create( $other_user_id, $this->client_id, array( Scope::READ ) );
+
+		// Caller is a different user, but presents the same client_id.
+		$result = Token::revoke( $token['access_token'], $this->user_id, $this->client_id );
+		$this->assertTrue( $result );
+
+		$this->assertInstanceOf( \WP_Error::class, Token::validate( $token['access_token'] ) );
+	}
+
+	/**
+	 * A mismatched caller client must not revoke a token issued to a different client.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_rejects_mismatched_caller_client() {
+		$other_client_result = Client::register(
+			array(
+				'name'          => 'Another Client',
+				'redirect_uris' => array( 'https://example.com/callback' ),
+			)
+		);
+		$other_client_id     = $other_client_result['client_id'];
+
+		$token = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		// Different user AND different client — both checks must fail.
+		$other_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$result        = Token::revoke( $token['access_token'], $other_user_id, $other_client_id );
+		$this->assertTrue( $result );
+
+		$validation = Token::validate( $token['access_token'] );
+		$this->assertNotWPError( $validation, 'Cross-client revoke must not delete.' );
+
+		Client::delete( $other_client_id );
+	}
+
+	/**
+	 * Refresh-token revocation must also honour the caller ownership check.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_refresh_token_honours_caller_check() {
+		$other_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$token         = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		$result = Token::revoke( $token['refresh_token'], $other_user_id );
+		$this->assertTrue( $result );
+
+		// Refresh must still work because revocation should have been skipped.
+		$refresh = Token::refresh( $token['refresh_token'], $this->client_id );
+		$this->assertIsArray( $refresh, 'Refresh token must survive a cross-user revoke attempt.' );
+	}
+
+	/**
+	 * Internal callers that pass neither caller user nor caller client
+	 * retain the pre-check behavior and delete the token regardless.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_without_caller_args_preserves_internal_behavior() {
+		$token = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		$result = Token::revoke( $token['access_token'] );
+		$this->assertTrue( $result );
+
+		$this->assertInstanceOf( \WP_Error::class, Token::validate( $token['access_token'] ) );
+	}
+
+	/**
 	 * Test revoke_all_for_user method.
 	 *
 	 * @covers ::revoke_all_for_user

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -339,7 +339,6 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, Token::validate( $token_data['access_token'] ) );
 	}
 
-
 	/**
 	 * Test introspect endpoint requires authentication.
 	 *

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -87,6 +87,9 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 		global $wp_rest_server;
 		$wp_rest_server = null;
 
+		// Reset the OAuth current_token static so Bearer-auth tests do not leak state.
+		$this->set_oauth_current_token( null );
+
 		if ( $this->client_id ) {
 			Client::delete( $this->client_id );
 		}
@@ -388,20 +391,20 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 		$this->set_oauth_current_token( $caller_token );
 		\wp_set_current_user( $this->user_id );
 
-		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/revoke' );
-		$request->set_param( 'token', $target_token_data['access_token'] );
+		try {
+			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/revoke' );
+			$request->set_param( 'token', $target_token_data['access_token'] );
 
-		$response = \rest_get_server()->dispatch( $request );
+			$response = \rest_get_server()->dispatch( $request );
 
-		$this->set_oauth_current_token( null );
+			$this->assertEquals( 200, $response->get_status(), 'Revoke must respond 200 regardless of ownership.' );
 
-		$this->assertEquals( 200, $response->get_status(), 'Revoke must respond 200 regardless of ownership.' );
-
-		$validation = Token::validate( $target_token_data['access_token'] );
-		$this->assertNotWPError( $validation, 'A bearer token from a different client must not revoke the target.' );
-		$this->assertEquals( $this->client_id, $validation->get_client_id() );
-
-		Client::delete( $other_client_id );
+			$validation = Token::validate( $target_token_data['access_token'] );
+			$this->assertNotWPError( $validation, 'A bearer token from a different client must not revoke the target.' );
+			$this->assertEquals( $this->client_id, $validation->get_client_id() );
+		} finally {
+			Client::delete( $other_client_id );
+		}
 	}
 
 	/**
@@ -427,8 +430,6 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 		$request->set_param( 'token', $target_token_data['access_token'] );
 
 		$response = \rest_get_server()->dispatch( $request );
-
-		$this->set_oauth_current_token( null );
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertInstanceOf( \WP_Error::class, Token::validate( $target_token_data['access_token'] ) );

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -294,6 +294,53 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A non-admin user must not be able to revoke a token belonging to another user.
+	 *
+	 * Per RFC 7009 the endpoint returns 200 either way so the caller cannot
+	 * probe for token existence, but the victim's token must still verify.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_cross_user_is_silently_skipped() {
+		$other_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$token_data    = Token::create( $other_user_id, $this->client_id, array( Scope::READ ) );
+
+		\wp_set_current_user( $this->user_id );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/revoke' );
+		$request->set_param( 'token', $token_data['access_token'] );
+
+		$response = \rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'Revoke must respond 200 regardless of ownership.' );
+
+		$validation = Token::validate( $token_data['access_token'] );
+		$this->assertNotWPError( $validation, 'Another user must not be able to revoke this token.' );
+		$this->assertEquals( $other_user_id, $validation->get_user_id() );
+	}
+
+	/**
+	 * A site admin may revoke any token.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_allows_admin_to_revoke_any_token() {
+		$admin_id   = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$token_data = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		\wp_set_current_user( $admin_id );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/revoke' );
+		$request->set_param( 'token', $token_data['access_token'] );
+
+		$response = \rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertInstanceOf( \WP_Error::class, Token::validate( $token_data['access_token'] ) );
+	}
+
+
+	/**
 	 * Test introspect endpoint requires authentication.
 	 *
 	 * @covers ::introspect_permissions_check

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -340,6 +340,95 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A bearer-authenticated client must not be able to revoke a token its
+	 * user granted to a different OAuth client.
+	 *
+	 * Per RFC 7009 §2.1, when the caller authenticated as a client, the
+	 * token being revoked must have been issued to that same client.
+	 * User-based ownership must not override the client scoping.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_cross_client_bearer_is_silently_skipped() {
+		$other_client_result = Client::register(
+			array(
+				'name'          => 'Other Client',
+				'redirect_uris' => array( $this->redirect_uri ),
+			)
+		);
+		$other_client_id     = $other_client_result['client_id'];
+
+		$caller_token_data = Token::create( $this->user_id, $other_client_id, array( Scope::READ ) );
+		$target_token_data = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		$caller_token = Token::validate( $caller_token_data['access_token'] );
+		$this->assertInstanceOf( Token::class, $caller_token );
+
+		$this->set_oauth_current_token( $caller_token );
+		\wp_set_current_user( $this->user_id );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/revoke' );
+		$request->set_param( 'token', $target_token_data['access_token'] );
+
+		$response = \rest_get_server()->dispatch( $request );
+
+		$this->set_oauth_current_token( null );
+
+		$this->assertEquals( 200, $response->get_status(), 'Revoke must respond 200 regardless of ownership.' );
+
+		$validation = Token::validate( $target_token_data['access_token'] );
+		$this->assertNotWPError( $validation, 'A bearer token from a different client must not revoke the target.' );
+		$this->assertEquals( $this->client_id, $validation->get_client_id() );
+
+		Client::delete( $other_client_id );
+	}
+
+	/**
+	 * A bearer-authenticated client must be able to revoke a token it
+	 * issued, even when the token belongs to a different user than the
+	 * one currently authenticated via the bearer.
+	 *
+	 * @covers ::revoke
+	 */
+	public function test_revoke_same_client_bearer_succeeds() {
+		$other_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+
+		$caller_token_data = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+		$target_token_data = Token::create( $other_user_id, $this->client_id, array( Scope::READ ) );
+
+		$caller_token = Token::validate( $caller_token_data['access_token'] );
+		$this->assertInstanceOf( Token::class, $caller_token );
+
+		$this->set_oauth_current_token( $caller_token );
+		\wp_set_current_user( $this->user_id );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/revoke' );
+		$request->set_param( 'token', $target_token_data['access_token'] );
+
+		$response = \rest_get_server()->dispatch( $request );
+
+		$this->set_oauth_current_token( null );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertInstanceOf( \WP_Error::class, Token::validate( $target_token_data['access_token'] ) );
+	}
+
+	/**
+	 * Inject an OAuth current_token via reflection so tests can simulate
+	 * bearer authentication without relying on the plugin bootstrap hook
+	 * that only fires when the `activitypub_api` option was enabled
+	 * before the plugin loaded.
+	 *
+	 * @param \Activitypub\OAuth\Token|null $token The token to inject, or null to reset.
+	 */
+	protected function set_oauth_current_token( $token ) {
+		$reflection = new \ReflectionClass( \Activitypub\OAuth\Server::class );
+		$property   = $reflection->getProperty( 'current_token' );
+		$property->setAccessible( true );
+		$property->setValue( null, $token );
+	}
+
+	/**
 	 * Test introspect endpoint requires authentication.
 	 *
 	 * @covers ::introspect_permissions_check


### PR DESCRIPTION
## Proposed changes:

Implements RFC 7009 §2.1 caller-ownership enforcement for the OAuth token revocation endpoint (`POST /wp-json/activitypub/1.0/oauth/revoke`). Before this change any authenticated caller could revoke any token by presenting its opaque value — the endpoint did not verify the token was issued to the requesting client or user. Addresses AUTH-1 from a recent security audit plus the follow-up review finding that user-match was short-circuiting the client check under bearer auth.

The feature is gated by the `activitypub_api` option (off by default), so only sites that enabled Mastodon Apps see any behavior change.

**Model layer (`Token::revoke()`)**

* Accepts optional `\$caller_user_id` and `\$caller_client_id`. When either is provided, the token is only deleted if its owner matches. OR-logic in the private `caller_owns_token()` helper — a user match or a client match is sufficient.
* A mismatch returns `true` without touching storage, preserving RFC 7009 §2.2's "always 200" response so callers cannot probe for other users' tokens.
* Null-null preserves the existing internal-caller path for admin unlink and uninstall flows that already hold authority.

**Controller layer (`Token_Controller::revoke()`)**

The caller context threaded into `Token::revoke()` reflects what actually authenticated the request, so user-based ownership cannot override client scoping:

* **Bearer auth**: pass only the caller's `client_id` (user match skipped). A low-trust client cannot revoke tokens its user granted to a different client — the original RFC 7009 §2.1 intent.
* **Cookie auth**: pass only the `user_id` (no client context available).
* **Admin (`manage_options`)**: bypass both checks, mirroring the introspect endpoint pattern.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

**Model** (`Test_Token`) — mismatched caller user rejected, matching caller user allowed, matching caller client allowed across users, mismatched caller client rejected (client cleanup wrapped in `try/finally`), refresh-token path honours the check, null-null internal behavior preserved.

**Controller** (`Test_Token_Controller`) — cross-user cookie-auth revoke silently skipped (200 returned, token survives), admin bypass allowed, bearer cross-client silently skipped (regression guard for the post-merge review finding, extra client cleanup wrapped in `try/finally`), bearer same-client cross-user succeeds.

Bearer tests use reflection on `OAuth_Server::\$current_token` to simulate authentication without depending on the `activitypub_api` bootstrap hook order. That static property is not part of `\$wp_filter`, so `Test_Token_Controller::tear_down()` now resets it unconditionally to prevent state leakage on assertion failure.

Full `@group oauth` suite: 143/143 passing. Lint clean.

## Testing instructions:

1. Enable Mastodon Apps: `wp option update activitypub_api 1`.
2. Create two editor-level users (Alice and Bob) and register two OAuth clients (Client X and Client Y).
3. Issue access tokens for Alice under both clients via the authorization code flow.
4. As Alice (cookie-authenticated), `POST /wp-json/activitypub/1.0/oauth/revoke` with Bob's token in the body. Response should be HTTP 200 and Bob's token must still validate.
5. Authenticate as Client X (bearer for Alice's X token) and attempt to revoke Alice's Client Y token. Response 200, Y token must still validate.
6. Authenticate as Client X and revoke Alice's Client X token. Response 200, token no longer validates.
7. As a site administrator, revoke any user's token. Response 200, token no longer validates.

### Changelog entry

Included as `.github/changelog/fix-oauth-token-revocation-ownership`, significance `patch` / type `fixed`.