### PR TITLE
Allow site admins to act as the blog actor via C2S

### DIFF
--- a/.github/changelog/blog-actor-c2s-admin
+++ b/.github/changelog/blog-actor-c2s-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow site administrators to perform Client-to-Server actions on behalf of the site's blog actor.

--- a/.github/changelog/blog-actor-c2s-admin
+++ b/.github/changelog/blog-actor-c2s-admin
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Allow site administrators to perform Client-to-Server actions on behalf of the site's blog actor.
+Allow site administrators to post from third-party apps on behalf of the site's blog account.

--- a/.github/changelog/fix-anonymous-blog-actor-ownership
+++ b/.github/changelog/fix-anonymous-blog-actor-ownership
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent the site's follower and following lists from being visible to logged-out visitors when the social graph is set to private.

--- a/.github/changelog/fix-blog-actor-outbox-permalink-privacy
+++ b/.github/changelog/fix-blog-actor-outbox-permalink-privacy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent private outbox items authored by the site account from being visible to logged-out visitors at their permalink URLs.

--- a/includes/collection/class-outbox.php
+++ b/includes/collection/class-outbox.php
@@ -14,6 +14,7 @@ use Activitypub\Webfinger;
 
 use function Activitypub\add_to_outbox;
 use function Activitypub\object_to_uri;
+use function Activitypub\user_can_act_as_blog;
 
 /**
  * ActivityPub Outbox Collection
@@ -431,9 +432,25 @@ class Outbox {
 			\Activitypub\OAuth\Server::authenticate_oauth( null );
 		}
 
-		// Allow the author to view their own outbox items regardless of visibility.
-		if ( \get_current_user_id() === (int) $outbox_item->post_author ) {
-			return self::get_activity( $outbox_item );
+		/*
+		 * Allow the author to view their own outbox items regardless of visibility.
+		 * The `is_user_logged_in()` guard prevents anonymous visitors from matching
+		 * the blog actor's items (where both `get_current_user_id()` and `post_author`
+		 * are `0`), which would otherwise expose private activities at their permalink.
+		 *
+		 * Users authorized to act as the blog actor are treated as the author of
+		 * blog-actor items so they can read the same private outbox they can post to.
+		 */
+		if ( \is_user_logged_in() ) {
+			$author = (int) $outbox_item->post_author;
+
+			if ( \get_current_user_id() === $author ) {
+				return self::get_activity( $outbox_item );
+			}
+
+			if ( Actors::BLOG_USER_ID === $author && user_can_act_as_blog() ) {
+				return self::get_activity( $outbox_item );
+			}
 		}
 
 		// Check if Outbox Activity is public.

