### PR TITLE
Surface ap_tombstone in the dev debug menu

### DIFF
--- a/.github/changelog/update-tombstone-debug-surface
+++ b/.github/changelog/update-tombstone-debug-surface
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add labels to the internal `ap_tombstone` post type so the dev debug surface can list and inspect tombstones alongside the other ActivityPub stores.

--- a/.github/changelog/update-tombstone-debug-surface
+++ b/.github/changelog/update-tombstone-debug-surface
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Add labels to the internal `ap_tombstone` post type so the dev debug surface can list and inspect tombstones alongside the other ActivityPub stores.

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -574,6 +574,10 @@ class Post_Types {
 		\register_post_type(
 			Tombstone::POST_TYPE,
 			array(
+				'labels'              => array(
+					'name'          => \_x( 'Tombstones', 'post_type plural name', 'activitypub' ),
+					'singular_name' => \_x( 'Tombstone', 'post_type single name', 'activitypub' ),
+				),
 				'public'              => false,
 				'publicly_queryable'  => false,
 				'show_ui'             => false,

--- a/local/class-debug.php
+++ b/local/class-debug.php
@@ -10,6 +10,7 @@ namespace Activitypub\Development;
 use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
 use Activitypub\Collection\Remote_Posts;
+use Activitypub\Tombstone;
 
 /**
  * Debug Class.
@@ -49,11 +50,12 @@ class Debug {
 	 * @return array The arguments for the post type.
 	 */
 	public static function debug_post_type( $args, $post_type ) {
-		if ( ! \in_array( $post_type, array( Outbox::POST_TYPE, Inbox::POST_TYPE, Remote_Posts::POST_TYPE ), true ) ) {
+		if ( ! \in_array( $post_type, array( Outbox::POST_TYPE, Inbox::POST_TYPE, Remote_Posts::POST_TYPE, Tombstone::POST_TYPE ), true ) ) {
 			return $args;
 		}
 
-		$args['show_ui'] = true;
+		$args['show_ui']      = true;
+		$args['show_in_menu'] = true;
 
 		if ( Outbox::POST_TYPE === $post_type ) {
 			$args['menu_icon'] = 'dashicons-upload';
@@ -61,6 +63,8 @@ class Debug {
 			$args['menu_icon'] = 'dashicons-download';
 		} elseif ( Remote_Posts::POST_TYPE === $post_type ) {
 			$args['menu_icon'] = 'dashicons-media-document';
+		} elseif ( Tombstone::POST_TYPE === $post_type ) {
+			$args['menu_icon'] = 'dashicons-trash';
 		}
 
 		return $args;


### PR DESCRIPTION
Follow-up to #3293 (tombstone storage) — makes the new CPT visible alongside Inbox / Outbox / Remote Posts when the dev debug helper is enabled.

## Proposed changes

* `Post_Types::register_tombstone_post_type()` — add `labels` (`Tombstones` / `Tombstone`). The CPT stays `'show_ui' => false` by default; the labels are just so any consumer that flips `show_ui` on (notably the dev `Debug` helper below) renders a sensible menu instead of the unlabeled fallback.
* `Debug::debug_post_type()` — include `Tombstone::POST_TYPE` in the list of debug-visible post types, set `show_in_menu => true` (so it actually surfaces in the admin sidebar when debug mode is on), and assign the `dashicons-trash` icon. Mirrors the existing pattern for the other AP CPTs.

## Why

After #3293 moved the tombstone registry onto a custom post type, the only way to inspect what's stored is `wp post list --post_type=ap_tombstone`. For day-to-day debugging it's nicer to have the same admin surface the inbox/outbox/remote-posts stores already get via `local/class-debug.php` (which is only loaded in development environments).

## Other information

- [x] Have you written new tests for your changes, if applicable?

No new tests — the change is two label entries on a CPT registration plus an array entry in a dev-only helper. The existing `Test_Post_Types` suite still passes (2 tests, 10 assertions).

## Testing instructions

1. Apply the branch on a development environment that loads `local/class-debug.php` (typically `define( 'WP_DEBUG', true );` plus the local dev bootstrap).
2. Bury a URL via the public API (`Tombstone::bury( 'https://fake.test/foo' );` from a `wp eval` shot or anywhere in the request lifecycle).
3. In the admin, confirm a new "Tombstones" entry appears in the menu with the trash icon, and that the row is listed there.

### Changelog entry

Added at `.github/changelog/update-tombstone-debug-surface`.