### PR TITLE
Defer Getting Started help-tab video until its panel is visible

### DIFF
--- a/.github/changelog/fix-getting-started-video-embed
+++ b/.github/changelog/fix-getting-started-video-embed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the introduction video failing to load on the Getting Started help screen.

--- a/assets/js/activitypub-admin.js
+++ b/assets/js/activitypub-admin.js
@@ -17,4 +17,33 @@ jQuery( function( $ ) {
 			$( '.activate-now' ).removeClass( 'thickbox open-plugin-details-modal' );
 		}, 1200 );
 	} );
+
+	/*
+	 * Lazy-load embedded iframes (e.g. the Fediverse intro video) only once their
+	 * container becomes visible. Help tab panels are rendered hidden, and players
+	 * like PeerTube abort with an "invalid width" error when initialized inside a
+	 * zero-width container. Deferring the src until the panel is shown avoids that.
+	 */
+	var lazyIframes = document.querySelectorAll( 'iframe[data-src]' );
+
+	if ( lazyIframes.length && 'IntersectionObserver' in window ) {
+		var iframeObserver = new IntersectionObserver( function( entries, observer ) {
+			entries.forEach( function( entry ) {
+				if ( entry.isIntersecting ) {
+					// Set once, then stop observing so it never reloads.
+					entry.target.src = entry.target.dataset.src;
+					observer.unobserve( entry.target );
+				}
+			} );
+		} );
+
+		lazyIframes.forEach( function( iframe ) {
+			iframeObserver.observe( iframe );
+		} );
+	} else {
+		// IntersectionObserver unsupported: load immediately as a fallback.
+		lazyIframes.forEach( function( iframe ) {
+			iframe.src = iframe.dataset.src;
+		} );
+	}
 } );

--- a/templates/help-tab/getting-started.php
+++ b/templates/help-tab/getting-started.php
@@ -11,7 +11,7 @@
 <p><?php esc_html_e( 'The Fediverse is a collection of social networks that talk to each other, similar to how email works between different providers. It allows people on different platforms to follow and interact with each other, regardless of which service they use.', 'activitypub' ); ?></p>
 <p><?php esc_html_e( 'Unlike traditional social media where everyone must use the same service (like Twitter or Facebook), the Fediverse lets you choose where your content lives while still reaching people across many different platforms.', 'activitypub' ); ?></p>
 <p style="position: relative; padding-top: 56.25%;">
-	<iframe title="<?php echo esc_attr__( 'What is the Fediverse?', 'activitypub' ); ?>" width="100%" height="100%" src="https://framatube.org/videos/embed/9dRFC6Ya11NCVeYKn8ZhiD?subtitle=<?php echo esc_attr( substr( get_locale(), 0, 2 ) ); ?>" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" style="position: absolute; inset: 0;"></iframe>
+	<iframe title="<?php echo esc_attr__( 'What is the Fediverse?', 'activitypub' ); ?>" width="100%" height="100%" data-src="https://framatube.org/videos/embed/9dRFC6Ya11NCVeYKn8ZhiD?subtitle=<?php echo esc_attr( substr( get_locale(), 0, 2 ) ); ?>" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" style="position: absolute; inset: 0;"></iframe>
 </p>
 
 <h2><?php esc_html_e( 'How WordPress fits into the Fediverse', 'activitypub' ); ?></h2>


### PR DESCRIPTION
Fixes #3349

## Proposed changes:

The "What is the Fediverse?" intro video on the **Getting Started** help screen rendered the error *"Sorry, invalid width to find appropriate image"* instead of the video.

**Root cause:** the video is a PeerTube (framatube.org) embed, and the Getting Started content is registered as a WordPress contextual Help tab (`add_help_tab()`). WordPress renders help-tab panels as `display:none` until selected, so the PeerTube player initialized inside a zero-width container and aborted with that error — and never recovered once the panel was shown. The embed URL itself is correct; this was purely an init-while-hidden problem.

* `templates/help-tab/getting-started.php` — the iframe now uses `data-src` instead of `src`, so it does not auto-load while hidden.
* `assets/js/activitypub-admin.js` (already enqueued on every ActivityPub admin page) — a small `IntersectionObserver` copies `data-src` → `src` the moment the iframe becomes visible, with an immediate-load fallback when `IntersectionObserver` is unavailable.

## Testing instructions:

1. Go to **Settings → ActivityPub**.
2. Open the **Help** dropdown (top right) and select **Getting Started**.
3. **Before:** the video area shows *"Sorry, invalid width to find appropriate image"*.
4. **After:** the "What is the Fediverse?" PeerTube player loads correctly (poster image + play button), and plays on click.
5. Confirm switching away and back to the tab keeps the player intact.

### Changelog entry

Included at `.github/changelog/fix-getting-started-video-embed`.
