### PR TITLE
Reject internal-address authority values on followers/sync at the route layer

### DIFF
--- a/.github/changelog/harden-followers-sync-authority
+++ b/.github/changelog/harden-followers-sync-authority
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Reject follower sync requests targeted at internal-network hosts at the route layer.

--- a/.github/changelog/harden-resolve-public-host-ipv6
+++ b/.github/changelog/harden-resolve-public-host-ipv6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Hardened outbound request safety to cover IPv6-only third-party hosts.

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -131,11 +131,13 @@ function get_remote_metadata_by_actor( $actor, $cached = true ) { // phpcs:ignor
  * callers can pin the connection to it (defends against DNS rebinding).
  *
  * Both IPv4 and IPv6 literals are accepted (bracketed IPv6 like `[::1]` is
- * normalised first). Hostname resolution uses `gethostbynamel()`, which is
- * IPv4-only, mirroring the default behaviour of `wp_http_validate_url`. If any
- * returned address is private or reserved the helper rejects, defending
- * against split-horizon DNS that returns a public answer to one resolver and a
- * private one to another.
+ * normalised first). For hostnames, A records are looked up via
+ * `gethostbynamel()` and AAAA records via `dns_get_record()` when available.
+ * Every returned address is validated against private/reserved ranges; a
+ * single bad address fails the whole resolution, defending against
+ * split-horizon DNS that returns a public answer to one resolver and a
+ * private one to another. IPv4 addresses are preferred over IPv6 when both
+ * exist, mirroring `wp_safe_remote_get()`'s default.
  *
  * @param string $host The hostname or IP literal to resolve.
  *
