### PR TITLE
Update @tanstack/history to clean release, remove supply-chain pin

### DIFF
--- a/.github/changelog/update-tanstack-history-clean
+++ b/.github/changelog/update-tanstack-history-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated a build dependency to a clean release now that a fixed version is available.

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -41,14 +41,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify @tanstack/history pin (GHSA-rmmr-r34h-pfm5)
-        run: |
-          EXPECTED=$(node -p "require('./package.json').overrides['@tanstack/history']")
-          INSTALLED=$(node -p "require('./node_modules/@tanstack/history/package.json').version")
-          if [ "$INSTALLED" != "$EXPECTED" ]; then
-            echo "::error::@tanstack/history install drift: package.json pins '$EXPECTED', node_modules has '$INSTALLED'. See GHSA-rmmr-r34h-pfm5."
-            exit 1
-          fi
-
       - name: Run JavaScript unit tests
         run: npm run test:unit

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,15 +38,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify @tanstack/history pin (GHSA-rmmr-r34h-pfm5)
-        run: |
-          EXPECTED=$(node -p "require('./package.json').overrides['@tanstack/history']")
-          INSTALLED=$(node -p "require('./node_modules/@tanstack/history/package.json').version")
-          if [ "$INSTALLED" != "$EXPECTED" ]; then
-            echo "::error::@tanstack/history install drift: package.json pins '$EXPECTED', node_modules has '$INSTALLED'. See GHSA-rmmr-r34h-pfm5."
-            exit 1
-          fi
-
       - name: Restore Playwright browsers from cache
         id: playwright-cache
         uses: actions/cache@v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"devDependencies": {
 				"@base-ui/react": "^1.5.0",
 				"@playwright/test": "^1.60.0",
-				"@tanstack/react-router": "^1.169.2",
+				"@tanstack/react-router": "^1.170.10",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.4.3",
@@ -7759,9 +7759,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@tanstack/history": {
-			"version": "1.161.6",
-			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.6.tgz",
-			"integrity": "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==",
+			"version": "1.162.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.162.0.tgz",
+			"integrity": "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7773,15 +7773,15 @@
 			}
 		},
 		"node_modules/@tanstack/react-router": {
-			"version": "1.169.2",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.169.2.tgz",
-			"integrity": "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ==",
+			"version": "1.170.10",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.10.tgz",
+			"integrity": "sha512-gVmWYq0ucWr+OB97Nud0YhKa9NOipB7/QrWI7wRZJJWEL0qUS8WPqAs0vA1f3IBXZpXmf8xxzf/tl5cmo4tlmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/history": "1.161.6",
+				"@tanstack/history": "1.162.0",
 				"@tanstack/react-store": "^0.9.3",
-				"@tanstack/router-core": "1.169.2",
+				"@tanstack/router-core": "1.171.8",
 				"isbot": "^5.1.22"
 			},
 			"engines": {
@@ -7816,13 +7816,13 @@
 			}
 		},
 		"node_modules/@tanstack/router-core": {
-			"version": "1.169.2",
-			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.169.2.tgz",
-			"integrity": "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw==",
+			"version": "1.171.8",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.8.tgz",
+			"integrity": "sha512-PbrTBbofFcacrH3RLgHYILRqTFnAGq+gXrXoA/vo7qUSkJpSO4GWfLtrtCahD4VayzRm19IPwcjPPLEugag6pw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/history": "1.161.6",
+				"@tanstack/history": "1.162.0",
 				"cookie-es": "^3.0.0",
 				"seroval": "^1.5.4",
 				"seroval-plugins": "^1.5.4"

--- a/package.json
+++ b/package.json
@@ -32,14 +32,10 @@
 		"url": "https://github.com/automattic/wordpress-activitypub/issues"
 	},
 	"homepage": "https://github.com/automattic/wordpress-activitypub#readme",
-	"_overrides_comment": "@tanstack/history pinned to 1.161.6 per GHSA-rmmr-r34h-pfm5 (versions 1.161.9 and 1.161.12 contain malware). Remove once TanStack ships a clean version above 1.161.12.",
-	"overrides": {
-		"@tanstack/history": "1.161.6"
-	},
 	"devDependencies": {
 		"@base-ui/react": "^1.5.0",
 		"@playwright/test": "^1.60.0",
-		"@tanstack/react-router": "^1.169.2",
+		"@tanstack/react-router": "^1.170.10",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
## Proposed changes:

Removes the supply-chain mitigation that pinned `@tanstack/history` to `1.161.6`. That pin was added in #3285 to block GHSA-rmmr-r34h-pfm5, where `@tanstack/history` `1.161.9` and `1.161.12` shipped malware.

Those malicious versions have since been **unpublished from npm**, and TanStack has shipped a clean `1.162.0`, which is exactly the documented exit condition in the pin's own code comment ("Remove once TanStack ships a clean version above 1.161.12").

This PR:

* Bumps `@tanstack/react-router` from `^1.169.2` to `^1.170.10`, whose dependency tree pulls in `@tanstack/history@1.162.0` transitively.
* Removes the `overrides` block and the `_overrides_comment` from `package.json`.
* Removes the now-redundant "Verify @tanstack/history pin" guard steps from the `jest` and `playwright` workflows.

After regenerating the lockfile, every `@tanstack/history` resolution in the tree is `1.162.0`, and neither malicious version appears anywhere in `package-lock.json`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

This is a dependency-hygiene change; no new tests apply. The existing JavaScript unit suite passes (238/238) against the updated tree.

## Testing instructions:

* Check out the branch and run `npm ci`.
* Run `node -p "require('./node_modules/@tanstack/history/package.json').version"` — it should report `1.162.0`.
* Run `grep -c "1.161.9\|1.161.12" package-lock.json` — it should report `0`.
* Run `npm run test:unit` — all tests should pass.

### Changelog entry

A changelog entry is included in `.github/changelog/update-tanstack-history-clean`.
