### PR TITLE
Require PKCE by default for public OAuth clients

### DIFF
--- a/.github/changelog/update-oauth-pkce-default
+++ b/.github/changelog/update-oauth-pkce-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+OAuth public clients must now use PKCE by default, matching OAuth 2.1. Site operators can relax this via the activitypub_oauth_require_pkce filter if legacy clients need to connect.

--- a/includes/oauth/class-authorization-code.php
+++ b/includes/oauth/class-authorization-code.php
@@ -64,23 +64,25 @@ class Authorization_Code {
 
 		/*
 		 * PKCE is strongly recommended for public clients (RFC 7636) and
-		 * mandatory in the OAuth 2.1 draft. By default, it is not enforced
-		 * to maintain compatibility with existing C2S clients, but site
-		 * operators can require it via filter.
+		 * mandatory in the OAuth 2.1 draft. It is enforced by default; site
+		 * operators who must support pre-PKCE clients can opt out via the
+		 * `activitypub_oauth_require_pkce` filter.
 		 */
 		if ( empty( $code_challenge ) && $client->is_public() ) {
 			/**
 			 * Filter whether PKCE is required for public OAuth clients.
 			 *
-			 * Return true to enforce PKCE (recommended per OAuth 2.1).
-			 * Default false for backward compatibility with older clients.
+			 * Return false to relax the default and allow public clients to
+			 * complete the authorization code grant without PKCE. This is
+			 * not recommended.
 			 *
 			 * @since 8.1.0
+			 * @since unreleased Default changed from false to true.
 			 *
-			 * @param bool   $require    Whether to require PKCE. Default false.
+			 * @param bool   $require    Whether to require PKCE. Default true.
 			 * @param string $client_id  The OAuth client ID.
 			 */
-			if ( \apply_filters( 'activitypub_oauth_require_pkce', false, $client_id ) ) {
+			if ( \apply_filters( 'activitypub_oauth_require_pkce', true, $client_id ) ) {
 				return new \WP_Error(
 					'activitypub_pkce_required',
 					\__( 'PKCE is required for public clients. Please include a code_challenge parameter.', 'activitypub' ),

--- a/tests/phpunit/tests/includes/oauth/class-test-authorization-code.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-authorization-code.php
@@ -491,31 +491,11 @@ class Test_Authorization_Code extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that public clients can skip PKCE by default.
+	 * Public clients must supply a PKCE challenge by default.
 	 *
 	 * @covers ::create
 	 */
-	public function test_create_without_pkce_allowed_by_default() {
-		$code = Authorization_Code::create(
-			$this->user_id,
-			$this->client_id,
-			$this->redirect_uri,
-			array( Scope::READ ),
-			'', // No PKCE.
-			'S256'
-		);
-
-		$this->assertIsString( $code );
-	}
-
-	/**
-	 * Test that the activitypub_oauth_require_pkce filter enforces PKCE.
-	 *
-	 * @covers ::create
-	 */
-	public function test_create_without_pkce_blocked_by_filter() {
-		\add_filter( 'activitypub_oauth_require_pkce', '__return_true' );
-
+	public function test_create_without_pkce_blocked_by_default() {
 		$result = Authorization_Code::create(
 			$this->user_id,
 			$this->client_id,
@@ -525,10 +505,30 @@ class Test_Authorization_Code extends \WP_UnitTestCase {
 			'S256'
 		);
 
-		\remove_filter( 'activitypub_oauth_require_pkce', '__return_true' );
-
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertEquals( 'activitypub_pkce_required', $result->get_error_code() );
+	}
+
+	/**
+	 * Operators can relax the PKCE requirement via the filter.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_without_pkce_allowed_when_filter_returns_false() {
+		\add_filter( 'activitypub_oauth_require_pkce', '__return_false' );
+
+		$code = Authorization_Code::create(
+			$this->user_id,
+			$this->client_id,
+			$this->redirect_uri,
+			array( Scope::READ ),
+			'', // No PKCE.
+			'S256'
+		);
+
+		\remove_filter( 'activitypub_oauth_require_pkce', '__return_false' );
+
+		$this->assertIsString( $code );
 	}
 
 	/**
@@ -536,9 +536,7 @@ class Test_Authorization_Code extends \WP_UnitTestCase {
 	 *
 	 * @covers ::create
 	 */
-	public function test_create_with_pkce_passes_when_filter_enabled() {
-		\add_filter( 'activitypub_oauth_require_pkce', '__return_true' );
-
+	public function test_create_with_pkce_passes_regardless_of_filter() {
 		$verifier  = $this->generate_code_verifier();
 		$challenge = Authorization_Code::compute_code_challenge( $verifier );
 
@@ -550,8 +548,6 @@ class Test_Authorization_Code extends \WP_UnitTestCase {
 			$challenge,
 			'S256'
 		);
-
-		\remove_filter( 'activitypub_oauth_require_pkce', '__return_true' );
 
 		$this->assertIsString( $code );
 	}

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
@@ -254,6 +254,9 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 		\wp_set_current_user( $this->user_id );
 		$nonce = \wp_create_nonce( 'activitypub_oauth_authorize' );
 
+		$verifier  = \bin2hex( \random_bytes( 32 ) );
+		$challenge = \Activitypub\OAuth\Authorization_Code::compute_code_challenge( $verifier );
+
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/authorize' );
 		$request->set_param( 'response_type', 'code' );
 		$request->set_param( 'client_id', $this->client_id );
@@ -262,6 +265,8 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 		$request->set_param( 'approve', true );
 		$request->set_param( '_wpnonce', $nonce );
 		$request->set_param( 'state', 'success_state' );
+		$request->set_param( 'code_challenge', $challenge );
+		$request->set_param( 'code_challenge_method', 'S256' );
 
 		$response = \rest_get_server()->dispatch( $request );
 

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -45,6 +45,13 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 	protected $redirect_uri = 'https://example.com/callback';
 
 	/**
+	 * PKCE verifier generated alongside the authorization code.
+	 *
+	 * @var string
+	 */
+	protected $code_verifier = '';
+
+	/**
 	 * Set up the test.
 	 */
 	public function set_up() {
@@ -90,14 +97,26 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 	/**
 	 * Helper: create an authorization code for the test user/client.
 	 *
-	 * @param array  $scopes Scopes for the code.
-	 * @param string $code_challenge Optional PKCE code challenge.
-	 * @param string $code_challenge_method Optional PKCE method.
+	 * Generates a PKCE verifier + challenge by default so the helper works
+	 * with the PKCE-required default. The verifier is stored on the test
+	 * case as `$this->code_verifier` so callers can pass it when exchanging.
+	 *
+	 * @param array       $scopes                Scopes for the code.
+	 * @param string|null $code_challenge        Optional explicit PKCE code challenge. Null auto-generates.
+	 * @param string      $code_challenge_method Optional PKCE method.
 	 * @return string The authorization code.
 	 */
-	protected function create_auth_code( $scopes = null, $code_challenge = '', $code_challenge_method = 'S256' ) {
+	protected function create_auth_code( $scopes = null, $code_challenge = null, $code_challenge_method = 'S256' ) {
 		if ( null === $scopes ) {
 			$scopes = array( Scope::READ, Scope::WRITE );
+		}
+
+		if ( null === $code_challenge ) {
+			$this->code_verifier = \bin2hex( \random_bytes( 32 ) );
+			$code_challenge      = Authorization_Code::compute_code_challenge( $this->code_verifier );
+		} else {
+			// Caller supplied an explicit challenge; they are responsible for the verifier.
+			$this->code_verifier = '';
 		}
 
 		return Authorization_Code::create(
@@ -191,6 +210,7 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 		$request->set_param( 'client_id', $this->client_id );
 		$request->set_param( 'code', $code );
 		$request->set_param( 'redirect_uri', $this->redirect_uri );
+		$request->set_param( 'code_verifier', $this->code_verifier );
 
 		$response = \rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -217,6 +237,7 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 		$request->set_param( 'client_id', $this->client_id );
 		$request->set_param( 'code', $code );
 		$request->set_param( 'redirect_uri', $this->redirect_uri );
+		$request->set_param( 'code_verifier', $this->code_verifier );
 
 		$response      = \rest_get_server()->dispatch( $request );
 		$token_data    = $response->get_data();


### PR DESCRIPTION
## Proposed changes:

Flips the default of the `activitypub_oauth_require_pkce` filter from `false` to `true` so public OAuth clients must supply a PKCE code challenge to complete the authorization code grant. Matches OAuth 2.1 (RFC 7636). Addresses OAUTH-1 from the recent security audit. The feature is gated by the `activitypub_api` option (off by default), so only sites that enabled Mastodon Apps see any behavior change.

* `includes/oauth/class-authorization-code.php` — one-line default flip, updated docblock with `@since unreleased Default changed from false to true.`
* Filter name is unchanged. Operators who need to support a legacy non-PKCE client can still opt out by returning `false` from the filter — documented in the updated docblock and the changelog entry.
* Test updates: three default-behavior unit tests inverted, one redundant filter-on test dropped, `create_auth_code()` helper now auto-generates a PKCE verifier and challenge (stored on `$this->code_verifier`) so downstream happy-path tests stay terse.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Full `@group oauth` suite: 133/133 passing. Coverage spans:
* PKCE blocked by default on `Authorization_Code::create()` for public clients.
* `__return_false` filter relaxes the block.
* PKCE-bearing codes always pass regardless of filter state.
* End-to-end authorization + token exchange using the auto-generated challenge/verifier.

### Behavior change — compatibility note for reviewers

Any public OAuth client that was relying on the old default and did not include a code challenge in its authorize request will now receive `activitypub_pkce_required`. Modern Mastodon API client libraries (Mastodon.py, Pinafore, Elk, Phanpy, Ivory, etc.) all emit PKCE by default. Impact is expected to be small, but worth flagging.

Escape hatch for an affected site:

```php
add_filter( 'activitypub_oauth_require_pkce', '__return_false' );
```

## Testing instructions:

1. Enable Mastodon Apps: `wp option update activitypub_api 1`.
2. Register a public OAuth client (via the admin UI or `POST /wp-json/activitypub/1.0/oauth/clients`).
3. Hit `GET /wp-json/activitypub/1.0/oauth/authorize` with `response_type=code&client_id=…&redirect_uri=…` but **no** `code_challenge` parameter. Log in and approve.
4. Expected: redirect back to the client with `error=server_error` and the message `PKCE is required for public clients.`
5. Repeat with a real `code_challenge` (S256) — authorization succeeds and a code is returned.
6. Optional: add `add_filter( 'activitypub_oauth_require_pkce', '__return_false' );` to a mu-plugin and repeat step 3 — authorization should now succeed without a challenge.

### Changelog entry

Included as `.github/changelog/update-oauth-pkce-default`, significance `minor` (backwards-incompatible default change to a public OAuth endpoint).