### PR TITLE
Respect force_signature in Delete handler's deferred verification

### DIFF
--- a/.github/changelog/fix-delete-handler-force-signature
+++ b/.github/changelog/fix-delete-handler-force-signature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Delete activities no longer bypass signature verification on endpoints that explicitly require it.

--- a/includes/handler/class-delete.php
+++ b/includes/handler/class-delete.php
@@ -24,7 +24,7 @@ class Delete {
 	public static function init() {
 		\add_action( 'activitypub_inbox_delete', array( self::class, 'handle_delete' ), 10, 2 );
 		\add_filter( 'activitypub_skip_inbox_storage', array( self::class, 'skip_inbox_storage' ), 10, 2 );
-		\add_filter( 'activitypub_defer_signature_verification', array( self::class, 'defer_signature_verification' ), 10, 2 );
+		\add_filter( 'activitypub_defer_signature_verification', array( self::class, 'defer_signature_verification' ), 10, 3 );
 		\add_action( 'activitypub_delete_remote_actor_interactions', array( self::class, 'delete_interactions' ) );
 		\add_action( 'activitypub_delete_remote_actor_posts', array( self::class, 'delete_posts' ) );
 
@@ -298,12 +298,25 @@ class Delete {
 	/**
 	 * Defer signature verification for `Delete` requests.
 	 *
-	 * @param bool             $defer   Whether to defer signature verification.
-	 * @param \WP_REST_Request $request The request object.
+	 * Endpoints that opt in to mandatory signing by calling
+	 * `verify_signature( $request, true )` must not be overridden — the
+	 * Delete carve-out is only for the default inbox path where the
+	 * remote actor's keys may legitimately be gone before the Delete
+	 * arrives.
+	 *
+	 * @since unreleased The `$force_signature` parameter is now respected.
+	 *
+	 * @param bool             $defer           Whether to defer signature verification.
+	 * @param \WP_REST_Request $request         The request object.
+	 * @param bool             $force_signature Whether the caller has forced signature verification.
 	 *
 	 * @return bool Whether to defer signature verification.
 	 */
-	public static function defer_signature_verification( $defer, $request ) {
+	public static function defer_signature_verification( $defer, $request, $force_signature = false ) {
+		if ( $force_signature ) {
+			return $defer;
+		}
+
 		$json = $request->get_json_params();
 
 		if ( isset( $json['type'] ) && 'Delete' === $json['type'] ) {

--- a/tests/phpunit/tests/includes/handler/class-test-delete.php
+++ b/tests/phpunit/tests/includes/handler/class-test-delete.php
@@ -644,4 +644,41 @@ class Test_Delete extends \WP_UnitTestCase {
 		// Clean up.
 		\delete_option( 'activitypub_tombstone_urls' );
 	}
+
+	/**
+	 * When a caller forces signature verification, the Delete carve-out
+	 * must not override it. The default inbox path (force_signature=false)
+	 * continues to defer for Delete activities.
+	 *
+	 * @covers ::defer_signature_verification
+	 */
+	public function test_defer_signature_verification_respects_force_signature() {
+		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( array( 'type' => 'Delete' ) ) );
+		$request->get_json_params();
+
+		// Default path: Delete activity on the inbox defers signature verification.
+		$this->assertTrue( Delete::defer_signature_verification( false, $request, false ) );
+
+		// Forced-signature path (e.g. FEP-8fcf /followers/sync) must not be overridden.
+		$this->assertFalse( Delete::defer_signature_verification( false, $request, true ) );
+	}
+
+	/**
+	 * Non-Delete activities pass through the filter unchanged regardless
+	 * of force_signature, preserving whatever the incoming $defer value was.
+	 *
+	 * @covers ::defer_signature_verification
+	 */
+	public function test_defer_signature_verification_passthrough_for_non_delete() {
+		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( array( 'type' => 'Create' ) ) );
+		$request->get_json_params();
+
+		$this->assertFalse( Delete::defer_signature_verification( false, $request, false ) );
+		$this->assertTrue( Delete::defer_signature_verification( true, $request, false ) );
+		$this->assertFalse( Delete::defer_signature_verification( false, $request, true ) );
+	}
 }


### PR DESCRIPTION
## Proposed changes:

Addresses DELETE-1 from a recent security audit. The `activitypub_defer_signature_verification` filter was extended in FEP-8fcf (PR #3202) to pass a third argument, `\$force_signature`, so deferred-verification callbacks could inspect it and opt out when mandatory signing was already in effect (e.g. `/followers/sync`). The Delete handler's registration was left at arity 2, silently dropping that argument. No live exploit today because the only `force_signature=true` endpoint is GET-only and the Delete carve-out only fires on POST bodies, but it's a footgun that would bite the next time someone adds a POST endpoint with mandatory signing.

* `includes/handler/class-delete.php:27` — raise filter arity from 2 to 3.
* `includes/handler/class-delete.php:306` — add `\$force_signature` parameter with `false` default; short-circuit returning `\$defer` unchanged when true. Non-Delete activities continue to pass through. Default preserves backwards compatibility for any third-party caller invoking the method directly.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Two new tests in `Test_Delete`:
* `test_defer_signature_verification_respects_force_signature` — Delete body with `force_signature=false` defers as before; with `force_signature=true` no longer overrides.
* `test_defer_signature_verification_passthrough_for_non_delete` — Create body preserves incoming `\$defer` regardless of force state.

Test_Delete: 40/40 passing, lint clean.

## Testing instructions:

Mostly a defensive change — no user-visible behavior difference today. To verify the fix:

1. Check out the branch and run `npm run env-test -- --filter=Test_Delete`. All 40 tests should pass.
2. Confirm regular inbox Delete flows still work (Mastodon delete a remote post, see the local comment/post disappear).
3. Confirm `/followers/sync` (FEP-8fcf) still rejects unsigned requests — this is the endpoint that already forces signatures, though it's GET-only so wasn't affected anyway.

### Changelog entry

Included as `.github/changelog/fix-delete-handler-force-signature`, significance `patch` / type `fixed`.