### PR TITLE
Use nodeinfo_discovery hook instead of deprecated wellknown_nodeinfo_data

### DIFF
--- a/.github/changelog/fix-nodeinfo-discovery-deprecation
+++ b/.github/changelog/fix-nodeinfo-discovery-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop a deprecation notice from appearing in the error log when the NodeInfo plugin is also active.

--- a/integration/class-nodeinfo.php
+++ b/integration/class-nodeinfo.php
@@ -26,7 +26,7 @@ class Nodeinfo {
 		\add_filter( 'nodeinfo_data', array( self::class, 'add_nodeinfo_data' ), 10, 2 );
 		\add_filter( 'nodeinfo2_data', array( self::class, 'add_nodeinfo2_data' ) );
 
-		\add_filter( 'wellknown_nodeinfo_data', array( self::class, 'add_wellknown_nodeinfo_data' ) );
+		\add_filter( 'nodeinfo_discovery', array( self::class, 'add_wellknown_nodeinfo_data' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/integration/class-test-nodeinfo.php
+++ b/tests/phpunit/tests/integration/class-test-nodeinfo.php
@@ -408,8 +408,8 @@ class Test_Nodeinfo extends \WP_UnitTestCase {
 		$nodeinfo2_data = apply_filters( 'nodeinfo2_data', array( 'protocols' => array() ) );
 		$this->assertContains( 'activitypub', $nodeinfo2_data['protocols'] );
 
-		// Test nodeinfo_discovery filter.
-		$discovery_data = apply_filters( 'nodeinfo_discovery', array() );
+		// Test nodeinfo_discovery filter. NodeInfo always passes a document that already contains a links array.
+		$discovery_data = apply_filters( 'nodeinfo_discovery', array( 'links' => array() ) );
 		$this->assertArrayHasKey( 'links', $discovery_data );
 	}
 }

--- a/tests/phpunit/tests/integration/class-test-nodeinfo.php
+++ b/tests/phpunit/tests/integration/class-test-nodeinfo.php
@@ -59,7 +59,7 @@ class Test_Nodeinfo extends \WP_UnitTestCase {
 		// Remove filters that may have been added during tests.
 		remove_filter( 'nodeinfo_data', array( Nodeinfo::class, 'add_nodeinfo_data' ) );
 		remove_filter( 'nodeinfo2_data', array( Nodeinfo::class, 'add_nodeinfo2_data' ) );
-		remove_filter( 'wellknown_nodeinfo_data', array( Nodeinfo::class, 'add_wellknown_nodeinfo_data' ) );
+		remove_filter( 'nodeinfo_discovery', array( Nodeinfo::class, 'add_wellknown_nodeinfo_data' ) );
 
 		parent::tear_down();
 	}
@@ -76,7 +76,7 @@ class Test_Nodeinfo extends \WP_UnitTestCase {
 		// Check that hooks are registered.
 		$this->assertTrue( has_filter( 'nodeinfo_data' ) );
 		$this->assertTrue( has_filter( 'nodeinfo2_data' ) );
-		$this->assertTrue( has_filter( 'wellknown_nodeinfo_data' ) );
+		$this->assertTrue( has_filter( 'nodeinfo_discovery' ) );
 	}
 
 	/**
@@ -408,8 +408,8 @@ class Test_Nodeinfo extends \WP_UnitTestCase {
 		$nodeinfo2_data = apply_filters( 'nodeinfo2_data', array( 'protocols' => array() ) );
 		$this->assertContains( 'activitypub', $nodeinfo2_data['protocols'] );
 
-		// Test wellknown_nodeinfo_data filter.
-		$wellknown_data = apply_filters( 'wellknown_nodeinfo_data', array() );
-		$this->assertArrayHasKey( 'links', $wellknown_data );
+		// Test nodeinfo_discovery filter.
+		$discovery_data = apply_filters( 'nodeinfo_discovery', array() );
+		$this->assertArrayHasKey( 'links', $discovery_data );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

The standalone [NodeInfo plugin](https://wordpress.org/plugins/nodeinfo/) deprecated its `wellknown_nodeinfo_data` filter in v3.0.0 in favor of `nodeinfo_discovery`. Our NodeInfo integration still registered its callback on the old hook name, so on sites running NodeInfo 3.x a PHP deprecation notice was logged on **every** `/.well-known/nodeinfo` discovery request:

```
PHP Deprecated: The hook wellknown_nodeinfo_data is deprecated since version 3.0.0! Use nodeinfo_discovery instead.
```

* Switch the `add_filter()` registration in `integration/class-nodeinfo.php` from `wellknown_nodeinfo_data` to `nodeinfo_discovery`. The new hook passes the same `array( 'links' => … )` discovery document, so the callback that appends the Application link is unchanged.
* Update the integration tests to assert on the new hook name.

Because nothing in the plugin hooks `wellknown_nodeinfo_data` anymore, NodeInfo's backwards-compat shim short-circuits (`has_filter()` is false) and the notice stops.

**Note:** sites still running NodeInfo < 3.0.0 (which predates `nodeinfo_discovery`) will no longer have the Application link added to their discovery document. NodeInfo 3.0.0 has been available for a while, so this is considered acceptable.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Updated the existing `Test_Nodeinfo` integration tests (20 tests, 99 assertions, all passing) to cover the new hook.

## Testing instructions:

1. Install and activate both the ActivityPub plugin and the NodeInfo plugin (v3.0.0 or later).
2. Enable `WP_DEBUG` and `WP_DEBUG_LOG`.
3. Request `/.well-known/nodeinfo` (or `/wp-json/...` discovery), e.g. `curl https://example.com/.well-known/nodeinfo`.
4. Before this change, `wp-content/debug.log` shows a `wellknown_nodeinfo_data is deprecated` notice for each request. After this change, no such notice appears.
5. Confirm the discovery document still contains the ActivityPub Application link (`rel` `https://www.w3.org/ns/activitystreams#Application`).

### Changelog entry

A changelog entry is included at `.github/changelog/fix-nodeinfo-discovery-deprecation`.
