### PR TITLE
Decode percent-encoded authority before the followers/sync blocklist

### DIFF
--- a/.github/changelog/harden-followers-sync-authority-urldecode
+++ b/.github/changelog/harden-followers-sync-authority-urldecode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Decoded percent-encoded forms in the follower sync authority before the safety check.

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -249,8 +249,9 @@ class Followers_Controller extends Actors_Controller {
 		 * matches the signing peer, so that instances cannot "get tricked
 		 * into requesting the followers list of a third-party individual".
 		 */
+		// Match the validate_callback's normalisation so semantically equivalent (decoded) authorities compare equal.
 		$signer_host = self::normalize_host( self::get_signer_host( $request ) );
-		$asked_host  = self::normalize_host( (string) \wp_parse_url( (string) $authority, \PHP_URL_HOST ) );
+		$asked_host  = self::normalize_host( (string) \wp_parse_url( \rawurldecode( (string) $authority ), \PHP_URL_HOST ) );
 
 		if ( ! $signer_host || ! $asked_host || $signer_host !== $asked_host ) {
 			return new \WP_Error(

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -241,17 +241,27 @@ class Followers_Controller extends Actors_Controller {
 	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_partial_followers( $request ) {
-		$user_id   = $request->get_param( 'user_id' );
-		$authority = $request->get_param( 'authority' );
+		$user_id = $request->get_param( 'user_id' );
+
+		/*
+		 * Decode the percent-encoded authority once and use the canonical form
+		 * everywhere downstream. The route accepts authorities whose host has
+		 * percent-encoded octets (RFC 3986 reg-name), so the signer-host
+		 * check, the inbox LIKE query in Followers::get_by_authority(), and
+		 * the response `id` all need to agree on one canonical string. Mixing
+		 * raw and decoded forms would let a request pass the authority match
+		 * yet return an empty follower set, because stored inbox URLs are
+		 * unencoded.
+		 */
+		$authority = \rawurldecode( (string) $request->get_param( 'authority' ) );
 
 		/*
 		 * FEP-8fcf: the responding server MUST ensure the requested authority
 		 * matches the signing peer, so that instances cannot "get tricked
 		 * into requesting the followers list of a third-party individual".
 		 */
-		// Match the validate_callback's normalisation so semantically equivalent (decoded) authorities compare equal.
 		$signer_host = self::normalize_host( self::get_signer_host( $request ) );
-		$asked_host  = self::normalize_host( (string) \wp_parse_url( \rawurldecode( (string) $authority ), \PHP_URL_HOST ) );
+		$asked_host  = self::normalize_host( (string) \wp_parse_url( $authority, \PHP_URL_HOST ) );
 
 		if ( ! $signer_host || ! $asked_host || $signer_host !== $asked_host ) {
 			return new \WP_Error(

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -118,11 +118,13 @@ class Followers_Controller extends Actors_Controller {
 								 * agree.
 								 *
 								 * Percent-decode the input first so encoded forms like
-								 * `http://%5B::1%5D/` (bracketed IPv6 literal hidden inside
+								 * `https://%5B::1%5D` (bracketed IPv6 literal hidden inside
 								 * %5B/%5D) get checked against the same blocklist as the
-								 * unencoded equivalent.
+								 * unencoded equivalent. Use rawurldecode() rather than
+								 * urldecode() — the latter also turns `+` into a space, which
+								 * would corrupt otherwise-valid reg-name hosts.
 								 */
-								$decoded = \urldecode( (string) $param );
+								$decoded = \rawurldecode( (string) $param );
 								$host    = self::normalize_host( (string) \wp_parse_url( $decoded, PHP_URL_HOST ) );
 								if ( '' === $host ) {
 									return false;

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -116,8 +116,14 @@ class Followers_Controller extends Actors_Controller {
 								 * that code at all. Both places run the value through
 								 * self::normalize_host() so semantically equivalent hosts always
 								 * agree.
+								 *
+								 * Percent-decode the input first so encoded forms like
+								 * `http://%5B::1%5D/` (bracketed IPv6 literal hidden inside
+								 * %5B/%5D) get checked against the same blocklist as the
+								 * unencoded equivalent.
 								 */
-								$host = self::normalize_host( (string) \wp_parse_url( (string) $param, PHP_URL_HOST ) );
+								$decoded = \urldecode( (string) $param );
+								$host    = self::normalize_host( (string) \wp_parse_url( $decoded, PHP_URL_HOST ) );
 								if ( '' === $host ) {
 									return false;
 								}

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -266,6 +266,10 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 			'documentation'              => array( 'https://[2001:db8::1]' ),
 			'nat64_well_known'           => array( 'https://[64:ff9b::8.8.8.8]' ),
 			'discard_prefix'             => array( 'https://[100::1]' ),
+			// Percent-encoded forms must be decoded before the blocklist check.
+			'pctenc_localhost'           => array( 'https://%6Cocalhost' ),
+			'pctenc_v6_brackets_lo'      => array( 'https://%5B::1%5D' ),
+			'pctenc_v6_brackets_rfc1918' => array( 'https://%5B::ffff:10.0.0.1%5D' ),
 		);
 	}
 

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -419,6 +419,42 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 	}
 
 	/**
+	 * A percent-encoded authority that decodes to a registered peer host must
+	 * pass the signer-host match AND return the matching follower set. The
+	 * route accepts percent-encoded reg-names, so the handler has to canonicalise
+	 * the value once and use that canonical form for both the authority match
+	 * and the inbox LIKE query — otherwise the request would pass the match
+	 * but fall through to an empty result because stored inbox URLs are
+	 * unencoded.
+	 *
+	 * @covers ::get_partial_followers
+	 */
+	public function test_sync_decodes_percent_encoded_authority_for_query() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		\delete_user_option( $user_id, 'activitypub_hide_social_graph' );
+
+		$post_id = $this->seed_follower_on_host( 'peer.example' );
+		Followers::add( $user_id, 'https://peer.example/users/alice' );
+
+		// "%70" decodes to "p"; "%65" decodes to "e". Decoded authority is "https://peer.example".
+		$request    = $this->build_sync_request( $user_id, 'https://%70eer.example', 'https://peer.example/users/peer' );
+		$controller = new \Activitypub\Rest\Followers_Controller();
+
+		try {
+			$response = $controller->get_partial_followers( $request );
+
+			$this->assertNotWPError( $response );
+			$data = $response->get_data();
+			$this->assertArrayHasKey( 'orderedItems', $data );
+			$this->assertContains( 'https://peer.example/users/alice', $data['orderedItems'] );
+		} finally {
+			\wp_delete_post( $post_id, true );
+			\delete_option( 'activitypub_actor_mode' );
+		}
+	}
+
+	/**
 	 * The defer-signature filter receives `$force_signature` as a third
 	 * argument so hooks can preserve mandatory signing on peer-only
 	 * endpoints like `/followers/sync` without touching unrelated requests.


### PR DESCRIPTION
## Proposed changes:

* The `/followers/sync` `authority` `validate_callback` parsed the host straight out of `wp_parse_url()` without first decoding percent-encoded characters. A value like `https://%5B::1%5D/` — bracketed IPv6 literal hidden behind `%5B`/`%5D` — yielded a host string of `%5B:` that didn't match any of the `localhost` / `*.local` / IP-literal exclusions, so it slipped past the validate_callback.
* The downstream signer-host check at `get_partial_followers()` would still reject the request (the signer's keyId never decodes to `%5b:`), so this isn't an exploitable SSRF on its own. The fix lines up the validator's decisions with the real host the request would target — defense-in-depth.
* Run `urldecode()` on the input before parsing so encoded forms are checked against the same blocklist as their decoded equivalents.
* Three encoded variants added to the test data provider: `%6Cocalhost`, `%5B::1%5D`, `%5B::ffff:10.0.0.1%5D`.

This is opt-in defense-in-depth — the touched path only fires when FEP-8fcf `/followers/sync` is hit by a remote peer.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Sign a `/followers/sync` request with `authority=https://%5B::1%5D/`. The validate_callback should reject it before signature verification, returning `400 rest_invalid_param`.
* Same with `authority=https://%6Cocalhost` (encoded `localhost`) — also rejected at the validator.
* Existing un-encoded authority strings continue to behave the same.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security

#### Message

Decoded percent-encoded forms in the follower sync authority before the safety check.

</details>