@@ -151,14 +153,7 @@ function resolve_public_host( $host ) {
 
 	// Already an IP literal — validate directly. Accepts IPv4 and IPv6.
 	if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
-		/*
-		 * Reject IPv4-mapped IPv6 literals (`::ffff:0:0/96`). PHP's
-		 * FILTER_FLAG_NO_RES_RANGE catches them on some builds but not
-		 * others, so let the SSRF guard not depend on that. These forms
-		 * serve no legitimate purpose for our callers anyway.
-		 */
-		$packed = \inet_pton( $host );
-		if ( false !== $packed && 16 === \strlen( $packed ) && "\0\0\0\0\0\0\0\0\0\0\xff\xff" === \substr( $packed, 0, 12 ) ) {
+		if ( is_ipv4_mapped_ipv6( $host ) ) {
 			return false;
 		}
 
@@ -167,17 +162,58 @@ function resolve_public_host( $host ) {
 			: false;
 	}
 
-	$ips = \gethostbynamel( $host );
-	if ( ! $ips ) {
+	$ipv4 = \gethostbynamel( $host ) ?: array();
+	$ipv6 = array();
+
+	if ( \function_exists( 'dns_get_record' ) ) {
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- dns_get_record() emits a warning on lookup failure; we already handle the empty case.
+		$aaaa = @\dns_get_record( $host, DNS_AAAA );
+		if ( \is_array( $aaaa ) ) {
+			foreach ( $aaaa as $record ) {
+				if ( ! empty( $record['ipv6'] ) ) {
+					$ipv6[] = $record['ipv6'];
+				}
+			}
+		}
+	}
+
+	if ( ! $ipv4 && ! $ipv6 ) {
 		return false;
 	}
 
-	// Reject if any resolved address is private/reserved.
-	foreach ( $ips as $ip ) {
+	foreach ( $ipv4 as $ip ) {
 		if ( ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
 			return false;
 		}
 	}
 
-	return $ips[0];
+	foreach ( $ipv6 as $ip ) {
+		if ( is_ipv4_mapped_ipv6( $ip ) ) {
+			return false;
+		}
+		if ( ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			return false;
+		}
+	}
+
+	return $ipv4[0] ?? $ipv6[0];
+}
+
+/**
+ * Detect IPv4-mapped IPv6 literals (`::ffff:0:0/96`).
+ *
+ * PHP's FILTER_FLAG_NO_RES_RANGE catches this range on some builds but not
+ * others. These forms serve no legitimate purpose for the SSRF-guard callers,
+ * so reject the entire range explicitly via packed-byte comparison.
+ *
+ * @param string $ip An IP literal.
+ *
+ * @return bool True if the value is an IPv4-mapped IPv6 address.
+ */
+function is_ipv4_mapped_ipv6( $ip ) {
+	$packed = \inet_pton( $ip );
+
+	return false !== $packed
+		&& 16 === \strlen( $packed )
+		&& "\0\0\0\0\0\0\0\0\0\0\xff\xff" === \substr( $packed, 0, 12 );
 }

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -175,8 +175,8 @@ function resolve_public_host( $host ) {
 	$pre = \apply_filters( 'activitypub_pre_resolve_public_host', null, $host );
 
 	if ( \is_array( $pre ) ) {
-		$ipv4 = $pre['ipv4'] ?? array();
-		$ipv6 = $pre['ipv6'] ?? array();
+		$ipv4 = isset( $pre['ipv4'] ) && \is_array( $pre['ipv4'] ) ? $pre['ipv4'] : array();
+		$ipv6 = isset( $pre['ipv6'] ) && \is_array( $pre['ipv6'] ) ? $pre['ipv6'] : array();
 	} else {
 		$ipv4 = \gethostbynamel( $host ) ?: array();
 		$ipv6 = array();
@@ -228,6 +228,11 @@ function resolve_public_host( $host ) {
  * @return bool True if the value is an IPv4-mapped IPv6 address.
  */
 function is_ipv4_mapped_ipv6( $ip ) {
+	// Short-circuit before inet_pton() so it doesn't emit a warning for non-IP input.
+	if ( ! is_string( $ip ) || ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+		return false;
+	}
+
 	$packed = \inet_pton( $ip );
 
 	return false !== $packed

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -162,16 +162,33 @@ function resolve_public_host( $host ) {
 			: false;
 	}
 
-	$ipv4 = \gethostbynamel( $host ) ?: array();
-	$ipv6 = array();
+	/**
+	 * Filters the resolved addresses for a hostname before validation.
+	 *
+	 * Returning a non-null array of `array{ipv4: string[], ipv6: string[]}` skips
+	 * the DNS lookup. Tests use this to exercise the validation/preference logic
+	 * without making real DNS queries; production code should leave it null.
+	 *
+	 * @param array{ipv4: string[], ipv6: string[]}|null $pre  Pre-resolved addresses, or null to perform DNS lookup.
+	 * @param string                                     $host The hostname being resolved.
+	 */
+	$pre = \apply_filters( 'activitypub_pre_resolve_public_host', null, $host );
 
-	if ( \function_exists( 'dns_get_record' ) ) {
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- dns_get_record() emits a warning on lookup failure; we already handle the empty case.
-		$aaaa = @\dns_get_record( $host, DNS_AAAA );
-		if ( \is_array( $aaaa ) ) {
-			foreach ( $aaaa as $record ) {
-				if ( ! empty( $record['ipv6'] ) ) {
-					$ipv6[] = $record['ipv6'];
+	if ( \is_array( $pre ) ) {
+		$ipv4 = $pre['ipv4'] ?? array();
+		$ipv6 = $pre['ipv6'] ?? array();
+	} else {
+		$ipv4 = \gethostbynamel( $host ) ?: array();
+		$ipv6 = array();
+
+		if ( \function_exists( 'dns_get_record' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- dns_get_record() emits a warning on lookup failure; we already handle the empty case.
+			$aaaa = @\dns_get_record( $host, DNS_AAAA );
+			if ( \is_array( $aaaa ) ) {
+				foreach ( $aaaa as $record ) {
+					if ( ! empty( $record['ipv6'] ) ) {
+						$ipv6[] = $record['ipv6'];
+					}
 				}
 			}
 		}

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -13,6 +13,7 @@ use Activitypub\Collection\Remote_Actors;
 
 use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_rest_url_by_path;
+use function Activitypub\is_ipv4_mapped_ipv6;
 
 /**
  * Followers_Controller class.
@@ -119,7 +120,18 @@ class Followers_Controller extends Actors_Controller {
 								// wp_parse_url returns IPv6 hosts with brackets (e.g. "[::1]") — strip before validation.
 								$host = \trim( $host, '[]' );
 
+								// FQDN trailing dot (e.g. "localhost.") is the same host — strip before comparison.
+								$host = \rtrim( $host, '.' );
+
+								if ( '' === $host ) {
+									return false;
+								}
+
 								if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
+									if ( is_ipv4_mapped_ipv6( $host ) ) {
+										return false;
+									}
+
 									return (bool) \filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
 								}
 

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -109,20 +109,15 @@ class Followers_Controller extends Actors_Controller {
 							'pattern'           => '^https?://[^/]+$',
 							'required'          => true,
 							'validate_callback' => static function ( $param ) {
-								// Reject internal-address shapes early. The signer-host check downstream
-								// already enforces authority matching the verified peer; this just
-								// keeps obviously-internal values from reaching that code at all.
-								$host = \strtolower( (string) \wp_parse_url( (string) $param, PHP_URL_HOST ) );
-								if ( '' === $host ) {
-									return false;
-								}
-
-								// wp_parse_url returns IPv6 hosts with brackets (e.g. "[::1]") — strip before validation.
-								$host = \trim( $host, '[]' );
-
-								// FQDN trailing dot (e.g. "localhost.") is the same host — strip before comparison.
-								$host = \rtrim( $host, '.' );
-
+								/*
+								 * Reject internal-address shapes early. The signer-host check
+								 * downstream already enforces authority matching the verified
+								 * peer; this just keeps obviously-internal values from reaching
+								 * that code at all. Both places run the value through
+								 * self::normalize_host() so semantically equivalent hosts always
+								 * agree.
+								 */
+								$host = self::normalize_host( (string) \wp_parse_url( (string) $param, PHP_URL_HOST ) );
 								if ( '' === $host ) {
 									return false;
 								}
@@ -246,8 +241,8 @@ class Followers_Controller extends Actors_Controller {
 		 * matches the signing peer, so that instances cannot "get tricked
 		 * into requesting the followers list of a third-party individual".
 		 */
-		$signer_host = self::get_signer_host( $request );
-		$asked_host  = \strtolower( (string) \wp_parse_url( (string) $authority, \PHP_URL_HOST ) );
+		$signer_host = self::normalize_host( self::get_signer_host( $request ) );
+		$asked_host  = self::normalize_host( (string) \wp_parse_url( (string) $authority, \PHP_URL_HOST ) );
 
 		if ( ! $signer_host || ! $asked_host || $signer_host !== $asked_host ) {
 			return new \WP_Error(
@@ -283,6 +278,23 @@ class Followers_Controller extends Actors_Controller {
 		$response->header( 'Content-Type', 'application/activity+json; charset=' . \get_option( 'blog_charset' ) );
 
 		return $response;
+	}
+
+	/**
+	 * Normalize a host so comparisons are consistent.
+	 *
+	 * Lowercases, strips IPv6 brackets, and trims a single FQDN trailing
+	 * dot. Used by both the validate_callback for the `authority` arg and
+	 * the signer-host comparison in get_partial_followers() so semantically
+	 * equivalent host strings always match.
+	 *
+	 * @param string $host Raw host string.
+	 * @return string Normalized host.
+	 */
+	private static function normalize_host( $host ) {
+		$host = \strtolower( (string) $host );
+		$host = \trim( $host, '[]' );
+		return \rtrim( $host, '.' );
 	}
 
 	/**

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -102,11 +102,34 @@ class Followers_Controller extends Actors_Controller {
 					},
 					'args'                => array(
 						'authority' => array(
-							'description' => 'The host to filter followers by.',
-							'type'        => 'string',
-							'format'      => 'uri',
-							'pattern'     => '^https?://[^/]+$',
-							'required'    => true,
+							'description'       => 'The host to filter followers by.',
+							'type'              => 'string',
+							'format'            => 'uri',
+							'pattern'           => '^https?://[^/]+$',
+							'required'          => true,
+							'validate_callback' => static function ( $param ) {
+								// Reject internal-address shapes early. The signer-host check downstream
+								// already enforces authority matching the verified peer; this just
+								// keeps obviously-internal values from reaching that code at all.
+								$host = \strtolower( (string) \wp_parse_url( (string) $param, PHP_URL_HOST ) );
+								if ( '' === $host ) {
+									return false;
+								}
+
+								// wp_parse_url returns IPv6 hosts with brackets (e.g. "[::1]") — strip before validation.
+								$host = \trim( $host, '[]' );
+
+								if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
+									return (bool) \filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
+								}
+
+								if ( 'localhost' === $host ) {
+									return false;
+								}
+
+								return ! \str_ends_with( $host, '.localhost' )
+									&& ! \str_ends_with( $host, '.local' );
+							},
 						),
 						'page'      => array(
 							'description' => 'Current page of the collection.',

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -144,7 +144,7 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 		};
 
 		$this->stub_callbacks[] = $callback;
-		\add_filter( 'activitypub_pre_resolve_public_host', $callback, 10, 2 );
+		\add_filter( 'activitypub_pre_resolve_public_host', $callback );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -76,4 +76,39 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 		$this->assertFalse( \Activitypub\resolve_public_host( 12345 ) );
 		$this->assertFalse( \Activitypub\resolve_public_host( array( '8.8.8.8' ) ) );
 	}
+
+	/**
+	 * Data provider for is_ipv4_mapped_ipv6.
+	 *
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public function is_ipv4_mapped_ipv6_provider() {
+		return array(
+			'mapped_loopback'    => array( '::ffff:127.0.0.1', true ),
+			'mapped_rfc1918'     => array( '::ffff:10.0.0.1', true ),
+			'mapped_link_local'  => array( '::ffff:169.254.169.254', true ),
+			'mapped_public'      => array( '::ffff:8.8.8.8', true ),
+			'mapped_hex_form'    => array( '::ffff:7f00:1', true ),
+			'pure_ipv6_loopback' => array( '::1', false ),
+			'pure_ipv6_public'   => array( '2606:4700:4700::1111', false ),
+			'pure_ipv4'          => array( '8.8.8.8', false ),
+			'private_ipv4'       => array( '10.0.0.1', false ),
+			'not_an_ip'          => array( 'not-an-ip', false ),
+			'empty_string'       => array( '', false ),
+		);
+	}
+
+	/**
+	 * Test the IPv4-mapped IPv6 detector.
+	 *
+	 * @dataProvider is_ipv4_mapped_ipv6_provider
+	 *
+	 * @covers \Activitypub\is_ipv4_mapped_ipv6
+	 *
+	 * @param string $ip       The IP literal to check.
+	 * @param bool   $expected Whether it's an IPv4-mapped IPv6 address.
+	 */
+	public function test_is_ipv4_mapped_ipv6( $ip, $expected ) {
+		$this->assertSame( $expected, \Activitypub\is_ipv4_mapped_ipv6( $ip ) );
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -13,6 +13,25 @@ namespace Activitypub\Tests;
 class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 
 	/**
+	 * Filter callbacks registered by stub_resolved_addresses(), removed in tear_down().
+	 *
+	 * @var callable[]
+	 */
+	private $stub_callbacks = array();
+
+	/**
+	 * Tear down registered stubs so they can't leak between tests.
+	 */
+	public function tear_down() {
+		foreach ( $this->stub_callbacks as $callback ) {
+			\remove_filter( 'activitypub_pre_resolve_public_host', $callback );
+		}
+		$this->stub_callbacks = array();
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Test the get_remote_metadata_by_actor function.
 	 *
 	 * @covers \Activitypub\get_remote_metadata_by_actor
@@ -114,19 +133,18 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 
 	/**
 	 * Inject a fixed set of resolved addresses for the next call so the test
-	 * doesn't depend on real DNS.
+	 * doesn't depend on real DNS. The registered filter is recorded and removed
+	 * automatically in tear_down() so it can't leak into later tests.
 	 *
 	 * @param array $addresses ipv4/ipv6 lists to inject.
 	 */
 	private function stub_resolved_addresses( $addresses ) {
-		\add_filter(
-			'activitypub_pre_resolve_public_host',
-			static function () use ( $addresses ) {
-				return $addresses;
-			},
-			10,
-			2
-		);
+		$callback = static function () use ( $addresses ) {
+			return $addresses;
+		};
+
+		$this->stub_callbacks[] = $callback;
+		\add_filter( 'activitypub_pre_resolve_public_host', $callback, 10, 2 );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -111,4 +111,119 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 	public function test_is_ipv4_mapped_ipv6( $ip, $expected ) {
 		$this->assertSame( $expected, \Activitypub\is_ipv4_mapped_ipv6( $ip ) );
 	}
+
+	/**
+	 * Inject a fixed set of resolved addresses for the next call so the test
+	 * doesn't depend on real DNS.
+	 *
+	 * @param array $addresses ipv4/ipv6 lists to inject.
+	 */
+	private function stub_resolved_addresses( $addresses ) {
+		\add_filter(
+			'activitypub_pre_resolve_public_host',
+			static function () use ( $addresses ) {
+				return $addresses;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Public IPv4 from DNS is preferred over the IPv6 fallback.
+	 *
+	 * @covers \Activitypub\resolve_public_host
+	 */
+	public function test_resolve_public_host_prefers_ipv4_when_both_exist() {
+		$this->stub_resolved_addresses(
+			array(
+				'ipv4' => array( '93.184.216.34' ),
+				'ipv6' => array( '2606:2800:220:1:248:1893:25c8:1946' ),
+			)
+		);
+
+		$this->assertSame( '93.184.216.34', \Activitypub\resolve_public_host( 'example.com' ) );
+	}
+
+	/**
+	 * IPv6 is returned when no A records resolve.
+	 *
+	 * @covers \Activitypub\resolve_public_host
+	 */
+	public function test_resolve_public_host_falls_through_to_ipv6() {
+		$this->stub_resolved_addresses(
+			array(
+				'ipv4' => array(),
+				'ipv6' => array( '2606:4700:4700::1111' ),
+			)
+		);
+
+		$this->assertSame( '2606:4700:4700::1111', \Activitypub\resolve_public_host( 'ipv6.example' ) );
+	}
+
+	/**
+	 * A single private IPv4 in the answer set rejects the whole resolution
+	 * (split-horizon DNS defence).
+	 *
+	 * @covers \Activitypub\resolve_public_host
+	 */
+	public function test_resolve_public_host_rejects_split_horizon_ipv4() {
+		$this->stub_resolved_addresses(
+			array(
+				'ipv4' => array( '93.184.216.34', '10.0.0.1' ),
+				'ipv6' => array(),
+			)
+		);
+
+		$this->assertFalse( \Activitypub\resolve_public_host( 'split.example' ) );
+	}
+
+	/**
+	 * A single private IPv6 in the answer set rejects the whole resolution.
+	 *
+	 * @covers \Activitypub\resolve_public_host
+	 */
+	public function test_resolve_public_host_rejects_split_horizon_ipv6() {
+		$this->stub_resolved_addresses(
+			array(
+				'ipv4' => array(),
+				'ipv6' => array( '2606:4700:4700::1111', 'fc00::1' ),
+			)
+		);
+
+		$this->assertFalse( \Activitypub\resolve_public_host( 'split6.example' ) );
+	}
+
+	/**
+	 * IPv4-mapped IPv6 in the AAAA path rejects the whole resolution, just
+	 * like the IP-literal path.
+	 *
+	 * @covers \Activitypub\resolve_public_host
+	 */
+	public function test_resolve_public_host_rejects_ipv4_mapped_aaaa() {
+		$this->stub_resolved_addresses(
+			array(
+				'ipv4' => array(),
+				'ipv6' => array( '::ffff:127.0.0.1' ),
+			)
+		);
+
+		$this->assertFalse( \Activitypub\resolve_public_host( 'mapped.example' ) );
+	}
+
+	/**
+	 * No resolved addresses (empty A and AAAA) yields false.
+	 *
+	 * @covers \Activitypub\resolve_public_host
+	 */
+	public function test_resolve_public_host_returns_false_for_unresolvable() {
+		$this->stub_resolved_addresses(
+			array(
+				'ipv4' => array(),
+				'ipv6' => array(),
+			)
+		);
+
+		$this->assertFalse( \Activitypub\resolve_public_host( 'nx.example' ) );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -237,6 +237,49 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 	}
 
 	/**
+	 * Data provider for authority values that must be rejected by route validation
+	 * before any handler logic runs.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function rejected_authority_provider() {
+		return array(
+			'loopback_ipv4'       => array( 'https://127.0.0.1' ),
+			'rfc1918'             => array( 'https://10.0.0.1' ),
+			'link_local_metadata' => array( 'https://169.254.169.254' ),
+			'unspecified'         => array( 'https://0.0.0.0' ),
+			'ipv6_loopback'       => array( 'https://[::1]' ),
+			'localhost_name'      => array( 'https://localhost' ),
+			'localhost_subdomain' => array( 'https://api.localhost' ),
+			'mdns_local'          => array( 'https://printer.local' ),
+		);
+	}
+
+	/**
+	 * Sync requests with an internal-address authority must be rejected at the
+	 * route validation stage, before signature verification or handler logic.
+	 *
+	 * @dataProvider rejected_authority_provider
+	 *
+	 * @param string $authority The authority value under test.
+	 */
+	public function test_sync_rejects_internal_authority( $authority ) {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
+		$request->set_param( 'authority', $authority );
+		$request->set_param( 'page', 1 );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+
+	/**
 	 * Unsigned anonymous requests to the sync endpoint must be rejected
 	 * because the route is not on the unsigned-GET allowlist.
 	 *

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -244,14 +244,21 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 	 */
 	public function rejected_authority_provider() {
 		return array(
-			'loopback_ipv4'       => array( 'https://127.0.0.1' ),
-			'rfc1918'             => array( 'https://10.0.0.1' ),
-			'link_local_metadata' => array( 'https://169.254.169.254' ),
-			'unspecified'         => array( 'https://0.0.0.0' ),
-			'ipv6_loopback'       => array( 'https://[::1]' ),
-			'localhost_name'      => array( 'https://localhost' ),
-			'localhost_subdomain' => array( 'https://api.localhost' ),
-			'mdns_local'          => array( 'https://printer.local' ),
+			'loopback_ipv4'              => array( 'https://127.0.0.1' ),
+			'rfc1918'                    => array( 'https://10.0.0.1' ),
+			'link_local_metadata'        => array( 'https://169.254.169.254' ),
+			'unspecified'                => array( 'https://0.0.0.0' ),
+			'ipv6_loopback'              => array( 'https://[::1]' ),
+			'localhost_name'             => array( 'https://localhost' ),
+			'localhost_subdomain'        => array( 'https://api.localhost' ),
+			'mdns_local'                 => array( 'https://printer.local' ),
+			// FQDN trailing dot is the same host as without the dot.
+			'localhost_trailing_dot'     => array( 'https://localhost.' ),
+			'mdns_local_trailing_dot'    => array( 'https://printer.local.' ),
+			'sub_localhost_trailing_dot' => array( 'https://api.localhost.' ),
+			// IPv4-mapped IPv6 literals are accepted by FILTER_FLAG_NO_RES_RANGE on some PHP builds; reject them explicitly.
+			'ipv4_mapped_loopback'       => array( 'https://[::ffff:127.0.0.1]' ),
+			'ipv4_mapped_rfc1918'        => array( 'https://[::ffff:10.0.0.1]' ),
 		);
 	}
 


### PR DESCRIPTION
## Proposed changes:

* The FEP-8fcf `/followers/sync` `authority` parameter is the verified peer's host, used downstream as a SQL filter against stored follower GUIDs. There's no outbound fetch, and the existing signer-host check already requires the asked authority to match the verified peer's keyId host — so a crafted authority is practically rejected today.
* Add a route-level `validate_callback` that refuses obvious internal-address shapes (RFC1918, loopback, link-local metadata, unspecified IPv4, IPv6 loopback, `localhost`, `*.localhost`, `*.local`) so those requests fail fast with a clean `rest_invalid_param` error instead of getting deeper into the handler.
* Defense-in-depth: cleaner request validation that doesn't change the security posture in the single-attacker model but documents the intent visibly in the route schema.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Sign a `/followers/sync` request with a valid peer keyId pointing to your real `mastodon.social` (or similar) authority. The request should round-trip as before.
* Replay that request with `authority=https://127.0.0.1`, `https://10.0.0.1`, `https://169.254.169.254`, `https://[::1]`, `https://localhost`, `https://api.localhost`, or `https://printer.local`. Each should return a `400` with `rest_invalid_param` before signature verification even runs.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security

#### Message

Reject follower sync requests targeted at internal-network hosts at the route layer.

</details>