### PR TITLE
Use FEP-3b86 follow intent for remote follow endpoint

### DIFF
--- a/.github/changelog/update-webfinger-fep-3b86-follow-intent
+++ b/.github/changelog/update-webfinger-fep-3b86-follow-intent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve compatibility with newer Fediverse servers by recognizing the standardized FEP-3b86 follow link for remote follows.

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -256,7 +256,7 @@ class Webfinger {
 	 * @return string|\WP_Error Error or the Remote-Follow endpoint URI.
 	 */
 	public static function get_remote_follow_endpoint( $uri ) {
-		return self::get_intent_endpoint( $uri, 'follow', true );
+		return self::get_intent_endpoint( $uri, 'Follow', true );
 	}
 
 	/**

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -256,7 +256,7 @@ class Webfinger {
 	 * @return string|\WP_Error Error or the Remote-Follow endpoint URI.
 	 */
 	public static function get_remote_follow_endpoint( $uri ) {
-		return self::get_intent_endpoint( $uri, 'http://ostatus.org/schema/1.0/subscribe' );
+		return self::get_intent_endpoint( $uri, 'follow', true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Prefer the standardized [FEP-3b86](https://codeberg.org/fediverse/fep/src/branch/main/fep/3b86/fep-3b86.md) `https://w3id.org/fep/3b86/Follow` rel when resolving the remote follow endpoint from a WebFinger response. The canonical form uses the CamelCase ActivityPub activity type (`Follow`), matching the convention for all FEP-3b86 intents (`Like`, `Announce`, …).
* Keep full backwards compatibility: fall back to the legacy OStatus `http://ostatus.org/schema/1.0/subscribe` rel, and as a last resort the Mastodon-compatible `authorize_interaction` URL.
* `get_intent_endpoint()` continues to normalize rel and intent values to lowercase before lookup, so remote servers advertising the rel with any casing still match — the canonical capitalized form is what we send out, but we stay tolerant on input.
* Originated from this Fediverse discussion: https://mastodon.social/@julian@activitypub.space/116589778427408680

### Other information:

- [x] Have you written new tests for your changes, if applicable?

`get_remote_follow_endpoint()` is now a thin wrapper around `get_intent_endpoint( $uri, 'Follow', true )`. The three underlying paths (FEP-3b86 lookup, OStatus subscribe fallback, Mastodon `authorize_interaction` last resort) are already covered by existing tests in `tests/phpunit/tests/includes/class-test-webfinger.php`.

## Testing instructions:

* On a site that advertises the FEP-3b86 `https://w3id.org/fep/3b86/Follow` rel in its WebFinger response, trigger the remote follow flow from another instance, confirm the FEP-3b86 template URL is used.
* On a site that advertises only the legacy `http://ostatus.org/schema/1.0/subscribe` rel (e.g. current Mastodon), confirm the existing behavior still works.
* On a site that advertises neither, confirm the Mastodon-compatible `authorize_interaction` URL is returned.
* Run `npm run env-test -- --filter=Webfinger`, all 86 tests should pass.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Improve compatibility with newer Fediverse servers by recognizing the standardized FEP-3b86 follow link for remote follows.

</details>