### PR TITLE
Sync version number and changelog from 8.2.1 release

### DIFF
--- a/.github/changelog/fix-cap-remote-recipient-fetches
+++ b/.github/changelog/fix-cap-remote-recipient-fetches
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Hardened how the inbox processes large recipient lists in incoming activities.

--- a/.github/changelog/fix-stats-report-email-idempotency
+++ b/.github/changelog/fix-stats-report-email-idempotency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix monthly and annual Fediverse Stats emails being sent more than once per period when the scheduler ran multiple times.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.2.1] - 2026-05-01
+### Security
+- Hardened how the inbox processes large recipient lists in incoming activities. [#3094]
+
+### Fixed
+- Fix monthly and annual Fediverse Stats emails being sent more than once per period when the scheduler ran multiple times. [#3252]
+
 ## [8.2.0] - 2026-04-27
 ### Security
 - ActivityPub REST endpoints no longer advertise credentialed cross-origin access. Browser-based clients using OAuth bearer tokens continue to work as before. [#3237]
@@ -1849,6 +1856,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - initial
 
+[8.2.1]: https://github.com/Automattic/wordpress-activitypub/compare/8.2.0...8.2.1
 [8.2.0]: https://github.com/Automattic/wordpress-activitypub/compare/8.1.1...8.2.0
 [8.1.1]: https://github.com/Automattic/wordpress-activitypub/compare/8.1.0...8.1.1
 [8.1.0]: https://github.com/Automattic/wordpress-activitypub/compare/8.0.2...8.1.0

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -237,7 +237,7 @@ class Remote_Actors {
 	 * recipient resolver, where a flood of unknown recipients would otherwise
 	 * trigger one DB query per recipient.
 	 *
-	 * @since unreleased
+	 * @since 8.2.1
 	 *
 	 * @param string[] $uris Candidate actor URIs.
 	 *

--- a/includes/rest/class-inbox-controller.php
+++ b/includes/rest/class-inbox-controller.php
@@ -387,7 +387,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 		 * Filters the maximum number of remote recipient URLs that can be
 		 * fetched per incoming activity.
 		 *
-		 * @since unreleased
+		 * @since 8.2.1
 		 *
 		 * @param int $max_remote_fetches Maximum number of remote fetches. Default 10.
 		 */
@@ -454,7 +454,7 @@ class Inbox_Controller extends \WP_REST_Controller {
 						 * not for each subsequent skipped recipient. Hook this to surface
 						 * cap hits in your logging system of choice (Jetpack, Sentry, syslog, etc.).
 						 *
-						 * @since unreleased
+						 * @since 8.2.1
 						 *
 						 * @param array  $activity  The incoming activity data.
 						 * @param string $recipient The recipient URI that was skipped.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,13 @@ For reasons of data protection, it is not possible to see the followers of other
 
 == Changelog ==
 
+### 8.2.1 - 2026-05-01
+#### Security
+- Hardened how the inbox processes large recipient lists in incoming activities.
+
+#### Fixed
+- Fix monthly and annual Fediverse Stats emails being sent more than once per period when the scheduler ran multiple times.
+
 ### 8.2.0 - 2026-04-27
 #### Security
 - ActivityPub REST endpoints no longer advertise credentialed cross-origin access. Browser-based clients using OAuth bearer tokens continue to work as before.


### PR DESCRIPTION


## Proposed changes:

* Add the `8.2.1` entry to `CHANGELOG.md` and `readme.txt` so future releases include it in their history.
* Replace the three `@since unreleased` markers introduced by #3094 with `@since 8.2.1` to reflect the version they shipped in.

This mirrors the changelog and `@since` updates from the [`8.2.1` release commit](https://github.com/Automattic/wordpress-activitypub/commit/8b4371d1) (on branch `release/8.2.1`) back to trunk. The 8.2.1 release was published from `release/8.2.1` and is already deployed to WordPress.org — this PR brings trunk into the same documentary state.

Intentionally does **not** bump `Version`, `Stable tag`, or `ACTIVITYPUB_PLUGIN_VERSION` — trunk continues to track the next-release version.

Pattern follows #3077 (post-8.0.2 sync).

### Other information:

- [x] Have you written new tests for your changes, if applicable? — N/A, docs/changelog only.

## Testing instructions:

* `git checkout update/sync-8.2.1-changelog`
* Confirm `CHANGELOG.md` has a new `## [8.2.1] - 2026-05-01` block at the top, mirroring what shipped on `release/8.2.1`, plus the `[8.2.1]: ...compare/8.2.0...8.2.1` link.
* Confirm `readme.txt` has a matching `### 8.2.1 - 2026-05-01` block under `== Changelog ==`, and that `Stable tag:` is **still** `8.2.0`.
* Confirm `activitypub.php` is unchanged (`Version: 8.2.0`, `ACTIVITYPUB_PLUGIN_VERSION = '8.2.0'`).
* `git grep "@since unreleased" includes/collection/class-remote-actors.php includes/rest/class-inbox-controller.php` returns no results; the three former `unreleased` markers now read `@since 8.2.1`.