### PR TITLE
Require signatures on HEAD requests to peer-only endpoints

### DIFF
--- a/.github/changelog/harden-head-mandatory-auth
+++ b/.github/changelog/harden-head-mandatory-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Required signatures on HEAD requests to peer-only endpoints.

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -27,20 +27,23 @@ trait Verification {
 	 *
 	 * Verifies the signature of POST, PUT, PATCH, and DELETE requests,
 	 * as well as GET requests when authorized fetch is enabled.
-	 * HEAD requests are always bypassed.
+	 * HEAD requests are bypassed by default so caches and link-checkers
+	 * can probe public endpoints; callers that pass `$force_signature`
+	 * (e.g. FEP-8fcf's `/followers/sync`) require signatures on HEAD too.
 	 *
 	 * @see https://www.w3.org/wiki/SocialCG/ActivityPub/Primer/Authentication_Authorization#Authorized_fetch
 	 * @see https://swicg.github.io/activitypub-http-signature/#authorized-fetch
 	 *
 	 * @param \WP_REST_Request $request         The request object.
-	 * @param bool             $force_signature Optional. When true, GET requests also require a
-	 *                                          valid signature even with Authorized Fetch
-	 *                                          disabled. Use for endpoints that are peer-only
-	 *                                          (e.g. FEP-8fcf's `/followers/sync`). Default false.
+	 * @param bool             $force_signature Optional. When true, GET and HEAD requests also
+	 *                                          require a valid signature even with Authorized
+	 *                                          Fetch disabled. Use for endpoints that are
+	 *                                          peer-only (e.g. FEP-8fcf's `/followers/sync`).
+	 *                                          Default false.
 	 * @return bool|\WP_Error True if authorized, WP_Error otherwise.
 	 */
 	public function verify_signature( $request, $force_signature = false ) {
-		if ( 'HEAD' === $request->get_method() ) {
+		if ( 'HEAD' === $request->get_method() && ! $force_signature ) {
 			return true;
 		}
 

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -307,7 +307,7 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 
 		\delete_option( 'activitypub_actor_mode' );
 
-		$this->assertSame( 401, $response->get_status() );
+		$this->assertErrorResponse( 'activitypub_signature_verification', $response, 401 );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -306,15 +306,17 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
-		$request = new \WP_REST_Request( 'HEAD', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
-		$request->set_param( 'authority', 'https://evil.example' );
-		$request->set_param( 'page', 1 );
+		try {
+			$request = new \WP_REST_Request( 'HEAD', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
+			$request->set_param( 'authority', 'https://evil.example' );
+			$request->set_param( 'page', 1 );
 
-		$response = rest_get_server()->dispatch( $request );
+			$response = rest_get_server()->dispatch( $request );
 
-		\delete_option( 'activitypub_actor_mode' );
-
-		$this->assertErrorResponse( 'activitypub_signature_verification', $response, 401 );
+			$this->assertErrorResponse( 'activitypub_signature_verification', $response, 401 );
+		} finally {
+			\delete_option( 'activitypub_actor_mode' );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -287,6 +287,30 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 	}
 
 	/**
+	 * HEAD requests to the FEP-8fcf endpoint must require a signature too.
+	 *
+	 * The default verify_signature() bypasses HEAD so caches/link-checkers
+	 * can probe public endpoints, but a peer-only route (`$force_signature`
+	 * = true) must not leak existence to unauthenticated callers via HEAD.
+	 *
+	 * @covers \Activitypub\Rest\Verification::verify_signature
+	 */
+	public function test_sync_rejects_unsigned_head_request() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$request = new \WP_REST_Request( 'HEAD', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
+		$request->set_param( 'authority', 'https://evil.example' );
+		$request->set_param( 'page', 1 );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
 	 * Unsigned anonymous requests to the sync endpoint must be rejected
 	 * because the route is not on the unsigned-GET allowlist.
 	 *


### PR DESCRIPTION
## Proposed changes:

* `verify_signature()` short-circuits on HEAD so caches and link-checkers can probe public endpoints without needing to sign — that's the right default. But the bypass also applied to peer-only routes that pass `$force_signature = true` (today only FEP-8fcf's `/followers/sync`). Result: an unauthenticated HEAD on `/followers/sync` reached the handler, which then rejected with 403 (authority mismatch) — same outcome as a malformed authority, instead of the spec-correct 401 (signature required).
* No data leak (HEAD always strips the body), but the status-code semantics violated the FEP-8fcf "authentication required" contract: a peer-only route shouldn't accept any unsigned method. RFC 9110 also treats HEAD identically to GET for authentication; FEP-8fcf doesn't carve out a method-specific allowance.
* Tighten the bypass to apply only when `$force_signature` is false. Mandatory-signing endpoints now reject unsigned HEAD with 401, matching how unsigned GET on the same endpoint is rejected.

**Browser-app compatibility verified:**
* Browser CORS preflight uses `OPTIONS`, not HEAD. WP core's `rest_handle_options_request` handles OPTIONS via the `rest_pre_dispatch` filter and never reaches `verify_signature`.
* The plugin's own OPTIONS preflight bypass in `class-router.php:92` is on the WordPress main-query path (outbox permalinks), not REST routes — also untouched.
* The only REST route currently passing `$force_signature = true` is `/followers/sync`, which is server-to-server (FEP-8fcf), not browser-facing.

So this fix narrows the HEAD bypass to non-mandatory-auth endpoints while leaving every browser flow untouched.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Sign a `/followers/sync` request with a valid keyId and round-trip it as a GET. Should respond as before.
* Send the same request as `HEAD` without a Signature header. Should now return `401` with `activitypub_signature_verification` (was `403 activitypub_authority_mismatch`).
* HEAD on any other endpoint (`/inbox`, `/actors/{id}`, `/oauth/authorization-server-metadata`, etc.) still returns whatever it would have returned on GET, body stripped. No regression for caches/link-checkers.
* Browser CORS preflight on the C2S API continues to work (OPTIONS, handled by WP core before `verify_signature` runs).

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Security

#### Message

Required signatures on HEAD requests to peer-only endpoints.

</details>