### PR TITLE
Make Fediverse Stats emails idempotent per period

### DIFF
--- a/.github/changelog/fix-stats-report-email-idempotency
+++ b/.github/changelog/fix-stats-report-email-idempotency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix monthly and annual Fediverse Stats emails being sent more than once per period when the scheduler ran multiple times.

--- a/includes/scheduler/class-statistics.php
+++ b/includes/scheduler/class-statistics.php
@@ -108,13 +108,13 @@ class Statistics {
 		// is race-safe across concurrent cron workers and re-entrant invocations.
 		// When $force is true, we still record the marker so a later non-forced cron run
 		// won't send another copy for the same period.
-		$marker_option = self::sent_marker_option_name( $user_id, $year );
-		if ( ! \add_option( $marker_option, \time(), '', false ) ) {
+		$email_sent_option = self::get_email_sent_option_name( $user_id, $year );
+		if ( ! \add_option( $email_sent_option, \time(), '', false ) ) {
 			if ( ! $force ) {
 				return;
 			}
 
-			\update_option( $marker_option, \time(), false );
+			\update_option( $email_sent_option, \time(), false );
 		}
 
 		// Get month name for most_active_month.
@@ -214,13 +214,13 @@ class Statistics {
 		// is race-safe across concurrent cron workers and re-entrant invocations.
 		// When $force is true, we still record the marker so a later non-forced cron run
 		// won't send another copy for the same period.
-		$marker_option = self::sent_marker_option_name( $user_id, $year, $month );
-		if ( ! \add_option( $marker_option, \time(), '', false ) ) {
+		$email_sent_option = self::get_email_sent_option_name( $user_id, $year, $month );
+		if ( ! \add_option( $email_sent_option, \time(), '', false ) ) {
 			if ( ! $force ) {
 				return;
 			}
 
-			\update_option( $marker_option, \time(), false );
+			\update_option( $email_sent_option, \time(), false );
 		}
 
 		$month_name = \date_i18n( 'F Y', \strtotime( \sprintf( '%d-%02d-01', $year, $month ) ) );
@@ -286,7 +286,10 @@ class Statistics {
 	}
 
 	/**
-	 * Build the option name used as an idempotency marker for a sent stats email.
+	 * Build the option name used to record that a stats email has been sent for a given period.
+	 *
+	 * The presence of this option is the idempotency signal: a row exists once an email
+	 * has been delivered (or claimed for delivery) for the given user and period.
 	 *
 	 * @param int      $user_id The user ID.
 	 * @param int      $year    The year.
@@ -294,7 +297,7 @@ class Statistics {
 	 *
 	 * @return string The option name. Truncated to fit MySQL's 191-character key.
 	 */
-	private static function sent_marker_option_name( $user_id, $year, $month = null ) {
+	private static function get_email_sent_option_name( $user_id, $year, $month = null ) {
 		$suffix = null === $month ? \sprintf( '%d_annual', $year ) : \sprintf( '%d_%d', $year, $month );
 		return \substr( \sprintf( 'activitypub_stats_emailed_%d_%s', $user_id, $suffix ), 0, 191 );
 	}

--- a/includes/scheduler/class-statistics.php
+++ b/includes/scheduler/class-statistics.php
@@ -104,6 +104,12 @@ class Statistics {
 			return;
 		}
 
+		// Atomic claim: add_option only succeeds if the row doesn't yet exist, so this
+		// is race-safe across concurrent cron workers and re-entrant invocations.
+		if ( ! $force && ! \add_option( self::sent_marker_option_name( $user_id, $year ), \time(), '', false ) ) {
+			return;
+		}
+
 		// Get month name for most_active_month.
 		$most_active_month_name = '';
 		if ( ! empty( $summary['most_active_month'] ) ) {
@@ -197,6 +203,12 @@ class Statistics {
 			return;
 		}
 
+		// Atomic claim: add_option only succeeds if the row doesn't yet exist, so this
+		// is race-safe across concurrent cron workers and re-entrant invocations.
+		if ( ! $force && ! \add_option( self::sent_marker_option_name( $user_id, $year, $month ), \time(), '', false ) ) {
+			return;
+		}
+
 		$month_name = \date_i18n( 'F Y', \strtotime( \sprintf( '%d-%02d-01', $year, $month ) ) );
 
 		// Build follower text.
@@ -257,6 +269,20 @@ class Statistics {
 		}
 
 		Mailer::send( $user_id, $subject, 'stats-report', $args, $alt_body );
+	}
+
+	/**
+	 * Build the option name used as an idempotency marker for a sent stats email.
+	 *
+	 * @param int      $user_id The user ID.
+	 * @param int      $year    The year.
+	 * @param int|null $month   The month (1-12), or null for the annual report.
+	 *
+	 * @return string The option name. Truncated to fit MySQL's 191-character key.
+	 */
+	private static function sent_marker_option_name( $user_id, $year, $month = null ) {
+		$suffix = null === $month ? \sprintf( '%d_annual', $year ) : \sprintf( '%d_%d', $year, $month );
+		return \substr( \sprintf( 'activitypub_stats_emailed_%d_%s', $user_id, $suffix ), 0, 191 );
 	}
 
 	/**

--- a/includes/scheduler/class-statistics.php
+++ b/includes/scheduler/class-statistics.php
@@ -106,8 +106,15 @@ class Statistics {
 
 		// Atomic claim: add_option only succeeds if the row doesn't yet exist, so this
 		// is race-safe across concurrent cron workers and re-entrant invocations.
-		if ( ! $force && ! \add_option( self::sent_marker_option_name( $user_id, $year ), \time(), '', false ) ) {
-			return;
+		// When $force is true, we still record the marker so a later non-forced cron run
+		// won't send another copy for the same period.
+		$marker_option = self::sent_marker_option_name( $user_id, $year );
+		if ( ! \add_option( $marker_option, \time(), '', false ) ) {
+			if ( ! $force ) {
+				return;
+			}
+
+			\update_option( $marker_option, \time(), false );
 		}
 
 		// Get month name for most_active_month.
@@ -205,8 +212,15 @@ class Statistics {
 
 		// Atomic claim: add_option only succeeds if the row doesn't yet exist, so this
 		// is race-safe across concurrent cron workers and re-entrant invocations.
-		if ( ! $force && ! \add_option( self::sent_marker_option_name( $user_id, $year, $month ), \time(), '', false ) ) {
-			return;
+		// When $force is true, we still record the marker so a later non-forced cron run
+		// won't send another copy for the same period.
+		$marker_option = self::sent_marker_option_name( $user_id, $year, $month );
+		if ( ! \add_option( $marker_option, \time(), '', false ) ) {
+			if ( ! $force ) {
+				return;
+			}
+
+			\update_option( $marker_option, \time(), false );
 		}
 
 		$month_name = \date_i18n( 'F Y', \strtotime( \sprintf( '%d-%02d-01', $year, $month ) ) );

--- a/tests/phpunit/tests/includes/scheduler/class-test-statistics.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-statistics.php
@@ -48,13 +48,25 @@ class Test_Statistics extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		$this->sent_count = 0;
-		\add_filter(
-			'pre_wp_mail',
-			function () {
-				++$this->sent_count;
-				return true;
-			}
-		);
+		\add_filter( 'pre_wp_mail', array( $this, 'short_circuit_wp_mail' ) );
+	}
+
+	/**
+	 * Remove the test mail filter so it doesn't leak across tests.
+	 */
+	public function tear_down() {
+		\remove_filter( 'pre_wp_mail', array( $this, 'short_circuit_wp_mail' ) );
+		parent::tear_down();
+	}
+
+	/**
+	 * Count sent emails and short-circuit wp_mail during tests.
+	 *
+	 * @return bool Always true to short-circuit wp_mail.
+	 */
+	public function short_circuit_wp_mail() {
+		++$this->sent_count;
+		return true;
 	}
 
 	/**
@@ -109,5 +121,74 @@ class Test_Statistics extends WP_UnitTestCase {
 
 		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_annual', self::$user_id, $year );
 		$this->assertNotFalse( \get_option( $marker, false ), 'Sent marker option should be persisted.' );
+	}
+
+	/**
+	 * Test that a forced monthly send still records the marker so a later non-forced
+	 * cron run cannot send another copy for the same period.
+	 *
+	 * @covers ::send_monthly_email
+	 */
+	public function test_send_monthly_email_force_records_marker() {
+		$year   = 2026;
+		$month  = 3;
+		$option = Statistics_Collector::get_monthly_option_name( self::$user_id, $year, $month );
+
+		\update_option(
+			$option,
+			array(
+				'posts_count'     => 1,
+				'followers_count' => 2,
+				'followers_total' => 7,
+			)
+		);
+
+		// Forced send writes the marker even though no marker existed yet.
+		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month, true );
+
+		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_%d', self::$user_id, $year, $month );
+		$this->assertNotFalse( \get_option( $marker, false ), 'Forced send should still persist the marker.' );
+
+		// A subsequent non-forced send must be suppressed by the marker.
+		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month );
+
+		$this->assertSame( 1, $this->sent_count, 'Marker written by forced send must block later non-forced sends.' );
+
+		// Forced still sends regardless of an existing marker.
+		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month, true );
+
+		$this->assertSame( 2, $this->sent_count, 'Forced send should bypass the marker check and still send.' );
+	}
+
+	/**
+	 * Test that a forced annual send still records the marker so a later non-forced
+	 * cron run cannot send another copy for the same year.
+	 *
+	 * @covers ::send_annual_email
+	 */
+	public function test_send_annual_email_force_records_marker() {
+		\update_user_option( self::$user_id, 'activitypub_mailer_annual_report', '1' );
+
+		$year    = 2025;
+		$summary = array(
+			'posts_count'     => 8,
+			'followers_count' => 4,
+		);
+
+		// Forced send writes the marker even though no marker existed yet.
+		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary, true );
+
+		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_annual', self::$user_id, $year );
+		$this->assertNotFalse( \get_option( $marker, false ), 'Forced send should still persist the marker.' );
+
+		// A subsequent non-forced send must be suppressed by the marker.
+		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary );
+
+		$this->assertSame( 1, $this->sent_count, 'Marker written by forced send must block later non-forced sends.' );
+
+		// Forced still sends regardless of marker presence.
+		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary, true );
+
+		$this->assertSame( 2, $this->sent_count, 'Forced send should bypass the marker check and still send.' );
 	}
 }

