### PR TITLE
Don't add the classic Fediverse metabox in the block editor

### DIFF
--- a/.github/changelog/fix-classic-editor-duplicate-metabox
+++ b/.github/changelog/fix-classic-editor-duplicate-metabox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Fediverse settings appearing twice and visibility changes not saving in the block editor when the Classic Editor plugin is also active.

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -20,7 +20,7 @@ class Classic_Editor {
 	public static function init() {
 		\add_filter( 'activitypub_attachments_media_markup', array( self::class, 'filter_attachments_media_markup' ), 10, 2 );
 		\add_filter( 'activitypub_attachment_ids', array( self::class, 'filter_attached_media_ids' ), 10, 2 );
-		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ) );
+		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ), 10, 2 );
 		\add_action( 'save_post', array( self::class, 'save_meta_data' ) );
 
 		if ( \function_exists( 'classicpress_version' ) ) {
@@ -104,11 +104,22 @@ class Classic_Editor {
 	/**
 	 * Add ActivityPub meta box to the post editor.
 	 *
-	 * @param string $post_type The post type.
+	 * @param string        $post_type The post type.
+	 * @param \WP_Post|null $post      The post being edited.
 	 */
-	public static function add_meta_box( $post_type ) {
+	public static function add_meta_box( $post_type, $post = null ) {
 		// Only add for post types that support ActivityPub.
 		if ( ! \post_type_supports( $post_type, 'activitypub' ) ) {
+			return;
+		}
+
+		/*
+		 * The block editor ships its own ActivityPub panel, so the classic meta box must not be
+		 * added there. With the Classic Editor plugin in switchable mode a post can still open in
+		 * the block editor, where both would otherwise render and the meta box's save_post handler
+		 * would overwrite the panel's value.
+		 */
+		if ( $post instanceof \WP_Post && \use_block_editor_for_post( $post ) ) {
 			return;
 		}
 

--- a/integration/class-classic-editor.php
+++ b/integration/class-classic-editor.php
@@ -117,9 +117,10 @@ class Classic_Editor {
 		 * The block editor ships its own ActivityPub panel, so the classic meta box must not be
 		 * added there. With the Classic Editor plugin in switchable mode a post can still open in
 		 * the block editor, where both would otherwise render and the meta box's save_post handler
-		 * would overwrite the panel's value.
+		 * would overwrite the panel's value. The function_exists() check keeps ClassicPress and
+		 * other block-less setups (where use_block_editor_for_post() is absent) safe.
 		 */
-		if ( $post instanceof \WP_Post && \use_block_editor_for_post( $post ) ) {
+		if ( $post instanceof \WP_Post && \function_exists( 'use_block_editor_for_post' ) && \use_block_editor_for_post( $post ) ) {
 			return;
 		}
 

--- a/tests/phpunit/tests/integration/class-test-classic-editor.php
+++ b/tests/phpunit/tests/integration/class-test-classic-editor.php
@@ -480,6 +480,10 @@ class Test_Classic_Editor extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'activitypub-settings', $wp_meta_boxes['post']['side']['default'] );
 		\remove_filter( 'use_block_editor_for_post', '__return_false' );
 
+		// Remove every hook init() registered so it can't leak into other tests.
 		\remove_action( 'add_meta_boxes', array( Classic_Editor::class, 'add_meta_box' ), 10 );
+		\remove_action( 'save_post', array( Classic_Editor::class, 'save_meta_data' ), 10 );
+		\remove_filter( 'activitypub_attachments_media_markup', array( Classic_Editor::class, 'filter_attachments_media_markup' ), 10 );
+		\remove_filter( 'activitypub_attachment_ids', array( Classic_Editor::class, 'filter_attached_media_ids' ), 10 );
 	}
 }

--- a/tests/phpunit/tests/integration/class-test-classic-editor.php
+++ b/tests/phpunit/tests/integration/class-test-classic-editor.php
@@ -445,4 +445,41 @@ class Test_Classic_Editor extends \WP_UnitTestCase {
 		Classic_Editor::add_meta_box( 'page' );
 		$this->assertArrayNotHasKey( 'page', $wp_meta_boxes );
 	}
+
+	/**
+	 * Test add_meta_box is skipped when the post opens in the block editor.
+	 *
+	 * The block editor provides its own ActivityPub panel, so the classic meta box
+	 * must not also render (e.g. with the Classic Editor plugin in switchable mode).
+	 * Fires the real add_meta_boxes action so the hook's accepted-args wiring (which
+	 * must pass the $post) is exercised, not just the method in isolation.
+	 *
+	 * @covers ::add_meta_box
+	 * @covers ::init
+	 */
+	public function test_add_meta_box_skipped_for_block_editor() {
+		global $wp_meta_boxes;
+
+		// Start from a clean slate, then register the hook exactly as the integration does.
+		\remove_action( 'add_meta_boxes', array( Classic_Editor::class, 'add_meta_box' ), 10 );
+		Classic_Editor::init();
+
+		$post = \get_post( self::factory()->post->create() );
+
+		// Force the block editor for this post: the meta box must not be added.
+		\add_filter( 'use_block_editor_for_post', '__return_true' );
+		$wp_meta_boxes = array();
+		\do_action( 'add_meta_boxes', 'post', $post );
+		$this->assertArrayNotHasKey( 'post', $wp_meta_boxes );
+		\remove_filter( 'use_block_editor_for_post', '__return_true' );
+
+		// Force the classic editor for this post: the meta box is added.
+		\add_filter( 'use_block_editor_for_post', '__return_false' );
+		$wp_meta_boxes = array();
+		\do_action( 'add_meta_boxes', 'post', $post );
+		$this->assertArrayHasKey( 'activitypub-settings', $wp_meta_boxes['post']['side']['default'] );
+		\remove_filter( 'use_block_editor_for_post', '__return_false' );
+
+		\remove_action( 'add_meta_boxes', array( Classic_Editor::class, 'add_meta_box' ), 10 );
+	}
 }


### PR DESCRIPTION
Fixes #3352

## Proposed changes:

When the **Classic Editor plugin** is active in switchable mode, opening an (older) post in the **block editor** showed the Fediverse settings **twice** — the block editor's own ActivityPub panel *and* the classic metabox — and changing the visibility didn't persist.

**Root cause:** `Classic_Editor` registers a `side` metabox on `add_meta_boxes` whenever the integration loads (Classic Editor plugin active / ClassicPress / no block support), with no check for which editor is actually rendering. Gutenberg also renders registered meta boxes, so in the block editor both UIs appeared. On save, the duplicate metabox's `save_post` handler then overwrote the block panel's REST-saved visibility with its own (stale) radio value — which is why the toggle "didn't save" but the post still federated per the metabox.

* `add_meta_box()` now receives the `$post` and returns early when `use_block_editor_for_post( $post )` is true, so the classic metabox is only added in the classic editor.
* The `add_meta_boxes` hook is registered with `accepted_args = 2` so the `$post` (core's 2nd hook arg) actually reaches the callback — without this the guard would never receive it.

Because the metabox (and its nonce) no longer render in the block editor, `save_meta_data()` already no-ops there (its nonce check), so this single guard fixes both the duplication and the overwrite. Classic-editor, ClassicPress, and no-block paths are unchanged.

## Other information:

- [x] Have you written new tests for your changes, if applicable?

`test_add_meta_box_skipped_for_block_editor` fires the real `add_meta_boxes` action (via `Classic_Editor::init()`) with `use_block_editor_for_post` filtered true/false. Firing through the hook means it also covers the `accepted_args` wiring — verified that the test fails if the registration is reverted to a single argument. All 20 Classic_Editor tests pass.

## Testing instructions:

1. Activate the Classic Editor plugin with "Allow users to switch editors" enabled.
2. Open an older post in the **block editor**.
3. **Before:** the Fediverse panel appears twice; setting visibility to Public and saving doesn't stick.
4. **After:** the Fediverse panel appears once (the block editor panel); visibility changes save and persist.
5. Open the same post in the **classic editor** and confirm the Fediverse metabox still appears and saves.

### Changelog entry

Included at `.github/changelog/fix-classic-editor-duplicate-metabox`.
