### PR TITLE
Accept WebFinger handles on the proxy endpoint

### DIFF
--- a/.github/changelog/fix-proxy-accept-webfinger-handle
+++ b/.github/changelog/fix-proxy-accept-webfinger-handle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Allow third-party apps connected to your site to look up Fediverse users by their handle (like @user@example.com).

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _site
 .claude/**/*.local*
 .claude/summaries/
 .agents/**/*.local*
+docs/superpowers/
 .cursor
 .DS_Store
 .php_cs.cache

--- a/includes/class-http.php
+++ b/includes/class-http.php
@@ -261,7 +261,7 @@ class Http {
 
 		$url = object_to_uri( $url_or_object );
 
-		if ( preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $url ) ) {
+		if ( Webfinger::is_acct( $url ) ) {
 			$url = Webfinger::resolve( $url );
 		}
 

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -20,6 +20,30 @@ use Activitypub\Collection\Remote_Actors;
  */
 class Webfinger {
 	/**
+	 * Check whether a value looks like an `acct` identifier.
+	 *
+	 * Matches a Mastodon-style `user@host` string, optionally prefixed with
+	 * a single `@` (e.g. `user@example.com` or `@user@example.com`). The
+	 * pattern is `ACTIVITYPUB_USERNAME_REGEXP`.
+	 *
+	 * The `acct:` URI scheme form is NOT accepted by this check; callers
+	 * that need to support it should strip the prefix first
+	 * (e.g. via {@see Sanitize::webfinger()}).
+	 *
+	 * @since unreleased
+	 *
+	 * @param mixed $value The candidate value.
+	 * @return bool True if the value matches the acct identifier pattern.
+	 */
+	public static function is_acct( $value ) {
+		if ( ! \is_string( $value ) || '' === $value ) {
+			return false;
+		}
+
+		return (bool) \preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $value );
+	}
+
+	/**
 	 * Returns a users WebFinger "resource".
 	 *
 	 * @param int $user_id The WordPress user id.

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -22,13 +22,13 @@ class Webfinger {
 	/**
 	 * Check whether a value looks like an `acct` identifier.
 	 *
-	 * Matches a Mastodon-style `user@host` string, optionally prefixed with
-	 * a single `@` (e.g. `user@example.com` or `@user@example.com`). The
-	 * pattern is `ACTIVITYPUB_USERNAME_REGEXP`.
+	 * Accepts any of:
 	 *
-	 * The `acct:` URI scheme form is NOT accepted by this check; callers
-	 * that need to support it should strip the prefix first
-	 * (e.g. via {@see Sanitize::webfinger()}).
+	 * - `user@host` — bare WebFinger handle.
+	 * - `@user@host` — Mastodon display form with a leading `@`.
+	 * - `acct:user@host` — full RFC 7565 URI form.
+	 *
+	 * The host/local-part pattern follows `ACTIVITYPUB_USERNAME_REGEXP`.
 	 *
 	 * @since unreleased
 	 *
@@ -40,7 +40,7 @@ class Webfinger {
 			return false;
 		}
 
-		return (bool) \preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $value );
+		return (bool) \preg_match( '/^(?:acct:)?@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $value );
 	}
 
 	/**

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -283,7 +283,7 @@ class Remote_Actors {
 			return self::fetch_by_uri( $uri_or_acct );
 		}
 
-		if ( preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $uri_or_acct ) ) {
+		if ( Webfinger::is_acct( $uri_or_acct ) ) {
 			return self::fetch_by_acct( $uri_or_acct );
 		}
 

--- a/includes/rest/class-proxy-controller.php
+++ b/includes/rest/class-proxy-controller.php
@@ -89,30 +89,47 @@ class Proxy_Controller extends \WP_REST_Controller {
 	}
 
 	/**
-	 * Sanitizes the URL parameter.
+	 * Sanitize the `id` parameter.
+	 *
+	 * Accepts either an HTTPS URL or a WebFinger handle (`user@host`,
+	 * `@user@host`). Handles are returned as-is; URLs are run through
+	 * `sanitize_url()`. Matches the dual-shape contract of
+	 * `Remote_Actors::fetch_by_various()`.
 	 *
 	 * @see https://developer.wordpress.org/reference/functions/sanitize_url/
 	 *
-	 * @param string $url The urlencoded URL to sanitize.
-	 * @return string The sanitized URL.
+	 * @param string $url The urlencoded URL or WebFinger handle to sanitize.
+	 * @return string The sanitized value.
 	 */
 	public function sanitize_url( $url ) {
-		// Decode and sanitize the URL.
-		return sanitize_url( urldecode( $url ) );
+		$decoded = urldecode( $url );
+
+		if ( $this->is_webfinger_handle( $decoded ) ) {
+			return $decoded;
+		}
+
+		return sanitize_url( $decoded );
 	}
+
 	/**
-	 * Validate the URL parameter.
+	 * Validate the `id` parameter.
 	 *
-	 * Uses wp_http_validate_url() which blocks local/private IPs and restricts ports.
+	 * Accepts either an HTTPS URL (validated via `wp_http_validate_url()`,
+	 * which blocks local/private IPs and restricts ports) or a WebFinger
+	 * handle that matches `ACTIVITYPUB_USERNAME_REGEXP`. Matches the
+	 * dual-shape contract of `Remote_Actors::fetch_by_various()`.
 	 *
 	 * @see https://developer.wordpress.org/reference/functions/wp_http_validate_url/
 	 *
-	 * @param string $url The URL to validate.
+	 * @param string $url The URL or WebFinger handle to validate.
 	 * @return bool True if valid, false otherwise.
 	 */
 	public function validate_url( $url ) {
-		// Decode the url.
 		$decoded_url = urldecode( $url );
+
+		if ( $this->is_webfinger_handle( $decoded_url ) ) {
+			return true;
+		}
 
 		// Must be HTTPS.
 		if ( 'https' !== \wp_parse_url( $decoded_url, PHP_URL_SCHEME ) ) {
@@ -121,6 +138,16 @@ class Proxy_Controller extends \WP_REST_Controller {
 
 		// Use WordPress built-in validation (blocks local IPs, restricts ports).
 		return (bool) \wp_http_validate_url( $decoded_url );
+	}
+
+	/**
+	 * Check whether a value is a WebFinger handle (optionally prefixed with `@`).
+	 *
+	 * @param string $value The candidate value.
+	 * @return bool True if the value looks like a WebFinger handle.
+	 */
+	private function is_webfinger_handle( $value ) {
+		return (bool) \preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $value );
 	}
 
 	/**

--- a/includes/rest/class-proxy-controller.php
+++ b/includes/rest/class-proxy-controller.php
@@ -54,7 +54,7 @@ class Proxy_Controller extends \WP_REST_Controller {
 					'permission_callback' => array( $this, 'verify_authentication' ),
 					'args'                => array(
 						'id' => array(
-							'description'       => 'The URI of the remote ActivityPub object to fetch.',
+							'description'       => 'The remote ActivityPub object to fetch: an HTTPS URL or an acct identifier (`user@host`, `@user@host`, or `acct:user@host`).',
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => array( $this, 'sanitize_url' ),
@@ -91,14 +91,14 @@ class Proxy_Controller extends \WP_REST_Controller {
 	/**
 	 * Sanitize the `id` parameter.
 	 *
-	 * Accepts either an HTTPS URL or a WebFinger handle (`user@host`,
-	 * `@user@host`). Handles are returned as-is; URLs are run through
-	 * `sanitize_url()`. Matches the dual-shape contract of
-	 * `Remote_Actors::fetch_by_various()`.
+	 * Accepts either an HTTPS URL or an acct identifier (`user@host`,
+	 * `@user@host`, or `acct:user@host`). Acct identifiers are returned
+	 * as-is; URLs are run through `sanitize_url()`. Matches the dual-shape
+	 * contract of `Remote_Actors::fetch_by_various()`.
 	 *
 	 * @see https://developer.wordpress.org/reference/functions/sanitize_url/
 	 *
-	 * @param string $url The urlencoded URL or WebFinger handle to sanitize.
+	 * @param string $url The urlencoded URL or acct identifier to sanitize.
 	 * @return string The sanitized value.
 	 */
 	public function sanitize_url( $url ) {
@@ -115,13 +115,14 @@ class Proxy_Controller extends \WP_REST_Controller {
 	 * Validate the `id` parameter.
 	 *
 	 * Accepts either an HTTPS URL (validated via `wp_http_validate_url()`,
-	 * which blocks local/private IPs and restricts ports) or a WebFinger
-	 * handle that matches `ACTIVITYPUB_USERNAME_REGEXP`. Matches the
+	 * which blocks local/private IPs and restricts ports) or an acct
+	 * identifier in any of the forms accepted by `Webfinger::is_acct()`:
+	 * `user@host`, `@user@host`, or `acct:user@host`. Matches the
 	 * dual-shape contract of `Remote_Actors::fetch_by_various()`.
 	 *
 	 * @see https://developer.wordpress.org/reference/functions/wp_http_validate_url/
 	 *
-	 * @param string $url The URL or WebFinger handle to validate.
+	 * @param string $url The URL or acct identifier to validate.
 	 * @return bool True if valid, false otherwise.
 	 */
 	public function validate_url( $url ) {

--- a/includes/rest/class-proxy-controller.php
+++ b/includes/rest/class-proxy-controller.php
@@ -12,6 +12,7 @@ namespace Activitypub\Rest;
 
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Http;
+use Activitypub\Webfinger;
 
 use function Activitypub\is_actor;
 
@@ -104,7 +105,7 @@ class Proxy_Controller extends \WP_REST_Controller {
 	public function sanitize_url( $url ) {
 		$decoded = urldecode( $url );
 
-		if ( $this->is_webfinger_handle( $decoded ) ) {
+		if ( Webfinger::is_acct( $decoded ) ) {
 			return $decoded;
 		}
 
@@ -127,7 +128,7 @@ class Proxy_Controller extends \WP_REST_Controller {
 	public function validate_url( $url ) {
 		$decoded_url = urldecode( $url );
 
-		if ( $this->is_webfinger_handle( $decoded_url ) ) {
+		if ( Webfinger::is_acct( $decoded_url ) ) {
 			return true;
 		}
 
@@ -138,16 +139,6 @@ class Proxy_Controller extends \WP_REST_Controller {
 
 		// Use WordPress built-in validation (blocks local IPs, restricts ports).
 		return (bool) \wp_http_validate_url( $decoded_url );
-	}
-
-	/**
-	 * Check whether a value is a WebFinger handle (optionally prefixed with `@`).
-	 *
-	 * @param string $value The candidate value.
-	 * @return bool True if the value looks like a WebFinger handle.
-	 */
-	private function is_webfinger_handle( $value ) {
-		return (bool) \preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $value );
 	}
 
 	/**

--- a/includes/rest/class-proxy-controller.php
+++ b/includes/rest/class-proxy-controller.php
@@ -102,13 +102,13 @@ class Proxy_Controller extends \WP_REST_Controller {
 	 * @return string The sanitized value.
 	 */
 	public function sanitize_url( $url ) {
-		$decoded = urldecode( $url );
+		$decoded = \urldecode( $url );
 
 		if ( Webfinger::is_acct( $decoded ) ) {
 			return $decoded;
 		}
 
-		return sanitize_url( $decoded );
+		return \sanitize_url( $decoded );
 	}
 
 	/**
@@ -126,7 +126,7 @@ class Proxy_Controller extends \WP_REST_Controller {
 	 * @return bool True if valid, false otherwise.
 	 */
 	public function validate_url( $url ) {
-		$decoded_url = urldecode( $url );
+		$decoded_url = \urldecode( $url );
 
 		if ( Webfinger::is_acct( $decoded_url ) ) {
 			return true;

--- a/includes/rest/class-proxy-controller.php
+++ b/includes/rest/class-proxy-controller.php
@@ -76,9 +76,8 @@ class Proxy_Controller extends \WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_stream_permissions_check' ),
 					'args'                => array(
 						'id' => array(
-							'description'       => 'The remote object ID (URI) whose eventStream to proxy.',
+							'description'       => 'The remote actor identifier (URL or WebFinger acct) whose eventStream to proxy.',
 							'type'              => 'string',
-							'format'            => 'uri',
 							'required'          => true,
 							'sanitize_callback' => array( $this, 'sanitize_url' ),
 							'validate_callback' => array( $this, 'validate_url' ),

--- a/tests/phpunit/tests/includes/class-test-webfinger.php
+++ b/tests/phpunit/tests/includes/class-test-webfinger.php
@@ -691,6 +691,7 @@ class Test_Webfinger extends \WP_UnitTestCase {
 		return array(
 			'plain acct'          => array( 'user@example.com' ),
 			'leading at'          => array( '@user@example.com' ),
+			'acct uri'            => array( 'acct:user@example.com' ),
 			'multi-segment host'  => array( 'user@subdomain.example.com' ),
 			'numeric local part'  => array( 'user42@example.com' ),
 			'dots in local part'  => array( 'first.last@example.com' ),
@@ -721,7 +722,6 @@ class Test_Webfinger extends \WP_UnitTestCase {
 			'empty string'   => array( '' ),
 			'plain word'     => array( 'user' ),
 			'url'            => array( 'https://example.com/users/user' ),
-			'acct uri'       => array( 'acct:user@example.com' ),
 			'mailto uri'     => array( 'mailto:user@example.com' ),
 			'host only'      => array( '@example.com' ),
 			'no tld'         => array( 'user@host' ),

--- a/tests/phpunit/tests/includes/class-test-webfinger.php
+++ b/tests/phpunit/tests/includes/class-test-webfinger.php
@@ -669,4 +669,66 @@ class Test_Webfinger extends \WP_UnitTestCase {
 		// Clean up.
 		\delete_transient( $transient_key );
 	}
+
+	/**
+	 * Test that valid acct identifiers are recognized.
+	 *
+	 * @covers ::is_acct
+	 * @dataProvider data_valid_accts
+	 *
+	 * @param string $value The value under test.
+	 */
+	public function test_is_acct_valid( $value ) {
+		$this->assertTrue( Webfinger::is_acct( $value ) );
+	}
+
+	/**
+	 * Provider for valid acct identifiers.
+	 *
+	 * @return array
+	 */
+	public function data_valid_accts() {
+		return array(
+			'plain acct'          => array( 'user@example.com' ),
+			'leading at'          => array( '@user@example.com' ),
+			'multi-segment host'  => array( 'user@subdomain.example.com' ),
+			'numeric local part'  => array( 'user42@example.com' ),
+			'dots in local part'  => array( 'first.last@example.com' ),
+			'underscore in local' => array( 'first_last@example.com' ),
+			'dash in local'       => array( 'first-last@example.com' ),
+		);
+	}
+
+	/**
+	 * Test that non-acct values are rejected.
+	 *
+	 * @covers ::is_acct
+	 * @dataProvider data_invalid_accts
+	 *
+	 * @param mixed $value The value under test.
+	 */
+	public function test_is_acct_invalid( $value ) {
+		$this->assertFalse( Webfinger::is_acct( $value ) );
+	}
+
+	/**
+	 * Provider for non-acct values.
+	 *
+	 * @return array
+	 */
+	public function data_invalid_accts() {
+		return array(
+			'empty string'   => array( '' ),
+			'plain word'     => array( 'user' ),
+			'url'            => array( 'https://example.com/users/user' ),
+			'acct uri'       => array( 'acct:user@example.com' ),
+			'mailto uri'     => array( 'mailto:user@example.com' ),
+			'host only'      => array( '@example.com' ),
+			'no tld'         => array( 'user@host' ),
+			'trailing slash' => array( 'user@example.com/' ),
+			'null'           => array( null ),
+			'integer'        => array( 42 ),
+			'array'          => array( array( 'user@example.com' ) ),
+		);
+	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
@@ -234,6 +234,67 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that proxy accepts an `acct:` URI and resolves it via WebFinger.
+	 *
+	 * @covers ::validate_url
+	 * @covers ::sanitize_url
+	 * @covers ::create_item
+	 */
+	public function test_successful_actor_fetch_by_acct_uri() {
+		$this->mock_oauth_auth();
+
+		$actor_data = array(
+			'@context'          => 'https://www.w3.org/ns/activitystreams',
+			'type'              => 'Person',
+			'id'                => 'https://example.com/users/test',
+			'inbox'             => 'https://example.com/users/test/inbox',
+			'preferredUsername' => 'test',
+			'name'              => 'Test User',
+		);
+
+		$filter = function ( $preempt, $args, $url ) use ( $actor_data ) {
+			if ( false !== \strpos( $url, '/.well-known/webfinger' ) ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => \wp_json_encode(
+						array(
+							'subject' => 'acct:test@example.com',
+							'links'   => array(
+								array(
+									'rel'  => 'self',
+									'type' => 'application/activity+json',
+									'href' => $actor_data['id'],
+								),
+							),
+						)
+					),
+					'headers'  => array( 'content-type' => 'application/jrd+json' ),
+				);
+			}
+
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode( $actor_data ),
+				'headers'  => array( 'content-type' => 'application/activity+json' ),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
+		$request->set_body_params( array( 'id' => 'acct:test@example.com' ) );
+
+		$response = $this->server->dispatch( $request );
+
+		\remove_filter( 'pre_http_request', $filter, 10 );
+		$this->unmock_oauth_auth();
+
+		$this->assertEquals( 200, $response->get_status(), \wp_json_encode( $response->get_data() ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'Person', $data['type'] );
+		$this->assertEquals( 'https://example.com/users/test', $data['id'] );
+	}
+
+	/**
 	 * Test that proxy accepts a WebFinger handle with leading `@`.
 	 *
 	 * @covers ::validate_url

--- a/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
@@ -295,28 +295,64 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that proxy accepts a WebFinger handle with leading `@`.
+	 * Test that proxy accepts a WebFinger handle with leading `@` and resolves it.
 	 *
 	 * @covers ::validate_url
+	 * @covers ::sanitize_url
+	 * @covers ::create_item
 	 */
-	public function test_handle_with_leading_at_accepted() {
+	public function test_successful_actor_fetch_by_handle_with_leading_at() {
 		$this->mock_oauth_auth();
+
+		$actor_data = array(
+			'@context'          => 'https://www.w3.org/ns/activitystreams',
+			'type'              => 'Person',
+			'id'                => 'https://example.com/users/test',
+			'inbox'             => 'https://example.com/users/test/inbox',
+			'preferredUsername' => 'test',
+			'name'              => 'Test User',
+		);
+
+		$filter = function ( $preempt, $args, $url ) use ( $actor_data ) {
+			if ( false !== \strpos( $url, '/.well-known/webfinger' ) ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => \wp_json_encode(
+						array(
+							'subject' => 'acct:test@example.com',
+							'links'   => array(
+								array(
+									'rel'  => 'self',
+									'type' => 'application/activity+json',
+									'href' => $actor_data['id'],
+								),
+							),
+						)
+					),
+					'headers'  => array( 'content-type' => 'application/jrd+json' ),
+				);
+			}
+
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode( $actor_data ),
+				'headers'  => array( 'content-type' => 'application/activity+json' ),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter, 10, 3 );
 
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
 		$request->set_body_params( array( 'id' => '@test@example.com' ) );
 
 		$response = $this->server->dispatch( $request );
 
+		\remove_filter( 'pre_http_request', $filter, 10 );
 		$this->unmock_oauth_auth();
 
-		// Must not be rejected at param validation. Downstream resolution may still
-		// 502 because no HTTP mock is installed, but the route should not 400 with
-		// rest_invalid_param.
-		$this->assertNotEquals(
-			'rest_invalid_param',
-			$response->get_data()['code'] ?? '',
-			'WebFinger handle with leading @ was rejected at route validation.'
-		);
+		$this->assertEquals( 200, $response->get_status(), \wp_json_encode( $response->get_data() ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'Person', $data['type'] );
+		$this->assertEquals( 'https://example.com/users/test', $data['id'] );
 	}
 
 	/**
@@ -372,15 +408,12 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 		\remove_filter( 'pre_http_request', $filter, 10 );
 		$this->unmock_oauth_auth();
 
-		// The route must accept the handle and reach get_stream, which then
-		// returns a 404 because the resolved actor has no eventStream field.
-		// What we explicitly do not expect is `rest_invalid_param` from
-		// schema-level validation.
-		$this->assertNotEquals(
-			'rest_invalid_param',
-			$response->get_data()['code'] ?? '',
-			'Stream route rejected the acct identifier at schema validation.'
-		);
+		// The route accepts the handle, the webfinger lookup resolves, and
+		// get_stream() reaches the "no eventStream" branch — returning 404
+		// rather than the schema-level `rest_invalid_param` 400 it would
+		// have produced with the previous `format => 'uri'` constraint.
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 'activitypub_no_event_stream', $response->get_data()['code'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
@@ -173,6 +173,111 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that proxy accepts a WebFinger handle (`user@host`) and resolves it.
+	 *
+	 * @covers ::validate_url
+	 * @covers ::sanitize_url
+	 * @covers ::create_item
+	 */
+	public function test_successful_actor_fetch_by_handle() {
+		$this->mock_oauth_auth();
+
+		$actor_data = array(
+			'@context'          => 'https://www.w3.org/ns/activitystreams',
+			'type'              => 'Person',
+			'id'                => 'https://mitra.social/users/silverpill',
+			'inbox'             => 'https://mitra.social/users/silverpill/inbox',
+			'preferredUsername' => 'silverpill',
+			'name'              => 'silverpill',
+		);
+
+		$filter = function ( $preempt, $args, $url ) use ( $actor_data ) {
+			if ( false !== \strpos( $url, '/.well-known/webfinger' ) ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => \wp_json_encode(
+						array(
+							'subject' => 'acct:silverpill@mitra.social',
+							'links'   => array(
+								array(
+									'rel'  => 'self',
+									'type' => 'application/activity+json',
+									'href' => $actor_data['id'],
+								),
+							),
+						)
+					),
+					'headers'  => array( 'content-type' => 'application/jrd+json' ),
+				);
+			}
+
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode( $actor_data ),
+				'headers'  => array( 'content-type' => 'application/activity+json' ),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
+		$request->set_body_params( array( 'id' => 'silverpill@mitra.social' ) );
+
+		$response = $this->server->dispatch( $request );
+
+		\remove_filter( 'pre_http_request', $filter, 10 );
+		$this->unmock_oauth_auth();
+
+		$this->assertEquals( 200, $response->get_status(), \wp_json_encode( $response->get_data() ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'Person', $data['type'] );
+		$this->assertEquals( 'https://mitra.social/users/silverpill', $data['id'] );
+	}
+
+	/**
+	 * Test that proxy accepts a WebFinger handle with leading `@`.
+	 *
+	 * @covers ::validate_url
+	 */
+	public function test_handle_with_leading_at_accepted() {
+		$this->mock_oauth_auth();
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
+		$request->set_body_params( array( 'id' => '@silverpill@mitra.social' ) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->unmock_oauth_auth();
+
+		// Must not be rejected at param validation. Downstream resolution may still
+		// 502 because no HTTP mock is installed, but the route should not 400 with
+		// rest_invalid_param.
+		$this->assertNotEquals(
+			'rest_invalid_param',
+			$response->get_data()['code'] ?? '',
+			'WebFinger handle with leading @ was rejected at route validation.'
+		);
+	}
+
+	/**
+	 * Test that proxy still rejects garbage input that is neither URL nor handle.
+	 *
+	 * @covers ::validate_url
+	 */
+	public function test_malformed_input_rejected() {
+		$this->mock_oauth_auth();
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
+		$request->set_body_params( array( 'id' => 'not-a-url-or-handle' ) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->unmock_oauth_auth();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+
+	/**
 	 * Mock OAuth authentication for testing.
 	 */
 	private function mock_oauth_auth() {

--- a/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
@@ -185,10 +185,10 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 		$actor_data = array(
 			'@context'          => 'https://www.w3.org/ns/activitystreams',
 			'type'              => 'Person',
-			'id'                => 'https://mitra.social/users/silverpill',
-			'inbox'             => 'https://mitra.social/users/silverpill/inbox',
-			'preferredUsername' => 'silverpill',
-			'name'              => 'silverpill',
+			'id'                => 'https://example.com/users/test',
+			'inbox'             => 'https://example.com/users/test/inbox',
+			'preferredUsername' => 'test',
+			'name'              => 'Test User',
 		);
 
 		$filter = function ( $preempt, $args, $url ) use ( $actor_data ) {
@@ -197,7 +197,7 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 					'response' => array( 'code' => 200 ),
 					'body'     => \wp_json_encode(
 						array(
-							'subject' => 'acct:silverpill@mitra.social',
+							'subject' => 'acct:test@example.com',
 							'links'   => array(
 								array(
 									'rel'  => 'self',
@@ -220,7 +220,7 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 		\add_filter( 'pre_http_request', $filter, 10, 3 );
 
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
-		$request->set_body_params( array( 'id' => 'silverpill@mitra.social' ) );
+		$request->set_body_params( array( 'id' => 'test@example.com' ) );
 
 		$response = $this->server->dispatch( $request );
 
@@ -230,7 +230,7 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 		$this->assertEquals( 200, $response->get_status(), \wp_json_encode( $response->get_data() ) );
 		$data = $response->get_data();
 		$this->assertEquals( 'Person', $data['type'] );
-		$this->assertEquals( 'https://mitra.social/users/silverpill', $data['id'] );
+		$this->assertEquals( 'https://example.com/users/test', $data['id'] );
 	}
 
 	/**
@@ -242,7 +242,7 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 		$this->mock_oauth_auth();
 
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
-		$request->set_body_params( array( 'id' => '@silverpill@mitra.social' ) );
+		$request->set_body_params( array( 'id' => '@test@example.com' ) );
 
 		$response = $this->server->dispatch( $request );
 

--- a/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
@@ -259,6 +259,70 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the stream sub-route also accepts acct identifiers.
+	 *
+	 * Guards against the `format => 'uri'` schema constraint that previously
+	 * rejected handles before the validate_callback ran.
+	 *
+	 * @covers ::register_routes
+	 * @covers ::get_stream
+	 */
+	public function test_stream_accepts_acct_identifier() {
+		$this->mock_oauth_auth();
+
+		$filter = function ( $preempt, $args, $url ) {
+			if ( false !== \strpos( $url, '/.well-known/webfinger' ) ) {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => \wp_json_encode(
+						array(
+							'subject' => 'acct:test@example.com',
+							'links'   => array(
+								array(
+									'rel'  => 'self',
+									'type' => 'application/activity+json',
+									'href' => 'https://example.com/users/test',
+								),
+							),
+						)
+					),
+					'headers'  => array( 'content-type' => 'application/jrd+json' ),
+				);
+			}
+
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode(
+					array(
+						'type' => 'Person',
+						'id'   => 'https://example.com/users/test',
+					)
+				),
+				'headers'  => array( 'content-type' => 'application/activity+json' ),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy/stream' );
+		$request->set_query_params( array( 'id' => 'test@example.com' ) );
+
+		$response = $this->server->dispatch( $request );
+
+		\remove_filter( 'pre_http_request', $filter, 10 );
+		$this->unmock_oauth_auth();
+
+		// The route must accept the handle and reach get_stream, which then
+		// returns a 404 because the resolved actor has no eventStream field.
+		// What we explicitly do not expect is `rest_invalid_param` from
+		// schema-level validation.
+		$this->assertNotEquals(
+			'rest_invalid_param',
+			$response->get_data()['code'] ?? '',
+			'Stream route rejected the acct identifier at schema validation.'
+		);
+	}
+
+	/**
 	 * Test that proxy still rejects garbage input that is neither URL nor handle.
 	 *
 	 * @covers ::validate_url


### PR DESCRIPTION
Fixes #3288

## Proposed changes:

The `POST /activitypub/1.0/proxy` route's `sanitize_url` / `validate_url` callbacks only accepted `https://` URLs, even though the downstream `Remote_Actors::fetch_by_various()` already branches on URL vs WebFinger acct. Result: passing `silverpill@mitra.social` (URL-encoded as `silverpill%40mitra.social`) was rejected at REST parameter validation with `400 rest_invalid_param` before any resolution could run.

* Loosen `sanitize_url` and `validate_url` to accept either an HTTPS URL or a WebFinger handle (`user@host`, optionally `@user@host`), matching `ACTIVITYPUB_USERNAME_REGEXP`.
* Add a private `is_webfinger_handle()` helper.
* `wp_http_validate_url()` is still used for HTTPS URLs, so the existing private-IP / port restrictions are preserved.

The stream endpoint shares the same callbacks, so it inherits the fix.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Three new tests in `Test_Proxy_Controller`:

* `test_successful_actor_fetch_by_handle` - happy path end-to-end with mocked WebFinger + actor fetch.
* `test_handle_with_leading_at_accepted` - confirms `@user@host` form clears route validation.
* `test_malformed_input_rejected` - confirms genuine garbage still 400s.

Regression sweep: `Test_Proxy_Controller` + `Test_Remote_Actors` + `Test_Webfinger` = 92 tests / 262 assertions all green. PHPCS clean.

## Testing instructions:

1. Enable the experimental ActivityPub API in `Settings -> ActivityPub -> Advanced`.
2. Get an OAuth Bearer token with read scope.
3. Hit the proxy with a WebFinger handle:

   ```bash
   curl -X POST -H "Authorization: Bearer <token>" \
     -d 'id=silverpill%40mitra.social' \
     https://<your-site>/wp-json/activitypub/1.0/proxy
   ```

4. Expect `200` with the resolved `Person` object body (`type`, `id`, `inbox`, `preferredUsername`, ...). Before this fix the same request returned `400 rest_invalid_param`.
5. Sanity checks:
   * URL form still works: `id=https%3A%2F%2Fmitra.social%2Fusers%2Fsilverpill`.
   * `@user@host` form works: `id=%40silverpill%40mitra.social`.
   * Garbage still 400s: `id=not-a-url-or-handle`.
   * `http://` URLs are still rejected (HTTPS-only constraint preserved).

### Changelog entry

Entry already lives in `.github/changelog/fix-proxy-accept-webfinger-handle` (Significance: patch, Type: fixed). No checkbox needed.