--- a/tests/phpunit/tests/includes/scheduler/class-test-statistics.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-statistics.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Test Statistics scheduler.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Scheduler;
+
+use Activitypub\Scheduler\Statistics as Statistics_Scheduler;
+use Activitypub\Statistics as Statistics_Collector;
+use WP_UnitTestCase;
+
+/**
+ * Test Statistics scheduler.
+ *
+ * @coversDefaultClass \Activitypub\Scheduler\Statistics
+ */
+class Test_Statistics extends WP_UnitTestCase {
+
+	/**
+	 * Test user.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Set up fixtures.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Helper that creates fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id = $factory->user->create( array( 'role' => 'author' ) );
+		\update_user_option( self::$user_id, 'activitypub_mailer_monthly_report', '1' );
+	}
+
+	/**
+	 * Counter for sent emails.
+	 *
+	 * @var int
+	 */
+	protected $sent_count = 0;
+
+	/**
+	 * Reset email counter and short-circuit wp_mail before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->sent_count = 0;
+		\add_filter(
+			'pre_wp_mail',
+			function () {
+				++$this->sent_count;
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Test that send_monthly_email only sends once per (user, year, month).
+	 *
+	 * @covers ::send_monthly_email
+	 */
+	public function test_send_monthly_email_is_idempotent() {
+		$year   = 2026;
+		$month  = 4;
+		$option = Statistics_Collector::get_monthly_option_name( self::$user_id, $year, $month );
+
+		// Seed a month of stats with meaningful activity.
+		\update_option(
+			$option,
+			array(
+				'posts_count'     => 3,
+				'followers_count' => 5,
+				'followers_total' => 10,
+			)
+		);
+
+		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month );
+		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month );
+		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month );
+
+		$this->assertSame( 1, $this->sent_count, 'Monthly email should only be sent once per period.' );
+
+		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_%d', self::$user_id, $year, $month );
+		$this->assertNotFalse( \get_option( $marker, false ), 'Sent marker option should be persisted.' );
+	}
+
+	/**
+	 * Test that send_annual_email only sends once per (user, year).
+	 *
+	 * @covers ::send_annual_email
+	 */
+	public function test_send_annual_email_is_idempotent() {
+		\update_user_option( self::$user_id, 'activitypub_mailer_annual_report', '1' );
+
+		$year    = 2026;
+		$summary = array(
+			'posts_count'     => 12,
+			'followers_count' => 30,
+		);
+
+		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary );
+		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary );
+		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary );
+
+		$this->assertSame( 1, $this->sent_count, 'Annual email should only be sent once per year.' );
+
+		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_annual', self::$user_id, $year );
+		$this->assertNotFalse( \get_option( $marker, false ), 'Sent marker option should be persisted.' );
+	}
+}

