### PR TITLE
Allow Jest to transpile uuid

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,4 +16,12 @@ module.exports = {
 		...defaultConfig.moduleNameMapper,
 		'^@wordpress/interactivity$': '<rootDir>/tests/js/__mocks__/@wordpress/interactivity.js',
 	},
+	/*
+	 * Allow `uuid` to be transformed by Babel. uuid@13+ ships as ESM, and a
+	 * nested copy gets pulled in transitively by @wordpress/components. Jest's
+	 * default `transformIgnorePatterns` skips everything under node_modules,
+	 * which would otherwise leave the bare `export` syntax in place and fail
+	 * any test suite that touches @wordpress/components.
+	 */
+	transformIgnorePatterns: [ 'node_modules/(?!(uuid)/)' ],
 };


### PR DESCRIPTION
Fixes the `jest` job failure on #3301 (and any future dependabot bump that pulls in uuid@13+).

## Proposed changes

- Add a `transformIgnorePatterns: [ 'node_modules/(?!(uuid)/)' ]` override to `jest.config.js` so Babel transpiles uuid even when it lives under `node_modules/`.

## Why

uuid@9 was CommonJS. uuid@13+ ships ESM-only — `dist/index.js` starts with a bare `export { ... }`. `@wordpress/components` pulls a nested copy of uuid as a transitive dependency. Jest's default `transformIgnorePatterns` is `['/node_modules/']`, and the upstream `@wordpress/jest-preset-default` doesn't override that, so the uuid module gets fed to Node as-is and trips a SyntaxError on the `export`. The result on CI (e.g. #3301):

```
node_modules/@wordpress/components/node_modules/uuid/dist/index.js:1
export { default as MAX } from './max.js';
^^^^^^
SyntaxError: Unexpected token 'export'
```

Currently the only suite that traverses this import chain is `src/reactions/__tests__/reactions.test.js` (via `src/reactions/reactions.js` → `@wordpress/components`), but any future test that imports `@wordpress/components` would trip the same wire.

The `node_modules/(?!(uuid)/)` regex is a negative-lookahead pattern that tells Jest: "ignore everything in node_modules EXCEPT uuid." Once `@wordpress/jest-preset-default` ships a fix upstream, this local override can be removed.

## Other information

- [x] Have you written new tests for your changes, if applicable?

This is a test-infrastructure fix; no new tests. Verified locally that the existing 238-test suite still passes with uuid@9 installed (the version on `trunk` today). True verification of the fix against uuid@14 will land via #3301's CI once this is merged and that PR rebases.

## Testing instructions

1. Pull this branch, run `npm run test:unit` — all 238 tests should still pass.
2. To verify the fix works against the actual problem, rebase #3301 onto this branch (or merge this and let dependabot rebase) and re-run jest.

### Changelog entry

This is a test-infrastructure fix; "Skip Changelog" label applied.