--- a/includes/functions-user.php
+++ b/includes/functions-user.php
@@ -158,6 +158,11 @@ function user_can_act_as_blog() {
 	 * Defaults to true for users with the `manage_options` capability (administrators).
 	 * Filter to broaden the allow-list, for example to editors on multi-author sites.
 	 *
+	 * Security note: returning a static `true` (e.g. via `__return_true`) grants
+	 * EVERY authenticated user the right to post as, read private outbox items of,
+	 * and view stats for the blog actor. Always inspect the current user inside
+	 * the callback (`current_user_can()`, role, allowlist) before returning `true`.
+	 *
 	 * @since unreleased
 	 *
 	 * @param bool $can_act_as_blog Whether the current user can act as the blog actor.

--- a/includes/functions-user.php
+++ b/includes/functions-user.php
@@ -140,6 +140,32 @@ function user_can_activitypub( $user_id ) {
 }
 
 /**
+ * Whether the current user is allowed to act on behalf of the blog actor.
+ *
+ * The blog actor is virtual (no `wp_users` row), so ownership and authoring
+ * checks against `BLOG_USER_ID = 0` cannot rely on identity equality. This
+ * helper centralizes the "can the current user post / read as the blog?"
+ * decision: administrators by default, filterable for integrations.
+ *
+ * @since unreleased
+ *
+ * @return bool True if the current user can act as the blog actor.
+ */
+function user_can_act_as_blog() {
+	/**
+	 * Filters whether the current user is allowed to act as the blog actor.
+	 *
+	 * Defaults to true for users with the `manage_options` capability (administrators).
+	 * Filter to broaden the allow-list, for example to editors on multi-author sites.
+	 *
+	 * @since unreleased
+	 *
+	 * @param bool $can_act_as_blog Whether the current user can act as the blog actor.
+	 */
+	return (bool) \apply_filters( 'activitypub_user_can_act_as_blog', \current_user_can( 'manage_options' ) );
+}
+
+/**
  * Checks if a User-Type is disabled for ActivityPub.
  *
  * This function is used to check if the 'blog' or 'user'

--- a/includes/rest/admin/class-statistics-controller.php
+++ b/includes/rest/admin/class-statistics-controller.php
@@ -10,6 +10,8 @@ namespace Activitypub\Rest\Admin;
 use Activitypub\Collection\Actors;
 use Activitypub\Statistics;
 
+use function Activitypub\user_can_act_as_blog;
+
 /**
  * ActivityPub Statistics_Controller class.
  *
@@ -67,7 +69,7 @@ class Statistics_Controller extends \WP_REST_Controller {
 
 		// Check if user can access stats for this actor.
 		if ( Actors::BLOG_USER_ID === $user_id ) {
-			if ( ! \current_user_can( 'manage_options' ) ) {
+			if ( ! user_can_act_as_blog() ) {
 				return new \WP_Error(
 					'rest_forbidden',
 					\__( 'You do not have permission to view blog stats.', 'activitypub' ),

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -18,6 +18,7 @@ use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_object_id;
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\object_to_uri;
+use function Activitypub\user_can_act_as_blog;
 
 /**
  * ActivityPub Outbox Controller.
@@ -178,9 +179,26 @@ class Outbox_Controller extends \WP_REST_Controller {
 			),
 		);
 
-		// When user_id=0 (blog actor), get_current_user_id() also returns 0 for unauthenticated
-		// visitors, so the equality check alone is insufficient — we must test login state first.
-		if ( ! \is_user_logged_in() || ( \get_current_user_id() !== (int) $user_id && ! \current_user_can( 'activitypub' ) ) ) {
+		/*
+		 * Whether the current user owns the outbox being queried. Owners see private
+		 * and non-public activity types without the visibility filters below.
+		 *
+		 * For the blog actor (user_id = 0) the identity-equality check is wrong on
+		 * two counts — `get_current_user_id()` returns 0 for anonymous visitors (so
+		 * `0 === 0` would leak everything to the public), and AP-capable authors
+		 * would otherwise pass the `current_user_can( 'activitypub' )` arm and read
+		 * the blog's private Accepts. Delegate to the capability helper instead.
+		 */
+		if ( Actors::BLOG_USER_ID === (int) $user_id ) {
+			$is_outbox_owner = user_can_act_as_blog();
+		} else {
+			$is_outbox_owner = \is_user_logged_in() && (
+				\get_current_user_id() === (int) $user_id
+				|| \current_user_can( 'activitypub' )
+			);
+		}
+
+		if ( ! $is_outbox_owner ) {
 			$args['meta_query'][] = array(
 				'key'     => '_activitypub_activity_type',
 				'value'   => $activity_types,

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -14,6 +14,7 @@ use Activitypub\Signature;
 
 use function Activitypub\object_to_uri;
 use function Activitypub\use_authorized_fetch;
+use function Activitypub\user_can_act_as_blog;
 
 /**
  * Verification Trait.
@@ -209,23 +210,9 @@ trait Verification {
 			return true;
 		}
 
-		/**
-		 * Filters whether the current user is allowed to act as the blog actor.
-		 *
-		 * The blog actor has no `wp_users` row, so no logged-in user satisfies the
-		 * identity-equality check above when `user_id` is `BLOG_USER_ID`. This filter
-		 * defaults to true for users with the `manage_options` capability (administrators).
-		 * Filter to broaden the allow-list, for example to editors on multi-author sites.
-		 *
-		 * @since unreleased
-		 *
-		 * @param bool $can_act_as_blog Whether the current user can act as the blog actor.
-		 * @param int  $user_id         The user ID being acted upon (always BLOG_USER_ID at this call site).
-		 */
-		if (
-			Actors::BLOG_USER_ID === (int) $user_id
-			&& \apply_filters( 'activitypub_user_can_act_as_blog', \current_user_can( 'manage_options' ), $user_id )
-		) {
+		// The blog actor has no `wp_users` row, so the identity-equality check above
+		// cannot match for a logged-in user. Delegate to the capability helper.
+		if ( Actors::BLOG_USER_ID === (int) $user_id && user_can_act_as_blog() ) {
 			return true;
 		}
 

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -191,6 +191,20 @@ trait Verification {
 			return $user;
 		}
 
+		/*
+		 * Require an authenticated session before the identity-equality check below.
+		 * Without this guard, anonymous requests with `user_id = 0` (blog actor)
+		 * would match because `\get_current_user_id()` also returns `0`, exposing
+		 * owner-only behaviors such as the hidden social graph for the blog actor.
+		 */
+		if ( ! \is_user_logged_in() ) {
+			return new \WP_Error(
+				'activitypub_forbidden',
+				\__( 'You can only access your own resources.', 'activitypub' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		if ( \get_current_user_id() === (int) $user_id ) {
 			return true;
 		}

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -195,6 +195,25 @@ trait Verification {
 			return true;
 		}
 
+		/**
+		 * Filters whether the current user is allowed to act as the blog actor.
+		 *
+		 * The blog actor has no `wp_users` row, so identity-equality can never match.
+		 * Defaults to true for users with the `manage_options` capability (administrators).
+		 * Filter to broaden the allow-list, for example to editors on multi-author sites.
+		 *
+		 * @since unreleased
+		 *
+		 * @param bool $can_act_as_blog Whether the current user can act as the blog actor.
+		 * @param int  $user_id         The user ID being acted upon (always BLOG_USER_ID at this call site).
+		 */
+		if (
+			Actors::BLOG_USER_ID === (int) $user_id
+			&& \apply_filters( 'activitypub_user_can_act_as_blog', \current_user_can( 'manage_options' ), $user_id )
+		) {
+			return true;
+		}
+
 		return new \WP_Error(
 			'activitypub_forbidden',
 			\__( 'You can only access your own resources.', 'activitypub' ),

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -198,8 +198,9 @@ trait Verification {
 		/**
 		 * Filters whether the current user is allowed to act as the blog actor.
 		 *
-		 * The blog actor has no `wp_users` row, so identity-equality can never match.
-		 * Defaults to true for users with the `manage_options` capability (administrators).
+		 * The blog actor has no `wp_users` row, so no logged-in user satisfies the
+		 * identity-equality check above when `user_id` is `BLOG_USER_ID`. This filter
+		 * defaults to true for users with the `manage_options` capability (administrators).
 		 * Filter to broaden the allow-list, for example to editors on multi-author sites.
 		 *
 		 * @since unreleased

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -141,6 +141,11 @@ trait Verification {
 	 *
 	 * Application Passwords are not accepted directly on C2S endpoints.
 	 *
+	 * Security: `check_oauth_permission()` requires a valid Bearer token via
+	 * `is_oauth_request()`. Cookie-authenticated sessions never satisfy that
+	 * check, so a wp-admin session in another browser tab cannot be hijacked
+	 * to drive C2S writes on behalf of the user (no CSRF path on this surface).
+	 *
 	 * @param \WP_REST_Request $request The request object.
 	 * @return bool|\WP_Error True if authorized, WP_Error otherwise.
 	 */

--- a/tests/phpunit/tests/includes/collection/class-test-outbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-outbox.php
@@ -680,4 +680,75 @@ class Test_Outbox extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 
 		$this->assertEquals( 10, $deleted );
 	}
+
+	/**
+	 * Create a private outbox item authored by the blog actor for the tests below.
+	 *
+	 * @return \WP_Post The created outbox post.
+	 */
+	private function create_private_blog_actor_outbox_item() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author'  => 0,
+				'post_type'    => Outbox::POST_TYPE,
+				'post_status'  => 'pending',
+				'post_content' => \wp_json_encode(
+					array(
+						'@context' => array( 'https://www.w3.org/ns/activitystreams' ),
+						'id'       => 'https://example.org/activity/private-accept',
+						'type'     => 'Accept',
+						'actor'    => 'https://example.org/blog',
+						'object'   => 'https://example.org/follow/1',
+					)
+				),
+				'meta_input'   => array(
+					'_activitypub_activity_type'     => 'Accept',
+					'_activitypub_activity_actor'    => 'blog',
+					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE,
+				),
+			)
+		);
+
+		return \get_post( $post_id );
+	}
+
+	/**
+	 * Test that anonymous visitors cannot fetch a private blog-actor outbox item by permalink.
+	 *
+	 * Regression test for the `0 === 0` identity match: when `post_author` is `0`
+	 * (blog actor) and the visitor is unauthenticated, `get_current_user_id()` also
+	 * returns `0`, so the author bypass at the top of `maybe_get_activity()` would
+	 * return private items without an `is_user_logged_in()` guard.
+	 *
+	 * @covers ::maybe_get_activity
+	 */
+	public function test_maybe_get_activity_anonymous_cannot_read_private_blog_actor_item() {
+		$post = $this->create_private_blog_actor_outbox_item();
+
+		\wp_set_current_user( 0 );
+
+		$result = Outbox::maybe_get_activity( $post );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'private_outbox_item', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that administrators can fetch a private blog-actor outbox item by permalink.
+	 *
+	 * Mirrors the `verify_owner` blog-actor capability bypass: a user authorized to
+	 * act as the blog actor reads the same private outbox they can post to.
+	 *
+	 * @covers ::maybe_get_activity
+	 */
+	public function test_maybe_get_activity_admin_can_read_private_blog_actor_item() {
+		$post = $this->create_private_blog_actor_outbox_item();
+
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin_id );
+
+		$result = Outbox::maybe_get_activity( $post );
+
+		$this->assertInstanceOf( Activity::class, $result );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/admin/class-test-statistics-controller.php
+++ b/tests/phpunit/tests/includes/rest/admin/class-test-statistics-controller.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Test file for Statistics_Controller permissions.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Rest\Admin;
+
+use Activitypub\Rest\Admin\Statistics_Controller;
+
+/**
+ * Test class for Statistics_Controller permissions.
+ *
+ * @group rest
+ * @coversDefaultClass \Activitypub\Rest\Admin\Statistics_Controller
+ */
+class Test_Statistics_Controller extends \WP_UnitTestCase {
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var Statistics_Controller
+	 */
+	protected $controller;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->controller = new Statistics_Controller();
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tear_down() {
+		\wp_set_current_user( 0 );
+		\remove_all_filters( 'activitypub_user_can_act_as_blog' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a request targeting a given user_id.
+	 *
+	 * @param int $user_id The user ID to request stats for.
+	 * @return \WP_REST_Request
+	 */
+	private function build_request( $user_id ) {
+		$request = new \WP_REST_Request( 'GET', '/activitypub/1.0/stats/' . $user_id );
+		$request->set_param( 'user_id', $user_id );
+
+		return $request;
+	}
+
+	/**
+	 * Test administrators can view blog actor stats.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_admin_can_view_blog_stats() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin_id );
+
+		$this->assertTrue( $this->controller->get_item_permissions_check( $this->build_request( 0 ) ) );
+	}
+
+	/**
+	 * Test non-administrators cannot view blog actor stats by default.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_non_admin_cannot_view_blog_stats() {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\wp_set_current_user( $author_id );
+
+		$result = $this->controller->get_item_permissions_check( $this->build_request( 0 ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test the `activitypub_user_can_act_as_blog` filter can grant access to non-admins.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_filter_can_grant_blog_stats_access() {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\wp_set_current_user( $author_id );
+		\add_filter( 'activitypub_user_can_act_as_blog', '__return_true' );
+
+		$this->assertTrue( $this->controller->get_item_permissions_check( $this->build_request( 0 ) ) );
+	}
+
+	/**
+	 * Test users can view their own stats.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_user_can_view_own_stats() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\wp_set_current_user( $user_id );
+
+		$this->assertTrue( $this->controller->get_item_permissions_check( $this->build_request( $user_id ) ) );
+	}
+
+	/**
+	 * Test users cannot view another user's stats.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_user_cannot_view_other_user_stats() {
+		$user_id  = self::factory()->user->create( array( 'role' => 'author' ) );
+		$other_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\wp_set_current_user( $user_id );
+
+		$result = $this->controller->get_item_permissions_check( $this->build_request( $other_id ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+	}
+}

--- a/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
@@ -680,6 +680,60 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * Test that AP-capable non-admin users cannot see private blog-actor activities.
+	 *
+	 * Regression test for the `! current_user_can( 'activitypub' )` branch in
+	 * `get_items()` which previously skipped visibility filters for anyone with the
+	 * `activitypub` capability, allowing every publisher to read the blog actor's
+	 * private Accepts. The blog-actor branch now routes through `user_can_act_as_blog()`.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_blog_actor_outbox_filters_private_activities_for_ap_capable_non_admin() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'id', $author_id )->add_cap( 'activitypub' );
+		\wp_set_current_user( $author_id );
+		$this->assertTrue( \current_user_can( 'activitypub' ) );
+
+		self::factory()->post->create(
+			array(
+				'post_author'  => 0,
+				'post_type'    => Outbox::POST_TYPE,
+				'post_status'  => 'pending',
+				'post_title'   => 'https://example.org/activity/private-accept-2',
+				'post_content' => \wp_json_encode(
+					array(
+						'@context' => array( 'https://www.w3.org/ns/activitystreams' ),
+						'id'       => 'https://example.org/activity/private-accept-2',
+						'type'     => 'Accept',
+						'actor'    => 'https://example.org/blog',
+						'object'   => 'https://example.org/follow/2',
+					)
+				),
+				'meta_input'   => array(
+					'_activitypub_activity_type'     => 'Accept',
+					'_activitypub_activity_actor'    => 'blog',
+					'activitypub_content_visibility' => ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE,
+				),
+			)
+		);
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 10 );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$activity_types = \wp_list_pluck( $data['orderedItems'], 'type' );
+		$this->assertNotContains( 'Accept', $activity_types, 'Private Accept must not be visible to non-admin AP-capable users on the blog actor outbox.' );
+
+		\delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
 	 * Test meta query behavior for non-privileged users.
 	 *
 	 * @covers ::get_items

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -55,6 +55,8 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 		\wp_set_current_user( 0 );
 		\remove_all_filters( 'activitypub_defer_signature_verification' );
 		\remove_all_filters( 'activitypub_oauth_check_permission' );
+		\remove_all_filters( 'activitypub_user_can_act_as_blog' );
+		\delete_option( 'activitypub_actor_mode' );
 
 		// Reset OAuth token state.
 		$reflection = new \ReflectionClass( OAuth_Server::class );
@@ -357,6 +359,63 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 		$request->set_param( 'user_id', $this->user_id );
 
 		$result = $this->instance->verify_owner( $request );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test administrators can act as the blog actor.
+	 *
+	 * @covers ::verify_owner
+	 */
+	public function test_verify_owner_admin_can_act_as_blog() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin_id );
+
+		$request = new \WP_REST_Request( 'GET', '/activitypub/1.0/actors/0/outbox' );
+		$request->set_param( 'user_id', 0 );
+
+		$result = $this->instance->verify_owner( $request );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test non-administrators cannot act as the blog actor by default.
+	 *
+	 * @covers ::verify_owner
+	 */
+	public function test_verify_owner_non_admin_cannot_act_as_blog() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		\wp_set_current_user( $this->user_id );
+
+		$request = new \WP_REST_Request( 'GET', '/activitypub/1.0/actors/0/outbox' );
+		$request->set_param( 'user_id', 0 );
+
+		$result = $this->instance->verify_owner( $request );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test the `activitypub_user_can_act_as_blog` filter can grant access.
+	 *
+	 * @covers ::verify_owner
+	 */
+	public function test_verify_owner_blog_actor_filter_grants_access() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		\wp_set_current_user( $this->user_id );
+		\add_filter( 'activitypub_user_can_act_as_blog', '__return_true' );
+
+		$request = new \WP_REST_Request( 'GET', '/activitypub/1.0/actors/0/outbox' );
+		$request->set_param( 'user_id', 0 );
+
+		$result = $this->instance->verify_owner( $request );
+
+		\remove_filter( 'activitypub_user_can_act_as_blog', '__return_true' );
 
 		$this->assertTrue( $result );
 	}

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -421,6 +421,28 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the `activitypub_user_can_act_as_blog` filter can revoke admin access.
+	 *
+	 * @covers ::verify_owner
+	 */
+	public function test_verify_owner_blog_actor_filter_revokes_admin_access() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		\wp_set_current_user( $admin_id );
+		\add_filter( 'activitypub_user_can_act_as_blog', '__return_false' );
+
+		$request = new \WP_REST_Request( 'GET', '/activitypub/1.0/actors/0/outbox' );
+		$request->set_param( 'user_id', 0 );
+
+		$result = $this->instance->verify_owner( $request );
+
+		\remove_filter( 'activitypub_user_can_act_as_blog', '__return_false' );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
+	}
+
+	/**
 	 * Data provider for verify_key_id tests.
 	 *
 	 * @return array[] Test cases: [ signature_header, actor, expected_pass ].

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -364,6 +364,28 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test unauthenticated requests cannot satisfy ownership for the blog actor.
+	 *
+	 * Guards against the pre-existing 0 === 0 path where `get_current_user_id()`
+	 * for an anonymous request would equal `BLOG_USER_ID`.
+	 *
+	 * @covers ::verify_owner
+	 */
+	public function test_verify_owner_anonymous_cannot_act_as_blog() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+		\wp_set_current_user( 0 );
+
+		$request = new \WP_REST_Request( 'GET', '/activitypub/1.0/actors/0/followers' );
+		$request->set_param( 'user_id', 0 );
+
+		$result = $this->instance->verify_owner( $request );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
 	 * Test administrators can act as the blog actor.
 	 *
 	 * @covers ::verify_owner


### PR DESCRIPTION
Fixes #3276

## Proposed changes:

* Add a capability-gated bypass in `verify_owner()`: users with `manage_options` (administrators by default) pass the ownership check for `Actors::BLOG_USER_ID`. The existing identity-equality check could never satisfy the blog actor because it has no `wp_users` row.
* Wrap the capability check in a new `activitypub_user_can_act_as_blog` filter so integrations can broaden (or narrow) the allow-list — for example, granting editors on multi-author sites the right to publish through the site's blog account.

This is the minimal-viable fix from the issue's option A — admins authorize as themselves via the existing OAuth flow, the token is stored against their real `user_id`, and this patch is the only ownership-check change needed. No DB migration, no new scope, no token-schema changes.

Out of scope (separate follow-ups):
- The `me = <blog URI>` advertising issue (option D in the ticket) — once admins can legitimately act as the blog, the response is correct for them; the misleading case for non-admins without user actors is still open.
- Full per-token `actor_id` plumbing (option B).
- Promoting the blog actor to a real `wp_users` row (option C).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Enable the blog actor: set Actor Mode to "Blog and User" (or "Blog only") under Settings → ActivityPub.
* Register an OAuth client and authorize it while logged in as an administrator.
* `POST /wp-json/activitypub/1.0/actors/0/outbox` with the resulting bearer token and a valid Create activity — request should be accepted (201).
* Repeat the OAuth flow as a non-admin (e.g. author). The token will issue, but `POST /actors/0/outbox` should be rejected (403, `activitypub_forbidden`).
* Add `add_filter( 'activitypub_user_can_act_as_blog', '__return_true' );` in a mu-plugin and retry as the non-admin — request should now be accepted.

### Changelog entry

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Minor

#### Type

- [x] Added

#### Message

Allow site administrators to post from third-party apps on behalf of the site's blog account.

</details>