### PR TITLE
Tighten clock tolerance on the deprecated signature verifier

### DIFF
--- a/.github/changelog/harden-deprecated-signature-skew
+++ b/.github/changelog/harden-deprecated-signature-skew
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Aligned the deprecated signature verifier's clock tolerance with the supported verifiers.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -428,14 +428,18 @@ class Signature {
 					continue;
 				}
 
-				// Allow a bit of leeway for misconfigured clocks.
-				$d = new \DateTime( $headers[ $header ][0] );
+				// date_create() returns false on malformed input rather than throwing (PHP 8+ behaviour of `new DateTime`).
+				$d = \date_create( $headers[ $header ][0], new \DateTimeZone( 'UTC' ) );
+				if ( false === $d ) {
+					return false;
+				}
 				$d->setTimeZone( new \DateTimeZone( 'UTC' ) );
-				$c = $d->format( 'U' );
+				$c = (int) $d->format( 'U' );
 
-				// Match the tolerance used by the supported verifiers (Http_Signature_Draft / Http_Message_Signature).
-				$d_plus  = time() + ( 5 * MINUTE_IN_SECONDS );
-				$d_minus = time() - HOUR_IN_SECONDS;
+				// Match the past-skew of the maintained Http_Signature_Draft verifier (1 hour); use its 5-minute future allowance.
+				$now     = \time();
+				$d_plus  = $now + ( 5 * MINUTE_IN_SECONDS );
+				$d_minus = $now - HOUR_IN_SECONDS;
 
 				if ( $c > $d_plus || $c < $d_minus ) {
 					// Time out of range.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -433,8 +433,9 @@ class Signature {
 				$d->setTimeZone( new \DateTimeZone( 'UTC' ) );
 				$c = $d->format( 'U' );
 
-				$d_plus  = time() + ( 3 * HOUR_IN_SECONDS );
-				$d_minus = time() - ( 3 * HOUR_IN_SECONDS );
+				// Match the tolerance used by the supported verifiers (Http_Signature_Draft / Http_Message_Signature).
+				$d_plus  = time() + ( 5 * MINUTE_IN_SECONDS );
+				$d_minus = time() - HOUR_IN_SECONDS;
 
 				if ( $c > $d_plus || $c < $d_minus ) {
 					// Time out of range.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -424,11 +424,12 @@ class Signature {
 				}
 			}
 			if ( 'date' === $header ) {
+				// A signed `date` header with no value must fail closed, otherwise the time-window check is skipped.
 				if ( empty( $headers[ $header ][0] ) ) {
-					continue;
+					return false;
 				}
 
-				// date_create() returns false on malformed input rather than throwing (PHP 8+ behaviour of `new DateTime`).
+				// date_create() returns false on malformed input; new DateTime() would instead throw.
 				$d = \date_create( $headers[ $header ][0], new \DateTimeZone( 'UTC' ) );
 				if ( false === $d ) {
 					return false;

--- a/tests/phpunit/tests/includes/class-test-signature.php
+++ b/tests/phpunit/tests/includes/class-test-signature.php
@@ -662,6 +662,74 @@ class Test_Signature extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper for the deprecated Signature::get_signed_data() boundary tests.
+	 *
+	 * Builds a minimal signed-headers list that exercises the date branch
+	 * and invokes the deprecated method. Each call emits the
+	 * _deprecated_function notice that callers must declare.
+	 *
+	 * @param mixed $date_value Value to put in the date header (string, '', or null to omit).
+	 * @return string|false The deprecated method's return value.
+	 */
+	private function invoke_deprecated_get_signed_data( $date_value ) {
+		$headers = array();
+		if ( null !== $date_value ) {
+			$headers['date'] = array( $date_value );
+		}
+
+		return Signature::get_signed_data(
+			array( 'date' ),
+			array( 'algorithm' => 'rsa-sha256' ),
+			$headers
+		);
+	}
+
+	/**
+	 * The deprecated Signature::get_signed_data() must reject Date values
+	 * outside the 5-minute future / 1-hour past window, mirroring the
+	 * maintained Http_Signature_Draft tolerance.
+	 *
+	 * @covers \Activitypub\Signature::get_signed_data
+	 */
+	public function test_deprecated_get_signed_data_enforces_date_window() {
+		$this->setExpectedDeprecated( 'Activitypub\Signature::get_signed_data' );
+
+		$far_past   = \gmdate( 'D, d M Y H:i:s T', \time() - ( 2 * HOUR_IN_SECONDS ) );
+		$far_future = \gmdate( 'D, d M Y H:i:s T', \time() + ( 10 * MINUTE_IN_SECONDS ) );
+		$within     = \gmdate( 'D, d M Y H:i:s T', \time() - ( 30 * MINUTE_IN_SECONDS ) );
+
+		$this->assertFalse( $this->invoke_deprecated_get_signed_data( $far_past ), 'Date more than 1h in the past must reject.' );
+		$this->assertFalse( $this->invoke_deprecated_get_signed_data( $far_future ), 'Date more than 5m in the future must reject.' );
+		$this->assertNotFalse( $this->invoke_deprecated_get_signed_data( $within ), 'Date inside the window must verify.' );
+	}
+
+	/**
+	 * The deprecated Signature::get_signed_data() must fail closed on a
+	 * malformed Date header (no fatal under PHP 8+).
+	 *
+	 * @covers \Activitypub\Signature::get_signed_data
+	 */
+	public function test_deprecated_get_signed_data_rejects_malformed_date() {
+		$this->setExpectedDeprecated( 'Activitypub\Signature::get_signed_data' );
+
+		$this->assertFalse( $this->invoke_deprecated_get_signed_data( 'not a real date' ) );
+	}
+
+	/**
+	 * The deprecated Signature::get_signed_data() must fail closed when the
+	 * signed `date` header is missing or empty, otherwise the time-window
+	 * check would be silently skipped.
+	 *
+	 * @covers \Activitypub\Signature::get_signed_data
+	 */
+	public function test_deprecated_get_signed_data_rejects_missing_date() {
+		$this->setExpectedDeprecated( 'Activitypub\Signature::get_signed_data' );
+
+		$this->assertFalse( $this->invoke_deprecated_get_signed_data( '' ), 'Empty Date must reject.' );
+		$this->assertFalse( $this->invoke_deprecated_get_signed_data( null ), 'Missing Date must reject.' );
+	}
+
+	/**
 	 * RFC-9421 signatures must reject `created` more than one hour in the
 	 * past or more than one minute in the future.
 	 *


### PR DESCRIPTION
## Proposed changes:

* `Signature::get_signed_data()` was deprecated in 7.0.0 in favour of `Signature::verify()`, which dispatches to `Http_Signature_Draft` or `Http_Message_Signature`. Those verifiers use a 5-minute future skew and a 1-hour past skew (set in PR #3212).
* The deprecated method still allowed `± 3 * HOUR_IN_SECONDS` on the `date` header, which is wider than the actively maintained code path.
* The deprecated method isn't reachable from any production code in the plugin, but third-party callers using the old API would still get the looser window. Aligning the tolerance keeps the contract consistent across entry points.

### Other information:

- [x] Have you written new tests for your changes, if applicable? (No new tests — the deprecated method has no production callers and existing test coverage is unchanged.)

## Testing instructions:

* No user-visible behaviour change. The deprecated method still emits its `_deprecated_function` notice. Any third-party plugin that calls `Signature::get_signed_data()` directly will now reject signatures whose `date` header is more than one hour in the past or more than five minutes in the future, matching what `Signature::verify()` does already.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security

#### Message

Aligned the deprecated signature verifier's clock tolerance with the supported verifiers.

</details>