### PR TITLE
Compose AP comment-type exclusion with other plugins' filters

### DIFF
--- a/.github/changelog/fix-comment-query-type-coexistence
+++ b/.github/changelog/fix-comment-query-type-coexistence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop ActivityPub Likes, Reposts, and Quotes from leaking into the front-end comment list on sites that also use other comment-filtering plugins.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -788,13 +788,15 @@ class Comment {
 
 		/*
 		 * If the caller is explicitly asking for one of the ActivityPub
-		 * comment types (likes, reposts, …), respect that. Otherwise we
-		 * still merge our slugs into `type__not_in`, so the AP exclusion
-		 * composes with whatever other plugins are filtering on. The
-		 * previous version bailed out as soon as any of `type__in`, `type`
-		 * or `type__not_in` was set — which let AP comments leak through
-		 * on themes that use plugins like GatherPress (which sets
-		 * `type__in` for its own RSVP filtering).
+		 * comment types (likes, reposts, …) — or for `'all'`, which WP
+		 * treats as a sentinel meaning "include everything, even types we
+		 * would normally exclude" — respect that. Otherwise we still merge
+		 * our slugs into `type__not_in`, so the AP exclusion composes with
+		 * whatever other plugins are filtering on. The previous version
+		 * bailed out as soon as any of `type__in`, `type` or `type__not_in`
+		 * was set — which let AP comments leak through on themes that use
+		 * plugins like GatherPress (which sets `type__in` for its own RSVP
+		 * filtering).
 		 */
 		foreach ( array( 'type__in', 'type' ) as $key ) {
 			if ( empty( $query->query_vars[ $key ] ) ) {
@@ -802,7 +804,7 @@ class Comment {
 			}
 
 			$requested = (array) $query->query_vars[ $key ];
-			if ( \array_intersect( $requested, $ap_types ) ) {
+			if ( \in_array( 'all', $requested, true ) || \array_intersect( $requested, $ap_types ) ) {
 				return;
 			}
 		}

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -784,18 +784,31 @@ class Comment {
 			return;
 		}
 
-		// Do not exclude likes and reposts if the query is for specific types.
-		if ( ! empty( $query->query_vars['type__in'] ) || ! empty( $query->query_vars['type'] ) ) {
-			return;
+		$ap_types = self::get_comment_type_slugs();
+
+		/*
+		 * If the caller is explicitly asking for one of the ActivityPub
+		 * comment types (likes, reposts, …), respect that. Otherwise we
+		 * still merge our slugs into `type__not_in`, so the AP exclusion
+		 * composes with whatever other plugins are filtering on. The
+		 * previous version bailed out as soon as any of `type__in`, `type`
+		 * or `type__not_in` was set — which let AP comments leak through
+		 * on themes that use plugins like GatherPress (which sets
+		 * `type__in` for its own RSVP filtering).
+		 */
+		foreach ( array( 'type__in', 'type' ) as $key ) {
+			if ( empty( $query->query_vars[ $key ] ) ) {
+				continue;
+			}
+
+			$requested = (array) $query->query_vars[ $key ];
+			if ( \array_intersect( $requested, $ap_types ) ) {
+				return;
+			}
 		}
 
-		// Do not exclude likes and reposts if the query is already excluding other comment types.
-		if ( ! empty( $query->query_vars['type__not_in'] ) ) {
-			return;
-		}
-
-		// Exclude likes and reposts by the ActivityPub plugin.
-		$query->query_vars['type__not_in'] = self::get_comment_type_slugs();
+		$existing                          = (array) ( $query->query_vars['type__not_in'] ?? array() );
+		$query->query_vars['type__not_in'] = \array_values( \array_unique( \array_merge( $existing, $ap_types ) ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -908,6 +908,73 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that AP exclusion composes with a caller's existing `type__in`.
+	 *
+	 * Regression for #3306: GatherPress sets `type__in` for its own RSVP
+	 * filtering, which previously caused `comment_query` to bail out, and
+	 * AP comment types leaked into the front-end comment list. The new
+	 * behavior merges AP slugs into `type__not_in` whenever `type__in`
+	 * does not request an AP type.
+	 *
+	 * @covers ::comment_query
+	 */
+	public function test_comment_query_merges_ap_exclusion_with_existing_type_in() {
+		$post_id = self::factory()->post->create();
+		$this->go_to( \get_permalink( $post_id ) );
+
+		$this->assertTrue( \is_singular(), 'Sanity: test setup must reach the singular branch.' );
+
+		$query             = new \WP_Comment_Query();
+		$query->query_vars = array( 'type__in' => array( 'gatherpress_rsvp' ) );
+
+		\Activitypub\Comment::comment_query( $query );
+
+		$this->assertSame( array( 'gatherpress_rsvp' ), $query->query_vars['type__in'] );
+		$this->assertArrayHasKey( 'type__not_in', $query->query_vars );
+		$this->assertContains( 'like', $query->query_vars['type__not_in'] );
+		$this->assertContains( 'repost', $query->query_vars['type__not_in'] );
+	}
+
+	/**
+	 * Test that AP exclusion composes with a caller's existing `type__not_in`.
+	 *
+	 * @covers ::comment_query
+	 */
+	public function test_comment_query_merges_ap_exclusion_with_existing_type_not_in() {
+		$post_id = self::factory()->post->create();
+		$this->go_to( \get_permalink( $post_id ) );
+
+		$query             = new \WP_Comment_Query();
+		$query->query_vars = array( 'type__not_in' => array( 'pingback' ) );
+
+		\Activitypub\Comment::comment_query( $query );
+
+		$this->assertContains( 'pingback', $query->query_vars['type__not_in'] );
+		$this->assertContains( 'like', $query->query_vars['type__not_in'] );
+		$this->assertContains( 'repost', $query->query_vars['type__not_in'] );
+	}
+
+	/**
+	 * Test that an explicit request for an AP comment type is respected.
+	 *
+	 * @covers ::comment_query
+	 */
+	public function test_comment_query_respects_explicit_ap_type_request() {
+		$post_id = self::factory()->post->create();
+		$this->go_to( \get_permalink( $post_id ) );
+
+		$query             = new \WP_Comment_Query();
+		$query->query_vars = array( 'type__in' => array( 'like' ) );
+
+		\Activitypub\Comment::comment_query( $query );
+
+		$this->assertTrue(
+			empty( $query->query_vars['type__not_in'] ),
+			'Caller is explicitly asking for AP likes; we must not add likes to type__not_in.'
+		);
+	}
+
+	/**
 	 * Test auto-approving comments on ap_post when option is enabled.
 	 *
 	 * @covers ::pre_comment_approved

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -975,6 +975,43 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the WordPress `'all'` sentinel disables AP exclusion.
+	 *
+	 * WP_Comment_Query treats `type => 'all'` and `type__in => array('all')`
+	 * as "include everything, even types we'd normally hide" (e.g. the
+	 * built-in `note` exclusion is also disabled in that case). Our filter
+	 * has to honor the same sentinel, otherwise a caller asking for the
+	 * full set still can't see ActivityPub Likes / Reposts / Quotes.
+	 *
+	 * @covers ::comment_query
+	 */
+	public function test_comment_query_respects_all_sentinel() {
+		$post_id = self::factory()->post->create();
+		$this->go_to( \get_permalink( $post_id ) );
+
+		$query             = new \WP_Comment_Query();
+		$query->query_vars = array( 'type' => 'all' );
+
+		\Activitypub\Comment::comment_query( $query );
+
+		$this->assertTrue(
+			empty( $query->query_vars['type__not_in'] ),
+			"Caller passed `type => 'all'`; AP slugs must not be appended to type__not_in."
+		);
+
+		// Same again via `type__in`.
+		$query             = new \WP_Comment_Query();
+		$query->query_vars = array( 'type__in' => array( 'all' ) );
+
+		\Activitypub\Comment::comment_query( $query );
+
+		$this->assertTrue(
+			empty( $query->query_vars['type__not_in'] ),
+			"Caller passed `type__in => array('all')`; AP slugs must not be appended to type__not_in."
+		);
+	}
+
+	/**
 	 * Test auto-approving comments on ap_post when option is enabled.
 	 *
 	 * @covers ::pre_comment_approved


### PR DESCRIPTION
Also for #2849, which was closed by bailing out; this is the actual fix for that shape.

## Proposed changes

* `Comment::comment_query()` merges our comment types into `type__not_in` on top of whatever the caller already set there. Before, any `type__not_in` on the query switched our exclusion off completely, so a theme excluding pingbacks got Likes and Reposts back in its comment list.
* It still bails when the caller asks for our types on purpose via `type` or `type__in`, and when `all` is requested.

## What it does not fix

#3306 (GatherPress). Their handler rewrites an empty `type` into a positive list of every registered comment type except rsvp, which is indistinguishable from a caller asking for Likes. No handler on our side can compose with that, it only worked in @Menrath's test when our filter ran before theirs, which is a race, not a fix. That one needs a change in GatherPress, see my comment on the issue.

## Other information

- [x] Have you written new tests for your changes, if applicable?

Three tests in `Test_Comment`: a foreign `type__in` still gets our types excluded, an existing `type__not_in` is merged rather than replaced, and an explicit `type__in => like` is left alone.

## Testing instructions

* Add `'type__not_in' => 'pingback'` to a theme's comment query on a post that has federated Likes. On trunk the Likes show up, with this branch they don't and pingbacks stay excluded.

### Changelog entry

On the branch.
