### PR TITLE
Fix C2S blog actor posts created without author

### DIFF
--- a/.github/changelog/fix-blog-actor-c2s-post-author
+++ b/.github/changelog/fix-blog-actor-c2s-post-author
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set a real author on posts created via the blog actor outbox so they no longer appear without a byline.

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -36,8 +36,17 @@ class Posts {
 	public static function create( $activity, $user_id, $visibility = null ) {
 		/*
 		 * Resolve the post author. For the blog actor (user_id = 0) fall back to
-		 * the current user so C2S posts get a real byline; the cron/CLI paths
-		 * have no current user and keep `post_author = 0`.
+		 * the current user so C2S posts get a real byline. The `get_current_user_id()`
+		 * read relies on the REST stack having already authenticated the request:
+		 * `Outbox_Controller::create_item` is gated by `verify_authentication`, which
+		 * calls `OAuth\Server::check_oauth_permission` and ultimately
+		 * `wp_set_current_user( $token->get_user_id() )` before this method runs.
+		 *
+		 * `$post_author = 0` survives only when no current user is loaded — i.e. the
+		 * internal scheduler / WP-Cron paths that legitimately have no actor. The
+		 * cap check below intentionally short-circuits for `post_author = 0`; any
+		 * new caller that can reach this method without a current user MUST stay
+		 * inside that trusted scheduler context.
 		 */
 		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
 

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -39,17 +39,25 @@ class Posts {
 		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
 
 		/*
-		 * Blog actor path (user_id = 0): require the act-as-blog grant.
-		 * `publish_posts` is implicit because the helper defaults to
-		 * `manage_options` (administrators). The cron/CLI path has no current
-		 * user and keeps `post_author = 0`, bypassing this check intentionally.
+		 * Authorize the request:
+		 * - Per-user path: require `publish_posts` on the URL-specified user.
+		 * - Blog actor path (post_author falls back to current user): require
+		 *   the act-as-blog grant. `publish_posts` is implicit because the
+		 *   helper defaults to `manage_options` (administrators).
+		 * - Cron/CLI path keeps `post_author = 0` and bypasses both checks.
 		 */
-		if ( $user_id <= 0 && $post_author > 0 && ! user_can_act_as_blog() ) {
-			return new \WP_Error(
-				'activitypub_forbidden',
-				\__( 'You do not have permission to create posts.', 'activitypub' ),
-				array( 'status' => 403 )
-			);
+		if ( $post_author > 0 ) {
+			$authorized = $post_author === (int) $user_id
+				? \user_can( $user_id, 'publish_posts' )
+				: user_can_act_as_blog();
+
+			if ( ! $authorized ) {
+				return new \WP_Error(
+					'activitypub_forbidden',
+					\__( 'You do not have permission to create posts.', 'activitypub' ),
+					array( 'status' => 403 )
+				);
+			}
 		}
 
 		$object = $activity['object'] ?? array();

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -35,22 +35,22 @@ class Posts {
 	 * @return \WP_Post|\WP_Error The created post on success, WP_Error on failure.
 	 */
 	public static function create( $activity, $user_id, $visibility = null ) {
+		// Resolve the post author. Blog actor falls back to the current user for a real byline.
+		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
+
 		/*
 		 * Blog actor path (user_id = 0): require the act-as-blog grant.
 		 * `publish_posts` is implicit because the helper defaults to
 		 * `manage_options` (administrators). The cron/CLI path has no current
 		 * user and keeps `post_author = 0`, bypassing this check intentionally.
 		 */
-		if ( $user_id <= 0 && \get_current_user_id() > 0 && ! user_can_act_as_blog() ) {
+		if ( $user_id <= 0 && $post_author > 0 && ! user_can_act_as_blog() ) {
 			return new \WP_Error(
 				'activitypub_forbidden',
 				\__( 'You do not have permission to create posts.', 'activitypub' ),
 				array( 'status' => 403 )
 			);
 		}
-
-		// Resolve the post author. Blog actor falls back to the current user for a real byline.
-		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
 
 		$object = $activity['object'] ?? array();
 

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -64,8 +64,11 @@ class Posts {
 			$visibility = get_content_visibility( $activity );
 		}
 
+		// Fall back to the current user for the blog actor so C2S posts get a real byline.
+		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
+
 		$post_data = array(
-			'post_author'  => $user_id > 0 ? $user_id : 0,
+			'post_author'  => $post_author,
 			'post_title'   => $title,
 			'post_content' => $content,
 			'post_excerpt' => $summary,

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -12,6 +12,7 @@ use Activitypub\Hashtag;
 use Activitypub\Link;
 
 use function Activitypub\get_content_visibility;
+use function Activitypub\user_can_act_as_blog;
 
 /**
  * Posts collection.
@@ -35,29 +36,21 @@ class Posts {
 	 */
 	public static function create( $activity, $user_id, $visibility = null ) {
 		/*
-		 * Resolve the post author. For the blog actor (user_id = 0) fall back to
-		 * the current user so C2S posts get a real byline. The `get_current_user_id()`
-		 * read relies on the REST stack having already authenticated the request:
-		 * `Outbox_Controller::create_item` is gated by `verify_authentication`, which
-		 * calls `OAuth\Server::check_oauth_permission` and ultimately
-		 * `wp_set_current_user( $token->get_user_id() )` before this method runs.
-		 *
-		 * `$post_author = 0` survives only when no current user is loaded — i.e. the
-		 * internal scheduler / WP-Cron paths that legitimately have no actor. The
-		 * cap check below intentionally short-circuits for `post_author = 0`; any
-		 * new caller that can reach this method without a current user MUST stay
-		 * inside that trusted scheduler context.
+		 * Blog actor path (user_id = 0): require the act-as-blog grant.
+		 * `publish_posts` is implicit because the helper defaults to
+		 * `manage_options` (administrators). The cron/CLI path has no current
+		 * user and keeps `post_author = 0`, bypassing this check intentionally.
 		 */
-		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
-
-		// Verify the resolved author has permission to publish posts.
-		if ( $post_author > 0 && ! \user_can( $post_author, 'publish_posts' ) ) {
+		if ( $user_id <= 0 && \get_current_user_id() > 0 && ! user_can_act_as_blog() ) {
 			return new \WP_Error(
 				'activitypub_forbidden',
 				\__( 'You do not have permission to create posts.', 'activitypub' ),
 				array( 'status' => 403 )
 			);
 		}
+
+		// Resolve the post author. Blog actor falls back to the current user for a real byline.
+		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
 
 		$object = $activity['object'] ?? array();
 

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -34,8 +34,15 @@ class Posts {
 	 * @return \WP_Post|\WP_Error The created post on success, WP_Error on failure.
 	 */
 	public static function create( $activity, $user_id, $visibility = null ) {
-		// Verify the user has permission to create posts.
-		if ( $user_id > 0 && ! \user_can( $user_id, 'publish_posts' ) ) {
+		/*
+		 * Resolve the post author. For the blog actor (user_id = 0) fall back to
+		 * the current user so C2S posts get a real byline; the cron/CLI paths
+		 * have no current user and keep `post_author = 0`.
+		 */
+		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
+
+		// Verify the resolved author has permission to publish posts.
+		if ( $post_author > 0 && ! \user_can( $post_author, 'publish_posts' ) ) {
 			return new \WP_Error(
 				'activitypub_forbidden',
 				\__( 'You do not have permission to create posts.', 'activitypub' ),
@@ -63,9 +70,6 @@ class Posts {
 		if ( null === $visibility ) {
 			$visibility = get_content_visibility( $activity );
 		}
-
-		// Fall back to the current user for the blog actor so C2S posts get a real byline.
-		$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
 
 		$post_data = array(
 			'post_author'  => $post_author,

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -192,6 +192,32 @@ class Test_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the blog actor path rejects a current user without `publish_posts`.
+	 *
+	 * Defense-in-depth: even if `verify_owner` lets a filter-granted user reach
+	 * `Posts::create` for the blog actor, the resolved author must still hold
+	 * `publish_posts`. Contributors do not.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_with_blog_actor_forbidden_for_contributor() {
+		$user_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
+		\wp_set_current_user( $user_id );
+
+		$activity = array(
+			'object' => array(
+				'type'    => 'Note',
+				'content' => '<p>Should not be created.</p>',
+			),
+		);
+
+		$result = Posts::create( $activity, 0 );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
+	}
+
+	/**
 	 * Test content is processed through prepare_content pipeline.
 	 *
 	 * @covers ::create

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -127,26 +127,6 @@ class Test_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test creating a post fails for users without publish_posts capability.
-	 *
-	 * @covers ::create
-	 */
-	public function test_create_forbidden_for_subscriber() {
-		$user_id  = self::factory()->user->create( array( 'role' => 'subscriber' ) );
-		$activity = array(
-			'object' => array(
-				'type'    => 'Note',
-				'content' => '<p>Should not be created.</p>',
-			),
-		);
-
-		$result = Posts::create( $activity, $user_id );
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
-	}
-
-	/**
 	 * Test creating a post with blog actor (user_id = 0) and no current user keeps post_author = 0.
 	 *
 	 * Covers the cron/CLI path where no user is loaded.
@@ -172,10 +152,12 @@ class Test_Posts extends \WP_UnitTestCase {
 	/**
 	 * Test creating a post with blog actor (user_id = 0) falls back to the current user for the byline.
 	 *
+	 * Administrators pass `user_can_act_as_blog()` by default (`manage_options`).
+	 *
 	 * @covers ::create
 	 */
 	public function test_create_with_blog_actor_uses_current_user() {
-		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		\wp_set_current_user( $user_id );
 
 		$activity = array(
@@ -194,16 +176,15 @@ class Test_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the blog actor path rejects a current user without `publish_posts`.
+	 * Test the blog actor path rejects users who cannot act as the blog.
 	 *
-	 * Defense-in-depth: even if `verify_owner` lets a filter-granted user reach
-	 * `Posts::create` for the blog actor, the resolved author must still hold
-	 * `publish_posts`. Contributors do not.
+	 * Editors do not hold `manage_options`, so `user_can_act_as_blog()` returns
+	 * false for them by default and `Posts::create` must 403.
 	 *
 	 * @covers ::create
 	 */
-	public function test_create_with_blog_actor_forbidden_for_contributor() {
-		$user_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
+	public function test_create_with_blog_actor_forbidden_without_grant() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		\wp_set_current_user( $user_id );
 
 		$activity = array(
@@ -219,6 +200,32 @@ class Test_Posts extends \WP_UnitTestCase {
 		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
 
 		\wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test the `activitypub_user_can_act_as_blog` filter unlocks the blog actor path.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_with_blog_actor_filter_grants_access() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		\wp_set_current_user( $user_id );
+		\add_filter( 'activitypub_user_can_act_as_blog', '__return_true' );
+
+		$activity = array(
+			'object' => array(
+				'type'    => 'Note',
+				'content' => '<p>Filter-granted blog actor post.</p>',
+			),
+		);
+
+		$post = Posts::create( $activity, 0 );
+
+		\remove_filter( 'activitypub_user_can_act_as_blog', '__return_true' );
+		\wp_set_current_user( 0 );
+
+		$this->assertInstanceOf( '\WP_Post', $post );
+		$this->assertEquals( $user_id, (int) $post->post_author );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -147,11 +147,15 @@ class Test_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test creating a post with blog actor (user_id = 0) skips permission check.
+	 * Test creating a post with blog actor (user_id = 0) and no current user keeps post_author = 0.
+	 *
+	 * Covers the cron/CLI path where no user is loaded.
 	 *
 	 * @covers ::create
 	 */
-	public function test_create_with_blog_actor() {
+	public function test_create_with_blog_actor_no_current_user() {
+		\wp_set_current_user( 0 );
+
 		$activity = array(
 			'object' => array(
 				'type'    => 'Note',
@@ -163,6 +167,28 @@ class Test_Posts extends \WP_UnitTestCase {
 
 		$this->assertInstanceOf( '\WP_Post', $post );
 		$this->assertEquals( 0, (int) $post->post_author );
+	}
+
+	/**
+	 * Test creating a post with blog actor (user_id = 0) falls back to the current user for the byline.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_with_blog_actor_uses_current_user() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		\wp_set_current_user( $user_id );
+
+		$activity = array(
+			'object' => array(
+				'type'    => 'Note',
+				'content' => '<p>Blog actor post from authenticated request.</p>',
+			),
+		);
+
+		$post = Posts::create( $activity, 0 );
+
+		$this->assertInstanceOf( '\WP_Post', $post );
+		$this->assertEquals( $user_id, (int) $post->post_author );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -127,6 +127,26 @@ class Test_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test creating a post fails for users without publish_posts capability.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_forbidden_for_subscriber() {
+		$user_id  = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$activity = array(
+			'object' => array(
+				'type'    => 'Note',
+				'content' => '<p>Should not be created.</p>',
+			),
+		);
+
+		$result = Posts::create( $activity, $user_id );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
+	}
+
+	/**
 	 * Test creating a post with blog actor (user_id = 0) and no current user keeps post_author = 0.
 	 *
 	 * Covers the cron/CLI path where no user is loaded.

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -189,6 +189,8 @@ class Test_Posts extends \WP_UnitTestCase {
 
 		$this->assertInstanceOf( '\WP_Post', $post );
 		$this->assertEquals( $user_id, (int) $post->post_author );
+
+		\wp_set_current_user( 0 );
 	}
 
 	/**
@@ -215,6 +217,8 @@ class Test_Posts extends \WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'activitypub_forbidden', $result->get_error_code() );
+
+		\wp_set_current_user( 0 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes CM-711

## Why

Posts published via the C2S outbox against the blog actor (`user_id = 0`) end up with `post_author = 0`. Any caller that routes through the blog actor — for example a Reader-side endpoint that posts on behalf of a site rather than a specific user — therefore produces posts with no real byline.

## What

`includes/collection/class-posts.php` hardcoded `post_author = 0` whenever `$user_id <= 0`:

```php
'post_author'  => $user_id > 0 ? $user_id : 0,
```

This change falls back to `get_current_user_id()` when the activity is dispatched against the blog actor:

```php
$post_author = $user_id > 0 ? $user_id : \get_current_user_id();
```

`get_current_user_id()` returns `0` when no user is loaded, so the cron and WP-CLI paths that legitimately have no user keep their existing behaviour.

The `publish_posts` capability check that gates the C2S outbox upstream of `Posts::create()` continues to enforce permissions for authenticated requests.

## Test plan

- [x] New unit test: blog actor + authenticated current user → `post_author === <current user id>`.
- [x] Existing regression-guard test (renamed): blog actor + no current user → `post_author === 0`.
- [x] Existing test: per-user actor (`$user_id > 0`) → `post_author === $user_id` (unchanged).
- [x] `vendor/bin/phpunit --filter Test_Posts` → 20 tests / 42 assertions pass.
- [x] `vendor/bin/phpcs` clean on touched files.
