### PR TITLE
Document idempotency requirement for scheduled handlers

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -56,6 +56,11 @@ Apply the **code-style** skill standards when reviewing. In addition, check for:
 - No breaking changes to public APIs without deprecation path
 - Integration points with third-party plugins preserved
 
+### Scheduling & Side Effects
+- New or modified WP-Cron callbacks (anything registered via `wp_schedule_event` / `wp_schedule_single_event`) that perform **user-visible side effects** — emails, push notifications, outbound HTTP calls, federated activities — must guard against re-entry. WP-Cron can fire the same callback more than once for the same logical period (concurrent loopback workers, plugin reactivate triggering `register_schedules()`, manual `wp cron event run`, traffic spikes).
+- Look for an **atomic claim before the side effect**: typically `add_option( $key, $value, '', false )` (or another single-shot insert) keyed on whatever uniquely identifies the period/recipient/activity. Bail early if the claim fails. Fixes after the fact (checking-then-sending, time-window checks, transient-based locks) are not race-safe.
+- For senders with a `$force` parameter: the marker must still be written/refreshed on forced runs, otherwise a manual or CLI-driven send leaves the door open for the next scheduled run to deliver the same message again.
+
 ### Tests
 - Apply the **test** skill patterns to evaluate test coverage for new/changed code.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ npm run dev                     # Development watch mode.
 - **`remove_all_filters('pre_http_request')` is forbidden in tests.** The pre-commit hook blocks this. Use targeted filter removal.
 - **Changelog entries MUST be end-user friendly and end with punctuation.** Users see these in the WordPress update screen. Describe what changed from their perspective — no jargon, class names, or method names.
 - **`post_date_gmt` may be empty.** Check for `0000-00-00` or empty values.
+- **Scheduled cron handlers must be idempotent if they have user-visible side effects** (emails, external API calls, push notifications). WP-Cron can re-enter the same callback via concurrent workers, plugin deactivate→reactivate (which re-runs `register_schedules()`), `wp cron event run`, and traffic spikes that fire overlapping loopback requests. Claim the unit of work atomically — `add_option( $key, $value, '', false )` only succeeds when the row doesn't yet exist, which makes it a race-safe sentinel — *before* the side effect runs, not after. See `Activitypub\Scheduler\Statistics::send_monthly_email()` for the canonical pattern.
 
 ## Pre-commit Hooks
 


### PR DESCRIPTION
Refs #3253, #3252

## Proposed changes:

* Add a Common Pitfalls bullet in `AGENTS.md` so anyone (human or agent) writing a new scheduled cron handler sees the idempotency requirement at write time.
* Add a new "Scheduling & Side Effects" subsection to the `code-review` agent's checklist (`.claude/agents/code-review.md`) so the auto-invoked reviewer flags missing guards even when the writer forgets — including the `$force`-still-records-marker nuance that came out of #3252.

### Why

The Fediverse Stats email flood (#3253, fixed in #3252) was caused by `Activitypub\Scheduler\Statistics::collect_all_monthly_stats()` re-entering on the 1st of the month — concurrent WP-Cron loopback workers all looping over the same active users and dispatching the monthly email each time. The pattern (cron callback with user-visible side effects, no atomic claim) is generic, not stats-specific. Without a written reminder anywhere, the next person adding a scheduled email/notification handler has no way to know this trap exists.

Both files are export-ignored (verified in `.gitattributes`), so this changes nothing in the shipped plugin — purely contributor-facing tooling.

### Other information:

- [x] Have you written new tests for your changes, if applicable? *(N/A — docs only.)*

## Testing instructions:

1. Open `AGENTS.md` and confirm the new bullet appears under the "Common Pitfalls" section, between the `post_date_gmt` bullet and the "Pre-commit Hooks" subsection.
2. Open `.claude/agents/code-review.md` and confirm the new "Scheduling & Side Effects" subsection sits between "Compatibility" and "Tests" in the Review Checklist.
3. Optionally: run the `code-review` agent on a fictional diff that adds a `wp_schedule_event(...)` callback firing `wp_mail()` without an idempotency guard — the agent should now flag the missing claim.

### Changelog entry

Skipped — no user-visible behavior change. Both touched files are export-ignored.