### PR TITLE
Contribute CORS Allow-Headers via rest_allowed_cors_headers filter

### DIFF
--- a/.github/changelog/fix-cors-allow-x-wp-nonce
+++ b/.github/changelog/fix-cors-allow-x-wp-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix ActivityPub blocks and widgets failing to load on cross-origin embeds (such as WordPress.com sites) due to a missing nonce header in the CORS allow-list.

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -24,6 +24,7 @@ class Server {
 
 		\add_filter( 'rest_post_dispatch', array( self::class, 'filter_output' ), 10, 3 );
 		\add_filter( 'rest_post_dispatch', array( self::class, 'add_cors_headers' ), 10, 3 );
+		\add_filter( 'rest_allowed_cors_headers', array( self::class, 'allow_cors_headers' ), 10, 2 );
 	}
 
 	/**
@@ -184,12 +185,41 @@ class Server {
 		 * REST nonce check, and OAuth Bearer tokens travel in the
 		 * Authorization header — which is permitted via Allow-Headers and
 		 * does not require Allow-Credentials.
+		 *
+		 * Allow-Headers is contributed by core (which already lists `X-WP-Nonce`,
+		 * `Authorization`, `Content-Type`, `Content-Disposition`, and `Content-MD5`)
+		 * and extended for ActivityPub via the `rest_allowed_cors_headers` filter
+		 * in self::allow_cors_headers().
 		 */
 		$response->header( 'Access-Control-Allow-Origin', '*' );
 		$response->header( 'Access-Control-Allow-Methods', 'GET, POST, OPTIONS' );
-		$response->header( 'Access-Control-Allow-Headers', 'Accept, Content-Type, Authorization, Last-Event-ID' );
 
 		return $response;