--- a/tests/phpunit/tests/includes/scheduler/class-test-statistics.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-statistics.php
@@ -95,8 +95,8 @@ class Test_Statistics extends WP_UnitTestCase {
 
 		$this->assertSame( 1, $this->sent_count, 'Monthly email should only be sent once per period.' );
 
-		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_%d', self::$user_id, $year, $month );
-		$this->assertNotFalse( \get_option( $marker, false ), 'Sent marker option should be persisted.' );
+		$email_sent_option = \sprintf( 'activitypub_stats_emailed_%d_%d_%d', self::$user_id, $year, $month );
+		$this->assertNotFalse( \get_option( $email_sent_option, false ), 'Email-sent option should be persisted.' );
 	}
 
 	/**
@@ -119,17 +119,17 @@ class Test_Statistics extends WP_UnitTestCase {
 
 		$this->assertSame( 1, $this->sent_count, 'Annual email should only be sent once per year.' );
 
-		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_annual', self::$user_id, $year );
-		$this->assertNotFalse( \get_option( $marker, false ), 'Sent marker option should be persisted.' );
+		$email_sent_option = \sprintf( 'activitypub_stats_emailed_%d_%d_annual', self::$user_id, $year );
+		$this->assertNotFalse( \get_option( $email_sent_option, false ), 'Email-sent option should be persisted.' );
 	}
 
 	/**
-	 * Test that a forced monthly send still records the marker so a later non-forced
-	 * cron run cannot send another copy for the same period.
+	 * Test that a forced monthly send still records the email-sent option so a later
+	 * non-forced cron run cannot send another copy for the same period.
 	 *
 	 * @covers ::send_monthly_email
 	 */
