### PR TITLE
Return 429 from the OAuth token endpoint when rate-limited

### DIFF
--- a/.github/changelog/update-oauth-token-rate-limit-status
+++ b/.github/changelog/update-oauth-token-rate-limit-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Returned the standard rate-limit response from the OAuth token endpoint when too many requests are sent.

--- a/includes/rest/oauth/class-token-controller.php
+++ b/includes/rest/oauth/class-token-controller.php
@@ -154,13 +154,13 @@ class Token_Controller extends \WP_REST_Controller {
 		// Rate-limit token requests to prevent brute-force attacks (max 20 per minute per IP).
 		$ip = get_client_ip();
 		if ( '' === $ip ) {
-			return $this->token_error( 'invalid_request', 'Too many token requests. Please try again later.' );
+			return $this->token_error( 'rate_limited', 'Too many token requests. Please try again later.', 429 );
 		}
 		$transient_key = 'ap_oauth_tok_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 
 		if ( $count >= 20 ) {
-			return $this->token_error( 'invalid_request', 'Too many token requests. Please try again later.' );
+			return $this->token_error( 'rate_limited', 'Too many token requests. Please try again later.', 429 );
 		}
 
 		\set_transient( $transient_key, $count + 1, MINUTE_IN_SECONDS );
@@ -392,15 +392,17 @@ class Token_Controller extends \WP_REST_Controller {
 	 *
 	 * @param string $error             Error code.
 	 * @param string $error_description Error description.
+	 * @param int    $status            Optional. HTTP status code. Defaults to 400 per RFC 6749 §5.2;
+	 *                                  callers should pass 429 for rate-limit responses (RFC 6585).
 	 * @return \WP_REST_Response
 	 */
-	private function token_error( $error, $error_description ) {
+	private function token_error( $error, $error_description, $status = 400 ) {
 		return new \WP_REST_Response(
 			array(
 				'error'             => $error,
 				'error_description' => $error_description,
 			),
-			400,
+			$status,
 			array( 'Content-Type' => 'application/json' )
 		);
 	}

--- a/includes/rest/oauth/class-token-controller.php
+++ b/includes/rest/oauth/class-token-controller.php
@@ -403,7 +403,12 @@ class Token_Controller extends \WP_REST_Controller {
 				'error_description' => $error_description,
 			),
 			$status,
-			array( 'Content-Type' => 'application/json' )
+			array(
+				'Content-Type'  => 'application/json',
+				// RFC 6749 §5.1 requires the same no-cache headers on error responses as on success responses.
+				'Cache-Control' => 'no-store',
+				'Pragma'        => 'no-cache',
+			)
 		);
 	}
 

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -147,6 +147,35 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the token endpoint returns 429 when the per-IP rate limit
+	 * is hit, rather than the previous 400 / `invalid_request` shape.
+	 *
+	 * @covers ::token
+	 */
+	public function test_token_rate_limited_returns_429() {
+		$ip            = \Activitypub\get_client_ip();
+		$transient_key = 'ap_oauth_tok_' . \md5( $ip );
+
+		\set_transient( $transient_key, 20, MINUTE_IN_SECONDS );
+
+		try {
+			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/token' );
+			$request->set_param( 'grant_type', 'authorization_code' );
+			$request->set_param( 'client_id', $this->client_id );
+			$request->set_param( 'code', 'irrelevant' );
+			$request->set_param( 'redirect_uri', $this->redirect_uri );
+
+			$response = \rest_get_server()->dispatch( $request );
+			$data     = $response->get_data();
+
+			$this->assertEquals( 429, $response->get_status() );
+			$this->assertEquals( 'rate_limited', $data['error'] );
+		} finally {
+			\delete_transient( $transient_key );
+		}
+	}
+
+	/**
 	 * Test token request with unknown client.
 	 *
 	 * @covers ::token

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -153,6 +153,13 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 	 * @covers ::token
 	 */
 	public function test_token_rate_limited_returns_429() {
+		// Pin REMOTE_ADDR so this test exercises the >=20 cap branch, not the
+		// fail-closed empty-IP branch (both produce 429 today, but the cap
+		// branch is what this test claims to cover).
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing test fixture for restore.
+		$snapshot_remote_addr   = \array_key_exists( 'REMOTE_ADDR', $_SERVER ) ? $_SERVER['REMOTE_ADDR'] : null;
+		$_SERVER['REMOTE_ADDR'] = '198.51.100.42';
+
 		$ip            = \Activitypub\get_client_ip();
 		$transient_key = 'ap_oauth_tok_' . \md5( $ip );
 
@@ -167,11 +174,19 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 
 			$response = \rest_get_server()->dispatch( $request );
 			$data     = $response->get_data();
+			$headers  = $response->get_headers();
 
 			$this->assertEquals( 429, $response->get_status() );
 			$this->assertEquals( 'rate_limited', $data['error'] );
+			$this->assertSame( 'no-store', $headers['Cache-Control'] ?? null, 'Token error responses must set Cache-Control: no-store per RFC 6749 §5.1.' );
+			$this->assertSame( 'no-cache', $headers['Pragma'] ?? null, 'Token error responses must set Pragma: no-cache per RFC 6749 §5.1.' );
 		} finally {
 			\delete_transient( $transient_key );
+			if ( null === $snapshot_remote_addr ) {
+				unset( $_SERVER['REMOTE_ADDR'] );
+			} else {
+				$_SERVER['REMOTE_ADDR'] = $snapshot_remote_addr;
+			}
 		}
 	}
 

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -147,17 +147,66 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * $_SERVER keys get_client_ip() walks. Tests that exercise specific
+	 * rate-limit branches need to control all of them so a stray header
+	 * from another test or the runner can't change which branch fires.
+	 *
+	 * @var string[]
+	 */
+	private static $client_ip_server_keys = array(
+		'REMOTE_ADDR',
+		'HTTP_CF_CONNECTING_IP',
+		'HTTP_CLIENT_IP',
+		'HTTP_X_FORWARDED_FOR',
+		'HTTP_X_FORWARDED',
+		'HTTP_X_CLUSTER_CLIENT_IP',
+		'HTTP_FORWARDED_FOR',
+		'HTTP_FORWARDED',
+	);
+
+	/**
+	 * Capture every $_SERVER key get_client_ip() touches so each test in
+	 * this group can restore them in its own try/finally.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function snapshot_client_ip_server() {
+		$snapshot = array();
+		foreach ( self::$client_ip_server_keys as $key ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing existing test fixture values for restore.
+			$snapshot[ $key ] = \array_key_exists( $key, $_SERVER ) ? $_SERVER[ $key ] : null;
+		}
+		return $snapshot;
+	}
+
+	/**
+	 * Restore $_SERVER values captured by snapshot_client_ip_server().
+	 *
+	 * @param array<string, mixed> $snapshot Snapshot returned by snapshot_client_ip_server().
+	 */
+	private function restore_client_ip_server( $snapshot ) {
+		foreach ( $snapshot as $key => $value ) {
+			if ( null === $value ) {
+				unset( $_SERVER[ $key ] );
+			} else {
+				$_SERVER[ $key ] = $value;
+			}
+		}
+	}
+
+	/**
 	 * Test that the token endpoint returns 429 when the per-IP rate limit
 	 * is hit, rather than the previous 400 / `invalid_request` shape.
 	 *
 	 * @covers ::token
 	 */
 	public function test_token_rate_limited_returns_429() {
-		// Pin REMOTE_ADDR so this test exercises the >=20 cap branch, not the
-		// fail-closed empty-IP branch (both produce 429 today, but the cap
-		// branch is what this test claims to cover).
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Capturing test fixture for restore.
-		$snapshot_remote_addr   = \array_key_exists( 'REMOTE_ADDR', $_SERVER ) ? $_SERVER['REMOTE_ADDR'] : null;
+		// Snapshot every IP-bearing header so a stray HTTP_X_FORWARDED_FOR from
+		// the runner or another test can't change which branch fires.
+		$snapshot = $this->snapshot_client_ip_server();
+		foreach ( self::$client_ip_server_keys as $key ) {
+			unset( $_SERVER[ $key ] );
+		}
 		$_SERVER['REMOTE_ADDR'] = '198.51.100.42';
 
 		$ip            = \Activitypub\get_client_ip();
@@ -182,11 +231,42 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 			$this->assertSame( 'no-cache', $headers['Pragma'] ?? null, 'Token error responses must set Pragma: no-cache per RFC 6749 §5.1.' );
 		} finally {
 			\delete_transient( $transient_key );
-			if ( null === $snapshot_remote_addr ) {
-				unset( $_SERVER['REMOTE_ADDR'] );
-			} else {
-				$_SERVER['REMOTE_ADDR'] = $snapshot_remote_addr;
-			}
+			$this->restore_client_ip_server( $snapshot );
+		}
+	}
+
+	/**
+	 * Test that the token endpoint fails closed with 429 when no client IP
+	 * can be determined — the empty-IP branch in token() must behave the
+	 * same as the >=20 cap branch.
+	 *
+	 * @covers ::token
+	 */
+	public function test_token_rate_limited_returns_429_without_client_ip() {
+		$snapshot = $this->snapshot_client_ip_server();
+		foreach ( self::$client_ip_server_keys as $key ) {
+			unset( $_SERVER[ $key ] );
+		}
+
+		$empty_ip_transient = 'ap_oauth_tok_' . \md5( '' );
+		\delete_transient( $empty_ip_transient );
+
+		try {
+			$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/token' );
+			$request->set_param( 'grant_type', 'authorization_code' );
+			$request->set_param( 'client_id', $this->client_id );
+			$request->set_param( 'code', 'irrelevant' );
+			$request->set_param( 'redirect_uri', $this->redirect_uri );
+
+			$response = \rest_get_server()->dispatch( $request );
+			$data     = $response->get_data();
+
+			$this->assertEquals( 429, $response->get_status() );
+			$this->assertEquals( 'rate_limited', $data['error'] );
+			// The fail-closed branch must not write a shared empty-IP transient.
+			$this->assertFalse( \get_transient( $empty_ip_transient ) );
+		} finally {
+			$this->restore_client_ip_server( $snapshot );
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:

* The `/oauth/token` endpoint's two rate-limit branches (no-IP fail-closed and the `>=20/min` cap) returned HTTP 400 with the OAuth `error_code: invalid_request` because the `token_error()` helper was hard-wired to status 400. That confused two unrelated cases — "your request was malformed" and "you're being throttled" — into the same response shape.
* RFC 6749 §5.2 specifies 400 for OAuth-defined error codes, but rate limiting isn't an OAuth-defined error. RFC 6585 defines 429 "Too Many Requests" for that case, and every other OAuth controller in this plugin (`/oauth/authorize`, `/oauth/clients`, `/oauth/revoke`) already returns 429. The token endpoint was the odd one out.
* Add an optional `$status` parameter to `token_error()` defaulting to 400 (existing callers unchanged) and use 429 with a `rate_limited` error code on both rate-limit branches. Adds a controller test asserting the new shape.

This is a UX/protocol-correctness improvement — clients can distinguish "I have a coding error" from "I am being throttled" and cooperative tooling that watches for 429 will now see the rate-limit signal.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Hit `/oauth/token` 21 times in a minute from the same IP. The 21st call should return `429 {"error":"rate_limited", …}` instead of `400 {"error":"invalid_request", …}`.
* On a misconfigured proxy / no-IP install, the very first token call should immediately return `429 rate_limited` (was `400 invalid_request`).
* All other token errors (`invalid_client`, `invalid_grant`, `unsupported_grant_type`, `invalid_request` for missing code/refresh_token) continue to return 400 with their existing OAuth error codes.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Changed

#### Message

Returned the standard rate-limit response from the OAuth token endpoint when too many requests are sent.

</details>