### PR TITLE
Recognize the FEP-3b86 Object Intent in the intent-endpoint fallback chain

### DIFF
--- a/.github/changelog/add-fep-3b86-object-intent-fallback
+++ b/.github/changelog/add-fep-3b86-object-intent-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve compatibility with newer Fediverse servers by recognizing the FEP-3b86 Object Intent link when resolving remote follow and other intent endpoints.

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -256,7 +256,7 @@ class Webfinger {
 	 * @return string|\WP_Error Error or the Remote-Follow endpoint URI.
 	 */
 	public static function get_remote_follow_endpoint( $uri ) {
-		return self::get_intent_endpoint( $uri, 'Follow', true );
+		return self::get_intent_endpoint( $uri, 'follow', true );
 	}
 
 	/**

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -363,8 +363,24 @@ class Webfinger {
 			);
 		}
 
+		/*
+		 * OStatus subscribe URL (deprecated but still widely supported)
+		 *
+		 * @see https://ostatus.github.io/spec/OStatus%201.0%20Draft%202.html#anchor10
+		 */
 		if ( isset( $links['http://ostatus.org/schema/1.0/subscribe'] ) ) {
 			return $links['http://ostatus.org/schema/1.0/subscribe'];
+		}
+
+		/*
+		 * FEP-3b86 Object Intent — the generic "open this object on my home
+		 * server" link, equivalent to pasting the URL into the home server's
+		 * search box. Useful when no verb-specific intent is advertised.
+		 *
+		 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/3b86/fep-3b86.md#5-1-object-intent
+		 */
+		if ( isset( $links['https://w3id.org/fep/3b86/object'] ) ) {
+			return $links['https://w3id.org/fep/3b86/object'];
 		}
 
 		// Last-resort: construct a Mastodon-compatible authorize_interaction URL.

--- a/tests/phpunit/tests/includes/class-test-webfinger.php
+++ b/tests/phpunit/tests/includes/class-test-webfinger.php
@@ -411,6 +411,78 @@ class Test_Webfinger extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_intent_endpoint falls back to the FEP-3b86 Object Intent link.
+	 *
+	 * The generic Object Intent acts as a "paste the URL into my home server"
+	 * link and is preferred over the last-resort Mastodon-style URL when
+	 * advertised by the remote actor.
+	 *
+	 * @covers ::get_intent_endpoint
+	 */
+	public function test_get_intent_endpoint_object_intent_fallback() {
+		$filter = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode(
+					array(
+						'subject' => 'acct:user@example.com',
+						'links'   => array(
+							array(
+								'rel'      => 'https://w3id.org/fep/3b86/Object',
+								'template' => 'https://example.com/intent/object?uri={uri}',
+							),
+						),
+					)
+				),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter );
+
+		// No `like` intent advertised, no OStatus subscribe link — should fall
+		// back to the Object Intent rather than the Mastodon-style last-resort URL.
+		$result = Webfinger::get_intent_endpoint( 'user@example.com', 'like', true );
+
+		$this->assertEquals( 'https://example.com/intent/object?uri={uri}', $result );
+
+		\remove_filter( 'pre_http_request', $filter );
+	}
+
+	/**
+	 * Test get_intent_endpoint prefers OStatus subscribe over the Object Intent.
+	 *
+	 * @covers ::get_intent_endpoint
+	 */
+	public function test_get_intent_endpoint_ostatus_preferred_over_object_intent() {
+		$filter = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode(
+					array(
+						'subject' => 'acct:user@example.com',
+						'links'   => array(
+							array(
+								'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+								'template' => 'https://example.com/authorize_interaction?uri={uri}',
+							),
+							array(
+								'rel'      => 'https://w3id.org/fep/3b86/Object',
+								'template' => 'https://example.com/intent/object?uri={uri}',
+							),
+						),
+					)
+				),
+			);
+		};
+		\add_filter( 'pre_http_request', $filter );
+
+		$result = Webfinger::get_intent_endpoint( 'user@example.com', 'like', true );
+
+		$this->assertEquals( 'https://example.com/authorize_interaction?uri={uri}', $result );
+
+		\remove_filter( 'pre_http_request', $filter );
+	}
+
+	/**
 	 * Test get_intent_endpoint last-resort Mastodon-compatible URL for handle.
 	 *
 	 * @covers ::get_intent_endpoint


### PR DESCRIPTION
Follow-up to #3307, which switched the remote-follow lookup to the FEP-3b86 intent mechanism.

## Proposed changes

* Extend `Webfinger::get_intent_endpoint()`'s fallback chain to recognize the generic FEP-3b86 Object Intent link (`https://w3id.org/fep/3b86/Object`) when no verb-specific intent or OStatus subscribe link is advertised.

## Why

[FEP-3b86](https://codeberg.org/fediverse/fep/src/branch/main/fep/3b86/fep-3b86.md) standardizes the way servers advertise actionable intents in WebFinger responses. The verb-specific links (e.g. `Follow`, `Like`, `Create`) cover most flows, but the generic **Object Intent** is the spec-defined catch-all — equivalent to pasting an object's URL into your home server's search box. Newer servers may advertise the Object Intent without (or in addition to) the verb-specific ones, so honoring it before our Mastodon-style last-resort URL improves coverage.

Resolution order now becomes:

1. The verb-specific intent the caller asked for (`https://w3id.org/fep/3b86/<verb>`).
2. (with `\$fallback = true`) The OStatus `subscribe` link — older but still widely deployed.
3. **(new)** The FEP-3b86 Object Intent link.
4. The synthetic Mastodon `authorize_interaction` URL.

The OStatus link is checked before the Object Intent intentionally: the existing remote-follow flow uses an OStatus-shaped URL, and most servers in the wild today advertise it, so preserving that ordering avoids any behavior change for the common path.

## Other information

- [x] Have you written new tests for your changes, if applicable?

Two new tests in `Test_Webfinger`:

- `test_get_intent_endpoint_object_intent_fallback` — Only an Object Intent link is advertised; the function should return it.
- `test_get_intent_endpoint_ostatus_preferred_over_object_intent` — Both are advertised; OStatus wins.

Both tests use the capitalized rel value (`https://w3id.org/fep/3b86/Object`) to match what real servers send. The plugin's internal `strtolower()` normalization handles the case conversion automatically.

## Testing instructions

1. Apply the branch, run `vendor/bin/phpunit --filter='Test_Webfinger'` — all 77 tests should pass.
2. To exercise the new fallback against a remote actor that advertises an Object Intent in its WebFinger response: dispatch any flow that calls `Webfinger::get_intent_endpoint( \$uri, '<some-verb-the-actor-doesnt-advertise>', true )` and observe the Object Intent URL coming back.

### Changelog entry

Added at `.github/changelog/add-fep-3b86-object-intent-fallback`.