-	public function test_send_monthly_email_force_records_marker() {
+	public function test_send_monthly_email_force_records_email_sent() {
 		$year   = 2026;
 		$month  = 3;
 		$option = Statistics_Collector::get_monthly_option_name( self::$user_id, $year, $month );
@@ -143,30 +143,30 @@ class Test_Statistics extends WP_UnitTestCase {
 			)
 		);
 
-		// Forced send writes the marker even though no marker existed yet.
+		// Forced send writes the email-sent option even when none existed yet.
 		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month, true );
 
-		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_%d', self::$user_id, $year, $month );
-		$this->assertNotFalse( \get_option( $marker, false ), 'Forced send should still persist the marker.' );
+		$email_sent_option = \sprintf( 'activitypub_stats_emailed_%d_%d_%d', self::$user_id, $year, $month );
+		$this->assertNotFalse( \get_option( $email_sent_option, false ), 'Forced send should still persist the email-sent option.' );
 
-		// A subsequent non-forced send must be suppressed by the marker.
+		// A subsequent non-forced send must be suppressed by the existing record.
 		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month );
 
-		$this->assertSame( 1, $this->sent_count, 'Marker written by forced send must block later non-forced sends.' );
+		$this->assertSame( 1, $this->sent_count, 'Email-sent record from a forced send must block later non-forced sends.' );
 
-		// Forced still sends regardless of an existing marker.
+		// Forced still sends regardless of an existing record.
 		Statistics_Scheduler::send_monthly_email( self::$user_id, $year, $month, true );
 
-		$this->assertSame( 2, $this->sent_count, 'Forced send should bypass the marker check and still send.' );
+		$this->assertSame( 2, $this->sent_count, 'Forced send should bypass the email-sent check and still send.' );
 	}
 
 	/**
-	 * Test that a forced annual send still records the marker so a later non-forced
-	 * cron run cannot send another copy for the same year.
+	 * Test that a forced annual send still records the email-sent option so a later
+	 * non-forced cron run cannot send another copy for the same year.
 	 *
 	 * @covers ::send_annual_email
 	 */
