### PR TITLE
Harden OAuth client discovery and SSE proxy outbound requests

### DIFF
--- a/.agents/skills/federation/SKILL.md
+++ b/.agents/skills/federation/SKILL.md
@@ -263,6 +263,18 @@ FEPs extend ActivityPub with additional features. Common FEP categories include:
 
 **For supported FEPs in this plugin:** See [FEDERATION.md](FEDERATION.md) for the authoritative list of implemented FEPs.
 
+## OAuth 2.0 Client-to-Server
+
+When the ActivityPub API option is enabled, third-party clients can authenticate via OAuth 2.0 under `activitypub/1.0/oauth/`. The plugin supports RFC 7591 dynamic registration, RFC 7636 PKCE (S256 only, required by default for public clients), and the CIMD draft (URL-form `client_id`).
+
+### RFC 8252 — Loopback Redirect URIs
+
+Native apps receive the OAuth callback on a loopback port they opened locally. Per RFC 8252 §7.3 / §8.3, redirect URIs of the form `http://127.0.0.1:{port}/{path}` and `http://[::1]:{port}/{path}` are accepted with port flexibility (any port may be used at request time). `localhost` is also accepted for compatibility, although §8.3 marks it "NOT RECOMMENDED".
+
+The loopback allowance applies *only* to redirect URI matching. Reserved-but-not-loopback addresses — `0.0.0.0`, link-local `169.254.0.0/16`, RFC1918 private ranges (`10/8`, `172.16/12`, `192.168/16`), and similar — are not treated as loopback and never bypass `wp_safe_remote_get()`. CIMD metadata fetches always go through `wp_safe_remote_get()` regardless of host, since the CIMD draft expects publicly resolvable HTTPS URLs for the metadata document.
+
+**For implementation details:** See `includes/oauth/class-client.php` (especially the class docblock and `is_loopback()`) and the OAuth section of [FEDERATION.md](FEDERATION.md).
+
 ## Implementation Notes
 
 ### WordPress Plugin Specifics
