### PR TITLE
Stop trusting client-supplied proxy headers for rate-limit IP by default

### DIFF
--- a/.github/changelog/fix-rate-limit-untrusted-proxy-headers
+++ b/.github/changelog/fix-rate-limit-untrusted-proxy-headers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Per-IP rate limits now only trust the actual TCP peer by default, so an attacker on a directly-exposed site cannot bypass the cap by spoofing X-Forwarded-For or similar proxy headers. Sites behind a trusted reverse proxy (Cloudflare, Akamai, nginx) can opt the relevant header back in via the new "activitypub_trusted_proxy_headers" filter.

--- a/.github/changelog/fix-rate-limit-untrusted-proxy-headers
+++ b/.github/changelog/fix-rate-limit-untrusted-proxy-headers
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Per-IP rate limits now only trust the actual TCP peer by default, so an attacker on a directly-exposed site cannot bypass the cap by spoofing X-Forwarded-For or similar proxy headers. Sites behind a trusted reverse proxy (Cloudflare, Akamai, nginx) can opt the relevant header back in via the new "activitypub_trusted_proxy_headers" filter.
+Per-IP rate limits now only trust the actual TCP peer by default, so an attacker on a directly-exposed site cannot bypass the cap by spoofing X-Forwarded-For or similar proxy headers. Sites behind a trusted reverse proxy (Cloudflare, Akamai, nginx) can opt the relevant header back in via the new "activitypub_client_ip_sources" filter.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -362,18 +362,36 @@ function get_client_ip() {
 	// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 	$ip = '';
 
-	$headers = array(
-		'HTTP_CF_CONNECTING_IP', // Cloudflare.
-		'HTTP_CLIENT_IP',
-		'HTTP_X_FORWARDED_FOR',
-		'HTTP_X_FORWARDED',
-		'HTTP_X_CLUSTER_CLIENT_IP',
-		'HTTP_FORWARDED_FOR',
-		'HTTP_FORWARDED',
-	);
+	/**
+	 * Filter the list of $_SERVER keys that should be trusted as a source for
+	 * the client IP, before falling back to REMOTE_ADDR.
+	 *
+	 * Empty by default. Only opt a header in here when a trusted reverse
+	 * proxy in front of the site sets it and overwrites any client-supplied
+	 * value. Trusting one of these headers on a site that PHP serves
+	 * directly lets attackers spoof the value and bypass the rate limits
+	 * that depend on it.
+	 *
+	 * Common values:
+	 *   array( 'HTTP_CF_CONNECTING_IP' )   on Cloudflare.
+	 *   array( 'HTTP_TRUE_CLIENT_IP' )     on Akamai or Cloudflare Enterprise.
+	 *   array( 'HTTP_X_REAL_IP' )          on nginx that strips the client copy.
+	 *
+	 * X-Forwarded-For pitfall: even with a trusted proxy, an attacker can
+	 * prepend their own value before the proxy appends the real client IP.
+	 * This helper takes the leftmost entry, which is correct only when the
+	 * trusted proxy fully overwrites the header. If you trust X-Forwarded-For
+	 * end-to-end, prefer to resolve from the right by your known proxy count
+	 * via the activitypub_client_ip filter.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string[] $headers $_SERVER keys to consult, in priority order.
+	 */
+	$headers = (array) \apply_filters( 'activitypub_trusted_proxy_headers', array() );
 
 	foreach ( $headers as $header ) {
-		if ( empty( $_SERVER[ $header ] ) ) {
+		if ( ! \is_string( $header ) || empty( $_SERVER[ $header ] ) ) {
 			continue;
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -363,19 +363,19 @@ function get_client_ip() {
 	$ip = '';
 
 	/**
-	 * Filter the list of $_SERVER keys that should be trusted as a source for
-	 * the client IP, before falling back to REMOTE_ADDR.
+	 * Filter the ordered list of $_SERVER keys to consult as a source for the
+	 * client IP. The first key whose value parses as a valid IP wins.
 	 *
-	 * Empty by default. Only opt a header in here when a trusted reverse
-	 * proxy in front of the site sets it and overwrites any client-supplied
-	 * value. Trusting one of these headers on a site that PHP serves
-	 * directly lets attackers spoof the value and bypass the rate limits
-	 * that depend on it.
+	 * Default: array( 'REMOTE_ADDR' ) — the actual TCP peer, the only value
+	 * that an HTTP client cannot spoof. Trusting any other $_SERVER key is
+	 * only safe when a reverse proxy in front of the site sets that key and
+	 * overwrites any client-supplied version; otherwise an attacker can spoof
+	 * the value and bypass the per-IP rate limits that depend on it.
 	 *
-	 * Common values:
-	 *   array( 'HTTP_CF_CONNECTING_IP' )   on Cloudflare.
-	 *   array( 'HTTP_TRUE_CLIENT_IP' )     on Akamai or Cloudflare Enterprise.
-	 *   array( 'HTTP_X_REAL_IP' )          on nginx that strips the client copy.
+	 * Common operator overrides:
+	 *   array( 'HTTP_CF_CONNECTING_IP' )                      on Cloudflare.
+	 *   array( 'HTTP_TRUE_CLIENT_IP', 'REMOTE_ADDR' )         Akamai with a fallback.
+	 *   array( 'HTTP_X_REAL_IP' )                             nginx that strips the client copy.
 	 *
 	 * X-Forwarded-For pitfall: even with a trusted proxy, an attacker can
 	 * prepend their own value before the proxy appends the real client IP.
@@ -386,29 +386,26 @@ function get_client_ip() {
 	 *
 	 * @since unreleased
 	 *
-	 * @param string[] $headers $_SERVER keys to consult, in priority order.
+	 * @param string[] $sources $_SERVER keys to consult, in priority order.
 	 */
-	$headers = (array) \apply_filters( 'activitypub_trusted_proxy_headers', array() );
+	$sources = \apply_filters( 'activitypub_client_ip_sources', array( 'REMOTE_ADDR' ) );
 
-	foreach ( $headers as $header ) {
-		if ( ! \is_string( $header ) || empty( $_SERVER[ $header ] ) ) {
+	if ( ! \is_array( $sources ) ) {
+		$sources = array( 'REMOTE_ADDR' );
+	}
+
+	foreach ( $sources as $source ) {
+		if ( ! \is_string( $source ) || empty( $_SERVER[ $source ] ) ) {
 			continue;
 		}
 
 		// Some headers (e.g. X-Forwarded-For) may contain a comma-separated list; use the first IP.
-		$ip_list   = \sanitize_text_field( \wp_unslash( $_SERVER[ $header ] ) );
+		$ip_list   = \sanitize_text_field( \wp_unslash( $_SERVER[ $source ] ) );
 		$candidate = \trim( \explode( ',', $ip_list )[0] );
 
 		if ( \filter_var( $candidate, FILTER_VALIDATE_IP ) ) {
 			$ip = $candidate;
 			break;
-		}
-	}
-
-	if ( '' === $ip && ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
-		$candidate = \sanitize_text_field( \wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
-		if ( \filter_var( $candidate, FILTER_VALIDATE_IP ) ) {
-			$ip = $candidate;
 		}
 	}
 	// phpcs:enable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -341,14 +341,18 @@ function get_embed_html( $url, $inline_css = true ) {
 /**
  * Get the client IP address for rate-limiting purposes.
  *
- * Checks common proxy headers before falling back to REMOTE_ADDR,
- * similar to Jetpack's approach. Every step validates the candidate
- * value with `filter_var( ..., FILTER_VALIDATE_IP )`, so the function
- * either returns a real IP literal or an empty string. The result can
- * be overridden via the `activitypub_client_ip` filter; filter output
- * is also validated and replaced with `''` if it isn't a valid IP, so
- * a misbehaving filter can't collide all callers into the same
- * rate-limit bucket.
+ * Walks the ordered list of $_SERVER keys returned by the
+ * `activitypub_client_ip_sources` filter (default: `['REMOTE_ADDR']`) and
+ * returns the first value that parses as a valid IP literal, validated via
+ * `filter_var( ..., FILTER_VALIDATE_IP )`. The result can be overridden
+ * outright via the `activitypub_client_ip` filter; that filter's output is
+ * also validated and replaced with `''` when it isn't a valid IP, so a
+ * misbehaving filter can't collide all callers into the same rate-limit
+ * bucket.
+ *
+ * Trusting any source other than `REMOTE_ADDR` is only safe behind a
+ * reverse proxy that sets and overwrites the corresponding header — see
+ * the `activitypub_client_ip_sources` filter docblock for guidance.
  *
  * Callers using the return value as a rate-limit key should treat an
  * empty return as "client unidentifiable" and fail closed rather than

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -421,23 +421,6 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_client_ip ignores a header that contains a non-IP value.
-	 *
-	 * @covers \Activitypub\get_client_ip
-	 */
-	public function test_get_client_ip_ignores_non_ip_header() {
-		$this->snapshot_client_ip_server();
-		try {
-			$_SERVER['REMOTE_ADDR']           = '198.51.100.10';
-			$_SERVER['HTTP_CF_CONNECTING_IP'] = 'unknown';
-
-			$this->assertSame( '198.51.100.10', \Activitypub\get_client_ip() );
-		} finally {
-			$this->restore_client_ip_server();
-		}
-	}
-
-	/**
 	 * Proxy headers must NOT be trusted by default. A site that PHP serves
 	 * directly receives X-Forwarded-For / CF-Connecting-IP straight from the
 	 * client, so trusting them by default would let an attacker rotate the
@@ -484,8 +467,8 @@ class Test_Functions extends \WP_UnitTestCase {
 
 	/**
 	 * When a configured source has a non-IP value, the next source in the
-	 * filter's list is consulted — so a misconfigured proxy doesn't
-	 * accidentally fail closed.
+	 * filter's list is consulted — so a typo'd or temporarily missing proxy
+	 * header doesn't lock all callers out of rate-limited endpoints.
 	 *
 	 * @covers \Activitypub\get_client_ip
 	 */

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -438,6 +438,127 @@ class Test_Functions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Proxy headers must NOT be trusted by default. A site that PHP serves
+	 * directly receives X-Forwarded-For / CF-Connecting-IP straight from the
+	 * client, so trusting them by default would let an attacker rotate the
+	 * spoofed value to bypass per-IP rate limits.
+	 *
+	 * @covers \Activitypub\get_client_ip
+	 */
+	public function test_get_client_ip_ignores_proxy_headers_by_default() {
+		$this->snapshot_client_ip_server();
+		try {
+			$_SERVER['REMOTE_ADDR']           = '10.0.0.1';
+			$_SERVER['HTTP_CF_CONNECTING_IP'] = '203.0.113.50';
+			$_SERVER['HTTP_X_FORWARDED_FOR']  = '203.0.113.51';
+
+			$this->assertSame( '10.0.0.1', \Activitypub\get_client_ip() );
+		} finally {
+			$this->restore_client_ip_server();
+		}
+	}
+
+	/**
+	 * Operators behind a trusted reverse proxy can opt the relevant header
+	 * back in via the activitypub_trusted_proxy_headers filter.
+	 *
+	 * @covers \Activitypub\get_client_ip
+	 */
+	public function test_get_client_ip_honors_trusted_proxy_filter() {
+		$this->snapshot_client_ip_server();
+		$filter = function () {
+			return array( 'HTTP_CF_CONNECTING_IP' );
+		};
+		\add_filter( 'activitypub_trusted_proxy_headers', $filter );
+
+		try {
+			$_SERVER['REMOTE_ADDR']           = '10.0.0.1';
+			$_SERVER['HTTP_CF_CONNECTING_IP'] = '203.0.113.50';
+
+			$this->assertSame( '203.0.113.50', \Activitypub\get_client_ip() );
+		} finally {
+			\remove_filter( 'activitypub_trusted_proxy_headers', $filter );
+			$this->restore_client_ip_server();
+		}
+	}
+
+	/**
+	 * When a trusted proxy header is present but contains a non-IP value,
+	 * the next trusted header is consulted, then REMOTE_ADDR — so a
+	 * misconfigured proxy doesn't accidentally fail closed.
+	 *
+	 * @covers \Activitypub\get_client_ip
+	 */
+	public function test_get_client_ip_falls_back_when_trusted_header_invalid() {
+		$this->snapshot_client_ip_server();
+		$filter = function () {
+			return array( 'HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR' );
+		};
+		\add_filter( 'activitypub_trusted_proxy_headers', $filter );
+
+		try {
+			$_SERVER['REMOTE_ADDR']           = '198.51.100.10';
+			$_SERVER['HTTP_CF_CONNECTING_IP'] = 'unknown';
+			$_SERVER['HTTP_X_FORWARDED_FOR']  = '203.0.113.7';
+
+			$this->assertSame( '203.0.113.7', \Activitypub\get_client_ip() );
+		} finally {
+			\remove_filter( 'activitypub_trusted_proxy_headers', $filter );
+			$this->restore_client_ip_server();
+		}
+	}
+
+	/**
+	 * X-Forwarded-For may carry "client, proxy1, proxy2" — when the operator
+	 * trusts the proxy that overwrites the header, the leftmost entry is the
+	 * client.
+	 *
+	 * @covers \Activitypub\get_client_ip
+	 */
+	public function test_get_client_ip_uses_leftmost_of_xff_list() {
+		$this->snapshot_client_ip_server();
+		$filter = function () {
+			return array( 'HTTP_X_FORWARDED_FOR' );
+		};
+		\add_filter( 'activitypub_trusted_proxy_headers', $filter );
+
+		try {
+			$_SERVER['REMOTE_ADDR']          = '10.0.0.1';
+			$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.50, 198.51.100.7';
+
+			$this->assertSame( '203.0.113.50', \Activitypub\get_client_ip() );
+		} finally {
+			\remove_filter( 'activitypub_trusted_proxy_headers', $filter );
+			$this->restore_client_ip_server();
+		}
+	}
+
+	/**
+	 * A filter that returns null (or any other empty-ish non-array) must
+	 * leave proxy headers untrusted; the function falls through to
+	 * REMOTE_ADDR.
+	 *
+	 * @covers \Activitypub\get_client_ip
+	 */
+	public function test_get_client_ip_tolerates_null_filter_return() {
+		$this->snapshot_client_ip_server();
+		$filter = function () {
+			return null;
+		};
+		\add_filter( 'activitypub_trusted_proxy_headers', $filter );
+
+		try {
+			$_SERVER['REMOTE_ADDR']           = '198.51.100.10';
+			$_SERVER['HTTP_CF_CONNECTING_IP'] = '203.0.113.50';
+
+			$this->assertSame( '198.51.100.10', \Activitypub\get_client_ip() );
+		} finally {
+			\remove_filter( 'activitypub_trusted_proxy_headers', $filter );
+			$this->restore_client_ip_server();
+		}
+	}
+
+	/**
 	 * Data provider for seconds_to_iso8601 tests.
 	 *
 	 * @return array Test cases with input seconds and expected ISO 8601 duration.

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -460,7 +460,7 @@ class Test_Functions extends \WP_UnitTestCase {
 
 	/**
 	 * Operators behind a trusted reverse proxy can opt the relevant header
-	 * back in via the activitypub_trusted_proxy_headers filter.
+	 * back in via the activitypub_client_ip_sources filter.
 	 *
 	 * @covers \Activitypub\get_client_ip
 	 */
@@ -469,7 +469,7 @@ class Test_Functions extends \WP_UnitTestCase {
 		$filter = function () {
 			return array( 'HTTP_CF_CONNECTING_IP' );
 		};
-		\add_filter( 'activitypub_trusted_proxy_headers', $filter );
+		\add_filter( 'activitypub_client_ip_sources', $filter );
 
 		try {
 			$_SERVER['REMOTE_ADDR']           = '10.0.0.1';
@@ -477,24 +477,24 @@ class Test_Functions extends \WP_UnitTestCase {
 
 			$this->assertSame( '203.0.113.50', \Activitypub\get_client_ip() );
 		} finally {
-			\remove_filter( 'activitypub_trusted_proxy_headers', $filter );
+			\remove_filter( 'activitypub_client_ip_sources', $filter );
 			$this->restore_client_ip_server();
 		}
 	}
 
 	/**
-	 * When a trusted proxy header is present but contains a non-IP value,
-	 * the next trusted header is consulted, then REMOTE_ADDR — so a
-	 * misconfigured proxy doesn't accidentally fail closed.
+	 * When a configured source has a non-IP value, the next source in the
+	 * filter's list is consulted — so a misconfigured proxy doesn't
+	 * accidentally fail closed.
 	 *
 	 * @covers \Activitypub\get_client_ip
 	 */
 	public function test_get_client_ip_falls_back_when_trusted_header_invalid() {
 		$this->snapshot_client_ip_server();
 		$filter = function () {
-			return array( 'HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR' );
+			return array( 'HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR' );
 		};
-		\add_filter( 'activitypub_trusted_proxy_headers', $filter );
+		\add_filter( 'activitypub_client_ip_sources', $filter );
 
 		try {
 			$_SERVER['REMOTE_ADDR']           = '198.51.100.10';
@@ -503,7 +503,7 @@ class Test_Functions extends \WP_UnitTestCase {
 
 			$this->assertSame( '203.0.113.7', \Activitypub\get_client_ip() );
 		} finally {
-			\remove_filter( 'activitypub_trusted_proxy_headers', $filter );
+			\remove_filter( 'activitypub_client_ip_sources', $filter );
 			$this->restore_client_ip_server();
 		}
 	}
@@ -520,7 +520,7 @@ class Test_Functions extends \WP_UnitTestCase {
 		$filter = function () {
 			return array( 'HTTP_X_FORWARDED_FOR' );
 		};
-		\add_filter( 'activitypub_trusted_proxy_headers', $filter );
+		\add_filter( 'activitypub_client_ip_sources', $filter );
 
 		try {
 			$_SERVER['REMOTE_ADDR']          = '10.0.0.1';
@@ -528,15 +528,14 @@ class Test_Functions extends \WP_UnitTestCase {
 
 			$this->assertSame( '203.0.113.50', \Activitypub\get_client_ip() );
 		} finally {
-			\remove_filter( 'activitypub_trusted_proxy_headers', $filter );
+			\remove_filter( 'activitypub_client_ip_sources', $filter );
 			$this->restore_client_ip_server();
 		}
 	}
 
 	/**
-	 * A filter that returns null (or any other empty-ish non-array) must
-	 * leave proxy headers untrusted; the function falls through to
-	 * REMOTE_ADDR.
+	 * A filter that returns null (or any other non-array) must not blow up;
+	 * the function falls back to its safe default of REMOTE_ADDR only.
 	 *
 	 * @covers \Activitypub\get_client_ip
 	 */
@@ -545,7 +544,7 @@ class Test_Functions extends \WP_UnitTestCase {
 		$filter = function () {
 			return null;
 		};
-		\add_filter( 'activitypub_trusted_proxy_headers', $filter );
+		\add_filter( 'activitypub_client_ip_sources', $filter );
 
 		try {
 			$_SERVER['REMOTE_ADDR']           = '198.51.100.10';
@@ -553,7 +552,7 @@ class Test_Functions extends \WP_UnitTestCase {
 
 			$this->assertSame( '198.51.100.10', \Activitypub\get_client_ip() );
 		} finally {
-			\remove_filter( 'activitypub_trusted_proxy_headers', $filter );
+			\remove_filter( 'activitypub_client_ip_sources', $filter );
 			$this->restore_client_ip_server();
 		}
 	}


### PR DESCRIPTION
## Summary

- \`get_client_ip()\` now drives entirely off a single ordered list of \`$_SERVER\` keys, defaulting to \`['REMOTE_ADDR']\`.
- New filter \`activitypub_client_ip_sources\` lets operators behind a trusted reverse proxy redefine the priority order.
- Adds tests covering: default-deny of unsanctioned headers, opt-in via filter, fallback within the configured source list, X-Forwarded-For comma-list, and tolerant non-array filter return.

## Why

Per-IP rate limits guard OAuth dynamic client registration (10/min), the OAuth token endpoint (20/min), and CIMD discovery (10/min). Previously, on any site that isn't behind a reverse proxy that strips and rewrites the proxy headers, an attacker controls all of \`X-Forwarded-For\`, \`CF-Connecting-IP\`, etc. directly. Rotating the spoofed value gives them effectively unlimited buckets and the cap is bypassed.

Defaulting to \`REMOTE_ADDR\` makes the rate limit honest on the largest fraction of installs (PHP-FPM directly facing the internet). Sites behind Cloudflare, Akamai, or nginx-with-stripping can redefine the priority order:

\`\`\`php
add_filter( 'activitypub_client_ip_sources', static function () {
    return array( 'HTTP_CF_CONNECTING_IP' );
} );
\`\`\`

Cloudflare operators specifically should NOT fall back to \`REMOTE_ADDR\` (which is Cloudflare's edge IP — every legitimate request would land in the same bucket).

The filter docblock also calls out the X-Forwarded-For prepend pitfall: even with a trusted proxy, an attacker can prepend a value before the proxy appends the real client. Operators who need correct end-to-end \`X-Forwarded-For\` handling should resolve from the right via the existing \`activitypub_client_ip\` filter.

## Test plan

- [ ] \`composer lint\` passes.
- [ ] \`vendor/bin/phpunit --filter=get_client_ip\` — 10 tests pass.
- [ ] \`vendor/bin/phpunit --filter=rate_limit\` — OAuth rate-limit tests still pass.
- [ ] On a Cloudflare-fronted site, verify the documented filter restores \`CF-Connecting-IP\` as the rate-limit key.
- [ ] On a directly-exposed site, verify \`curl -H 'X-Forwarded-For: 1.2.3.4'\` no longer changes the rate-limit bucket.