-	public function test_send_annual_email_force_records_marker() {
+	public function test_send_annual_email_force_records_email_sent() {
 		\update_user_option( self::$user_id, 'activitypub_mailer_annual_report', '1' );
 
 		$year    = 2025;
@@ -175,20 +175,20 @@ class Test_Statistics extends WP_UnitTestCase {
 			'followers_count' => 4,
 		);
 
-		// Forced send writes the marker even though no marker existed yet.
+		// Forced send writes the email-sent option even when none existed yet.
 		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary, true );
 
-		$marker = \sprintf( 'activitypub_stats_emailed_%d_%d_annual', self::$user_id, $year );
-		$this->assertNotFalse( \get_option( $marker, false ), 'Forced send should still persist the marker.' );
+		$email_sent_option = \sprintf( 'activitypub_stats_emailed_%d_%d_annual', self::$user_id, $year );
+		$this->assertNotFalse( \get_option( $email_sent_option, false ), 'Forced send should still persist the email-sent option.' );
 
-		// A subsequent non-forced send must be suppressed by the marker.
+		// A subsequent non-forced send must be suppressed by the existing record.
 		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary );
 
-		$this->assertSame( 1, $this->sent_count, 'Marker written by forced send must block later non-forced sends.' );
+		$this->assertSame( 1, $this->sent_count, 'Email-sent record from a forced send must block later non-forced sends.' );
 
-		// Forced still sends regardless of marker presence.
+		// Forced still sends regardless of an existing record.
 		Statistics_Scheduler::send_annual_email( self::$user_id, $year, $summary, true );
 
-		$this->assertSame( 2, $this->sent_count, 'Forced send should bypass the marker check and still send.' );
+		$this->assertSame( 2, $this->sent_count, 'Forced send should bypass the email-sent check and still send.' );
 	}
 }


### PR DESCRIPTION
Fixes #3253
Fixes p1777602888866079-slack-C02FMH4G8

## Proposed changes:

* Add an atomic per-`(user, year[, month])` "sent" marker (`activitypub_stats_emailed_*` option) that is claimed via `add_option()` immediately before `Mailer::send()` is invoked for the monthly and annual stats emails. Subsequent calls for the same period bail early.
* The marker lives in its own option (separate from the stored stats option) so it can be refreshed without rewriting the stats payload, and so the row keys stay short.
* Forced sends (`$force = true`, e.g. WP-CLI) still **write/refresh** the marker — they only bypass the early-return — so a manual run can't be silently re-delivered by the next scheduled cron.

### Why

`Activitypub\Scheduler\Statistics::collect_all_monthly_stats()` iterates every active user and calls `send_monthly_email()` for each, then clears + reschedules the cron at the end. With no idempotency guard, anything that re-enters the function (concurrent WP-Cron workers, plugin deactivate→reactivate which triggers `register_schedules()`, manual `wp cron event run`, traffic spikes triggering parallel cron) sends the same message again. The annual variant has the same shape.

This patch is the minimal behavioral fix and intentionally does not touch the opt-in default for the blog actor — that's a separate discussion.

Receipt-driven emails (`Mailer::direct_message`, `Mailer::mention`, `Mailer::new_follower`) are NOT covered here: they have a different failure mode (remote-server retry of an inbox POST) and a different blast radius (single extra email, not a flood). Tracked in #3254.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. As a user with `activitypub_mailer_monthly_report` enabled, ensure a populated monthly stats option exists for some prior month (e.g. `activitypub_stats_<user>_2026_4`).
2. Call `Activitypub\Scheduler\Statistics::send_monthly_email( $user_id, 2026, 4 )` twice.
3. Verify only one email is dispatched (e.g. via `pre_wp_mail` filter or `WP_Mock`), and that an `activitypub_stats_emailed_<user>_2026_4` option now exists.
4. Repeat for `send_annual_email()` (option will be `activitypub_stats_emailed_<user>_2026_annual`).
5. Verify the forced-send path: call `send_monthly_email( $user_id, 2026, 5, true )` against a period that has no marker yet, then call it again without `$force` — only one email should go out, and the marker should exist after step one.
6. Run the new PHPUnit tests:
   ```
   npm run env-test -- --filter=Test_Statistics
   ```

### Changelog entry

Already added at `.github/changelog/fix-stats-report-email-idempotency`.