### PR TITLE
Add the quoting post link to quote notification emails

### DIFF
--- a/.github/changelog/add-quote-notification-link
+++ b/.github/changelog/add-quote-notification-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Quote notification emails now include a link to the post that quoted you, so you can review and respond more quickly.

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -120,7 +120,19 @@ class Mailer {
 		/* translators: 1: Website name, 2: Website IP address, 3: Website hostname. */
 		$notify_message .= \sprintf( \esc_html__( 'From: %1$s (IP address: %2$s, %3$s)', 'activitypub' ), \esc_html( $comment->comment_author ), \esc_html( $comment->comment_author_IP ), \esc_html( $comment_author_domain ) ) . "\r\n";
 		/* translators: Reaction author URL. */
-		$notify_message .= \sprintf( \esc_html__( 'URL: %s', 'activitypub' ), \esc_url( $comment->comment_author_url ) ) . "\r\n\r\n";
+		$notify_message .= \sprintf( \esc_html__( 'URL: %s', 'activitypub' ), \esc_url( $comment->comment_author_url ) ) . "\r\n";
+
+		// For quotes, link to the quoting post itself so the author can review and respond.
+		if ( 'quote' === $comment->comment_type ) {
+			$quote_url = Comment::get_source_url( $comment->comment_ID );
+
+			if ( $quote_url ) {
+				/* translators: Quoting post URL. */
+				$notify_message .= \sprintf( \esc_html__( 'Quoting post: %s', 'activitypub' ), \esc_url( $quote_url ) ) . "\r\n";
+			}
+		}
+
+		$notify_message .= "\r\n";
 		/* translators: Comment type label */
 		$notify_message .= \sprintf( \esc_html__( 'You can see all %s on this post here:', 'activitypub' ), \esc_html( $comment_type['label'] ) ) . "\r\n";
 		$notify_message .= \get_permalink( $comment->comment_post_ID ) . '#' . \esc_attr( $comment_type['type'] ) . "\r\n\r\n";

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -145,6 +145,101 @@ class Test_Mailer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that quote notifications include a link to the quoting post.
+	 *
+	 * @covers ::comment_notification_text
+	 */
+	public function test_comment_quote_notification_includes_quoting_post_link() {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'    => self::$post_id,
+				'comment_type'       => 'quote',
+				'comment_author'     => 'Quote Author',
+				'comment_author_url' => 'https://example.com/author',
+				'comment_author_IP'  => '127.0.0.1',
+			)
+		);
+
+		update_comment_meta( $comment_id, 'protocol', 'activitypub' );
+		update_comment_meta( $comment_id, 'source_url', 'https://example.com/quoting-post' );
+
+		$text = Mailer::comment_notification_text( 'Default Message', $comment_id );
+
+		$this->assertStringContainsString( 'Quoting post: https://example.com/quoting-post', $text );
+	}
+
+	/**
+	 * Test that quote notifications omit the link when no source is stored.
+	 *
+	 * @covers ::comment_notification_text
+	 */
+	public function test_comment_quote_notification_without_source() {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'    => self::$post_id,
+				'comment_type'       => 'quote',
+				'comment_author'     => 'Quote Author',
+				'comment_author_url' => 'https://example.com/author',
+				'comment_author_IP'  => '127.0.0.1',
+			)
+		);
+
+		update_comment_meta( $comment_id, 'protocol', 'activitypub' );
+
+		$text = Mailer::comment_notification_text( 'Default Message', $comment_id );
+
+		$this->assertStringNotContainsString( 'Quoting post:', $text );
+	}
+
+	/**
+	 * Test that quote notifications fall back to the source ID when no source URL is stored.
+	 *
+	 * @covers ::comment_notification_text
+	 */
+	public function test_comment_quote_notification_falls_back_to_source_id() {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'    => self::$post_id,
+				'comment_type'       => 'quote',
+				'comment_author'     => 'Quote Author',
+				'comment_author_url' => 'https://example.com/author',
+				'comment_author_IP'  => '127.0.0.1',
+			)
+		);
+
+		update_comment_meta( $comment_id, 'protocol', 'activitypub' );
+		update_comment_meta( $comment_id, 'source_id', 'https://example.com/quoting-activity' );
+
+		$text = Mailer::comment_notification_text( 'Default Message', $comment_id );
+
+		$this->assertStringContainsString( 'https://example.com/quoting-activity', $text );
+	}
+
+	/**
+	 * Test that non-quote notifications do not include a quoting-post link.
+	 *
+	 * @covers ::comment_notification_text
+	 */
+	public function test_comment_repost_notification_has_no_quoting_post_link() {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'    => self::$post_id,
+				'comment_type'       => 'repost',
+				'comment_author'     => 'Repost Author',
+				'comment_author_url' => 'https://example.com/author',
+				'comment_author_IP'  => '127.0.0.1',
+			)
+		);
+
+		update_comment_meta( $comment_id, 'protocol', 'activitypub' );
+		update_comment_meta( $comment_id, 'source_url', 'https://example.com/reposting-post' );
+
+		$text = Mailer::comment_notification_text( 'Default Message', $comment_id );
+
+		$this->assertStringNotContainsString( 'Quoting post:', $text );
+	}
+
+	/**
 	 * Test new follower notification.
 	 *
 	 * @covers ::new_follower


### PR DESCRIPTION
Fixes #3309

## Proposed changes:

Quote interactions are stored as comments (`comment_type = 'quote'`) and reuse WordPress's comment-notification email, whose body the plugin customizes in `Mailer::comment_notification_text()`. Until now that email linked only the quoting author's **profile** (`URL:`), not the post that did the quoting.

* For quote comments, the notification email now includes a **`Quoting post: <url>`** line, resolved via the existing `Comment::get_source_url()` helper (uses `source_url`, falls back to `source_id`, omitted when neither is stored).
* Non-quote notifications (likes, reposts, …) are unchanged — the output is byte-for-byte identical.

Example quote email:

```
New quote on your post "Title".

From: Author (IP address: …)
URL: https://remote.example/@author
Quoting post: https://remote.example/the-post-that-quoted-you

You can see all quotes on this post here:
https://yoursite.example/title#quote
```

This covers the email half of the request. The facepile link is tracked as a separate follow-up.

## Other information:

- [x] Have you written new tests for your changes, if applicable?

Added four `Test_Mailer` cases: link present for quotes, `source_id` fallback, no link when no source is stored, and no link for non-quote (repost) comments. All 35 Mailer tests pass.

## Testing instructions:

1. Enable email notifications and have a quote of one of your posts federate in (or simulate a `quote` comment with `protocol=activitypub` and a `source_url` meta).
2. Check the notification email to the post author.
3. Confirm it now contains a `Quoting post: <url>` line pointing at the remote post that quoted you, in addition to the existing author `URL:` line.
4. Confirm like/repost notifications are unchanged.

### Changelog entry

Included at `.github/changelog/add-quote-notification-link`.
