### PR TITLE
Fail closed in OAuth rate limits when client IP can't be determined

### DIFF
--- a/.github/changelog/harden-client-ip-unknown-fallback
+++ b/.github/changelog/harden-client-ip-unknown-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Fail closed when an OAuth request can't be tied to a client IP, instead of sharing one rate-limit bucket.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -342,16 +342,25 @@ function get_embed_html( $url, $inline_css = true ) {
  * Get the client IP address for rate-limiting purposes.
  *
  * Checks common proxy headers before falling back to REMOTE_ADDR,
- * similar to Jetpack's approach. The result can be overridden via
- * the `activitypub_client_ip` filter.
+ * similar to Jetpack's approach. Every step validates the candidate
+ * value with `filter_var( ..., FILTER_VALIDATE_IP )`, so the function
+ * either returns a real IP literal or an empty string. The result can
+ * be overridden via the `activitypub_client_ip` filter; filter output
+ * is also validated and replaced with `''` if it isn't a valid IP, so
+ * a misbehaving filter can't collide all callers into the same
+ * rate-limit bucket.
+ *
+ * Callers using the return value as a rate-limit key should treat an
+ * empty return as "client unidentifiable" and fail closed rather than
+ * share a single bucket across every such request.
  *
  * @since 8.1.0
  *
