### PR TITLE
Sanitize inbox activity type to prevent action hook pollution

### DIFF
--- a/.github/changelog/fix-sanitize-inbox-activity-type
+++ b/.github/changelog/fix-sanitize-inbox-activity-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Hardened input handling for incoming federated activity types.

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -89,6 +89,10 @@ class Actors_Inbox_Controller extends Actors_Controller {
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'sanitize_html_class',
+							'validate_callback' => static function ( $param ) {
+								// Reject values that sanitize to empty so dynamic hook names always have a suffix.
+								return '' !== \sanitize_html_class( (string) $param );
+							},
 						),
 						'object' => array(
 							'description'       => 'The object of the activity.',
@@ -384,7 +388,8 @@ class Actors_Inbox_Controller extends Actors_Controller {
 		$data = \json_decode( $inbox_item->post_content, true );
 		// Reconstruct activity from inbox post.
 		$activity = Activity::init_from_array( $data );
-		$type     = camel_to_snake_case( $activity->get_type() );
+		// Sanitize again here: the type comes from stored activity JSON, which bypassed REST arg sanitization.
+		$type     = camel_to_snake_case( \sanitize_html_class( (string) $activity->get_type() ) );
 		$context  = Inbox::CONTEXT_INBOX;
 		$user_ids = Inbox::get_recipients( $inbox_item->ID );
 

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -85,9 +85,10 @@ class Actors_Inbox_Controller extends Actors_Controller {
 							'sanitize_callback' => '\Activitypub\object_to_uri',
 						),
 						'type'   => array(
-							'description' => 'The type of the activity.',
-							'type'        => 'string',
-							'required'    => true,
+							'description'       => 'The type of the activity.',
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_html_class',
 						),
 						'object' => array(
 							'description'       => 'The object of the activity.',

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -76,6 +76,10 @@ class Inbox_Controller extends \WP_REST_Controller {
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'sanitize_html_class',
+							'validate_callback' => static function ( $param ) {
+								// Reject values that sanitize to empty so dynamic hook names always have a suffix.
+								return '' !== \sanitize_html_class( (string) $param );
+							},
 						),
 						'object' => array(
 							'description'       => 'The object of the activity.',

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -72,9 +72,10 @@ class Inbox_Controller extends \WP_REST_Controller {
 							'sanitize_callback' => '\Activitypub\object_to_uri',
 						),
 						'type'   => array(
-							'description' => 'The type of the activity.',
-							'type'        => 'string',
-							'required'    => true,
+							'description'       => 'The type of the activity.',
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_html_class',
 						),
 						'object' => array(
 							'description'       => 'The object of the activity.',

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -422,6 +422,55 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 	}
 
 	/**
+	 * Test that a crafted activity type is sanitized so it can't pollute action hook names.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_sanitizes_activity_type() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		$user_actor    = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
+		$captured_type = null;
+
+		$capture = function ( $data, $user_id, $type ) use ( &$captured_type ) {
+			$captured_type = $type;
+		};
+		\add_action( 'activitypub_inbox', $capture, 10, 3 );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body(
+			\wp_json_encode(
+				array(
+					'id'     => 'https://remote.example/@id',
+					'type'   => 'Create/../evil',
+					'actor'  => 'https://remote.example/@test',
+					'object' => array(
+						'id'        => 'https://remote.example/post/test',
+						'type'      => 'Note',
+						'content'   => 'Hi.',
+						'to'        => array( $user_actor->get_id() ),
+						'published' => '2020-01-01T00:00:00Z',
+					),
+					'to'     => array( $user_actor->get_id() ),
+				)
+			)
+		);
+
+		\rest_do_request( $request );
+
+		$this->assertNotNull( $captured_type, 'activitypub_inbox should fire' );
+		$this->assertStringNotContainsString( '/', $captured_type, 'Slashes must be stripped from the activity type' );
+		$this->assertStringNotContainsString( '.', $captured_type, 'Dots must be stripped from the activity type' );
+		$this->assertMatchesRegularExpression( '/^[a-z0-9_]+$/', $captured_type, 'Type passed to action hooks must be safe' );
+
+		\remove_action( 'activitypub_inbox', $capture, 10 );
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
 	 * Test creating an inbox item with invalid request.
 	 *
 	 * @covers ::create_item

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -438,36 +438,81 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 		};
 		\add_action( 'activitypub_inbox', $capture, 10, 3 );
 
-		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
-		$request->set_header( 'Content-Type', 'application/activity+json' );
-		$request->set_body(
-			\wp_json_encode(
-				array(
-					'id'     => 'https://remote.example/@id',
-					'type'   => 'Create/../evil',
-					'actor'  => 'https://remote.example/@test',
-					'object' => array(
-						'id'        => 'https://remote.example/post/test',
-						'type'      => 'Note',
-						'content'   => 'Hi.',
-						'to'        => array( $user_actor->get_id() ),
-						'published' => '2020-01-01T00:00:00Z',
-					),
-					'to'     => array( $user_actor->get_id() ),
+		try {
+			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+			$request->set_header( 'Content-Type', 'application/activity+json' );
+			$request->set_body(
+				\wp_json_encode(
+					array(
+						'id'     => 'https://remote.example/@id',
+						'type'   => 'Create/../evil',
+						'actor'  => 'https://remote.example/@test',
+						'object' => array(
+							'id'        => 'https://remote.example/post/test',
+							'type'      => 'Note',
+							'content'   => 'Hi.',
+							'to'        => array( $user_actor->get_id() ),
+							'published' => '2020-01-01T00:00:00Z',
+						),
+						'to'     => array( $user_actor->get_id() ),
+					)
 				)
-			)
-		);
+			);
 
-		\rest_do_request( $request );
+			\rest_do_request( $request );
 
-		$this->assertNotNull( $captured_type, 'activitypub_inbox should fire' );
-		$this->assertStringNotContainsString( '/', $captured_type, 'Slashes must be stripped from the activity type' );
-		$this->assertStringNotContainsString( '.', $captured_type, 'Dots must be stripped from the activity type' );
-		$this->assertMatchesRegularExpression( '/^[a-z0-9_]+$/', $captured_type, 'Type passed to action hooks must be safe' );
+			$this->assertNotNull( $captured_type, 'activitypub_inbox should fire' );
+			$this->assertSame( 'createevil', $captured_type, 'Crafted activity types should be normalized to the expected canonical value' );
+		} finally {
+			\remove_action( 'activitypub_inbox', $capture, 10 );
+			\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+			\delete_option( 'activitypub_actor_mode' );
+		}
+	}
 
-		\remove_action( 'activitypub_inbox', $capture, 10 );
-		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
-		\delete_option( 'activitypub_actor_mode' );
+	/**
+	 * Test that activity types that sanitize to an empty string are rejected.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_rejects_empty_sanitized_activity_type() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		$user_actor   = \Activitypub\Collection\Actors::get_by_id( self::$user_id );
+		$inbox_action = new \MockAction();
+		\add_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+
+		try {
+			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+			$request->set_header( 'Content-Type', 'application/activity+json' );
+			$request->set_body(
+				\wp_json_encode(
+					array(
+						'id'     => 'https://remote.example/@id',
+						'type'   => '!!!',
+						'actor'  => 'https://remote.example/@test',
+						'object' => array(
+							'id'        => 'https://remote.example/post/test',
+							'type'      => 'Note',
+							'content'   => 'Hi.',
+							'to'        => array( $user_actor->get_id() ),
+							'published' => '2020-01-01T00:00:00Z',
+						),
+						'to'     => array( $user_actor->get_id() ),
+					)
+				)
+			);
+
+			$response = \rest_do_request( $request );
+
+			$this->assertSame( 400, $response->get_status(), 'A type that sanitizes to empty must be rejected' );
+			$this->assertSame( 0, $inbox_action->get_call_count(), 'No inbox hook may fire for a rejected request' );
+		} finally {
+			\remove_action( 'activitypub_inbox', array( $inbox_action, 'action' ) );
+			\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+			\delete_option( 'activitypub_actor_mode' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* Adds `sanitize_html_class` as a `sanitize_callback` on the `type` argument of both inbox REST routes (`/inbox` and `/users/{id}/inbox`).
* The `type` value is fed into `camel_to_snake_case` and then concatenated into a dynamic action hook name (`do_action( 'activitypub_inbox_' . $type, ... )`). Without sanitization, a crafted value like `Create/foo` or `Update.evil` would survive the snake_case conversion intact, polluting the hook namespace and possibly invoking unrelated third-party action handlers — or silently misrouting the activity past the intended handler.
* `sanitize_html_class` strips to `[A-Za-z0-9_-]` and preserves CamelCase, so all standard ActivityPub activity types (Create, Follow, Update, OrderedCollection, etc.) are unaffected.

Closes finding **H-03** from a recent security audit. Not exploitable as RCE; the impact is action-hook namespace pollution and silent handler misfire.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* POST an activity with `type: "Create/../evil"` to `/wp-json/activitypub/1.0/inbox` (signature verification can be deferred locally for testing).
* Verify the `activitypub_inbox` action's `$type` argument is `createevil` (slashes and dots stripped) — not `create/../evil`.
* Re-run the inbox test suite and confirm legitimate activity types (`Create`, `Follow`, `Update`, `Delete`, `Accept`, `Reject`, `Announce`, `Like`) still dispatch correctly.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security

#### Message

Hardened input handling for incoming federated activity types.

</details>