### PR TITLE
Store content warnings sent through the outbox API

### DIFF
--- a/.github/changelog/add-outbox-content-warning
+++ b/.github/changelog/add-outbox-content-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Store content warnings from posts published through third-party ActivityPub apps so they federate correctly.

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -67,6 +67,10 @@ class Posts {
 		$name        = \sanitize_text_field( $object['name'] ?? '' );
 		$summary     = \wp_kses_post( $object['summary'] ?? '' );
 
+		// A summary marked sensitive is a content warning (plain text); otherwise it's a regular excerpt.
+		$content_warning = ! empty( $object['sensitive'] ) && '' !== $summary ? \sanitize_text_field( $summary ) : '';
+		$post_excerpt    = '' === $content_warning ? $summary : '';
+
 		// Process content: autop, autolink, hashtags, and convert to blocks.
 		$content = self::prepare_content( $content );
 
@@ -85,11 +89,12 @@ class Posts {
 			'post_author'  => $post_author,
 			'post_title'   => $title,
 			'post_content' => $content,
-			'post_excerpt' => $summary,
+			'post_excerpt' => $post_excerpt,
 			'post_status'  => ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE === $visibility ? 'private' : 'publish',
 			'post_type'    => 'post',
 			'meta_input'   => array(
 				'activitypub_content_visibility' => $visibility,
+				'activitypub_content_warning'    => $content_warning,
 			),
 		);
 
@@ -125,6 +130,10 @@ class Posts {
 		$name    = \sanitize_text_field( $object['name'] ?? '' );
 		$summary = \wp_kses_post( $object['summary'] ?? '' );
 
+		// A summary marked sensitive is a content warning (plain text); otherwise it's a regular excerpt.
+		$content_warning = ! empty( $object['sensitive'] ) && '' !== $summary ? \sanitize_text_field( $summary ) : '';
+		$post_excerpt    = '' === $content_warning ? $summary : '';
+
 		// Process content: autop, autolink, hashtags, and convert to blocks.
 		$content = self::prepare_content( $content );
 
@@ -143,9 +152,10 @@ class Posts {
 			'ID'           => $post->ID,
 			'post_title'   => $title,
 			'post_content' => $content,
-			'post_excerpt' => $summary,
+			'post_excerpt' => $post_excerpt,
 			'meta_input'   => array(
 				'activitypub_content_visibility' => $visibility,
+				'activitypub_content_warning'    => $content_warning,
 			),
 		);
 

--- a/includes/collection/class-posts.php
+++ b/includes/collection/class-posts.php
@@ -62,14 +62,16 @@ class Posts {
 
 		$object = $activity['object'] ?? array();
 
-		$object_type = $object['type'] ?? '';
-		$content     = \wp_kses_post( $object['content'] ?? '' );
-		$name        = \sanitize_text_field( $object['name'] ?? '' );
-		$summary     = \wp_kses_post( $object['summary'] ?? '' );
+		$object_type   = $object['type'] ?? '';
+		$content       = \wp_kses_post( $object['content'] ?? '' );
+		$name          = \sanitize_text_field( $object['name'] ?? '' );
+		$summary       = \wp_kses_post( $object['summary'] ?? '' );
+		$plain_summary = \sanitize_text_field( $summary );
 
 		// A summary marked sensitive is a content warning (plain text); otherwise it's a regular excerpt.
-		$content_warning = ! empty( $object['sensitive'] ) && '' !== $summary ? \sanitize_text_field( $summary ) : '';
-		$post_excerpt    = '' === $content_warning ? $summary : '';
+		// Route on the sanitized summary so whitespace-only values don't pollute either field.
+		$content_warning = ! empty( $object['sensitive'] ) && '' !== $plain_summary ? $plain_summary : '';
+		$post_excerpt    = '' === $content_warning && '' !== $plain_summary ? $summary : '';
 
 		// Process content: autop, autolink, hashtags, and convert to blocks.
 		$content = self::prepare_content( $content );
@@ -126,13 +128,15 @@ class Posts {
 	public static function update( $post, $activity, $visibility = null ) {
 		$object = $activity['object'] ?? array();
 
-		$content = \wp_kses_post( $object['content'] ?? '' );
-		$name    = \sanitize_text_field( $object['name'] ?? '' );
-		$summary = \wp_kses_post( $object['summary'] ?? '' );
+		$content       = \wp_kses_post( $object['content'] ?? '' );
+		$name          = \sanitize_text_field( $object['name'] ?? '' );
+		$summary       = \wp_kses_post( $object['summary'] ?? '' );
+		$plain_summary = \sanitize_text_field( $summary );
 
 		// A summary marked sensitive is a content warning (plain text); otherwise it's a regular excerpt.
-		$content_warning = ! empty( $object['sensitive'] ) && '' !== $summary ? \sanitize_text_field( $summary ) : '';
-		$post_excerpt    = '' === $content_warning ? $summary : '';
+		// Route on the sanitized summary so whitespace-only values don't pollute either field.
+		$content_warning = ! empty( $object['sensitive'] ) && '' !== $plain_summary ? $plain_summary : '';
+		$post_excerpt    = '' === $content_warning && '' !== $plain_summary ? $summary : '';
 
 		// Process content: autop, autolink, hashtags, and convert to blocks.
 		$content = self::prepare_content( $content );

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -271,6 +271,141 @@ class Test_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test creating a post with a content warning (sensitive=true + summary).
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_with_content_warning() {
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$activity = array(
+			'object' => array(
+				'type'      => 'Note',
+				'content'   => '<p>Spoilery content.</p>',
+				'summary'   => 'Spoilers ahead',
+				'sensitive' => true,
+			),
+		);
+
+		$post = Posts::create( $activity, $user_id );
+
+		$this->assertInstanceOf( '\WP_Post', $post );
+		$this->assertSame( 'Spoilers ahead', \get_post_meta( $post->ID, 'activitypub_content_warning', true ) );
+		$this->assertSame( '', $post->post_excerpt );
+	}
+
+	/**
+	 * Test that a summary without sensitive=true is treated as a regular excerpt.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_summary_without_sensitive_is_excerpt() {
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$activity = array(
+			'object' => array(
+				'type'    => 'Article',
+				'name'    => 'Title',
+				'content' => '<p>Body.</p>',
+				'summary' => 'A regular abstract.',
+			),
+		);
+
+		$post = Posts::create( $activity, $user_id );
+
+		$this->assertInstanceOf( '\WP_Post', $post );
+		$this->assertSame( 'A regular abstract.', $post->post_excerpt );
+		$this->assertSame( '', \get_post_meta( $post->ID, 'activitypub_content_warning', true ) );
+	}
+
+	/**
+	 * Test that sensitive=true without a summary is ignored.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_sensitive_without_summary_is_ignored() {
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$activity = array(
+			'object' => array(
+				'type'      => 'Note',
+				'content'   => '<p>No spoilers, just a flag.</p>',
+				'sensitive' => true,
+			),
+		);
+
+		$post = Posts::create( $activity, $user_id );
+
+		$this->assertInstanceOf( '\WP_Post', $post );
+		$this->assertSame( '', \get_post_meta( $post->ID, 'activitypub_content_warning', true ) );
+		$this->assertSame( '', $post->post_excerpt );
+	}
+
+	/**
+	 * Test updating a post to add a content warning.
+	 *
+	 * @covers ::update
+	 */
+	public function test_update_adds_content_warning() {
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$activity = array(
+			'object' => array(
+				'type'    => 'Note',
+				'content' => '<p>Original.</p>',
+				'summary' => 'Plain abstract.',
+			),
+		);
+
+		$post = Posts::create( $activity, $user_id );
+		$this->assertSame( 'Plain abstract.', $post->post_excerpt );
+
+		$update_activity = array(
+			'object' => array(
+				'type'      => 'Note',
+				'content'   => '<p>Now with spoilers.</p>',
+				'summary'   => 'Spoilers',
+				'sensitive' => true,
+			),
+		);
+
+		$updated = Posts::update( $post, $update_activity );
+
+		$this->assertInstanceOf( '\WP_Post', $updated );
+		$this->assertSame( 'Spoilers', \get_post_meta( $updated->ID, 'activitypub_content_warning', true ) );
+		$this->assertSame( '', $updated->post_excerpt );
+	}
+
+	/**
+	 * Test updating a post to remove a previously set content warning.
+	 *
+	 * @covers ::update
+	 */
+	public function test_update_clears_content_warning() {
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$activity = array(
+			'object' => array(
+				'type'      => 'Note',
+				'content'   => '<p>Spoilery.</p>',
+				'summary'   => 'Spoilers',
+				'sensitive' => true,
+			),
+		);
+
+		$post = Posts::create( $activity, $user_id );
+		$this->assertSame( 'Spoilers', \get_post_meta( $post->ID, 'activitypub_content_warning', true ) );
+
+		$update_activity = array(
+			'object' => array(
+				'type'    => 'Note',
+				'content' => '<p>No longer sensitive.</p>',
+			),
+		);
+
+		$updated = Posts::update( $post, $update_activity );
+
+		$this->assertInstanceOf( '\WP_Post', $updated );
+		$this->assertSame( '', \get_post_meta( $updated->ID, 'activitypub_content_warning', true ) );
+		$this->assertSame( '', $updated->post_excerpt );
+	}
+
+	/**
 	 * Test updating a post.
 	 *
 	 * @covers ::update

--- a/tests/phpunit/tests/includes/collection/class-test-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-posts.php
@@ -339,6 +339,32 @@ class Test_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test creating a post with sensitive=true and a whitespace-only summary.
+	 *
+	 * The whitespace becomes empty after sanitize_text_field, so no CW is set
+	 * and the post_excerpt is also empty (no whitespace pollution).
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_whitespace_summary_with_sensitive_is_ignored() {
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$activity = array(
+			'object' => array(
+				'type'      => 'Note',
+				'content'   => '<p>Content.</p>',
+				'summary'   => '   ',
+				'sensitive' => true,
+			),
+		);
+
+		$post = Posts::create( $activity, $user_id );
+
+		$this->assertInstanceOf( '\WP_Post', $post );
+		$this->assertSame( '', \get_post_meta( $post->ID, 'activitypub_content_warning', true ) );
+		$this->assertSame( '', $post->post_excerpt );
+	}
+
+	/**
 	 * Test updating a post to add a content warning.
 	 *
 	 * @covers ::update


### PR DESCRIPTION
Fixes #3291

## Proposed changes:
* Route an incoming `summary` into the existing `activitypub_content_warning` post meta when the object has `sensitive: true` and a non-empty summary, leaving `post_excerpt` empty. Without `sensitive: true`, the existing `summary` → `post_excerpt` mapping is preserved.
* The transformer already reads `activitypub_content_warning` on the way out and emits `sensitive: true` + `summary`, so this completes the C2S round-trip with no transformer changes.
* Update path follows full-replace semantics: if a later Update lacks `sensitive`/`summary`, the CW meta is cleared.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Authenticate against `POST /wp-json/activitypub/1.0/actors/{user_id}/outbox` as a user with `publish_posts`.
* Post an AP `Note` body: `{ "type": "Note", "content": "...", "summary": "Spoilers", "sensitive": true }`.
* Check the created post: `activitypub_content_warning` meta is `"Spoilers"`, `post_excerpt` is empty.
* Fetch the post's federated representation (e.g. via `?activitypub` or the outbox) — the JSON has `"sensitive": true` and `"summary": "Spoilers"`.
* Post a follow-up Update without `sensitive` and without `summary` — the CW meta is cleared.
* Post a `Note` with `summary` but no `sensitive` — summary still ends up in `post_excerpt` (existing behavior).

### Changelog entry

Already included in `.github/changelog/add-outbox-content-warning`.