- * @return string The client IP address.
+ * @return string A valid IP address, or '' when no IP could be determined.
  */
 function get_client_ip() {
 	// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
-	$ip = 'unknown';
+	$ip = '';
 
 	$headers = array(
 		'HTTP_CF_CONNECTING_IP', // Cloudflare.
@@ -364,21 +373,25 @@ function get_client_ip() {
 	);
 
 	foreach ( $headers as $header ) {
-		if ( ! empty( $_SERVER[ $header ] ) ) {
-			// Some headers (e.g. X-Forwarded-For) may contain a comma-separated list; use the first IP.
-			$ip_list = \sanitize_text_field( \wp_unslash( $_SERVER[ $header ] ) );
-			$ip      = \trim( \explode( ',', $ip_list )[0] );
+		if ( empty( $_SERVER[ $header ] ) ) {
+			continue;
+		}
 
-			if ( \filter_var( $ip, FILTER_VALIDATE_IP ) ) {
-				break;
-			}
+		// Some headers (e.g. X-Forwarded-For) may contain a comma-separated list; use the first IP.
+		$ip_list   = \sanitize_text_field( \wp_unslash( $_SERVER[ $header ] ) );
+		$candidate = \trim( \explode( ',', $ip_list )[0] );
 
-			$ip = 'unknown';
+		if ( \filter_var( $candidate, FILTER_VALIDATE_IP ) ) {
+			$ip = $candidate;
+			break;
 		}
 	}
 
-	if ( 'unknown' === $ip && isset( $_SERVER['REMOTE_ADDR'] ) ) {
-		$ip = \sanitize_text_field( \wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+	if ( '' === $ip && ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+		$candidate = \sanitize_text_field( \wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+		if ( \filter_var( $candidate, FILTER_VALIDATE_IP ) ) {
+			$ip = $candidate;
+		}
 	}
 	// phpcs:enable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 
@@ -387,7 +400,10 @@ function get_client_ip() {
 	 *
 	 * @since 8.1.0
 	 *
-	 * @param string $ip The detected client IP address.
+	 * @param string $ip The detected client IP address (empty when none could be determined).
 	 */
-	return \apply_filters( 'activitypub_client_ip', $ip );
+	$ip = \apply_filters( 'activitypub_client_ip', $ip );
+
+	// Re-validate so a misbehaving filter can't return a sentinel string that would collapse all callers into one bucket.
+	return \is_string( $ip ) && \filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '';
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -404,6 +404,11 @@ function get_client_ip() {
 	 */
 	$ip = \apply_filters( 'activitypub_client_ip', $ip );
 
+	// Tolerate surrounding whitespace from filter callbacks; FILTER_VALIDATE_IP would otherwise reject it.
+	if ( \is_string( $ip ) ) {
+		$ip = \trim( $ip );
+	}
+
 	// Re-validate so a misbehaving filter can't return a sentinel string that would collapse all callers into one bucket.
 	return \is_string( $ip ) && \filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '';
 }

--- a/includes/oauth/class-client.php
+++ b/includes/oauth/class-client.php
@@ -234,7 +234,14 @@ class Client {
 	 */
 	private static function discover_and_register( $client_id ) {
 		// Rate-limit auto-discovery to prevent SSRF abuse (max 10 per minute per IP).
-		$ip            = get_client_ip();
+		$ip = get_client_ip();
+		if ( '' === $ip ) {
+			return new \WP_Error(
+				'activitypub_rate_limited',
+				\__( 'Too many client discovery requests. Please try again later.', 'activitypub' ),
+				array( 'status' => 429 )
+			);
+		}
 		$transient_key = 'ap_oauth_disc_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 

--- a/includes/rest/oauth/class-authorization-controller.php
+++ b/includes/rest/oauth/class-authorization-controller.php
@@ -151,7 +151,14 @@ class Authorization_Controller extends \WP_REST_Controller {
 	 */
 	public function authorize( \WP_REST_Request $request ) {
 		// Rate-limit authorization requests to prevent abuse (max 20 per minute per IP).
-		$ip            = get_client_ip();
+		$ip = get_client_ip();
+		if ( '' === $ip ) {
+			return new \WP_Error(
+				'activitypub_rate_limit',
+				\__( 'Too many authorization requests. Please try again later.', 'activitypub' ),
+				array( 'status' => 429 )
+			);
+		}
 		$transient_key = 'ap_oauth_auth_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 

--- a/includes/rest/oauth/class-clients-controller.php
+++ b/includes/rest/oauth/class-clients-controller.php
@@ -116,7 +116,14 @@ class Clients_Controller extends \WP_REST_Controller {
 		}
 
 		// Rate-limit registrations to prevent DB spam (max 10 per minute per IP).
-		$ip            = get_client_ip();
+		$ip = get_client_ip();
+		if ( '' === $ip ) {
+			return new \WP_Error(
+				'activitypub_rate_limited',
+				\__( 'Too many client registration requests. Please try again later.', 'activitypub' ),
+				array( 'status' => 429 )
+			);
+		}
 		$transient_key = 'ap_oauth_reg_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 

--- a/includes/rest/oauth/class-token-controller.php
+++ b/includes/rest/oauth/class-token-controller.php
@@ -152,7 +152,10 @@ class Token_Controller extends \WP_REST_Controller {
 	 */
 	public function token( \WP_REST_Request $request ) {
 		// Rate-limit token requests to prevent brute-force attacks (max 20 per minute per IP).
-		$ip            = get_client_ip();
+		$ip = get_client_ip();
+		if ( '' === $ip ) {
+			return $this->token_error( 'invalid_request', 'Too many token requests. Please try again later.' );
+		}
 		$transient_key = 'ap_oauth_tok_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -331,13 +331,45 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_client_ip returns unknown when REMOTE_ADDR is missing.
+	 * Test get_client_ip returns an empty string when REMOTE_ADDR is missing.
 	 *
 	 * @covers \Activitypub\get_client_ip
 	 */
 	public function test_get_client_ip_missing_remote_addr() {
 		unset( $_SERVER['REMOTE_ADDR'] );
-		$this->assertSame( 'unknown', \Activitypub\get_client_ip() );
+		$this->assertSame( '', \Activitypub\get_client_ip() );
+	}
+
+	/**
+	 * Test get_client_ip rejects non-IP values from a filter so a misbehaving
+	 * filter can't collapse all callers into one rate-limit bucket.
+	 *
+	 * @covers \Activitypub\get_client_ip
+	 */
+	public function test_get_client_ip_rejects_invalid_filter_output() {
+		$_SERVER['REMOTE_ADDR'] = '198.51.100.10';
+
+		$filter = function () {
+			return 'unknown';
+		};
+
+		\add_filter( 'activitypub_client_ip', $filter );
+		$this->assertSame( '', \Activitypub\get_client_ip() );
+		\remove_filter( 'activitypub_client_ip', $filter );
+	}
+
+	/**
+	 * Test get_client_ip ignores a header that contains a non-IP value.
+	 *
+	 * @covers \Activitypub\get_client_ip
+	 */
+	public function test_get_client_ip_ignores_non_ip_header() {
+		$_SERVER['REMOTE_ADDR']           = '198.51.100.10';
+		$_SERVER['HTTP_CF_CONNECTING_IP'] = 'unknown';
+
+		$this->assertSame( '198.51.100.10', \Activitypub\get_client_ip() );
+
+		unset( $_SERVER['HTTP_CF_CONNECTING_IP'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -304,8 +304,9 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Snapshot the $_SERVER keys this group mutates so tear_down can restore
-	 * them, keeping the suite order-independent.
+	 * Holds the $_SERVER values captured by snapshot_client_ip_server() so
+	 * each test in this group can restore them in its own try/finally,
+	 * keeping the suite order-independent.
 	 *
 	 * @var array<string, mixed>
 	 */

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -304,13 +304,61 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Snapshot the $_SERVER keys this group mutates so tear_down can restore
+	 * them, keeping the suite order-independent.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $client_ip_server_snapshot = array();
+
+	/**
+	 * Capture the values of every $_SERVER key get_client_ip touches before
+	 * each test in this group.
+	 */
+	private function snapshot_client_ip_server() {
+		$keys                            = array(
+			'REMOTE_ADDR',
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_CLIENT_IP',
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_X_FORWARDED',
+			'HTTP_X_CLUSTER_CLIENT_IP',
+			'HTTP_FORWARDED_FOR',
+			'HTTP_FORWARDED',
+		);
+		$this->client_ip_server_snapshot = array();
+		foreach ( $keys as $key ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing existing test fixture values for restore.
+			$this->client_ip_server_snapshot[ $key ] = \array_key_exists( $key, $_SERVER ) ? $_SERVER[ $key ] : null;
+		}
+	}
+
+	/**
+	 * Restore $_SERVER values captured by snapshot_client_ip_server.
+	 */
+	private function restore_client_ip_server() {
+		foreach ( $this->client_ip_server_snapshot as $key => $value ) {
+			if ( null === $value ) {
+				unset( $_SERVER[ $key ] );
+			} else {
+				$_SERVER[ $key ] = $value;
+			}
+		}
+	}
+
+	/**
 	 * Test get_client_ip returns REMOTE_ADDR by default.
 	 *
 	 * @covers \Activitypub\get_client_ip
 	 */
 	public function test_get_client_ip_default() {
-		$_SERVER['REMOTE_ADDR'] = '192.168.1.1';
-		$this->assertSame( '192.168.1.1', \Activitypub\get_client_ip() );
+		$this->snapshot_client_ip_server();
+		try {
+			$_SERVER['REMOTE_ADDR'] = '192.168.1.1';
+			$this->assertSame( '192.168.1.1', \Activitypub\get_client_ip() );
+		} finally {
+			$this->restore_client_ip_server();
+		}
 	}
 
 	/**
@@ -319,15 +367,19 @@ class Test_Functions extends \WP_UnitTestCase {
 	 * @covers \Activitypub\get_client_ip
 	 */
 	public function test_get_client_ip_filter() {
-		$_SERVER['REMOTE_ADDR'] = '10.0.0.1';
-
+		$this->snapshot_client_ip_server();
 		$filter = function () {
 			return '203.0.113.50';
 		};
-
 		\add_filter( 'activitypub_client_ip', $filter );
-		$this->assertSame( '203.0.113.50', \Activitypub\get_client_ip() );
-		\remove_filter( 'activitypub_client_ip', $filter );
+
+		try {
+			$_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+			$this->assertSame( '203.0.113.50', \Activitypub\get_client_ip() );
+		} finally {
+			\remove_filter( 'activitypub_client_ip', $filter );
+			$this->restore_client_ip_server();
+		}
 	}
 
 	/**
@@ -336,8 +388,13 @@ class Test_Functions extends \WP_UnitTestCase {
 	 * @covers \Activitypub\get_client_ip
 	 */
 	public function test_get_client_ip_missing_remote_addr() {
-		unset( $_SERVER['REMOTE_ADDR'] );
-		$this->assertSame( '', \Activitypub\get_client_ip() );
+		$this->snapshot_client_ip_server();
+		try {
+			unset( $_SERVER['REMOTE_ADDR'] );
+			$this->assertSame( '', \Activitypub\get_client_ip() );
+		} finally {
+			$this->restore_client_ip_server();
+		}
 	}
 
 	/**
@@ -347,15 +404,19 @@ class Test_Functions extends \WP_UnitTestCase {
 	 * @covers \Activitypub\get_client_ip
 	 */
 	public function test_get_client_ip_rejects_invalid_filter_output() {
-		$_SERVER['REMOTE_ADDR'] = '198.51.100.10';
-
+		$this->snapshot_client_ip_server();
 		$filter = function () {
 			return 'unknown';
 		};
-
 		\add_filter( 'activitypub_client_ip', $filter );
-		$this->assertSame( '', \Activitypub\get_client_ip() );
-		\remove_filter( 'activitypub_client_ip', $filter );
+
+		try {
+			$_SERVER['REMOTE_ADDR'] = '198.51.100.10';
+			$this->assertSame( '', \Activitypub\get_client_ip() );
+		} finally {
+			\remove_filter( 'activitypub_client_ip', $filter );
+			$this->restore_client_ip_server();
+		}
 	}
 
 	/**
@@ -364,12 +425,15 @@ class Test_Functions extends \WP_UnitTestCase {
 	 * @covers \Activitypub\get_client_ip
 	 */
 	public function test_get_client_ip_ignores_non_ip_header() {
-		$_SERVER['REMOTE_ADDR']           = '198.51.100.10';
-		$_SERVER['HTTP_CF_CONNECTING_IP'] = 'unknown';
+		$this->snapshot_client_ip_server();
+		try {
+			$_SERVER['REMOTE_ADDR']           = '198.51.100.10';
+			$_SERVER['HTTP_CF_CONNECTING_IP'] = 'unknown';
 
-		$this->assertSame( '198.51.100.10', \Activitypub\get_client_ip() );
-
-		unset( $_SERVER['HTTP_CF_CONNECTING_IP'] );
+			$this->assertSame( '198.51.100.10', \Activitypub\get_client_ip() );
+		} finally {
+			$this->restore_client_ip_server();
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/oauth/class-test-client.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-client.php
@@ -376,6 +376,57 @@ class Test_Client extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that auto-discovery via Client::get() fails closed when no client
+	 * IP can be determined.
+	 *
+	 * The discover_and_register() rate limiter must reject the request
+	 * rather than share a single bucket across every unidentifiable caller.
+	 *
+	 * @covers ::get
+	 */
+	public function test_discovery_fails_closed_without_client_ip() {
+		$server_keys = array(
+			'REMOTE_ADDR',
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_CLIENT_IP',
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_X_FORWARDED',
+			'HTTP_X_CLUSTER_CLIENT_IP',
+			'HTTP_FORWARDED_FOR',
+			'HTTP_FORWARDED',
+		);
+		$snapshot    = array();
+		foreach ( $server_keys as $key ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing existing test fixture values for restore.
+			$snapshot[ $key ] = \array_key_exists( $key, $_SERVER ) ? $_SERVER[ $key ] : null;
+		}
+
+		$empty_ip_transient = 'ap_oauth_disc_' . \md5( '' );
+		\delete_transient( $empty_ip_transient );
+
+		try {
+			foreach ( $server_keys as $key ) {
+				unset( $_SERVER[ $key ] );
+			}
+
+			// URL-form client_id triggers discover_and_register().
+			$result = Client::get( 'https://unidentifiable.example.com/cimd.json' );
+
+			$this->assertInstanceOf( \WP_Error::class, $result );
+			$this->assertEquals( 'activitypub_rate_limited', $result->get_error_code() );
+			$this->assertFalse( \get_transient( $empty_ip_transient ) );
+		} finally {
+			foreach ( $snapshot as $key => $value ) {
+				if ( null === $value ) {
+					unset( $_SERVER[ $key ] );
+				} else {
+					$_SERVER[ $key ] = $value;
+				}
+			}
+		}
+	}
+
+	/**
 	 * Test get method returns error for non-existent client.
 	 *
 	 * @covers ::get

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
@@ -131,6 +131,61 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that GET authorize fails closed when no client IP can be determined.
+	 *
+	 * The endpoint must reject the request rather than share a single
+	 * rate-limit bucket across every unidentifiable caller.
+	 *
+	 * @covers ::authorize
+	 */
+	public function test_authorize_fails_closed_without_client_ip() {
+		$server_keys = array(
+			'REMOTE_ADDR',
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_CLIENT_IP',
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_X_FORWARDED',
+			'HTTP_X_CLUSTER_CLIENT_IP',
+			'HTTP_FORWARDED_FOR',
+			'HTTP_FORWARDED',
+		);
+		$snapshot    = array();
+		foreach ( $server_keys as $key ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing existing test fixture values for restore.
+			$snapshot[ $key ] = \array_key_exists( $key, $_SERVER ) ? $_SERVER[ $key ] : null;
+		}
+
+		$empty_ip_transient = 'ap_oauth_auth_' . \md5( '' );
+		\delete_transient( $empty_ip_transient );
+
+		try {
+			foreach ( $server_keys as $key ) {
+				unset( $_SERVER[ $key ] );
+			}
+
+			$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/authorize' );
+			$request->set_param( 'response_type', 'code' );
+			$request->set_param( 'client_id', $this->client_id );
+			$request->set_param( 'redirect_uri', $this->redirect_uri );
+
+			$response = \rest_get_server()->dispatch( $request );
+			$data     = $response->get_data();
+
+			$this->assertEquals( 429, $response->get_status() );
+			$this->assertEquals( 'activitypub_rate_limit', $data['code'] );
+			$this->assertFalse( \get_transient( $empty_ip_transient ) );
+		} finally {
+			foreach ( $snapshot as $key => $value ) {
+				if ( null === $value ) {
+					unset( $_SERVER[ $key ] );
+				} else {
+					$_SERVER[ $key ] = $value;
+				}
+			}
+		}
+	}
+
+	/**
 	 * Test that GET authorize redirects to wp-login.php error page for unknown client.
 	 *
 	 * @covers ::authorize

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
@@ -154,6 +154,42 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that registration fails closed when no client IP can be determined.
+	 *
+	 * The endpoint must reject the request rather than share a single
+	 * rate-limit bucket across every unidentifiable caller.
+	 *
+	 * @covers ::register_client
+	 */
+	public function test_register_client_fails_closed_without_client_ip() {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing existing test fixture value for restore.
+		$snapshot = \array_key_exists( 'REMOTE_ADDR', $_SERVER ) ? $_SERVER['REMOTE_ADDR'] : null;
+
+		try {
+			unset( $_SERVER['REMOTE_ADDR'] );
+
+			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/clients' );
+			$request->set_param( 'client_name', 'No-IP App' );
+			$request->set_param( 'redirect_uris', array( 'https://no-ip.example.com/callback' ) );
+
+			$response = \rest_get_server()->dispatch( $request );
+			$data     = $response->get_data();
+
+			$this->assertEquals( 429, $response->get_status() );
+			$this->assertEquals( 'activitypub_rate_limited', $data['code'] );
+
+			// Ensure the empty-IP path didn't write a shared transient.
+			$this->assertFalse( \get_transient( 'ap_oauth_reg_' . \md5( '' ) ) );
+		} finally {
+			if ( null === $snapshot ) {
+				unset( $_SERVER['REMOTE_ADDR'] );
+			} else {
+				$_SERVER['REMOTE_ADDR'] = $snapshot;
+			}
+		}
+	}
+
+	/**
 	 * Test that registrations below the limit succeed and increment the counter.
 	 *
 	 * @covers ::register_client

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
@@ -162,11 +162,31 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 	 * @covers ::register_client
 	 */
 	public function test_register_client_fails_closed_without_client_ip() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing existing test fixture value for restore.
-		$snapshot = \array_key_exists( 'REMOTE_ADDR', $_SERVER ) ? $_SERVER['REMOTE_ADDR'] : null;
+		// Snapshot every $_SERVER key get_client_ip walks: any leftover proxy header from another
+		// test would otherwise let the endpoint find a valid IP and skip the fail-closed branch.
+		$server_keys = array(
+			'REMOTE_ADDR',
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_CLIENT_IP',
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_X_FORWARDED',
+			'HTTP_X_CLUSTER_CLIENT_IP',
+			'HTTP_FORWARDED_FOR',
+			'HTTP_FORWARDED',
+		);
+		$snapshot    = array();
+		foreach ( $server_keys as $key ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing existing test fixture values for restore.
+			$snapshot[ $key ] = \array_key_exists( $key, $_SERVER ) ? $_SERVER[ $key ] : null;
+		}
+
+		$empty_ip_transient = 'ap_oauth_reg_' . \md5( '' );
+		\delete_transient( $empty_ip_transient );
 
 		try {
-			unset( $_SERVER['REMOTE_ADDR'] );
+			foreach ( $server_keys as $key ) {
+				unset( $_SERVER[ $key ] );
+			}
 
 			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/clients' );
 			$request->set_param( 'client_name', 'No-IP App' );
@@ -179,12 +199,14 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 			$this->assertEquals( 'activitypub_rate_limited', $data['code'] );
 
 			// Ensure the empty-IP path didn't write a shared transient.
-			$this->assertFalse( \get_transient( 'ap_oauth_reg_' . \md5( '' ) ) );
+			$this->assertFalse( \get_transient( $empty_ip_transient ) );
 		} finally {
-			if ( null === $snapshot ) {
-				unset( $_SERVER['REMOTE_ADDR'] );
-			} else {
-				$_SERVER['REMOTE_ADDR'] = $snapshot;
+			foreach ( $snapshot as $key => $value ) {
+				if ( null === $value ) {
+					unset( $_SERVER[ $key ] );
+				} else {
+					$_SERVER[ $key ] = $value;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed changes:

* `get_client_ip()` previously returned the magic string `'unknown'` when no proxy header had a valid IP and `REMOTE_ADDR` was missing, and the `activitypub_client_ip` filter could pass any string through unchecked. Both paths fed straight into rate-limit cache keys via `md5()`, so any literal sentinel value (the default `'unknown'`, or a misbehaving filter returning a constant) collapsed every such caller into a single shared rate-limit bucket.
* `get_client_ip()` now validates each candidate via `filter_var( ..., FILTER_VALIDATE_IP )` and returns an empty string when no valid IP can be determined. The filter's output is also re-validated, so it cannot inject a non-IP sentinel that would create a shared bucket.
* OAuth discovery (`Client::discover_and_register`), registration (`Clients_Controller::create_item`), authorization (`Authorization_Controller::authorize`), and token (`Token_Controller::token`) endpoints now fail closed when the helper returns an empty string. They emit the same rate-limit error they would have emitted at the cap, but without ever incrementing or sharing a bucket. A client we can't identify cannot consume rate-limit headroom.

This is opt-in defense-in-depth — the touched paths only run when the ActivityPub API option is enabled.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Default-config sites with `REMOTE_ADDR` correctly populated (typical PHP-FPM, Apache, or nginx setup) see no behaviour change. OAuth flows continue to rate-limit per real client IP.
* On a deployment where `REMOTE_ADDR` is stripped *and* no recognised proxy header carries a valid IP, OAuth discovery / registration / authorization / token endpoints now return their rate-limit error rather than processing the request. Operators who genuinely need that traffic should add an `activitypub_client_ip` filter that returns a valid IP from their environment-specific source.
* If a third-party plugin filters `activitypub_client_ip` to a non-IP value (e.g. `'unknown'`, `'cli'`), the helper now ignores that override and treats the request as unidentifiable.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security

#### Message

Fail closed when an OAuth request can't be tied to a client IP, instead of sharing one rate-limit bucket.

</details>