+	}
+
+	/**
+	 * Extend the CORS Allow-Headers list for ActivityPub REST endpoints.
+	 *
+	 * Adds the headers ActivityPub clients need on top of WordPress core's
+	 * defaults: `Accept` for content negotiation and `Last-Event-ID` for
+	 * Server-Sent Events resume.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string[]         $allow_headers Headers core currently permits in CORS requests.
+	 * @param \WP_REST_Request $request       The current REST request.
+	 *
+	 * @return string[] The (possibly extended) list of allowed headers.
+	 */
+	public static function allow_cors_headers( $allow_headers, $request ) {
+		$route     = $request->get_route();
+		$namespace = '/' . ACTIVITYPUB_REST_NAMESPACE;
+
+		if ( ! \str_starts_with( $route, $namespace ) || \str_starts_with( $route, $namespace . '/oauth/authorize' ) ) {
+			return $allow_headers;
+		}
+
+		return \array_values( \array_unique( \array_merge( (array) $allow_headers, array( 'Accept', 'Last-Event-ID' ) ) ) );
 	}
 
 	/**
@@ -203,6 +233,6 @@ class Server {
 	public static function send_cors_headers() {
 		\header( 'Access-Control-Allow-Origin: *' );
 		\header( 'Access-Control-Allow-Methods: GET, POST, OPTIONS' );
-		\header( 'Access-Control-Allow-Headers: Accept, Content-Type, Authorization, Last-Event-ID' );
+		\header( 'Access-Control-Allow-Headers: Authorization, X-WP-Nonce, Content-Disposition, Content-MD5, Content-Type, Accept, Last-Event-ID' );
 	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-server.php
+++ b/tests/phpunit/tests/includes/rest/class-test-server.php
@@ -34,6 +34,49 @@ class Test_Server extends \WP_Test_REST_TestCase {
 		$this->assertEquals( 9, \has_filter( 'rest_request_before_callbacks', array( Server::class, 'validate_requests' ) ) );
 		$this->assertEquals( 10, \has_filter( 'rest_request_parameter_order', array( Server::class, 'request_parameter_order' ) ) );
 		$this->assertEquals( 10, \has_filter( 'rest_post_dispatch', array( Server::class, 'filter_output' ) ) );
+		$this->assertEquals( 10, \has_filter( 'rest_post_dispatch', array( Server::class, 'add_cors_headers' ) ) );
+		$this->assertEquals( 10, \has_filter( 'rest_allowed_cors_headers', array( Server::class, 'allow_cors_headers' ) ) );
+	}
+
+	/**
+	 * The Allow-Headers filter must extend core's defaults with the headers
+	 * ActivityPub clients use, scoped to ActivityPub routes only.
+	 *
+	 * @covers ::allow_cors_headers
+	 */
+	public function test_allow_cors_headers_extends_for_activitypub_routes() {
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$result  = Server::allow_cors_headers( array( 'Authorization', 'X-WP-Nonce', 'Content-Type' ), $request );
+
+		$this->assertContains( 'X-WP-Nonce', $result );
+		$this->assertContains( 'Accept', $result );
+		$this->assertContains( 'Last-Event-ID', $result );
+	}
+
+	/**
+	 * Non-ActivityPub routes must keep core's Allow-Headers untouched.
+	 *
+	 * @covers ::allow_cors_headers
+	 */
+	public function test_allow_cors_headers_skips_non_activitypub_routes() {
+		$defaults = array( 'Authorization', 'X-WP-Nonce', 'Content-Type' );
+		$request  = new \WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$result   = Server::allow_cors_headers( $defaults, $request );
+
+		$this->assertSame( $defaults, $result );
+	}
+
+	/**
+	 * The interactive OAuth authorize endpoint must not advertise CORS.
+	 *
+	 * @covers ::allow_cors_headers
+	 */
+	public function test_allow_cors_headers_skips_oauth_authorize() {
+		$defaults = array( 'Authorization', 'X-WP-Nonce', 'Content-Type' );
+		$request  = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/oauth/authorize' );
+		$result   = Server::allow_cors_headers( $defaults, $request );
+
+		$this->assertSame( $defaults, $result );
 	}
 
 	/**
@@ -309,6 +352,8 @@ class Test_Server extends \WP_Test_REST_TestCase {
 			$this->assertSame( '*', $headers['Access-Control-Allow-Origin'] );
 			$this->assertArrayNotHasKey( 'Access-Control-Allow-Credentials', $headers );
 			$this->assertArrayNotHasKey( 'Vary', $headers );
+			// Allow-Headers is contributed via rest_allowed_cors_headers, not set on the response.
+			$this->assertArrayNotHasKey( 'Access-Control-Allow-Headers', $headers );
 		} finally {
 			if ( null === $origin_backup ) {
 				unset( $_SERVER['HTTP_ORIGIN'] );


### PR DESCRIPTION
Fixes #

## Proposed changes:

* Stop overriding \`Access-Control-Allow-Headers\` with a narrow hardcoded list in \`Server::add_cors_headers()\`. Hook the \`rest_allowed_cors_headers\` filter instead, so WordPress core's defaults (\`Authorization\`, \`X-WP-Nonce\`, \`Content-Type\`, \`Content-Disposition\`, \`Content-MD5\`) flow through, and only ActivityPub-specific extensions (\`Accept\`, \`Last-Event-ID\`) are added.
* Update the SSE path (\`Server::send_cors_headers()\`) to emit the full canonical list including \`X-WP-Nonce\`.
* Keep route scoping (filter is a no-op for non-AP routes and the OAuth \`authorize\` endpoint).
* Origin and Methods overrides remain on \`rest_post_dispatch\` — there's no filter equivalent for those in core.

### Why

Without \`X-WP-Nonce\` in the Allow-Headers list, browsers preflight any cross-origin \`wp.apiFetch\` request, see the nonce header isn't permitted, and reject the actual request with a CORS error (status \`(null)\`).

Two real-world surfaces hit this:

1. **WordPress.com sites** — every REST URL is rewritten to \`public-api.wordpress.com/wpcom/activitypub-1.0/sites/<id>/...\`, which means every \`apiFetch\` from an ActivityPub block is cross-origin and goes through preflight.
2. **Self-hosted sites embedding AP blocks on a different domain** — same preflight path.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New tests cover the filter behavior (extends AP routes, passthrough for non-AP, skips OAuth authorize) and an updated assertion that the response object no longer carries \`Access-Control-Allow-Headers\` (since core + filter handles it).

## Testing instructions:

* From an origin different than the WordPress site (e.g. an AP block embedded on \`activitypub.blog\` calling a WordPress.com hosted AP REST API), trigger an \`apiFetch\` request that sends \`X-WP-Nonce\`. The browser preflight should succeed and the request should complete. Before this PR it fails with a CORS error.
* Inspect the response of any preflight to an AP route — \`Access-Control-Allow-Headers\` should contain at minimum \`Authorization\`, \`X-WP-Nonce\`, \`Content-Type\`, \`Accept\`, \`Last-Event-ID\`.
* Run \`npm run env-test -- --filter='Test_Server'\` — 21 tests should pass.
* Confirm non-AP REST routes (e.g. \`/wp/v2/posts\`) still get core's default Allow-Headers untouched.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Fix ActivityPub blocks and widgets failing to load on cross-origin embeds (such as WordPress.com sites) due to a missing nonce header in the CORS allow-list.

</details>