### PR TITLE
Block additional reserved IPv6 ranges in resolve_public_host

### DIFF
--- a/.github/changelog/harden-block-ipv6-transitional-ranges
+++ b/.github/changelog/harden-block-ipv6-transitional-ranges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Blocked additional reserved IPv6 ranges from outbound request safety checks.

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -249,7 +249,10 @@ function is_ipv4_mapped_ipv6( $ip ) {
  *
  * - `2002::/16` — 6to4 (RFC 3056). Embeds an IPv4 address in the next 32 bits,
  *   so e.g. `2002:7f00:0001::1` routes back to `127.0.0.1` on a host with 6to4.
- * - `2001::/32` — Teredo tunneling (RFC 4380).
+ * - `2001:0000::/32` — Teredo tunneling (RFC 4380). The check matches the
+ *   exact 32-bit prefix `2001:0000`, so legitimate `2001::/16` allocations
+ *   like Google DNS `2001:4860::/32` or `2001:db8::/32` (handled separately
+ *   below) are unaffected.
  * - `2001:db8::/32` — Documentation prefix (RFC 3849); should never be routed.
  * - `64:ff9b::/96` — NAT64 well-known prefix (RFC 6052).
  * - `64:ff9b:1::/48` — NAT64 local-use prefix (RFC 8215).

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -250,9 +250,10 @@ function is_ipv4_mapped_ipv6( $ip ) {
  * - `2002::/16` — 6to4 (RFC 3056). Embeds an IPv4 address in the next 32 bits,
  *   so e.g. `2002:7f00:0001::1` routes back to `127.0.0.1` on a host with 6to4.
  * - `2001:0000::/32` — Teredo tunneling (RFC 4380). The check matches the
- *   exact 32-bit prefix `2001:0000`, so legitimate `2001::/16` allocations
- *   like Google DNS `2001:4860::/32` or `2001:db8::/32` (handled separately
- *   below) are unaffected.
+ *   exact 32-bit prefix `2001:0000`, so legitimate `2001::/16` global unicast
+ *   allocations (e.g. Google DNS `2001:4860::/32`) are unaffected. The
+ *   `2001:db8::/32` documentation range is also blocked, by its own entry
+ *   below — they're separate `2001::/16` sub-allocations.
  * - `2001:db8::/32` — Documentation prefix (RFC 3849); should never be routed.
  * - `64:ff9b::/96` — NAT64 well-known prefix (RFC 6052).
  * - `64:ff9b:1::/48` — NAT64 local-use prefix (RFC 8215).

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -153,7 +153,7 @@ function resolve_public_host( $host ) {
 
 	// Already an IP literal — validate directly. Accepts IPv4 and IPv6.
 	if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
-		if ( is_ipv4_mapped_ipv6( $host ) ) {
+		if ( is_unsafe_ipv6_literal( $host ) ) {
 			return false;
 		}
 
@@ -205,7 +205,7 @@ function resolve_public_host( $host ) {
 	}
 
 	foreach ( $ipv6 as $ip ) {
-		if ( is_ipv4_mapped_ipv6( $ip ) ) {
+		if ( is_unsafe_ipv6_literal( $ip ) ) {
 			return false;
 		}
 		if ( ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
@@ -238,4 +238,74 @@ function is_ipv4_mapped_ipv6( $ip ) {
 	return false !== $packed
 		&& 16 === \strlen( $packed )
 		&& "\0\0\0\0\0\0\0\0\0\0\xff\xff" === \substr( $packed, 0, 12 );
+}
+
+/**
+ * Detect IPv6 literals in transitional / special-use ranges that PHP's
+ * FILTER_FLAG_NO_RES_RANGE doesn't reliably block.
+ *
+ * Covers, in addition to the IPv4-mapped range handled by
+ * {@see is_ipv4_mapped_ipv6()}:
+ *
+ * - `2002::/16` — 6to4 (RFC 3056). Embeds an IPv4 address in the next 32 bits,
+ *   so e.g. `2002:7f00:0001::1` routes back to `127.0.0.1` on a host with 6to4.
+ * - `2001::/32` — Teredo tunneling (RFC 4380).
+ * - `2001:db8::/32` — Documentation prefix (RFC 3849); should never be routed.
+ * - `64:ff9b::/96` — NAT64 well-known prefix (RFC 6052).
+ * - `64:ff9b:1::/48` — NAT64 local-use prefix (RFC 8215).
+ * - `100::/64` — Discard prefix (RFC 6666).
+ *
+ * Returns false for IPv4 literals, hostnames, and IPv6 literals outside the
+ * listed ranges.
+ *
+ * @param string $ip An IP literal.
+ *
+ * @return bool True if the value is an unsafe IPv6 literal.
+ */
+function is_unsafe_ipv6_literal( $ip ) {
+	if ( ! is_string( $ip ) || ! \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+		return false;
+	}
+
+	$packed = \inet_pton( $ip );
+	if ( false === $packed || 16 !== \strlen( $packed ) ) {
+		return false;
+	}
+
+	// IPv4-mapped IPv6 prefix.
+	if ( "\0\0\0\0\0\0\0\0\0\0\xff\xff" === \substr( $packed, 0, 12 ) ) {
+		return true;
+	}
+
+	// 6to4 prefix.
+	if ( "\x20\x02" === \substr( $packed, 0, 2 ) ) {
+		return true;
+	}
+
+	// Teredo prefix.
+	if ( "\x20\x01\x00\x00" === \substr( $packed, 0, 4 ) ) {
+		return true;
+	}
+
+	// Documentation prefix.
+	if ( "\x20\x01\x0d\xb8" === \substr( $packed, 0, 4 ) ) {
+		return true;
+	}
+
+	// NAT64 well-known prefix.
+	if ( "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00" === \substr( $packed, 0, 12 ) ) {
+		return true;
+	}
+
+	// NAT64 local-use prefix.
+	if ( "\x00\x64\xff\x9b\x00\x01" === \substr( $packed, 0, 6 ) ) {
+		return true;
+	}
+
+	// Discard prefix.
+	if ( "\x01\x00\x00\x00\x00\x00\x00\x00" === \substr( $packed, 0, 8 ) ) {
+		return true;
+	}
+
+	return false;
 }

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -13,7 +13,7 @@ use Activitypub\Collection\Remote_Actors;
 
 use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_rest_url_by_path;
-use function Activitypub\is_ipv4_mapped_ipv6;
+use function Activitypub\is_unsafe_ipv6_literal;
 
 /**
  * Followers_Controller class.
@@ -123,7 +123,7 @@ class Followers_Controller extends Actors_Controller {
 								}
 
 								if ( \filter_var( $host, FILTER_VALIDATE_IP ) ) {
-									if ( is_ipv4_mapped_ipv6( $host ) ) {
+									if ( is_unsafe_ipv6_literal( $host ) ) {
 										return false;
 									}
 

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -67,6 +67,13 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'ipv4_mapped_rfc1918'         => array( '::ffff:10.0.0.1', false ),
 			'ipv4_mapped_link_local'      => array( '::ffff:169.254.169.254', false ),
 			'ipv4_mapped_public'          => array( '::ffff:8.8.8.8', false ),
+			'sixtofour_loopback'          => array( '2002:7f00:1::1', false ),
+			'sixtofour_rfc1918'           => array( '2002:0a00:0001::1', false ),
+			'teredo'                      => array( '2001:0:53aa:64c:18:7d:11ee:c4', false ),
+			'documentation'               => array( '2001:db8::1', false ),
+			'nat64_well_known'            => array( '64:ff9b::8.8.8.8', false ),
+			'nat64_local_use'             => array( '64:ff9b:1::8.8.8.8', false ),
+			'discard_prefix'              => array( '100::1', false ),
 			'empty_string'                => array( '', false ),
 		);
 	}
@@ -129,6 +136,59 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 	 */
 	public function test_is_ipv4_mapped_ipv6( $ip, $expected ) {
 		$this->assertSame( $expected, \Activitypub\is_ipv4_mapped_ipv6( $ip ) );
+	}
+
+	/**
+	 * Data provider for is_unsafe_ipv6_literal.
+	 *
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public function is_unsafe_ipv6_literal_provider() {
+		return array(
+			// IPv4-mapped IPv6 prefix.
+			'mapped_loopback'        => array( '::ffff:127.0.0.1', true ),
+			'mapped_rfc1918'         => array( '::ffff:10.0.0.1', true ),
+			'mapped_public'          => array( '::ffff:8.8.8.8', true ),
+			// 6to4 prefix; embeds IPv4 in the next 32 bits.
+			'sixtofour_loopback'     => array( '2002:7f00:1::1', true ),
+			'sixtofour_rfc1918'      => array( '2002:0a00:0001::1', true ),
+			'sixtofour_public_embed' => array( '2002:0808:0808::1', true ),
+			// Teredo prefix.
+			'teredo'                 => array( '2001:0:53aa:64c:18:7d:11ee:c4', true ),
+			// Documentation prefix.
+			'documentation'          => array( '2001:db8::1', true ),
+			'documentation_long'     => array( '2001:0db8:85a3::8a2e:0370:7334', true ),
+			// NAT64 well-known prefix.
+			'nat64_well_known'       => array( '64:ff9b::8.8.8.8', true ),
+			// NAT64 local-use prefix.
+			'nat64_local_use'        => array( '64:ff9b:1::8.8.8.8', true ),
+			// Discard prefix.
+			'discard_prefix'         => array( '100::1', true ),
+			// Routable IPv6, unaffected.
+			'pure_ipv6_public'       => array( '2606:4700:4700::1111', false ),
+			'google_dns_v6'          => array( '2001:4860:4860::8888', false ),
+			// Loopback caught elsewhere by NO_RES_RANGE, not by this helper.
+			'pure_ipv6_loopback'     => array( '::1', false ),
+			// Non-IPv6 input.
+			'pure_ipv4'              => array( '8.8.8.8', false ),
+			'private_ipv4'           => array( '10.0.0.1', false ),
+			'not_an_ip'              => array( 'not-an-ip', false ),
+			'empty_string'           => array( '', false ),
+		);
+	}
+
+	/**
+	 * Test the unsafe IPv6 literal detector.
+	 *
+	 * @dataProvider is_unsafe_ipv6_literal_provider
+	 *
+	 * @covers \Activitypub\is_unsafe_ipv6_literal
+	 *
+	 * @param string $ip       The IP literal to check.
+	 * @param bool   $expected Whether it's in an unsafe IPv6 range.
+	 */
+	public function test_is_unsafe_ipv6_literal( $ip, $expected ) {
+		$this->assertSame( $expected, \Activitypub\is_unsafe_ipv6_literal( $ip ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -259,6 +259,13 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 			// IPv4-mapped IPv6 literals are accepted by FILTER_FLAG_NO_RES_RANGE on some PHP builds; reject them explicitly.
 			'ipv4_mapped_loopback'       => array( 'https://[::ffff:127.0.0.1]' ),
 			'ipv4_mapped_rfc1918'        => array( 'https://[::ffff:10.0.0.1]' ),
+			// IPv6 transitional / reserved ranges PHP filter doesn't catch.
+			'sixtofour_loopback'         => array( 'https://[2002:7f00:1::1]' ),
+			'sixtofour_rfc1918'          => array( 'https://[2002:0a00:0001::1]' ),
+			'teredo'                     => array( 'https://[2001:0:53aa:64c:18:7d:11ee:c4]' ),
+			'documentation'              => array( 'https://[2001:db8::1]' ),
+			'nat64_well_known'           => array( 'https://[64:ff9b::8.8.8.8]' ),
+			'discard_prefix'             => array( 'https://[100::1]' ),
 		);
 	}
 


### PR DESCRIPTION
## Proposed changes:

* PHP's `FILTER_FLAG_NO_RES_RANGE` doesn't reject several IPv6 transitional / special-purpose ranges that are unsafe destinations for outbound requests. The most exploitable of these is **6to4** (`2002::/16`): the prefix embeds an IPv4 address in the next 32 bits, so a value like `2002:7f00:0001::1` routes back to `127.0.0.1` on a 6to4-capable host. An attacker controlling DNS for a domain can ship an AAAA record pointing to that, sneak past `resolve_public_host()` today, and reach loopback.
* Add an `is_unsafe_ipv6_literal()` helper that subsumes the existing `is_ipv4_mapped_ipv6()` check and rejects the entire union via packed-byte comparison. The blocklist covers:
  * IPv4-mapped IPv6 (`::ffff:0:0/96`)
  * 6to4 (`2002::/16`)
  * Teredo (`2001::/32`)
  * Documentation (`2001:db8::/32`)
  * NAT64 well-known (`64:ff9b::/96`)
  * NAT64 local-use (`64:ff9b:1::/48`)
  * Discard prefix (`100::/64`)
* Use the new helper in both call sites: `resolve_public_host()`'s IP-literal path and AAAA validation loop, and the `/followers/sync` authority `validate_callback`.
* Test data providers cover every newly-blocked range plus regression coverage for routable IPv6 addresses (Cloudflare, Google) that must continue to pass.

This is opt-in defense-in-depth — the touched paths only fire when the ActivityPub API or SSE features are enabled. Default-config sites are not affected.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* With OAuth (`activitypub_api`) enabled, register a CIMD `client_id` whose AAAA points at a 6to4 address embedding an internal IPv4 (e.g. `2002:0a00:0001::1`). Discovery should be rejected with `activitypub_client_unsafe_host`.
* Same with the SSE eventStream proxy: a remote actor advertising an `eventStream` whose host's AAAA resolves to any of the listed ranges should produce `activitypub_proxy_unsafe_host`.
* Sign a `/followers/sync` request with `authority=https://[2002:7f00:1::1]` (or any other newly-blocked literal). It should return `400 rest_invalid_param` before signature verification.
* Existing public IPv4 / IPv6 traffic continues to work unchanged.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security

#### Message

Blocked additional reserved IPv6 ranges from outbound request safety checks.

</details>