### PR TITLE
Bail from maybe_migrate when concurrent worker holds the lock

### DIFF
--- a/.github/changelog/fix-migration-lock-race
+++ b/.github/changelog/fix-migration-lock-race
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent migrations from running twice when concurrent requests race through the upgrade check.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -117,7 +117,14 @@ class Migration {
 			return;
 		}
 
-		self::lock();
+		/*
+		 * Atomic claim. lock() returns true only when this caller's INSERT IGNORE
+		 * actually inserted the row. If a concurrent worker won the race (lock
+		 * returns the existing timestamp), bail so we don't double-run migrations.
+		 */
+		if ( true !== self::lock() ) {
+			return;
+		}
 
 		$version_from_db = self::get_version();
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -142,5 +142,3 @@ require $_tests_dir . '/includes/bootstrap.php';
 require __DIR__ . '/includes/class-activitypub-outbox-testcase.php';
 require __DIR__ . '/includes/class-activitypub-testcase-cache-http.php';
 require __DIR__ . '/includes/class-test-rest-controller-testcase.php';
-
-\Activitypub\Migration::add_default_settings();

--- a/tests/phpunit/tests/includes/class-test-migration.php
+++ b/tests/phpunit/tests/includes/class-test-migration.php
@@ -374,6 +374,65 @@ class Test_Migration extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that maybe_migrate() bails when another worker holds the lock,
+	 * even if is_locked() failed to see it (the time-of-check / time-of-use race).
+	 *
+	 * @covers ::maybe_migrate
+	 */
+	public function test_maybe_migrate_bails_when_lock_acquired_by_concurrent_worker() {
+		// Create a user that would receive a default extra field if migration runs.
+		$user_id = self::factory()->user->create();
+		$user    = \get_user_by( 'id', $user_id );
+		$user->add_cap( 'activitypub' );
+
+		\delete_option( 'activitypub_db_version' );
+		\delete_option( 'activitypub_migration_lock' );
+
+		// Physically insert a lock row — simulates a concurrent worker
+		// that won the INSERT IGNORE race.
+		\update_option( 'activitypub_migration_lock', \time(), false );
+
+		// Hide the lock from is_locked()'s get_option call, simulating the
+		// race window where the existence check ran before the other worker
+		// inserted. lock()'s raw INSERT IGNORE will still see the conflict
+		// and return the existing timestamp.
+		\add_filter( 'option_activitypub_migration_lock', '__return_false' );
+
+		// Capture db_version before migration runs to detect whether it actually executed.
+		$db_version_before = \get_option( 'activitypub_db_version', 'missing' );
+
+		Migration::maybe_migrate();
+
+		\remove_filter( 'option_activitypub_migration_lock', '__return_false' );
+
+		$db_version_after = \get_option( 'activitypub_db_version', 'missing' );
+
+		// Sanity: confirm lock() actually saw the existing row.
+		$this->assertNotSame( true, Migration::lock(), 'lock() must report the existing lock' );
+
+		// Did maybe_migrate run? If db_version changed, it ran.
+		$this->assertSame( $db_version_before, $db_version_after, 'maybe_migrate must not have run (db_version unchanged)' );
+
+		// Defaults must NOT have been created: the caller must bail when
+		// lock() returns a non-true value.
+		$fields = \get_posts(
+			array(
+				'post_type'      => Extra_Fields::USER_POST_TYPE,
+				'author'         => $user_id,
+				'posts_per_page' => -1,
+			)
+		);
+		$this->assertCount( 0, $fields, 'maybe_migrate must not provision defaults when lock acquisition failed' );
+
+		// db_version must remain unset too.
+		$this->assertFalse( \get_option( 'activitypub_db_version' ) );
+
+		\delete_option( 'activitypub_migration_lock' );
+		\delete_option( 'activitypub_db_version' );
+		_delete_all_data();
+	}
+
+	/**
 	 * Test update_comment_counts() properly cleans up the lock.
 	 *
 	 * @covers ::update_comment_counts


### PR DESCRIPTION
## Proposed changes:

* `Migration::lock()` returns `true` on a successful claim and the existing lock timestamp otherwise (see its docblock and the existing `test_lock_acquire_new` / `test_lock_get_existing` tests). The contract has always been there; `Migration::maybe_migrate()` just wasn't using it — it called `self::lock()` and threw the return value away. Two concurrent requests could therefore both pass `is_locked()`, both call `lock()`, and only one would actually insert the lock row — but both would proceed into the migration body. Every migration callback then runs twice.
* Fix: bail when `lock()` returns anything other than `true`. The `is_locked()` fast-path stays as an early return + stale-lock recovery; the new check closes the time-of-check / time-of-use race that lives inside it.
* This is the deeper companion to #3294, which made the "Powered by WordPress" default-field provisioning idempotent at the per-author level. Together, the two fixes mean:
  * #3294 prevents duplicates from any cause, even if migrations rerun (defense in depth).
  * This PR prevents migrations from rerunning in the first place when a concurrent worker is already in flight.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run the new test `test_maybe_migrate_bails_when_lock_acquired_by_concurrent_worker`. It pre-inserts a lock row, hides it from `get_option` via the `option_*` filter (simulating the race window where `is_locked()` failed to see it), and asserts that `maybe_migrate()` does not provision any defaults and does not set `activitypub_db_version`.
* Without the fix, the same test fails because `maybe_migrate` ignores `lock()`'s return value and runs the full migration body.

### Changelog entry

Already included in `.github/changelog/fix-migration-lock-race`.