@@ -312,5 +324,9 @@ curl https://site.com/.well-known/nodeinfo
 
 - [ActivityPub Spec](https://www.w3.org/TR/activitypub/)
 - [ActivityStreams Vocabulary](https://www.w3.org/TR/activitystreams-vocabulary/)
+- [RFC 8252 — OAuth 2.0 for Native Apps](https://datatracker.ietf.org/doc/html/rfc8252)
+- [RFC 7591 — OAuth 2.0 Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591)
+- [RFC 7636 — PKCE](https://datatracker.ietf.org/doc/html/rfc7636)
+- [draft-ietf-oauth-client-id-metadata-document](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document)
 - [Project FEDERATION.md](FEDERATION.md)
 - [FEPs Repository](https://codeberg.org/fediverse/fep)

--- a/.agents/skills/federation/SKILL.md
+++ b/.agents/skills/federation/SKILL.md
@@ -265,13 +265,13 @@ FEPs extend ActivityPub with additional features. Common FEP categories include:
 
 ## OAuth 2.0 Client-to-Server
 
-When the ActivityPub API option is enabled, third-party clients can authenticate via OAuth 2.0 under `activitypub/1.0/oauth/`. The plugin supports RFC 7591 dynamic registration, RFC 7636 PKCE (S256 only, required by default for public clients), and the CIMD draft (URL-form `client_id`).
+When the ActivityPub API option is enabled, third-party clients can authenticate via OAuth 2.0 under `activitypub/1.0/oauth/`. The plugin supports RFC 7591 dynamic registration, RFC 7636 PKCE (S256 only, required by default for public clients), and the CIMD draft (URL-form `client_id`, HTTPS required).
 
 ### RFC 8252 — Loopback Redirect URIs
 
 Native apps receive the OAuth callback on a loopback port they opened locally. Per RFC 8252 §7.3 / §8.3, redirect URIs of the form `http://127.0.0.1:{port}/{path}` and `http://[::1]:{port}/{path}` are accepted with port flexibility (any port may be used at request time). `localhost` is also accepted for compatibility, although §8.3 marks it "NOT RECOMMENDED".
 
-The loopback allowance applies *only* to redirect URI matching. Reserved-but-not-loopback addresses — `0.0.0.0`, link-local `169.254.0.0/16`, RFC1918 private ranges (`10/8`, `172.16/12`, `192.168/16`), and similar — are not treated as loopback and never bypass `wp_safe_remote_get()`. CIMD metadata fetches always go through `wp_safe_remote_get()` regardless of host, since the CIMD draft expects publicly resolvable HTTPS URLs for the metadata document.
+The loopback allowance applies *only* to redirect URI matching. Reserved-but-not-loopback addresses — `0.0.0.0`, link-local `169.254.0.0/16`, RFC1918 private ranges (`10/8`, `172.16/12`, `192.168/16`), and similar — are not treated as loopback and never bypass `wp_safe_remote_get()`. CIMD metadata URLs must use `https://`, and the metadata host is resolved and validated against private/reserved ranges before any fetch — loopback CIMD origins are not supported, even on dev installs.
 
 **For implementation details:** See `includes/oauth/class-client.php` (especially the class docblock and `is_loopback()`) and the OAuth section of [FEDERATION.md](FEDERATION.md).
 

--- a/.github/changelog/harden-oauth-client-discovery
+++ b/.github/changelog/harden-oauth-client-discovery
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hardened OAuth client discovery to block requests to internal network addresses.

--- a/.github/changelog/harden-oauth-client-discovery
+++ b/.github/changelog/harden-oauth-client-discovery
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: security
 
-Hardened OAuth client discovery to block requests to internal network addresses.
+Hardened outbound request handling for third-party app connections and live activity streams.

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -230,11 +230,11 @@ When the ActivityPub API option is enabled, the plugin exposes OAuth 2.0 endpoin
 - [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) - OAuth 2.0 for Native Apps. Loopback redirect URIs (`http://127.0.0.1:{port}` and `http://[::1]:{port}`) are accepted with port flexibility per §7.3/§8.3. `localhost` is also accepted for compatibility; §8.3 marks this "NOT RECOMMENDED" but it remains common practice.
 - [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) - Dynamic Client Registration.
 - [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636) - PKCE. Required by default for public clients; only `S256` is accepted.
-- [`draft-ietf-oauth-client-id-metadata-document`](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) - Client Identifier Metadata Document (CIMD). When `client_id` is a URL, the plugin fetches the metadata document and auto-registers the client.
+- [`draft-ietf-oauth-client-id-metadata-document`](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) - Client Identifier Metadata Document (CIMD). When `client_id` is an `https://` URL, the plugin fetches the metadata document and auto-registers the client. Cleartext (`http://`) `client_id` URLs are rejected.
 
 **Loopback scope:**
 
-The loopback allowance from RFC 8252 applies *only* to redirect URI matching. Reserved-but-not-loopback addresses (`0.0.0.0`, link-local `169.254.0.0/16`, RFC1918 private ranges, etc.) are not treated as loopback. CIMD metadata fetches always use `wp_safe_remote_get()` regardless of host, since the spec expects publicly resolvable HTTPS URLs for the metadata document.
+The loopback allowance from RFC 8252 applies *only* to redirect URI matching. Reserved-but-not-loopback addresses (`0.0.0.0`, link-local `169.254.0.0/16`, RFC1918 private ranges, etc.) are not treated as loopback. CIMD metadata URLs must use `https://`, and the metadata host is resolved and validated against private/reserved ranges before any fetch. Loopback CIMD origins are not supported, even on dev installs.
 
 ## Additional documentation
 

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -221,6 +221,21 @@ All REST API endpoints use the `activitypub/1.0` namespace.
 
 Posts and author pages serve ActivityPub JSON-LD when the request includes an appropriate `Accept` header (`application/activity+json` or `application/ld+json`).
 
+### OAuth 2.0 for Client-to-Server
+
+When the ActivityPub API option is enabled, the plugin exposes OAuth 2.0 endpoints under the `activitypub/1.0/oauth/` namespace for third-party clients (Mastodon-compatible apps, native apps, browser apps).
+
+**Supported standards:**
+
+- [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) - OAuth 2.0 for Native Apps. Loopback redirect URIs (`http://127.0.0.1:{port}` and `http://[::1]:{port}`) are accepted with port flexibility per §7.3/§8.3. `localhost` is also accepted for compatibility; §8.3 marks this "NOT RECOMMENDED" but it remains common practice.
+- [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) - Dynamic Client Registration.
+- [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636) - PKCE. Required by default for public clients; only `S256` is accepted.
+- [`draft-ietf-oauth-client-id-metadata-document`](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) - Client Identifier Metadata Document (CIMD). When `client_id` is a URL, the plugin fetches the metadata document and auto-registers the client.
+
+**Loopback scope:**
+
+The loopback allowance from RFC 8252 applies *only* to redirect URI matching. Reserved-but-not-loopback addresses (`0.0.0.0`, link-local `169.254.0.0/16`, RFC1918 private ranges, etc.) are not treated as loopback. CIMD metadata fetches always use `wp_safe_remote_get()` regardless of host, since the spec expects publicly resolvable HTTPS URLs for the metadata document.
+
 ## Additional documentation
 
 - Plugin Documentation: [docs/readme.md](docs/readme.md)

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -151,6 +151,17 @@ function resolve_public_host( $host ) {
 
 	// Already an IP literal — validate directly. Accepts IPv4 and IPv6.
 	if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
+		/*
+		 * Reject IPv4-mapped IPv6 literals (`::ffff:0:0/96`). PHP's
+		 * FILTER_FLAG_NO_RES_RANGE catches them on some builds but not
+		 * others, so let the SSRF guard not depend on that. These forms
+		 * serve no legitimate purpose for our callers anyway.
+		 */
+		$packed = \inet_pton( $host );
+		if ( false !== $packed && 16 === \strlen( $packed ) && "\0\0\0\0\0\0\0\0\0\0\xff\xff" === \substr( $packed, 0, 12 ) ) {
+			return false;
+		}
+
 		return \filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE )
 			? $host
 			: false;

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -121,7 +121,7 @@ function get_remote_metadata_by_actor( $actor, $cached = true ) { // phpcs:ignor
 }
 
 /**
- * Resolve a hostname or IP literal to a public IPv4 address.
+ * Resolve a hostname or IP literal to a public IP address.
  *
  * Used as an SSRF guard before opening connections to user-supplied URLs.
  * `wp_safe_remote_get()` ultimately calls `wp_http_validate_url()`, which has
@@ -130,11 +130,12 @@ function get_remote_metadata_by_actor( $actor, $cached = true ) { // phpcs:ignor
  * resolve-and-validate without that carve-out, and returns the resolved IP so
  * callers can pin the connection to it (defends against DNS rebinding).
  *
- * IP literals are validated directly. Hostnames are resolved via
- * `gethostbynamel()`; if any returned address is private or reserved the
- * helper rejects, defending against split-horizon DNS that returns a public
- * answer to one resolver and a private one to another. Only IPv4 records are
- * considered, mirroring the default behaviour of `wp_http_validate_url`.
+ * Both IPv4 and IPv6 literals are accepted (bracketed IPv6 like `[::1]` is
+ * normalised first). Hostname resolution uses `gethostbynamel()`, which is
+ * IPv4-only, mirroring the default behaviour of `wp_http_validate_url`. If any
+ * returned address is private or reserved the helper rejects, defending
+ * against split-horizon DNS that returns a public answer to one resolver and a
+ * private one to another.
  *
  * @param string $host The hostname or IP literal to resolve.
  *
@@ -145,7 +146,10 @@ function resolve_public_host( $host ) {
 		return false;
 	}
 
-	// Already an IP literal — validate directly.
+	// Normalise bracketed IPv6 literals (parse_url returns "[::1]").
+	$host = \trim( $host, '[]' );
+
+	// Already an IP literal — validate directly. Accepts IPv4 and IPv6.
 	if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
 		return \filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE )
 			? $host

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -119,3 +119,50 @@ function get_remote_metadata_by_actor( $actor, $cached = true ) { // phpcs:ignor
 
 	return json_decode( $remote_actor->post_content, true );
 }
+
+/**
+ * Resolve a hostname or IP literal to a public IPv4 address.
+ *
+ * Used as an SSRF guard before opening connections to user-supplied URLs.
+ * `wp_safe_remote_get()` ultimately calls `wp_http_validate_url()`, which has
+ * a same-host carve-out that lets local/private addresses through when the
+ * WordPress site itself is hosted on one. This helper performs an explicit
+ * resolve-and-validate without that carve-out, and returns the resolved IP so
+ * callers can pin the connection to it (defends against DNS rebinding).
+ *
+ * IP literals are validated directly. Hostnames are resolved via
+ * `gethostbynamel()`; if any returned address is private or reserved the
+ * helper rejects, defending against split-horizon DNS that returns a public
+ * answer to one resolver and a private one to another. Only IPv4 records are
+ * considered, mirroring the default behaviour of `wp_http_validate_url`.
+ *
+ * @param string $host The hostname or IP literal to resolve.
+ *
+ * @return string|false A safe public IP, or false when no safe address is available.
+ */
+function resolve_public_host( $host ) {
+	if ( ! is_string( $host ) || '' === $host ) {
+		return false;
+	}
+
+	// Already an IP literal — validate directly.
+	if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
+		return \filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE )
+			? $host
+			: false;
+	}
+
+	$ips = \gethostbynamel( $host );
+	if ( ! $ips ) {
+		return false;
+	}
+
+	// Reject if any resolved address is private/reserved.
+	foreach ( $ips as $ip ) {
+		if ( ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			return false;
+		}
+	}
+
+	return $ips[0];
+}

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -288,18 +288,14 @@ class Client {
 			'redirection' => 0, // CIMDs prohibit following redirects to prevent client impersonation.
 		);
 
-		$host = \wp_parse_url( $url, PHP_URL_HOST );
-
 		/*
-		 * Use wp_remote_get for loopback hosts (localhost, *.localhost, 127.x.x.x, ::1).
-		 * wp_safe_remote_get blocks private IPs as SSRF protection, but the OAuth spec
-		 * explicitly allows loopback clients for development (RFC 8252 Section 8.3).
+		 * Always use wp_safe_remote_get for the metadata document fetch. RFC 8252's
+		 * loopback allowance applies to redirect URIs (Section 7.3), not to the
+		 * client metadata document — that's expected to be a publicly resolvable
+		 * HTTPS URL. Allowing loopback here would expose the server to SSRF via a
+		 * crafted client_id pointing at localhost or *.localhost subdomains.
 		 */
-		if ( $host && self::is_loopback( $host ) ) {
-			$response = \wp_remote_get( $url, $args );
-		} else {
-			$response = \wp_safe_remote_get( $url, $args );
-		}
+		$response = \wp_safe_remote_get( $url, $args );
 
 		if ( \is_wp_error( $response ) ) {
 			return new \WP_Error(

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -34,10 +34,12 @@ use function Activitypub\resolve_public_host;
  * treated as loopback and never bypass `wp_safe_remote_get()`.
  *
  * RFC 8252's loopback allowance applies to redirect URIs only. The CIMD
- * document is expected to be a publicly resolvable HTTPS resource, so
- * `fetch_client_metadata()` always uses `wp_safe_remote_get()` regardless of
- * host. Local development against a loopback CIMD endpoint is intentionally
- * not supported.
+ * document must be served over HTTPS from a publicly resolvable host:
+ * `client_id` discovery rejects non-`https` URLs up front, and
+ * `fetch_client_metadata()` resolves the host first and rejects anything
+ * private or loopback before falling through to `wp_safe_remote_get()`.
+ * Local development against a loopback CIMD endpoint is intentionally not
+ * supported.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc8252 RFC 8252 — OAuth 2.0 for Native Apps
  * @see https://datatracker.ietf.org/doc/html/rfc7591 RFC 7591 — OAuth 2.0 Dynamic Client Registration

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -14,7 +14,32 @@ use function Activitypub\get_client_ip;
 /**
  * Client class for managing OAuth 2.0 client registrations.
  *
- * Supports both manual registration and RFC 7591 dynamic client registration.
+ * Supports both manual registration and RFC 7591 dynamic client registration,
+ * plus Client Identifier Metadata Documents (CIMD) where the `client_id` is
+ * itself a URL hosting a metadata document.
+ *
+ * ## Loopback policy (RFC 8252)
+ *
+ * Native apps register loopback redirect URIs to receive the OAuth callback
+ * on a port the app opened locally. RFC 8252 §7.3 / §8.3 cover this and
+ * specifically authorise `http://127.0.0.1:{port}/{path}` (IPv4) and
+ * `http://[::1]:{port}/{path}` (IPv6). `localhost` is permitted by common
+ * practice, though §8.3 marks it "NOT RECOMMENDED".
+ *
+ * `is_loopback()` reflects that scope: it matches `127.0.0.0/8`, `::1`
+ * (any spelling, normalised via `inet_pton`), `::ffff:127.x.x.x`, `localhost`,
+ * and `*.localhost`. Reserved-but-not-loopback addresses such as `0.0.0.0`,
+ * link-local `169.254.0.0/16`, and RFC1918 ranges are explicitly *not*
+ * treated as loopback and never bypass `wp_safe_remote_get()`.
+ *
+ * RFC 8252's loopback allowance applies to redirect URIs only. The CIMD
+ * document is expected to be a publicly resolvable HTTPS resource, so
+ * `fetch_client_metadata()` always uses `wp_safe_remote_get()` regardless of
+ * host. Local development against a loopback CIMD endpoint is intentionally
+ * not supported.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8252 RFC 8252 — OAuth 2.0 for Native Apps
+ * @see https://datatracker.ietf.org/doc/html/rfc7591 RFC 7591 — OAuth 2.0 Dynamic Client Registration
  */
 class Client {
 	/**

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -546,20 +546,28 @@ class Client {
 		}
 
 		// Strip brackets from IPv6 (parse_url returns "[::1]").
-		$ip = trim( $host, '[]' );
+		$ip = \trim( $host, '[]' );
+
+		if ( ! \filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return false;
+		}
+
+		// IPv4 loopback 127.0.0.0/8 (RFC 1122 Section 3.2.1.3).
+		if ( \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+			return 0 === \strpos( $ip, '127.' );
+		}
 
 		/*
-		 * PHP's FILTER_FLAG_NO_RES_RANGE rejects reserved IPs including
-		 * the full 127.0.0.0/8 range and ::1, so a valid IP that fails
-		 * this filter is a loopback/reserved address.
+		 * IPv6 loopback ::1 (RFC 4291 Section 2.5.3). Normalised via inet_pton
+		 * so equivalents like 0:0:0:0:0:0:0:1 and ::0001 also match.
 		 */
-		$is_ip = \filter_var( $ip, FILTER_VALIDATE_IP );
-		if ( $is_ip && ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE ) ) {
+		$packed = \inet_pton( $ip );
+		if ( false !== $packed && "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1" === $packed ) {
 			return true;
 		}
 
-		// IPv4-mapped IPv6 loopback (::ffff:127.x.x.x) — not caught by FILTER_FLAG_NO_RES_RANGE.
-		return 0 === \strpos( \strtolower( $ip ), '::ffff:127.' );
+		// IPv4-mapped IPv6 loopback ::ffff:127.x.x.x (RFC 4291 Section 2.5.5.2).
+		return 0 === \strpos( $ip, '::ffff:127.' );
 	}
 
 	/**

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -10,6 +10,7 @@ namespace Activitypub\OAuth;
 use Activitypub\Sanitize;
 
 use function Activitypub\get_client_ip;
+use function Activitypub\resolve_public_host;
 
 /**
  * Client class for managing OAuth 2.0 client registrations.
@@ -181,7 +182,7 @@ class Client {
 			 * This can happen when a previous discovery failed to parse the metadata
 			 * correctly (e.g. before ActivityStreams vocabulary support was added).
 			 */
-			if ( $client->is_discovered() && empty( $client->get_redirect_uris() ) && \filter_var( $client_id, FILTER_VALIDATE_URL ) ) {
+			if ( $client->is_discovered() && empty( $client->get_redirect_uris() ) && self::is_discoverable_url( $client_id ) ) {
 				\wp_delete_post( $posts[0]->ID, true );
 				return self::discover_and_register( $client_id );
 			}
@@ -189,8 +190,8 @@ class Client {
 			return $client;
 		}
 
-		// If client_id is a URL, try auto-discovery.
-		if ( \filter_var( $client_id, FILTER_VALIDATE_URL ) ) {
+		// If client_id is a discoverable URL (HTTPS), try auto-discovery.
+		if ( self::is_discoverable_url( $client_id ) ) {
 			return self::discover_and_register( $client_id );
 		}
 
@@ -199,6 +200,25 @@ class Client {
 			\__( 'OAuth client not found.', 'activitypub' ),
 			array( 'status' => 404 )
 		);
+	}
+
+	/**
+	 * Determine whether a client_id is a discoverable URL.
+	 *
+	 * Only HTTPS URLs are eligible. The CIMD draft requires HTTPS for
+	 * production, and accepting cleartext URLs would let a network-position
+	 * attacker rewrite the metadata response and inject attacker-controlled
+	 * redirect URIs that preserve the same client_id.
+	 *
+	 * @param string $client_id The client ID to check.
+	 * @return bool True if the client_id is an HTTPS URL eligible for discovery.
+	 */
+	private static function is_discoverable_url( $client_id ) {
+		if ( ! \filter_var( $client_id, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
+
+		return 'https' === \strtolower( (string) \wp_parse_url( $client_id, PHP_URL_SCHEME ) );
 	}
 
 	/**
@@ -305,6 +325,22 @@ class Client {
 	 * @return array|\WP_Error Metadata array or error.
 	 */
 	private static function fetch_client_metadata( $url ) {
+		/*
+		 * Resolve the host explicitly and reject private/loopback addresses.
+		 * wp_safe_remote_get() also performs URL validation but has a same-host
+		 * carve-out (it allows requests to the WordPress site's own host even
+		 * when that host is loopback/private). The CIMD document is meant to
+		 * be a publicly resolvable HTTPS URL, so close that gap up front.
+		 */
+		$host = \wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! $host || false === resolve_public_host( $host ) ) {
+			return new \WP_Error(
+				'activitypub_client_unsafe_host',
+				\__( 'The client metadata URL host is not allowed.', 'activitypub' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		$args = array(
 			'timeout'     => 10,
 			'headers'     => array(
@@ -317,8 +353,7 @@ class Client {
 		 * Always use wp_safe_remote_get for the metadata document fetch. RFC 8252's
 		 * loopback allowance applies to redirect URIs (Section 7.3), not to the
 		 * client metadata document — that's expected to be a publicly resolvable
-		 * HTTPS URL. Allowing loopback here would expose the server to SSRF via a
-		 * crafted client_id pointing at localhost or *.localhost subdomains.
+		 * HTTPS URL.
 		 */
 		$response = \wp_safe_remote_get( $url, $args );
 

--- a/includes/rest/trait-event-stream.php
+++ b/includes/rest/trait-event-stream.php
@@ -18,6 +18,8 @@ use Activitypub\Collection\Outbox;
 use Activitypub\OAuth\Scope;
 use Activitypub\OAuth\Server as OAuth_Server;
 
+use function Activitypub\resolve_public_host;
+
 
 /**
  * Event Stream Trait.
@@ -211,7 +213,7 @@ trait Event_Stream {
 		 * stream_socket_client would otherwise do its own lookup, which opens
 		 * a DNS-rebinding window after validate_url() already passed.
 		 */
-		$ip = self::resolve_public_host( $host );
+		$ip = resolve_public_host( $host );
 		if ( false === $ip ) {
 			\status_header( 502 );
 			\header( 'Content-Type: application/json' );
@@ -567,37 +569,5 @@ trait Event_Stream {
 		}
 
 		return $query->posts;
-	}
-
-	/**
-	 * Resolve a hostname to an IP address and reject anything in a private
-	 * or reserved range. Returns the resolved IP for direct connection so
-	 * the actual TCP connect can't be redirected by a later DNS change.
-	 *
-	 * @param string $host The hostname to resolve.
-	 *
-	 * @return string|false Resolved public IP, or false when no safe address is available.
-	 */
-	private static function resolve_public_host( $host ) {
-		// Already an IP literal — validate directly.
-		if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
-			return \filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE )
-				? $host
-				: false;
-		}
-
-		$ips = \gethostbynamel( $host );
-		if ( ! $ips ) {
-			return false;
-		}
-
-		// Reject if any resolved address is private/reserved (defends against split-horizon DNS).
-		foreach ( $ips as $ip ) {
-			if ( ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
-				return false;
-			}
-		}
-
-		return $ips[0];
 	}
 }

--- a/includes/rest/trait-event-stream.php
+++ b/includes/rest/trait-event-stream.php
@@ -221,7 +221,7 @@ trait Event_Stream {
 			echo \wp_json_encode(
 				array(
 					'code'    => 'activitypub_proxy_unsafe_host',
-					'message' => \__( 'The remote eventStream host is not reachable.', 'activitypub' ),
+					'message' => \__( 'The remote eventStream host is not allowed.', 'activitypub' ),
 				)
 			);
 			exit;

--- a/includes/rest/trait-event-stream.php
+++ b/includes/rest/trait-event-stream.php
@@ -206,19 +206,41 @@ trait Event_Stream {
 			$path .= '?' . $parsed['query'];
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_stream_socket_client -- SSE proxy requires raw streaming.
+		/*
+		 * Resolve the host once and verify every returned address is public.
+		 * stream_socket_client would otherwise do its own lookup, which opens
+		 * a DNS-rebinding window after validate_url() already passed.
+		 */
+		$ip = self::resolve_public_host( $host );
+		if ( false === $ip ) {
+			\status_header( 502 );
+			\header( 'Content-Type: application/json' );
+			Server::send_cors_headers();
+			echo \wp_json_encode(
+				array(
+					'code'    => 'activitypub_proxy_unsafe_host',
+					'message' => \__( 'The remote eventStream host is not reachable.', 'activitypub' ),
+				)
+			);
+			exit;
+		}
+
 		$context = stream_context_create(
 			array(
 				'ssl' => array(
 					'verify_peer'      => true,
 					'verify_peer_name' => true,
+					// Pin SNI / cert verification to the original hostname even though we connect by IP.
+					'peer_name'        => $host,
 				),
 			)
 		);
 
+		$target = ( false !== strpos( $ip, ':' ) ? '[' . $ip . ']' : $ip ) . ':' . $port;
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_stream_socket_client -- SSE proxy requires raw streaming.
 		$stream = stream_socket_client(
-			'ssl://' . $host . ':' . $port,
+			'ssl://' . $target,
 			$errno,
 			$errstr,
 			30,
@@ -545,5 +567,37 @@ trait Event_Stream {
 		}
 
 		return $query->posts;
+	}
+
+	/**
+	 * Resolve a hostname to an IP address and reject anything in a private
+	 * or reserved range. Returns the resolved IP for direct connection so
+	 * the actual TCP connect can't be redirected by a later DNS change.
+	 *
+	 * @param string $host The hostname to resolve.
+	 *
+	 * @return string|false Resolved public IP, or false when no safe address is available.
+	 */
+	private static function resolve_public_host( $host ) {
+		// Already an IP literal — validate directly.
+		if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return \filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE )
+				? $host
+				: false;
+		}
+
+		$ips = \gethostbynamel( $host );
+		if ( ! $ips ) {
+			return false;
+		}
+
+		// Reject if any resolved address is private/reserved (defends against split-horizon DNS).
+		foreach ( $ips as $ip ) {
+			if ( ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+				return false;
+			}
+		}
+
+		return $ips[0];
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -41,6 +41,9 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'rfc1918_172'                 => array( '172.20.0.7', false ),
 			'rfc1918_192'                 => array( '192.168.1.1', false ),
 			'ipv6_loopback'               => array( '::1', false ),
+			'ipv6_loopback_bracketed'     => array( '[::1]', false ),
+			'public_ipv6'                 => array( '2001:db8::1', '2001:db8::1' ),
+			'public_ipv6_bracketed'       => array( '[2001:db8::1]', '2001:db8::1' ),
 			'empty_string'                => array( '', false ),
 		);
 	}

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -23,4 +23,50 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 		$this->assertEquals( 'pfefferle', $metadata['preferredUsername'] );
 		$this->assertEquals( 'Matthias Pfefferle', $metadata['name'] );
 	}
+
+	/**
+	 * Data provider for resolve_public_host IP-literal cases.
+	 *
+	 * @return array<string, array{0: string, 1: string|false}>
+	 */
+	public function resolve_public_host_ip_provider() {
+		return array(
+			'public_ipv4'                 => array( '8.8.8.8', '8.8.8.8' ),
+			'cloudflare_ipv4'             => array( '1.1.1.1', '1.1.1.1' ),
+			'loopback_ipv4'               => array( '127.0.0.1', false ),
+			'loopback_ipv4_anywhere_in_8' => array( '127.5.4.3', false ),
+			'unspecified_ipv4'            => array( '0.0.0.0', false ),
+			'link_local_metadata'         => array( '169.254.169.254', false ),
+			'rfc1918_10'                  => array( '10.0.0.1', false ),
+			'rfc1918_172'                 => array( '172.20.0.7', false ),
+			'rfc1918_192'                 => array( '192.168.1.1', false ),
+			'ipv6_loopback'               => array( '::1', false ),
+			'empty_string'                => array( '', false ),
+		);
+	}
+
+	/**
+	 * Test resolve_public_host returns the IP for public addresses and false otherwise.
+	 *
+	 * @dataProvider resolve_public_host_ip_provider
+	 *
+	 * @covers \Activitypub\resolve_public_host
+	 *
+	 * @param string       $host     The host or IP literal under test.
+	 * @param string|false $expected Expected return value.
+	 */
+	public function test_resolve_public_host_ip_literals( $host, $expected ) {
+		$this->assertSame( $expected, \Activitypub\resolve_public_host( $host ) );
+	}
+
+	/**
+	 * Test that non-string input is rejected.
+	 *
+	 * @covers \Activitypub\resolve_public_host
+	 */
+	public function test_resolve_public_host_rejects_non_string() {
+		$this->assertFalse( \Activitypub\resolve_public_host( null ) );
+		$this->assertFalse( \Activitypub\resolve_public_host( 12345 ) );
+		$this->assertFalse( \Activitypub\resolve_public_host( array( '8.8.8.8' ) ) );
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -44,6 +44,10 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'ipv6_loopback_bracketed'     => array( '[::1]', false ),
 			'public_ipv6'                 => array( '2606:4700:4700::1111', '2606:4700:4700::1111' ),
 			'public_ipv6_bracketed'       => array( '[2606:4700:4700::1111]', '2606:4700:4700::1111' ),
+			'ipv4_mapped_loopback'        => array( '::ffff:127.0.0.1', false ),
+			'ipv4_mapped_rfc1918'         => array( '::ffff:10.0.0.1', false ),
+			'ipv4_mapped_link_local'      => array( '::ffff:169.254.169.254', false ),
+			'ipv4_mapped_public'          => array( '::ffff:8.8.8.8', false ),
 			'empty_string'                => array( '', false ),
 		);
 	}

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -42,8 +42,8 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'rfc1918_192'                 => array( '192.168.1.1', false ),
 			'ipv6_loopback'               => array( '::1', false ),
 			'ipv6_loopback_bracketed'     => array( '[::1]', false ),
-			'public_ipv6'                 => array( '2001:db8::1', '2001:db8::1' ),
-			'public_ipv6_bracketed'       => array( '[2001:db8::1]', '2001:db8::1' ),
+			'public_ipv6'                 => array( '2606:4700:4700::1111', '2606:4700:4700::1111' ),
+			'public_ipv6_bracketed'       => array( '[2606:4700:4700::1111]', '2606:4700:4700::1111' ),
 			'empty_string'                => array( '', false ),
 		);
 	}

--- a/tests/phpunit/tests/includes/oauth/class-test-client.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-client.php
@@ -288,9 +288,8 @@ class Test_Client extends \WP_UnitTestCase {
 	/**
 	 * Test register method rejects reserved addresses that are not loopback.
 	 *
-	 * Guards against treating any reserved IP as loopback and routing it past
-	 * SSRF protection. Each host below must flow through wp_safe_remote_get()
-	 * rather than wp_remote_get().
+	 * Guards against treating reserved or otherwise non-loopback hosts as
+	 * loopback for the `http://` redirect URI allowance during registration.
 	 *
 	 * @covers ::register
 	 * @dataProvider non_loopback_host_provider

--- a/tests/phpunit/tests/includes/oauth/class-test-client.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-client.php
@@ -249,6 +249,94 @@ class Test_Client extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test register method accepts every legitimate loopback form.
+	 *
+	 * @covers ::register
+	 * @dataProvider loopback_host_provider
+	 *
+	 * @param string $host Host portion of the redirect URI.
+	 */
+	public function test_register_allows_loopback_variants( $host ) {
+		$result = $this->create_client(
+			array(
+				'name'          => 'Loopback Variant Client',
+				'redirect_uris' => array( 'http://' . $host . ':3000/callback' ),
+			)
+		);
+
+		$this->assertIsArray( $result, \sprintf( 'Loopback host %s should be accepted.', $host ) );
+		$this->assertArrayHasKey( 'client_id', $result );
+	}
+
+	/**
+	 * Data provider for loopback hosts that must be treated as loopback.
+	 *
+	 * @return array[]
+	 */
+	public function loopback_host_provider() {
+		return array(
+			'IPv4 loopback literal'       => array( '127.0.0.1' ),
+			'IPv4 loopback upper range'   => array( '127.0.0.2' ),
+			'IPv4 loopback high address'  => array( '127.255.255.254' ),
+			'IPv6 loopback shorthand'     => array( '[::1]' ),
+			'IPv6 loopback full form'     => array( '[0:0:0:0:0:0:0:1]' ),
+			'IPv6 loopback leading zeros' => array( '[::0001]' ),
+			'IPv4-mapped IPv6 loopback'   => array( '[::ffff:127.0.0.1]' ),
+		);
+	}
+
+	/**
+	 * Test register method rejects reserved addresses that are not loopback.
+	 *
+	 * Guards against treating any reserved IP as loopback and routing it past
+	 * SSRF protection. Each host below must flow through wp_safe_remote_get()
+	 * rather than wp_remote_get().
+	 *
+	 * @covers ::register
+	 * @dataProvider non_loopback_host_provider
+	 *
+	 * @param string $host Host portion of the redirect URI.
+	 */
+	public function test_register_rejects_non_loopback_reserved_hosts( $host ) {
+		$result = $this->create_client(
+			array(
+				'name'          => 'Non-loopback Reserved Client',
+				'redirect_uris' => array( 'http://' . $host . ':3000/callback' ),
+			)
+		);
+
+		$this->assertInstanceOf(
+			\WP_Error::class,
+			$result,
+			\sprintf( 'Host %s must not be treated as loopback.', $host )
+		);
+	}
+
+	/**
+	 * Data provider for reserved or external hosts that must not be loopback.
+	 *
+	 * @return array[]
+	 */
+	public function non_loopback_host_provider() {
+		return array(
+			'unspecified IPv4'           => array( '0.0.0.0' ),
+			'link-local cloud metadata'  => array( '169.254.169.254' ),
+			'link-local generic'         => array( '169.254.1.1' ),
+			'multicast'                  => array( '224.0.0.1' ),
+			'reserved future use'        => array( '240.0.0.1' ),
+			'TEST-NET-1'                 => array( '192.0.2.1' ),
+			'TEST-NET-2'                 => array( '198.51.100.1' ),
+			'TEST-NET-3'                 => array( '203.0.113.1' ),
+			'private 10/8'               => array( '10.0.0.5' ),
+			'private 172.16/12'          => array( '172.20.0.7' ),
+			'private 192.168/16'         => array( '192.168.1.1' ),
+			'public host'                => array( '8.8.8.8' ),
+			'IPv4-mapped public address' => array( '[::ffff:8.8.8.8]' ),
+			'IPv4-mapped link-local'     => array( '[::ffff:169.254.169.254]' ),
+		);
+	}
+
+	/**
 	 * Test register method allows http for non-loopback when filter permits.
 	 *
 	 * @covers ::register


### PR DESCRIPTION
## Proposed changes:

Tightens the safety checks on outbound requests triggered by two **opt-in** features:

* **OAuth 2.0 client discovery** — only active when the ActivityPub API option is enabled (off by default; advertised as opt-in for third-party app integrations).
* **SSE eventStream proxy** — only active when SSE is enabled.

The intent is defense-in-depth: make it harder for a crafted `client_id` URL or a malicious remote `eventStream` to coerce the server into requesting an internal address, including on dev and private-network installs where WordPress's same-host carve-out can otherwise apply.

What's in the branch:

* Tighter `is_loopback()` for OAuth redirect URI matching. Now matches only `127.0.0.0/8`, `::1` (any spelling, normalized via `inet_pton`), `::ffff:127.x.x.x`, `localhost`, and `*.localhost`. Reserved-but-not-loopback addresses (`0.0.0.0`, link-local `169.254.0.0/16`, RFC1918) are no longer treated as loopback.
* Client Identifier Metadata Document (CIMD) fetches now go through `wp_safe_remote_get()` unconditionally — the loopback bypass for the metadata fetch path is removed.
* `client_id` URLs must use `https://` to be eligible for discovery.
* The metadata host is resolved up front and rejected if it resolves to a private/reserved/loopback range. This closes the same-host carve-out gap inside `wp_safe_remote_get()` for dev/private-network installs.
* SSE eventStream relay resolves the upstream host once, validates the IP, and connects to that IP literal directly (with `peer_name` set so SNI and cert verification still match the original hostname). Closes the DNS-rebinding window between URL validation and the socket open.
* New `Activitypub\resolve_public_host()` helper shared between OAuth discovery and the SSE proxy. Unit-tested for IPv4 literals (public, loopback, unspecified, link-local metadata, RFC1918, IPv6 loopback, empty, non-string).
* Documentation: class docblock, FEDERATION.md, and the federation skill now spell out the RFC 8252 alignment for redirect URIs and the strict CIMD policy.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

Sites running the default configuration are not affected by any of the behaviour changes — the touched code only runs when the feature flags are on.

With the ActivityPub API option enabled:

* Connect a third-party OAuth app whose `client_id` is a real `https://` CIMD URL. Discovery and authorization should round-trip as before.
* Try `client_id=http://example.com/cimd.json`. The flow should refuse to discover (HTTPS required).
* Try `client_id=https://127.0.0.1/...`, `https://0.0.0.0/...`, `https://169.254.169.254/...`, or any RFC1918 host. Discovery should refuse without an outbound fetch.
* A native app callback `redirect_uri=http://127.0.0.1:1234/callback` (RFC 8252 §7.3) should continue to work — the loopback redirect path is unchanged.

With SSE enabled, on an actor that advertises `eventStream`:

* Subscribe via the proxy endpoint to a public peer. The stream should relay as before.
* Subscribe via the proxy to an actor whose `eventStream` host's public DNS resolves to a private address. The proxy should respond `502` with `activitypub_proxy_unsafe_host`.

Heads-up for dev workflows: loopback-only client metadata documents are no longer supported, even on `WP_ENVIRONMENT_TYPE=local`. Devs hosting CIMD test fixtures on `localhost` will need to stub the response via `pre_http_request` instead.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security

#### Message

Hardened outbound request handling for third-party app connections and live activity streams.

</details>