### PR TITLE
Require PHPUnit 9.6.33+ (CVE-2026-24765)

### DIFF
--- a/.github/changelog/update-composer-phpunit-min
+++ b/.github/changelog/update-composer-phpunit-min
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Development tooling: require PHPUnit 9.6.33 or newer (security fix CVE-2026-24765). No runtime impact for end users.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "6.0.0",
-		"phpunit/phpunit": "^9",
+		"phpunit/phpunit": "^9.6.33",
 		"phpcompatibility/php-compatibility": "*",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"squizlabs/php_codesniffer": "3.*",


### PR DESCRIPTION
## Proposed changes:

Tightens the `phpunit/phpunit` constraint from `^9` to `^9.6.33` so that every fresh `composer install` picks up the patched release. The old range resolves to 9.6.29 on a clean install, which has a **high-severity** advisory for unsafe deserialization in PHPT code coverage handling ([CVE-2026-24765](https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p)).

Dev-only dependency — no runtime impact on end users or production sites, only on developer and CI environments that run the test suite.

After the bump, `composer audit` reports no advisories. `symfony/process` also had a Medium advisory ([CVE-2026-24739](https://github.com/advisories/GHSA-r39x-jcww-82v6)) but it is a transitive dep via `jetpack-changelogger → symfony/console`; the resolver already picks the patched 7.4.8 without any direct change needed.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

No new tests required — this is a dependency constraint update. The full suite continues to pass under the updated PHPUnit 9.6.34.

## Testing instructions:

1. Check out the branch.
2. Run `composer install` — verify it resolves PHPUnit 9.6.33 or newer.
3. Run `composer audit` — should report "No security vulnerability advisories found."
4. Run `npm run env-test` — full suite should still pass.

### Changelog entry

Included as `.github/changelog/update-composer-phpunit-min`, significance `patch` / type `changed`.