### PR TITLE
Guard against null post in statistics earliest-date lookup

### DIFF
--- a/.github/changelog/fix-statistics-earliest-date-null
+++ b/.github/changelog/fix-statistics-earliest-date-null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent a PHP warning during the monthly statistics backfill when an outbox item disappears between lookup steps.

--- a/includes/class-statistics.php
+++ b/includes/class-statistics.php
@@ -948,6 +948,23 @@ class Statistics {
 			}
 
 			$earliest_post = \get_post( $earliest_outbox[0] );
+
+			/*
+			 * `get_post()` returns null if the row was deleted between the
+			 * `get_posts()` lookup and this call (cron race / cache miss).
+			 * `post_date_gmt` can also be empty or the MySQL zero-date — both
+			 * would fall through to `strtotime( false ) === false` below and
+			 * silently produce 1970 as the earliest year. Bail in all three
+			 * cases.
+			 */
+			if (
+				! $earliest_post
+				|| empty( $earliest_post->post_date_gmt )
+				|| '0000-00-00 00:00:00' === $earliest_post->post_date_gmt
+			) {
+				return null;
+			}
+
 			$earliest_date = $earliest_post->post_date_gmt;
 		}
 

--- a/includes/class-statistics.php
+++ b/includes/class-statistics.php
@@ -921,10 +921,12 @@ class Statistics {
 		// phpcs:enable
 
 		if ( ! $earliest_date ) {
-			// No ActivityPub data, check outbox instead. Outbox items are never
-			// updated after insertion, so `post_modified_gmt` mirrors the
-			// creation time and is more resilient than `post_date_gmt` to the
-			// rare zero-date corruption seen on some production sites.
+			/*
+			 * No ActivityPub data, check outbox instead. Outbox items are never
+			 * updated after insertion, so `post_modified_gmt` mirrors the
+			 * creation time and is more resilient than `post_date_gmt` to the
+			 * rare zero-date corruption seen on some production sites.
+			 */
 			$outbox_args = array(
 				'post_type'      => Outbox::POST_TYPE,
 				'posts_per_page' => 1,

--- a/includes/class-statistics.php
+++ b/includes/class-statistics.php
@@ -921,13 +921,15 @@ class Statistics {
 		// phpcs:enable
 
 		if ( ! $earliest_date ) {
-			// No ActivityPub data, check outbox instead.
+			// No ActivityPub data, check outbox instead. Outbox items are never
+			// updated after insertion, so `post_modified_gmt` mirrors the
+			// creation time and is more resilient than `post_date_gmt` to the
+			// rare zero-date corruption seen on some production sites.
 			$outbox_args = array(
 				'post_type'      => Outbox::POST_TYPE,
 				'posts_per_page' => 1,
 				'orderby'        => 'date',
 				'order'          => 'ASC',
-				'fields'         => 'ids',
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query'     => array(
 					array(
@@ -942,32 +944,14 @@ class Statistics {
 			}
 
 			$earliest_outbox = \get_posts( $outbox_args );
-
-			if ( empty( $earliest_outbox ) ) {
-				return null;
-			}
-
-			$earliest_post = \get_post( $earliest_outbox[0] );
-
-			/*
-			 * `get_post()` returns null if the row was deleted between the
-			 * `get_posts()` lookup and this call (cron race / cache miss).
-			 * `post_date_gmt` can also be empty or the MySQL zero-date — both
-			 * would fall through to `strtotime( false ) === false` below and
-			 * silently produce 1970 as the earliest year. Bail in all three
-			 * cases.
-			 */
-			if (
-				! $earliest_post
-				|| empty( $earliest_post->post_date_gmt )
-				|| '0000-00-00 00:00:00' === $earliest_post->post_date_gmt
-			) {
-				return null;
-			}
-
-			$earliest_date = $earliest_post->post_date_gmt;
+			$earliest_date   = $earliest_outbox ? $earliest_outbox[0]->post_modified_gmt : '';
 		}
 
-		return (int) \gmdate( 'Y', \strtotime( $earliest_date ) );
+		$timestamp = \strtotime( (string) $earliest_date );
+		if ( $timestamp <= 0 ) {
+			return null;
+		}
+
+		return (int) \gmdate( 'Y', $timestamp );
 	}
 }

--- a/includes/class-statistics.php
+++ b/includes/class-statistics.php
@@ -942,15 +942,23 @@ class Statistics {
 
 			$earliest_outbox = \get_posts( $outbox_args );
 
-			// Prefer `post_date_gmt`; fall back to local `post_date` if the GMT field is
-			// empty (rare zero-date corruption seen on some production sites).
-			$earliest_date = $earliest_outbox
-				? ( $earliest_outbox[0]->post_date_gmt ?: $earliest_outbox[0]->post_date )
-				: '';
+			/*
+			 * Prefer `post_date_gmt`; fall back to local `post_date` when the GMT field
+			 * is empty or the MySQL zero-date (rare corruption seen on some production
+			 * sites). The zero-date is a truthy string, so it has to be detected
+			 * explicitly rather than via `?:`.
+			 */
+			$earliest_date = '';
+			if ( $earliest_outbox ) {
+				$gmt           = $earliest_outbox[0]->post_date_gmt;
+				$earliest_date = ( empty( $gmt ) || '0000-00-00 00:00:00' === $gmt )
+					? $earliest_outbox[0]->post_date
+					: $gmt;
+			}
 		}
 
 		$timestamp = \strtotime( (string) $earliest_date );
-		if ( $timestamp <= 0 ) {
+		if ( false === $timestamp ) {
 			return null;
 		}
 

--- a/includes/class-statistics.php
+++ b/includes/class-statistics.php
@@ -947,12 +947,15 @@ class Statistics {
 			 * is empty or the MySQL zero-date (rare corruption seen on some production
 			 * sites). The zero-date is a truthy string, so it has to be detected
 			 * explicitly rather than via `?:`.
+			 *
+			 * Convert the local `post_date` fallback to GMT first so the later
+			 * `strtotime()` + `gmdate()` flow consistently derives the year in UTC.
 			 */
 			$earliest_date = '';
 			if ( $earliest_outbox ) {
 				$gmt           = $earliest_outbox[0]->post_date_gmt;
 				$earliest_date = ( empty( $gmt ) || '0000-00-00 00:00:00' === $gmt )
-					? $earliest_outbox[0]->post_date
+					? \get_gmt_from_date( $earliest_outbox[0]->post_date )
 					: $gmt;
 			}
 		}

--- a/includes/class-statistics.php
+++ b/includes/class-statistics.php
@@ -921,12 +921,7 @@ class Statistics {
 		// phpcs:enable
 
 		if ( ! $earliest_date ) {
-			/*
-			 * No ActivityPub data, check outbox instead. Outbox items are never
-			 * updated after insertion, so `post_modified_gmt` mirrors the
-			 * creation time and is more resilient than `post_date_gmt` to the
-			 * rare zero-date corruption seen on some production sites.
-			 */
+			// No ActivityPub data, check outbox instead.
 			$outbox_args = array(
 				'post_type'      => Outbox::POST_TYPE,
 				'posts_per_page' => 1,
@@ -946,7 +941,12 @@ class Statistics {
 			}
 
 			$earliest_outbox = \get_posts( $outbox_args );
-			$earliest_date   = $earliest_outbox ? $earliest_outbox[0]->post_modified_gmt : '';
+
+			// Prefer `post_date_gmt`; fall back to local `post_date` if the GMT field is
+			// empty (rare zero-date corruption seen on some production sites).
+			$earliest_date = $earliest_outbox
+				? ( $earliest_outbox[0]->post_date_gmt ?: $earliest_outbox[0]->post_date )
+				: '';
 		}
 
 		$timestamp = \strtotime( (string) $earliest_date );

--- a/tests/phpunit/tests/includes/class-test-statistics.php
+++ b/tests/phpunit/tests/includes/class-test-statistics.php
@@ -18,16 +18,15 @@ use Activitypub\Statistics;
 class Test_Statistics extends \WP_UnitTestCase {
 
 	/**
-	 * Test that the earliest-outbox lookup ignores a corrupt `post_date_gmt`
-	 * by reading the auto-stamped `post_modified_gmt` instead.
+	 * Test that the earliest-outbox lookup falls back to `post_date` when
+	 * `post_date_gmt` is the MySQL zero-date.
 	 *
-	 * Regression for a production warning where `post_date_gmt` on the
-	 * earliest outbox row was empty/null, dereferenced into a PHP warning,
-	 * and silently produced 1970 as the earliest year.
+	 * Regression for a production warning where dereferencing
+	 * `post_date_gmt` produced a PHP warning and a silent 1970 year.
 	 *
 	 * @covers ::backfill_historical_stats
 	 */
-	public function test_backfill_uses_post_modified_gmt_when_post_date_gmt_corrupt() {
+	public function test_backfill_falls_back_to_post_date_when_gmt_is_corrupt() {
 		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		\get_user_by( 'id', $user_id )->add_cap( 'activitypub' );
 		self::factory()->post->create( array( 'post_author' => $user_id ) );
@@ -41,7 +40,7 @@ class Test_Statistics extends \WP_UnitTestCase {
 			)
 		);
 
-		// Corrupt `post_date_gmt` after insert; `post_modified_gmt` stays valid.
+		// Corrupt `post_date_gmt` after insert; `post_date` stays valid.
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$wpdb->update(
@@ -53,19 +52,27 @@ class Test_Statistics extends \WP_UnitTestCase {
 		);
 		\clean_post_cache( $outbox_id );
 
+		// Target the regression user explicitly so the assertion isn't sensitive
+		// to other AP-capable users that may already exist in the suite.
+		$user_index = \array_search( $user_id, Statistics::get_active_user_ids(), true );
+		$this->assertNotFalse( $user_index, 'Test user should be in the active-user list.' );
+
 		$errors = array();
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		\set_error_handler(
 			static function ( $errno, $errstr ) use ( &$errors ) {
 				$errors[] = $errstr;
+				return true;
 			}
 		);
 
-		$result = Statistics::backfill_historical_stats();
+		try {
+			$result = Statistics::backfill_historical_stats( 12, $user_index );
+		} finally {
+			\restore_error_handler();
+		}
 
-		\restore_error_handler();
-
-		$this->assertEmpty( $errors, 'No warnings should fire when the outbox row has a zero `post_date_gmt`.' );
+		$this->assertEmpty( $errors, 'No warnings should fire when `post_date_gmt` is zero-dated.' );
 		$this->assertIsArray( $result, 'Scheduler should keep going, not crash.' );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-statistics.php
+++ b/tests/phpunit/tests/includes/class-test-statistics.php
@@ -18,30 +18,40 @@ use Activitypub\Statistics;
 class Test_Statistics extends \WP_UnitTestCase {
 
 	/**
-	 * Test that backfill_historical_stats handles a get_post() null result gracefully.
+	 * Test that the earliest-outbox lookup ignores a corrupt `post_date_gmt`
+	 * by reading the auto-stamped `post_modified_gmt` instead.
 	 *
-	 * Regression test for a production warning where `get_post()` returned null
-	 * (cron race / cache miss) and the next line dereferenced `->post_date_gmt`
-	 * on null. The guard inside `get_earliest_data_year()` keeps the cron call
-	 * silent and lets the scheduler advance to the next user.
+	 * Regression for a production warning where `post_date_gmt` on the
+	 * earliest outbox row was empty/null, dereferenced into a PHP warning,
+	 * and silently produced 1970 as the earliest year.
 	 *
 	 * @covers ::backfill_historical_stats
 	 */
-	public function test_backfill_historical_stats_handles_missing_post() {
+	public function test_backfill_uses_post_modified_gmt_when_post_date_gmt_corrupt() {
 		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		\get_user_by( 'id', $user_id )->add_cap( 'activitypub' );
-
-		// Publish a post so the user shows up in `get_active_user_ids()`.
 		self::factory()->post->create( array( 'post_author' => $user_id ) );
 
-		// Force the outbox query to return a non-existent ID so `get_post()` returns null.
-		$filter = function ( $posts, $query ) {
-			if ( Outbox::POST_TYPE === ( $query->query['post_type'] ?? '' ) ) {
-				return array( 999999 );
-			}
-			return $posts;
-		};
-		\add_filter( 'posts_pre_query', $filter, 10, 2 );
+		$outbox_id = self::factory()->post->create(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_author' => $user_id,
+				'post_date'   => '2024-06-15 12:00:00',
+				'meta_input'  => array( '_activitypub_activity_type' => 'Create' ),
+			)
+		);
+
+		// Corrupt `post_date_gmt` after insert; `post_modified_gmt` stays valid.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->update(
+			$wpdb->posts,
+			array( 'post_date_gmt' => '0000-00-00 00:00:00' ),
+			array( 'ID' => $outbox_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		\clean_post_cache( $outbox_id );
 
 		$errors = array();
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
@@ -54,17 +64,8 @@ class Test_Statistics extends \WP_UnitTestCase {
 		$result = Statistics::backfill_historical_stats();
 
 		\restore_error_handler();
-		\remove_filter( 'posts_pre_query', $filter, 10 );
 
-		$this->assertEmpty(
-			\array_filter(
-				$errors,
-				static function ( $msg ) {
-					return false !== \strpos( $msg, 'post_date_gmt' );
-				}
-			),
-			'No "post_date_gmt on null" warning should fire when get_post() returns null.'
-		);
-		$this->assertIsArray( $result, 'Scheduler should advance to the next user, not crash.' );
+		$this->assertEmpty( $errors, 'No warnings should fire when the outbox row has a zero `post_date_gmt`.' );
+		$this->assertIsArray( $result, 'Scheduler should keep going, not crash.' );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-statistics.php
+++ b/tests/phpunit/tests/includes/class-test-statistics.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Test file for Statistics.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+use Activitypub\Collection\Outbox;
+use Activitypub\Statistics;
+
+/**
+ * Test class for Statistics.
+ *
+ * @coversDefaultClass \Activitypub\Statistics
+ */
+class Test_Statistics extends \WP_UnitTestCase {
+
+	/**
+	 * Test that backfill_historical_stats handles a get_post() null result gracefully.
+	 *
+	 * Regression test for a production warning where `get_post()` returned null
+	 * (cron race / cache miss) and the next line dereferenced `->post_date_gmt`
+	 * on null. The guard inside `get_earliest_data_year()` keeps the cron call
+	 * silent and lets the scheduler advance to the next user.
+	 *
+	 * @covers ::backfill_historical_stats
+	 */
+	public function test_backfill_historical_stats_handles_missing_post() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'id', $user_id )->add_cap( 'activitypub' );
+
+		// Publish a post so the user shows up in `get_active_user_ids()`.
+		self::factory()->post->create( array( 'post_author' => $user_id ) );
+
+		// Force the outbox query to return a non-existent ID so `get_post()` returns null.
+		$filter = function ( $posts, $query ) {
+			if ( Outbox::POST_TYPE === ( $query->query['post_type'] ?? '' ) ) {
+				return array( 999999 );
+			}
+			return $posts;
+		};
+		\add_filter( 'posts_pre_query', $filter, 10, 2 );
+
+		$errors = array();
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		\set_error_handler(
+			static function ( $errno, $errstr ) use ( &$errors ) {
+				$errors[] = $errstr;
+			}
+		);
+
+		$result = Statistics::backfill_historical_stats();
+
+		\restore_error_handler();
+		\remove_filter( 'posts_pre_query', $filter, 10 );
+
+		$this->assertEmpty(
+			\array_filter(
+				$errors,
+				static function ( $msg ) {
+					return false !== \strpos( $msg, 'post_date_gmt' );
+				}
+			),
+			'No "post_date_gmt on null" warning should fire when get_post() returns null.'
+		);
+		$this->assertIsArray( $result, 'Scheduler should advance to the next user, not crash.' );
+	}
+}

--- a/tests/phpunit/tests/includes/class-test-statistics.php
+++ b/tests/phpunit/tests/includes/class-test-statistics.php
@@ -71,7 +71,9 @@ class Test_Statistics extends \WP_UnitTestCase {
 		);
 
 		try {
-			$result = Statistics::backfill_historical_stats( 12, $user_index );
+			// Single-month batch so the returned `year` is exactly the derived
+			// earliest year, not the year-after-batch.
+			$result = Statistics::backfill_historical_stats( 1, $user_index );
 		} finally {
 			\restore_error_handler();
 		}
@@ -83,10 +85,15 @@ class Test_Statistics extends \WP_UnitTestCase {
 			$result['user_index'],
 			'User should not be skipped — fallback to `post_date` must yield a valid earliest year.'
 		);
-		$this->assertGreaterThan(
-			0,
+		$this->assertSame(
+			2024,
 			$result['year'],
-			'A valid earliest year must be derived from `post_date` when `post_date_gmt` is zero-dated.'
+			'Earliest year must come from `post_date` (2024-06-15), not a coerced epoch / null.'
+		);
+		$this->assertSame(
+			2,
+			$result['month'],
+			'After one batched month starting at January, the cursor should advance to February.'
 		);
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-statistics.php
+++ b/tests/phpunit/tests/includes/class-test-statistics.php
@@ -57,13 +57,17 @@ class Test_Statistics extends \WP_UnitTestCase {
 		$user_index = \array_search( $user_id, Statistics::get_active_user_ids(), true );
 		$this->assertNotFalse( $user_index, 'Test user should be in the active-user list.' );
 
-		$errors = array();
+		$errors   = array();
+		$relevant = E_WARNING | E_USER_WARNING | E_NOTICE | E_USER_NOTICE;
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		\set_error_handler(
-			static function ( $errno, $errstr ) use ( &$errors ) {
-				$errors[] = $errstr;
-				return true;
-			}
+			static function ( $errno, $errstr ) use ( &$errors, $relevant ) {
+				if ( $errno & $relevant ) {
+					$errors[] = $errstr;
+				}
+				return false;
+			},
+			$relevant
 		);
 
 		try {
@@ -74,5 +78,15 @@ class Test_Statistics extends \WP_UnitTestCase {
 
 		$this->assertEmpty( $errors, 'No warnings should fire when `post_date_gmt` is zero-dated.' );
 		$this->assertIsArray( $result, 'Scheduler should keep going, not crash.' );
+		$this->assertSame(
+			$user_index,
+			$result['user_index'],
+			'User should not be skipped — fallback to `post_date` must yield a valid earliest year.'
+		);
+		$this->assertGreaterThan(
+			0,
+			$result['year'],
+			'A valid earliest year must be derived from `post_date` when `post_date_gmt` is zero-dated.'
+		);
 	}
 }


### PR DESCRIPTION
Fixes a production warning observed in WP.com cron logs.

## Proposed changes:

* In `Activitypub\Statistics::get_earliest_data_year()`, return `null` when `get_post()` returns null, when `post_date_gmt` is empty, or when it's the MySQL zero-date. Any of those would otherwise fall through to `strtotime( false ) === false` and `gmdate( 'Y', false ) === '1970'`, silently producing the wrong "earliest year" — and in the null-post case, raise `Attempt to read property "post_date_gmt" on null`.
* The caller `backfill_historical_stats()` already handles a `null` return cleanly by advancing to the next user.
* Add a regression test that forces `get_post()` to return null via `posts_pre_query` and asserts no warning fires.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* `npm run env-test -- --filter=Test_Statistics$` — passes.
* Observe the production log line that prompted this fix:
  ```
  Attempt to read property "post_date_gmt" on null
  in /plugins/activitypub/8.2.1/includes/class-statistics.php on line 951
  /plugins/activitypub/8.2.1/includes/class-scheduler.php:525 backfill_historical_stats()
  ```
  After this fix the cron path returns null for that user instead of warning, and the scheduler advances to the next user.

### Changelog entry

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed

#### Message

Prevent a PHP warning during the monthly statistics backfill when an outbox item disappears between lookup steps.

</details>