### PR TITLE
Improve SWICG ActivityPub API Basic Profile conformance for C2S

### DIFF
--- a/.github/changelog/oauth-rate-limit-retry-after
+++ b/.github/changelog/oauth-rate-limit-retry-after
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+OAuth rate-limit responses now include a `Retry-After` header so clients know how long to wait before retrying.

--- a/.github/changelog/swicg-basic-profile-scope-aliases
+++ b/.github/changelog/swicg-basic-profile-scope-aliases
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+C2S clients can now request canonical SWICG ActivityPub API scope names such as `activitypub:read:all` and `activitypub:write:all`, and the OAuth discovery metadata advertises them.

--- a/.github/changelog/swicg-basic-profile-token-fields
+++ b/.github/changelog/swicg-basic-profile-token-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+C2S token responses now include `activitypub_actor_id` so clients following the SWICG ActivityPub API Basic Profile can discover the authenticated actor.

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -5,6 +5,7 @@ The WordPress plugin largely follows ActivityPub's server-to-server specificatio
 ## Supported federation protocols and standards
 
 - [ActivityPub](https://www.w3.org/TR/activitypub/) (Server-to-Server)
+- [ActivityPub API: Basic Profile](https://swicg.github.io/activitypub-api/basicprofile) (Client-to-Server, partial; see [OAuth 2.0 for Client-to-Server](#oauth-20-for-client-to-server))
 - [ActivityPub API: Server-Sent Events](https://swicg.github.io/activitypub-api/sse) (partial, see below)
 - [WebFinger](https://www.w3.org/community/reports/socialcg/CG-FINAL-apwf-20240608/)
 - [HTTP Signatures](https://swicg.github.io/activitypub-http-signature/)
@@ -227,9 +228,11 @@ When the ActivityPub API option is enabled, the plugin exposes OAuth 2.0 endpoin
 
 **Supported standards:**
 
+- [SWICG ActivityPub API: Basic Profile](https://swicg.github.io/activitypub-api/basicprofile) - C2S baseline. The token response includes `activitypub_actor_id` alongside the IndieAuth `me` URI, and `scopes_supported` advertises the canonical aliases `activitypub:read:all` and `activitypub:write:all`. Any `activitypub:read:*` or `activitypub:write:*` scope is accepted and collapsed to the plugin's coarse `read` / `write` scope — there is no per-activity-type access control yet.
 - [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) - OAuth 2.0 for Native Apps. Loopback redirect URIs (`http://127.0.0.1:{port}` and `http://[::1]:{port}`) are accepted with port flexibility per §7.3/§8.3. `localhost` is also accepted for compatibility; §8.3 marks this "NOT RECOMMENDED" but it remains common practice.
 - [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) - Dynamic Client Registration.
 - [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636) - PKCE. Required by default for public clients; only `S256` is accepted.
+- [RFC 6585](https://datatracker.ietf.org/doc/html/rfc6585) - Additional HTTP Status Codes. OAuth rate-limit responses use `429 Too Many Requests` and include a `Retry-After` header.
 - [`draft-ietf-oauth-client-id-metadata-document`](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) - Client Identifier Metadata Document (CIMD). When `client_id` is an `https://` URL, the plugin fetches the metadata document and auto-registers the client. Cleartext (`http://`) `client_id` URLs are rejected.
 
 **Loopback scope:**

--- a/includes/oauth/class-scope.php
+++ b/includes/oauth/class-scope.php
@@ -52,6 +52,23 @@ class Scope {
 	);
 
 	/**
+	 * SWICG ActivityPub API Basic Profile canonical scope aliases.
+	 *
+	 * Advertised in OAuth metadata so Basic Profile clients can discover them,
+	 * and accepted in scope requests (any `activitypub:read:*` collapses to
+	 * `read`, any `activitypub:write:*` collapses to `write`). Enforcement
+	 * stays coarse: there is no per-activity-type access control yet.
+	 *
+	 * @since unreleased
+	 *
+	 * @var array
+	 */
+	const CANONICAL_ALIASES = array(
+		'activitypub:read:all',
+		'activitypub:write:all',
+	);
+
+	/**
 	 * Human-readable descriptions for each scope.
 	 *
 	 * @var array
@@ -79,6 +96,10 @@ class Scope {
 	/**
 	 * Validate and filter requested scopes.
 	 *
+	 * Canonical SWICG ActivityPub API Basic Profile scope names of the form
+	 * `activitypub:read:*` and `activitypub:write:*` are normalized to the
+	 * plugin's internal `read` and `write` scopes before validation.
+	 *
 	 * @param string|array $scopes The requested scopes (space-separated string or array).
 	 * @return array Valid scopes.
 	 */
@@ -91,13 +112,67 @@ class Scope {
 			return self::DEFAULT_SCOPES;
 		}
 
+		$scopes       = self::normalize( $scopes );
 		$valid_scopes = array_intersect( $scopes, self::ALL );
 
 		if ( empty( $valid_scopes ) ) {
 			return self::DEFAULT_SCOPES;
 		}
 
-		return array_values( $valid_scopes );
+		return array_values( array_unique( $valid_scopes ) );
+	}
+
+	/**
+	 * Normalize canonical Basic Profile scope names to internal scopes.
+	 *
+	 * Maps any `activitypub:read:*` to {@see self::READ} and any
+	 * `activitypub:write:*` to {@see self::WRITE}. Unknown values pass through
+	 * unchanged so they can be filtered out by the caller.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $scopes Requested scope strings.
+	 * @return array Normalized scope strings.
+	 */
+	public static function normalize( $scopes ) {
+		if ( ! is_array( $scopes ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $scopes as $scope ) {
+			if ( ! is_string( $scope ) || '' === $scope ) {
+				continue;
+			}
+
+			if ( 0 === strpos( $scope, 'activitypub:read:' ) ) {
+				$normalized[] = self::READ;
+				continue;
+			}
+
+			if ( 0 === strpos( $scope, 'activitypub:write:' ) ) {
+				$normalized[] = self::WRITE;
+				continue;
+			}
+
+			$normalized[] = $scope;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Return the scope identifiers advertised in OAuth authorization-server metadata.
+	 *
+	 * Includes the plugin's internal scopes plus the SWICG Basic Profile
+	 * canonical aliases so spec-aware clients can discover them.
+	 *
+	 * @since unreleased
+	 *
+	 * @return array Scope identifiers.
+	 */
+	public static function supported() {
+		return array_merge( self::ALL, self::CANONICAL_ALIASES );
 	}
 
 	/**

--- a/includes/oauth/class-server.php
+++ b/includes/oauth/class-server.php
@@ -248,7 +248,7 @@ class Server {
 			'revocation_endpoint'                   => $base_url . 'oauth/revoke',
 			'introspection_endpoint'                => $base_url . 'oauth/introspect',
 			'registration_endpoint'                 => $base_url . 'oauth/clients',
-			'scopes_supported'                      => Scope::ALL,
+			'scopes_supported'                      => Scope::supported(),
 			'response_types_supported'              => array( 'code' ),
 			'response_modes_supported'              => array( 'query' ),
 			'grant_types_supported'                 => array( 'authorization_code', 'refresh_token' ),

--- a/includes/oauth/class-token.php
+++ b/includes/oauth/class-token.php
@@ -141,7 +141,8 @@ class Token {
 		self::enforce_token_limit( $user_id );
 
 		/*
-		 * Get the actor URI for the 'me' parameter (IndieAuth convention).
+		 * Get the actor URI for the 'me' parameter (IndieAuth convention) and
+		 * `activitypub_actor_id` (SWICG ActivityPub API Basic Profile).
 		 * Fall back to blog actor when user actors are disabled.
 		 */
 		$actor = Actors::get_by_id( $user_id );
@@ -151,12 +152,13 @@ class Token {
 		$me = ! \is_wp_error( $actor ) ? $actor->get_id() : null;
 
 		return array(
-			'access_token'  => $access_token,
-			'token_type'    => 'Bearer',
-			'expires_in'    => $expires,
-			'refresh_token' => $refresh_token,
-			'scope'         => Scope::to_string( $token_data['scopes'] ),
-			'me'            => $me,
+			'access_token'         => $access_token,
+			'token_type'           => 'Bearer',
+			'expires_in'           => $expires,
+			'refresh_token'        => $refresh_token,
+			'scope'                => Scope::to_string( $token_data['scopes'] ),
+			'me'                   => $me,
+			'activitypub_actor_id' => $me,
 		);
 	}
 
@@ -919,15 +921,16 @@ class Token {
 		$me = ! \is_wp_error( $actor ) ? $actor->get_id() : null;
 
 		return array(
-			'active'     => true,
-			'scope'      => Scope::to_string( $validated->get_scopes() ),
-			'client_id'  => $validated->get_client_id(),
-			'username'   => $user ? $user->user_login : null,
-			'token_type' => 'Bearer',
-			'exp'        => $validated->get_expires_at(),
-			'iat'        => $validated->get_created_at(),
-			'sub'        => (string) $user_id,
-			'me'         => $me,
+			'active'               => true,
+			'scope'                => Scope::to_string( $validated->get_scopes() ),
+			'client_id'            => $validated->get_client_id(),
+			'username'             => $user ? $user->user_login : null,
+			'token_type'           => 'Bearer',
+			'exp'                  => $validated->get_expires_at(),
+			'iat'                  => $validated->get_created_at(),
+			'sub'                  => (string) $user_id,
+			'me'                   => $me,
+			'activitypub_actor_id' => $me,
 		);
 	}
 }

--- a/includes/rest/oauth/class-authorization-controller.php
+++ b/includes/rest/oauth/class-authorization-controller.php
@@ -153,21 +153,13 @@ class Authorization_Controller extends \WP_REST_Controller {
 		// Rate-limit authorization requests to prevent abuse (max 20 per minute per IP).
 		$ip = get_client_ip();
 		if ( '' === $ip ) {
-			return new \WP_Error(
-				'activitypub_rate_limit',
-				\__( 'Too many authorization requests. Please try again later.', 'activitypub' ),
-				array( 'status' => 429 )
-			);
+			return $this->rate_limit_response( \__( 'Too many authorization requests. Please try again later.', 'activitypub' ) );
 		}
 		$transient_key = 'ap_oauth_auth_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 
 		if ( $count >= 20 ) {
-			return new \WP_Error(
-				'activitypub_rate_limit',
-				\__( 'Too many authorization requests. Please try again later.', 'activitypub' ),
-				array( 'status' => 429 )
-			);
+			return $this->rate_limit_response( \__( 'Too many authorization requests. Please try again later.', 'activitypub' ) );
 		}
 
 		\set_transient( $transient_key, $count + 1, MINUTE_IN_SECONDS );
@@ -401,6 +393,27 @@ class Authorization_Controller extends \WP_REST_Controller {
 			null,
 			302,
 			array( 'Location' => $redirect_url )
+		);
+	}
+
+	/**
+	 * Build a 429 rate-limit response with a Retry-After header.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $message Translated human-readable error message.
+	 * @return \WP_REST_Response
+	 */
+	private function rate_limit_response( $message ) {
+		return new \WP_REST_Response(
+			array(
+				'code'    => 'activitypub_rate_limit',
+				'message' => $message,
+				'data'    => array( 'status' => 429 ),
+			),
+			429,
+			// RFC 6585 §4: send Retry-After so clients can back off.
+			array( 'Retry-After' => (string) MINUTE_IN_SECONDS )
 		);
 	}
 }

--- a/includes/rest/oauth/class-clients-controller.php
+++ b/includes/rest/oauth/class-clients-controller.php
@@ -118,21 +118,13 @@ class Clients_Controller extends \WP_REST_Controller {
 		// Rate-limit registrations to prevent DB spam (max 10 per minute per IP).
 		$ip = get_client_ip();
 		if ( '' === $ip ) {
-			return new \WP_Error(
-				'activitypub_rate_limited',
-				\__( 'Too many client registration requests. Please try again later.', 'activitypub' ),
-				array( 'status' => 429 )
-			);
+			return $this->rate_limit_response( \__( 'Too many client registration requests. Please try again later.', 'activitypub' ) );
 		}
 		$transient_key = 'ap_oauth_reg_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 
 		if ( $count >= 10 ) {
-			return new \WP_Error(
-				'activitypub_rate_limited',
-				\__( 'Too many client registration requests. Please try again later.', 'activitypub' ),
-				array( 'status' => 429 )
-			);
+			return $this->rate_limit_response( \__( 'Too many client registration requests. Please try again later.', 'activitypub' ) );
 		}
 
 		\set_transient( $transient_key, $count + 1, MINUTE_IN_SECONDS );
@@ -181,6 +173,27 @@ class Clients_Controller extends \WP_REST_Controller {
 			OAuth_Server::get_metadata(),
 			200,
 			array( 'Content-Type' => 'application/json' )
+		);
+	}
+
+	/**
+	 * Build a 429 rate-limit response with a Retry-After header.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $message Translated human-readable error message.
+	 * @return \WP_REST_Response
+	 */
+	private function rate_limit_response( $message ) {
+		return new \WP_REST_Response(
+			array(
+				'code'    => 'activitypub_rate_limited',
+				'message' => $message,
+				'data'    => array( 'status' => 429 ),
+			),
+			429,
+			// RFC 6585 §4: send Retry-After so clients can back off.
+			array( 'Retry-After' => (string) MINUTE_IN_SECONDS )
 		);
 	}
 }

--- a/includes/rest/oauth/class-token-controller.php
+++ b/includes/rest/oauth/class-token-controller.php
@@ -397,18 +397,25 @@ class Token_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response
 	 */
 	private function token_error( $error, $error_description, $status = 400 ) {
+		$headers = array(
+			'Content-Type'  => 'application/json',
+			// RFC 6749 §5.1 requires the same no-cache headers on error responses as on success responses.
+			'Cache-Control' => 'no-store',
+			'Pragma'        => 'no-cache',
+		);
+
+		// RFC 6585 §4: send Retry-After with rate-limit responses so clients can back off.
+		if ( 429 === $status ) {
+			$headers['Retry-After'] = (string) MINUTE_IN_SECONDS;
+		}
+
 		return new \WP_REST_Response(
 			array(
 				'error'             => $error,
 				'error_description' => $error_description,
 			),
 			$status,
-			array(
-				'Content-Type'  => 'application/json',
-				// RFC 6749 §5.1 requires the same no-cache headers on error responses as on success responses.
-				'Cache-Control' => 'no-store',
-				'Pragma'        => 'no-cache',
-			)
+			$headers
 		);
 	}
 

--- a/tests/phpunit/tests/includes/oauth/class-test-scope.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-scope.php
@@ -299,4 +299,87 @@ class Test_Scope extends \WP_UnitTestCase {
 		$result = Scope::sanitize( 123 );
 		$this->assertEquals( array(), $result );
 	}
+
+	/**
+	 * Canonical SWICG Basic Profile read scopes collapse to the internal `read` scope.
+	 *
+	 * @covers ::validate
+	 * @covers ::normalize
+	 *
+	 * @dataProvider data_canonical_read_aliases
+	 *
+	 * @param string $canonical Canonical Basic Profile scope identifier.
+	 */
+	public function test_validate_normalizes_canonical_read_aliases( $canonical ) {
+		$this->assertEquals( array( Scope::READ ), Scope::validate( $canonical ) );
+	}
+
+	/**
+	 * Data provider for canonical read aliases.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function data_canonical_read_aliases() {
+		return array(
+			'umbrella'  => array( 'activitypub:read:all' ),
+			'inbox'     => array( 'activitypub:read:me:inbox' ),
+			'outbox'    => array( 'activitypub:read:me:outbox' ),
+			'followers' => array( 'activitypub:read:me:followers' ),
+		);
+	}
+
+	/**
+	 * Canonical SWICG Basic Profile write scopes collapse to the internal `write` scope.
+	 *
+	 * @covers ::validate
+	 * @covers ::normalize
+	 *
+	 * @dataProvider data_canonical_write_aliases
+	 *
+	 * @param string $canonical Canonical Basic Profile scope identifier.
+	 */
+	public function test_validate_normalizes_canonical_write_aliases( $canonical ) {
+		$this->assertEquals( array( Scope::WRITE ), Scope::validate( $canonical ) );
+	}
+
+	/**
+	 * Data provider for canonical write aliases.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function data_canonical_write_aliases() {
+		return array(
+			'umbrella' => array( 'activitypub:write:all' ),
+			'create'   => array( 'activitypub:write:create' ),
+			'follow'   => array( 'activitypub:write:follow' ),
+			'like'     => array( 'activitypub:write:like' ),
+		);
+	}
+
+	/**
+	 * Mixed legacy + canonical names dedupe to a single read/write pair.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_dedupes_mixed_canonical_and_legacy_aliases() {
+		$result = Scope::validate( 'read activitypub:read:me:inbox write activitypub:write:all' );
+		$this->assertEquals( array( Scope::READ, Scope::WRITE ), $result );
+	}
+
+	/**
+	 * Supported() advertises both internal scopes and Basic Profile canonical aliases.
+	 *
+	 * @covers ::supported
+	 */
+	public function test_supported_includes_canonical_aliases() {
+		$supported = Scope::supported();
+
+		// Internal scopes still advertised for backwards-compatible clients.
+		$this->assertContains( Scope::READ, $supported );
+		$this->assertContains( Scope::WRITE, $supported );
+
+		// Basic Profile canonical aliases are now discoverable.
+		$this->assertContains( 'activitypub:read:all', $supported );
+		$this->assertContains( 'activitypub:write:all', $supported );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-authorization-controller.php
@@ -170,9 +170,11 @@ class Test_Authorization_Controller extends \WP_UnitTestCase {
 
 			$response = \rest_get_server()->dispatch( $request );
 			$data     = $response->get_data();
+			$headers  = $response->get_headers();
 
 			$this->assertEquals( 429, $response->get_status() );
 			$this->assertEquals( 'activitypub_rate_limit', $data['code'] );
+			$this->assertSame( (string) MINUTE_IN_SECONDS, $headers['Retry-After'] ?? null, 'Rate-limit responses must include Retry-After per RFC 6585 §4.' );
 			$this->assertFalse( \get_transient( $empty_ip_transient ) );
 		} finally {
 			foreach ( $snapshot as $key => $value ) {

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-clients-controller.php
@@ -148,9 +148,11 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 
 		$response = \rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		$headers  = $response->get_headers();
 
 		$this->assertEquals( 429, $response->get_status() );
 		$this->assertEquals( 'activitypub_rate_limited', $data['code'] );
+		$this->assertSame( (string) MINUTE_IN_SECONDS, $headers['Retry-After'] ?? null, 'Rate-limit responses must include Retry-After per RFC 6585 §4.' );
 	}
 
 	/**
@@ -194,9 +196,11 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 
 			$response = \rest_get_server()->dispatch( $request );
 			$data     = $response->get_data();
+			$headers  = $response->get_headers();
 
 			$this->assertEquals( 429, $response->get_status() );
 			$this->assertEquals( 'activitypub_rate_limited', $data['code'] );
+			$this->assertSame( (string) MINUTE_IN_SECONDS, $headers['Retry-After'] ?? null, 'Rate-limit responses must include Retry-After per RFC 6585 §4.' );
 
 			// Ensure the empty-IP path didn't write a shared transient.
 			$this->assertFalse( \get_transient( $empty_ip_transient ) );
@@ -260,5 +264,9 @@ class Test_Clients_Controller extends \WP_UnitTestCase {
 		$this->assertContains( 'code', $data['response_types_supported'] );
 		$this->assertContains( 'authorization_code', $data['grant_types_supported'] );
 		$this->assertContains( 'refresh_token', $data['grant_types_supported'] );
+
+		// Advertise SWICG ActivityPub API Basic Profile canonical scope aliases.
+		$this->assertContains( 'activitypub:read:all', $data['scopes_supported'] );
+		$this->assertContains( 'activitypub:write:all', $data['scopes_supported'] );
 	}
 }

--- a/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/oauth/class-test-token-controller.php
@@ -229,6 +229,7 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 			$this->assertEquals( 'rate_limited', $data['error'] );
 			$this->assertSame( 'no-store', $headers['Cache-Control'] ?? null, 'Token error responses must set Cache-Control: no-store per RFC 6749 §5.1.' );
 			$this->assertSame( 'no-cache', $headers['Pragma'] ?? null, 'Token error responses must set Pragma: no-cache per RFC 6749 §5.1.' );
+			$this->assertSame( (string) MINUTE_IN_SECONDS, $headers['Retry-After'] ?? null, 'Rate-limit responses must include Retry-After per RFC 6585 §4.' );
 		} finally {
 			\delete_transient( $transient_key );
 			$this->restore_client_ip_server( $snapshot );
@@ -260,9 +261,11 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 
 			$response = \rest_get_server()->dispatch( $request );
 			$data     = $response->get_data();
+			$headers  = $response->get_headers();
 
 			$this->assertEquals( 429, $response->get_status() );
 			$this->assertEquals( 'rate_limited', $data['error'] );
+			$this->assertSame( (string) MINUTE_IN_SECONDS, $headers['Retry-After'] ?? null, 'Rate-limit responses must include Retry-After per RFC 6585 §4.' );
 			// The fail-closed branch must not write a shared empty-IP transient.
 			$this->assertFalse( \get_transient( $empty_ip_transient ) );
 		} finally {
@@ -348,6 +351,12 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'expires_in', $data );
 		$this->assertArrayHasKey( 'refresh_token', $data );
 		$this->assertEquals( 'Bearer', $data['token_type'] );
+
+		// IndieAuth `me` and SWICG Basic Profile `activitypub_actor_id` must both be present and equal.
+		$this->assertArrayHasKey( 'me', $data );
+		$this->assertArrayHasKey( 'activitypub_actor_id', $data );
+		$this->assertNotEmpty( $data['me'] );
+		$this->assertSame( $data['me'], $data['activitypub_actor_id'] );
 	}
 
 	/**
@@ -610,6 +619,12 @@ class Test_Token_Controller extends \WP_UnitTestCase {
 		$this->assertTrue( $data['active'] );
 		$this->assertEquals( $this->client_id, $data['client_id'] );
 		$this->assertEquals( 'Bearer', $data['token_type'] );
+
+		// IndieAuth `me` and SWICG Basic Profile `activitypub_actor_id` must both be present and equal.
+		$this->assertArrayHasKey( 'me', $data );
+		$this->assertArrayHasKey( 'activitypub_actor_id', $data );
+		$this->assertNotEmpty( $data['me'] );
+		$this->assertSame( $data['me'], $data['activitypub_actor_id'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes:

Three additive, backward-compatible changes to bring the OAuth-based Client-to-Server surface closer to the [SWICG ActivityPub API Basic Profile](https://swicg.github.io/activitypub-api/basicprofile):

* Return `activitypub_actor_id` alongside the existing IndieAuth `me` field in token and introspect responses, so SWICG-aware clients can discover the authenticated actor under the spec property name. Same value for both fields; nothing is removed.
* Accept canonical SWICG scope identifiers. `Scope::validate()` now collapses any `activitypub:read:*` to the internal `read` scope and any `activitypub:write:*` to `write`. The `scopes_supported` advertised at `/oauth/authorization-server-metadata` now includes the canonical aliases `activitypub:read:all` and `activitypub:write:all` alongside the existing `read` / `write` / `follow` / `push` / `profile`. Enforcement stays coarse — there is no per-activity-type access control yet.
* Send `Retry-After: 60` on all OAuth 429 rate-limit responses (token, authorize, register) per RFC 6585 §4, so clients can back off cleanly. The token controller threads this through the existing `token_error()` helper; the authorize and register controllers convert their `WP_Error` paths to `WP_REST_Response` via a small `rate_limit_response()` helper kept private to each controller.

`FEDERATION.md` adds the Basic Profile to the list of supported standards and documents the C2S behavior in the OAuth section.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Enable the ActivityPub API option in **Settings → ActivityPub**.
* Hit `GET /wp-json/activitypub/1.0/oauth/authorization-server-metadata` and confirm `scopes_supported` contains both `read`/`write` and `activitypub:read:all`/`activitypub:write:all`.
* Drive the standard authorization-code + PKCE flow with a request like `scope=activitypub:read:me:inbox` and verify:
  * The token response includes both `me` and `activitypub_actor_id`, set to the same actor URI.
  * The granted `scope` in the response is `read` (collapsed from the canonical name).
* Trigger the rate limiter by hammering `/oauth/token`, `/oauth/authorize`, or `/oauth/clients` past their per-minute caps and confirm the 429 response carries `Retry-After: 60`.
* `npm run env-test -- --group=oauth` should pass (179/179 locally).

### Changelog entry

Three entries already added under `.github/changelog/`. No new entry needed via the workflow.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Added - for new features
-   [x] Changed - for changes in existing functionality

#### Message

C2S token responses now include `activitypub_actor_id`; canonical SWICG scope names are accepted; OAuth rate-limit responses send `Retry-After`.

</details>