### PR TITLE
Add jitter to backfill statistics migration

### DIFF
--- a/.github/changelog/update-migration-jitter
+++ b/.github/changelog/update-migration-jitter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stagger background data processing after plugin updates to reduce server load on hosts running many sites.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -209,8 +209,8 @@ class Migration {
 			\wp_schedule_single_event( \time(), 'activitypub_migrate_actor_emoji' );
 		}
 		if ( \version_compare( $version_from_db, '8.1.0', '<' ) ) {
-			// Backfill historical statistics data (delay to avoid load immediately after upgrade).
-			\wp_schedule_single_event( \time() + HOUR_IN_SECONDS, 'activitypub_backfill_statistics' );
+			// Backfill historical statistics data (delay + jitter to avoid load spikes on hosts running many sites).
+			\wp_schedule_single_event( \time() + HOUR_IN_SECONDS + \wp_rand( 0, 6 * HOUR_IN_SECONDS ), 'activitypub_backfill_statistics' );
 		}
 
 		/*

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -208,7 +208,7 @@ class Migration {
 		if ( \version_compare( $version_from_db, '7.9.0', '<' ) ) {
 			\wp_schedule_single_event( \time(), 'activitypub_migrate_actor_emoji' );
 		}
-		if ( \version_compare( $version_from_db, '8.1.0', '<' ) ) {
+		if ( \version_compare( $version_from_db, '8.1.0', '<' ) && ! \wp_next_scheduled( 'activitypub_backfill_statistics' ) ) {
 			// Backfill historical statistics data (delay + jitter to avoid load spikes on hosts running many sites).
 			\wp_schedule_single_event( \time() + HOUR_IN_SECONDS + \wp_rand( 0, 6 * HOUR_IN_SECONDS ), 'activitypub_backfill_statistics' );
 		}


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Add random jitter (0–6h) on top of the existing 1h delay when scheduling the `activitypub_backfill_statistics` cron event during the 8.1.0 upgrade path. On hosts running many sites that upgrade in lockstep, the previous fixed 1h delay caused all backfill jobs to fire at exactly the same minute. Spreading the event across a 7h window prevents that synchronized load spike.

### Other information:

- [x] Have you written new tests for your changes, if applicable? — n/a; the change is a single arithmetic expression passed to `wp_schedule_single_event()` and the randomness is not meaningfully testable without mocking `wp_rand()`.

## Testing instructions:

* On a site running an older version of the plugin (`< 8.1.0`), upgrade to a build that includes this change.
* Inspect the scheduled cron via `wp cron event list` (or a plugin like WP Crontrol).
* Confirm `activitypub_backfill_statistics` is scheduled somewhere between 1h and 7h in the future, not exactly at +1h.
* Verify the event still runs and backfills statistics as expected once it fires.