### PR TITLE
Drop credentialed CORS reflection on ActivityPub REST endpoints

### DIFF
--- a/.github/changelog/fix-cors-drop-allow-credentials
+++ b/.github/changelog/fix-cors-drop-allow-credentials
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+ActivityPub REST endpoints no longer advertise credentialed cross-origin access. Browser-based clients using OAuth bearer tokens continue to work as before.

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -173,7 +173,7 @@ class Server {
 		$namespace = '/' . ACTIVITYPUB_REST_NAMESPACE;
 
 		// Only add CORS to ActivityPub endpoints, except the interactive OAuth authorize endpoint.
-		if ( ! \str_starts_with( $route, $namespace ) || \str_contains( $route, $namespace . '/oauth/authorize' ) ) {
+		if ( ! \str_starts_with( $route, $namespace ) || \str_starts_with( $route, $namespace . '/oauth/authorize' ) ) {
 			return $response;
 		}
 

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -177,15 +177,17 @@ class Server {
 			return $response;
 		}
 
-		$origin = self::get_cors_origin();
-		$response->header( 'Access-Control-Allow-Origin', $origin ? $origin : '*' );
+		/*
+		 * ActivityPub data is meant to be publicly readable by federation peers
+		 * and browser-side clients. We do not enable credentialed cross-origin
+		 * access: cookie auth would still be rejected by WordPress core's
+		 * REST nonce check, and OAuth Bearer tokens travel in the
+		 * Authorization header — which is permitted via Allow-Headers and
+		 * does not require Allow-Credentials.
+		 */
+		$response->header( 'Access-Control-Allow-Origin', '*' );
 		$response->header( 'Access-Control-Allow-Methods', 'GET, POST, OPTIONS' );
 		$response->header( 'Access-Control-Allow-Headers', 'Accept, Content-Type, Authorization, Last-Event-ID' );
-
-		if ( $origin ) {
-			$response->header( 'Access-Control-Allow-Credentials', 'true' );
-			$response->header( 'Vary', 'Origin' );
-		}
 
 		return $response;
 	}
@@ -199,29 +201,8 @@ class Server {
 	 * @since 8.1.0
 	 */
 	public static function send_cors_headers() {
-		$origin = self::get_cors_origin();
-
-		\header( 'Access-Control-Allow-Origin: ' . ( $origin ? $origin : '*' ) );
+		\header( 'Access-Control-Allow-Origin: *' );
 		\header( 'Access-Control-Allow-Methods: GET, POST, OPTIONS' );
 		\header( 'Access-Control-Allow-Headers: Accept, Content-Type, Authorization, Last-Event-ID' );
-
-		if ( $origin ) {
-			\header( 'Access-Control-Allow-Credentials: true' );
-			\header( 'Vary: Origin' );
-		}
-	}
-
-	/**
-	 * Get the CORS origin from the request.
-	 *
-	 * Reflects the request Origin instead of using a wildcard to avoid
-	 * leaking private data to arbitrary origins on authenticated endpoints.
-	 *
-	 * @since 8.1.0
-	 *
-	 * @return string The origin or empty string.
-	 */
-	private static function get_cors_origin() {
-		return isset( $_SERVER['HTTP_ORIGIN'] ) ? \esc_url_raw( \wp_unslash( $_SERVER['HTTP_ORIGIN'] ) ) : '';
 	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-server.php
+++ b/tests/phpunit/tests/includes/rest/class-test-server.php
@@ -283,4 +283,69 @@ class Test_Server extends \WP_Test_REST_TestCase {
 		$this->assertEquals( $expected_title, $data['title'] );
 		$this->assertEquals( $expected_detail, $data['detail'] );
 	}
+
+	/**
+	 * ActivityPub data is publicly readable, so CORS uses a wildcard origin
+	 * with no credentials. Reflecting an arbitrary Origin together with
+	 * Allow-Credentials would let a logged-in user's browser expose
+	 * authenticated responses to a third-party page; we explicitly avoid
+	 * that combination on every ActivityPub REST response.
+	 *
+	 * @covers ::add_cors_headers
+	 */
+	public function test_add_cors_headers_uses_wildcard_without_credentials() {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Test snapshot of raw global; restored verbatim.
+		$origin_backup = $_SERVER['HTTP_ORIGIN'] ?? null;
+
+		try {
+			$_SERVER['HTTP_ORIGIN'] = 'https://evil.example';
+
+			$response = new \WP_REST_Response( array(), 200 );
+			$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+
+			$result  = Server::add_cors_headers( $response, new \WP_REST_Server(), $request );
+			$headers = $result->get_headers();
+
+			$this->assertSame( '*', $headers['Access-Control-Allow-Origin'] );
+			$this->assertArrayNotHasKey( 'Access-Control-Allow-Credentials', $headers );
+			$this->assertArrayNotHasKey( 'Vary', $headers );
+		} finally {
+			if ( null === $origin_backup ) {
+				unset( $_SERVER['HTTP_ORIGIN'] );
+			} else {
+				$_SERVER['HTTP_ORIGIN'] = $origin_backup;
+			}
+		}
+	}
+
+	/**
+	 * Non-ActivityPub routes must not receive ActivityPub CORS headers.
+	 *
+	 * @covers ::add_cors_headers
+	 */
+	public function test_add_cors_headers_skips_non_activitypub_routes() {
+		$response = new \WP_REST_Response( array(), 200 );
+		$request  = new \WP_REST_Request( 'GET', '/wp/v2/posts' );
+
+		$result  = Server::add_cors_headers( $response, new \WP_REST_Server(), $request );
+		$headers = $result->get_headers();
+
+		$this->assertArrayNotHasKey( 'Access-Control-Allow-Origin', $headers );
+	}
+
+	/**
+	 * The interactive OAuth authorize endpoint must not advertise CORS;
+	 * it relies on top-level navigation, not cross-origin XHR.
+	 *
+	 * @covers ::add_cors_headers
+	 */
+	public function test_add_cors_headers_skips_oauth_authorize() {
+		$response = new \WP_REST_Response( array(), 200 );
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/authorize' );
+
+		$result  = Server::add_cors_headers( $response, new \WP_REST_Server(), $request );
+		$headers = $result->get_headers();
+
+		$this->assertArrayNotHasKey( 'Access-Control-Allow-Origin', $headers );
+	}
 }


### PR DESCRIPTION
## Summary

- ActivityPub REST endpoints stop setting \`Access-Control-Allow-Credentials: true\` and stop reflecting the request \`Origin\`. They always emit \`Access-Control-Allow-Origin: *\` instead.
- Removes the unused \`get_cors_origin()\` helper.
- Adds tests covering the wildcard-without-credentials shape, plus the non-ActivityPub-route and OAuth-authorize bypass paths.

## Why

ActivityPub data is meant to be publicly readable, so the credentialed cross-origin shape was the wrong one. The reflect + \`Allow-Credentials: true\` combination would in principle let a third-party page read authenticated cross-origin responses; in practice WordPress core's REST nonce check rejects cookie auth without a nonce, and modern browsers' SameSite=Lax default stops the cookies from being sent on cross-site \`fetch()\` at all — so this isn't directly exploitable today. But the headers shouldn't invite the attempt, and a misconfigured cookie or a third-party plugin removing the nonce check would turn it into a real bug.

The C2S browser flow uses OAuth Bearer tokens via the \`Authorization\` header, which is permitted via \`Allow-Headers\` and does not require \`Allow-Credentials\` — so this change preserves every intended use case.

## Test plan

- [ ] \`composer lint\` passes.
- [ ] \`Test_Server\` suite passes (18 tests).
- [ ] Browser-based C2S app (OAuth Bearer token) can still read \`/wp-json/activitypub/1.0/...\` cross-origin.
- [ ] Federation peer GET to actor / outbox / followers still returns the public collection.