### PR TITLE
Prevent duplicate Powered by extra fields on migration rerun

### DIFF
--- a/.github/changelog/fix-powered-by-duplicate
+++ b/.github/changelog/fix-powered-by-duplicate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop the "Powered by WordPress" profile field from being added more than once.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -775,6 +775,10 @@ class Migration {
 
 		// Add a default extra field for each user.
 		foreach ( $users as $user ) {
+			if ( self::has_powered_by_extra_field( $user->ID, Extra_Fields::USER_POST_TYPE ) ) {
+				continue;
+			}
+
 			\wp_insert_post(
 				array(
 					'post_type'    => Extra_Fields::USER_POST_TYPE,
@@ -786,6 +790,10 @@ class Migration {
 			);
 		}
 
+		if ( self::has_powered_by_extra_field( 0, Extra_Fields::BLOG_POST_TYPE ) ) {
+			return;
+		}
+
 		\wp_insert_post(
 			array(
 				'post_type'    => Extra_Fields::BLOG_POST_TYPE,
@@ -795,6 +803,31 @@ class Migration {
 				'post_content' => $content,
 			)
 		);
+	}
+
+	/**
+	 * Whether a Powered-by extra field already exists for the given author and post type.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int    $author_id The author ID (0 for the blog actor).
+	 * @param string $post_type The extra field post type.
+	 * @return bool True if a matching extra field exists, false otherwise.
+	 */
+	private static function has_powered_by_extra_field( $author_id, $post_type ) {
+		$query = new \WP_Query(
+			array(
+				'post_type'      => $post_type,
+				'author'         => $author_id,
+				'post_status'    => 'any',
+				'title'          => \__( 'Powered by', 'activitypub' ),
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		return $query->have_posts();
 	}
 
 	/**

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -773,9 +773,15 @@ class Migration {
 		$title   = \__( 'Powered by', 'activitypub' );
 		$content = 'WordPress';
 
-		// Add a default extra field for each user.
+		/*
+		 * Skip users that already have any user extra field — they were either provisioned
+		 * by a previous run of this migration or have manually added fields. Locale-independent,
+		 * and one prefetched query rather than one per user.
+		 */
+		$authors_with_user_fields = self::get_extra_field_authors( Extra_Fields::USER_POST_TYPE );
+
 		foreach ( $users as $user ) {
-			if ( self::has_powered_by_extra_field( $user->ID, Extra_Fields::USER_POST_TYPE ) ) {
+			if ( \in_array( (int) $user->ID, $authors_with_user_fields, true ) ) {
 				continue;
 			}
 
@@ -790,7 +796,8 @@ class Migration {
 			);
 		}
 
-		if ( self::has_powered_by_extra_field( 0, Extra_Fields::BLOG_POST_TYPE ) ) {
+		// Same idea for the blog actor: skip if any blog extra field already exists.
+		if ( ! empty( self::get_extra_field_authors( Extra_Fields::BLOG_POST_TYPE ) ) ) {
 			return;
 		}
 
@@ -806,28 +813,24 @@ class Migration {
 	}
 
 	/**
-	 * Whether a Powered-by extra field already exists for the given author and post type.
+	 * Return the distinct author IDs that already own at least one extra field post.
 	 *
 	 * @since unreleased
 	 *
-	 * @param int    $author_id The author ID (0 for the blog actor).
 	 * @param string $post_type The extra field post type.
-	 * @return bool True if a matching extra field exists, false otherwise.
+	 * @return int[] Distinct author IDs.
 	 */
-	private static function has_powered_by_extra_field( $author_id, $post_type ) {
-		$query = new \WP_Query(
-			array(
-				'post_type'      => $post_type,
-				'author'         => $author_id,
-				'post_status'    => 'any',
-				'title'          => \__( 'Powered by', 'activitypub' ),
-				'posts_per_page' => 1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
+	private static function get_extra_field_authors( $post_type ) {
+		global $wpdb;
+
+		$authors = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				"SELECT DISTINCT post_author FROM $wpdb->posts WHERE post_type = %s",
+				$post_type
 			)
 		);
 
-		return $query->have_posts();
+		return \array_map( 'intval', $authors );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-migration.php
+++ b/tests/phpunit/tests/includes/class-test-migration.php
@@ -708,6 +708,44 @@ class Test_Migration extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test add_default_extra_field does not duplicate entries when called more than once.
+	 */
+	public function test_add_default_extra_field_is_idempotent() {
+		$user_id = self::factory()->user->create();
+		$user    = get_user_by( 'id', $user_id );
+		$user->add_cap( 'activitypub' );
+
+		$reflection = new \ReflectionClass( Migration::class );
+		$method     = $reflection->getMethod( 'add_default_extra_field' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$method->invoke( null );
+		$method->invoke( null );
+
+		$user_fields = get_posts(
+			array(
+				'post_type'      => Extra_Fields::USER_POST_TYPE,
+				'author'         => $user_id,
+				'posts_per_page' => -1,
+			)
+		);
+		$this->assertCount( 1, $user_fields, 'A second run must not create another user extra field.' );
+
+		$blog_fields = get_posts(
+			array(
+				'post_type'      => Extra_Fields::BLOG_POST_TYPE,
+				'author'         => 0,
+				'posts_per_page' => -1,
+			)
+		);
+		$this->assertCount( 1, $blog_fields, 'A second run must not create another blog extra field.' );
+
+		_delete_all_data();
+	}
+
+	/**
 	 * Test update_notification_options.
 	 *
 	 * @covers ::update_notification_options


### PR DESCRIPTION
Fixes #3280

## Proposed changes:

* `Migration::add_default_extra_field()` previously did an unconditional `wp_insert_post()` for every user with the `activitypub` capability plus one for the blog actor. If the migration ever ran more than once — concurrent requests during initial activation, plugin re-install after uninstall, or any other path that resets `activitypub_db_version` — duplicate "Powered by WordPress" entries accumulated. The user-reported symptom (a field reappearing after manual deletion) traces to surviving duplicates being re-rendered on the next admin request.
* Guard each insert with a small `has_powered_by_extra_field( $author_id, $post_type )` helper. If a matching entry already exists, skip the insert.
* Added a new test asserting `add_default_extra_field` is idempotent (call twice, get one entry).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* On a fresh install of `trunk`, plugin activation creates one "Powered by WordPress" extra field per user + one for the blog actor.
* Delete `activitypub_db_version` from the options table (simulating a re-install / racey activation).
* Reload an admin page (re-triggers `Migration::maybe_migrate()` → `add_default_settings()`).
* Confirm no new "Powered by WordPress" entries are added (compare counts in `Profiles → Extra Fields` and `Settings → Blog Profile`).
* Repeat the reload — still no duplicates.

### Changelog entry

Already included in `.github/changelog/fix-powered-by-duplicate`.