### PR TITLE
Pin @tanstack/history to avoid compromised npm versions

### DIFF
--- a/.github/changelog/pin-tanstack-history-supply-chain
+++ b/.github/changelog/pin-tanstack-history-supply-chain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Block a recently compromised JavaScript dependency from being installed during builds.

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -43,9 +43,10 @@ jobs:
 
       - name: Verify @tanstack/history pin (GHSA-rmmr-r34h-pfm5)
         run: |
+          EXPECTED=$(node -p "require('./package.json').overrides['@tanstack/history']")
           INSTALLED=$(node -p "require('./node_modules/@tanstack/history/package.json').version")
-          if [ "$INSTALLED" != "1.161.6" ]; then
-            echo "::error::@tanstack/history must be pinned to 1.161.6 (got $INSTALLED). See GHSA-rmmr-r34h-pfm5."
+          if [ "$INSTALLED" != "$EXPECTED" ]; then
+            echo "::error::@tanstack/history install drift: package.json pins '$EXPECTED', node_modules has '$INSTALLED'. See GHSA-rmmr-r34h-pfm5."
             exit 1
           fi
 

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -41,5 +41,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify @tanstack/history pin (GHSA-rmmr-r34h-pfm5)
+        run: |
+          INSTALLED=$(node -p "require('./node_modules/@tanstack/history/package.json').version")
+          if [ "$INSTALLED" != "1.161.6" ]; then
+            echo "::error::@tanstack/history must be pinned to 1.161.6 (got $INSTALLED). See GHSA-rmmr-r34h-pfm5."
+            exit 1
+          fi
+
       - name: Run JavaScript unit tests
         run: npm run test:unit

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,6 +38,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify @tanstack/history pin (GHSA-rmmr-r34h-pfm5)
+        run: |
+          INSTALLED=$(node -p "require('./node_modules/@tanstack/history/package.json').version")
+          if [ "$INSTALLED" != "1.161.6" ]; then
+            echo "::error::@tanstack/history must be pinned to 1.161.6 (got $INSTALLED). See GHSA-rmmr-r34h-pfm5."
+            exit 1
+          fi
+
       - name: Restore Playwright browsers from cache
         id: playwright-cache
         uses: actions/cache@v5

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,9 +40,10 @@ jobs:
 
       - name: Verify @tanstack/history pin (GHSA-rmmr-r34h-pfm5)
         run: |
+          EXPECTED=$(node -p "require('./package.json').overrides['@tanstack/history']")
           INSTALLED=$(node -p "require('./node_modules/@tanstack/history/package.json').version")
-          if [ "$INSTALLED" != "1.161.6" ]; then
-            echo "::error::@tanstack/history must be pinned to 1.161.6 (got $INSTALLED). See GHSA-rmmr-r34h-pfm5."
+          if [ "$INSTALLED" != "$EXPECTED" ]; then
+            echo "::error::@tanstack/history install drift: package.json pins '$EXPECTED', node_modules has '$INSTALLED'. See GHSA-rmmr-r34h-pfm5."
             exit 1
           fi
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
 		"url": "https://github.com/automattic/wordpress-activitypub/issues"
 	},
 	"homepage": "https://github.com/automattic/wordpress-activitypub#readme",
+	"overrides": {
+		"@tanstack/history": "1.161.6"
+	},
 	"devDependencies": {
 		"@base-ui/react": "^1.4.1",
 		"@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"url": "https://github.com/automattic/wordpress-activitypub/issues"
 	},
 	"homepage": "https://github.com/automattic/wordpress-activitypub#readme",
+	"_overrides_comment": "@tanstack/history pinned to 1.161.6 per GHSA-rmmr-r34h-pfm5 (versions 1.161.9 and 1.161.12 contain malware). Remove once TanStack ships a clean version above 1.161.12.",
 	"overrides": {
 		"@tanstack/history": "1.161.6"
 	},


### PR DESCRIPTION
## Proposed changes:

Forward-defensive pin against the recent TanStack npm supply-chain attack ("mini-Shai-Hulud") flagged in [GHSA-rmmr-r34h-pfm5](https://github.com/advisories/GHSA-rmmr-r34h-pfm5) and reported by [Socket.dev](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack). Versions `1.161.9` and `1.161.12` of `@tanstack/history` contain malware; `1.161.6` (currently resolved transitively by `@tanstack/react-router@^1.169.2`) predates both and is safe.

Changes:

* `package.json` — add an `overrides` block pinning `@tanstack/history` to `1.161.6`, with an `_overrides_comment` documenting GHSA-rmmr-r34h-pfm5 and the remove-when condition (a clean TanStack release above `1.161.12`).
* `.github/workflows/jest.yml` + `.github/workflows/playwright.yml` — add a post-`npm ci` step that reads the installed version of `@tanstack/history` out of `node_modules` and fails the build with a GitHub `::error::` annotation if it isn't `1.161.6`. Belt-and-suspenders if a future `npm install`, `npm update`, or dependabot bump ever drifts the resolution.

Indicators of compromise verified absent from the repo and `node_modules`:

* Files: `router_init.js`, `router_runtime.js`, `tanstack_runner.js`, `.claude/router_runtime.js`, `.claude/setup.mjs`, `.vscode/setup.mjs`, and the malware variant of `.vscode/tasks.json`. The existing `.claude/settings.json` and `.vscode/settings.json` are the legitimate IDE configs.
* Exfiltration endpoint: `filev2.getsession.org` / `getsession.org`.
* Commits authored as `claude@users.noreply.github.com`.
* SHA256 `ab4fcadaec49c03278063dd269ea5eef82d24f2124a8e15d7b90f2fa8601266c` (the malicious `router_init.js`).

Also confirmed: no `@opensearch-project/opensearch@3.5.3/3.6.2/3.7.0/3.8.0`, no `@squawk/mcp@0.9.5`, no `@squawk/weather@0.5.10`, no `@squawk/flightplan@0.5.6` anywhere in the dependency tree.

### Note on `npm audit`:

`npm audit` will continue to report `@tanstack/history` as critical because the GHSA advisory has a catch-all `>=0` vulnerability range alongside the two specific compromised versions. This is upstream noise that resolves once TanStack publishes a clean version and the advisory is narrowed. The CI assertion (`/jest.yml`, `/playwright.yml`) is the real gate.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* `npm install` — verify the install completes without errors.
* `node -p "require('./node_modules/@tanstack/history/package.json').version"` — should output `1.161.6`.
* On a PR that mutates `package.json` or `package-lock.json`, the jest and playwright workflows now run an extra "Verify @tanstack/history pin" step. Confirm it passes today and would fail (locally simulated) if the version drifted.

### Changelog entry

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Security

#### Message

Block a recently compromised JavaScript dependency from being installed during builds.

</details>