### PR TITLE
Scope the outbox event stream to the requesting actor

### DIFF
--- a/.github/changelog/fix-outbox-stream-scope
+++ b/.github/changelog/fix-outbox-stream-scope
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Fix the real-time activity stream so it only returns the requesting user's own activities.

--- a/includes/rest/trait-event-stream.php
+++ b/includes/rest/trait-event-stream.php
@@ -480,6 +480,7 @@ trait Event_Stream {
 		);
 
 		if ( 'outbox' === $collection ) {
+			$args['author'] = $user_id > 0 ? $user_id : null;
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$args['meta_query'] = array(
 				array(
@@ -536,6 +537,7 @@ trait Event_Stream {
 		);
 
 		if ( 'outbox' === $collection ) {
+			$args['author'] = $user_id > 0 ? $user_id : null;
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$args['meta_query'] = array(
 				array(

--- a/tests/phpunit/tests/includes/rest/class-test-trait-event-stream.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-event-stream.php
@@ -323,6 +323,44 @@ class Test_Trait_Event_Stream extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the outbox stream only returns the requested actor's own items.
+	 *
+	 * Regression: the outbox query previously filtered solely by the shared actor
+	 * *type* meta ('user'), so one author's stream emitted every author's outbox
+	 * items. The query must be scoped to the requesting actor.
+	 *
+	 * @covers ::get_new_items
+	 * @covers ::get_latest_item_id
+	 */
+	public function test_outbox_stream_is_scoped_to_owner() {
+		$other_user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$own_post   = self::factory()->post->create(
+			array(
+				'post_author' => $this->user_id,
+				'post_status' => 'publish',
+			)
+		);
+		$own_outbox = add_to_outbox( \get_post( $own_post ), 'Create', $this->user_id );
+
+		// Created after the owner's item, so it has a higher ID and would be the global "latest".
+		$other_post   = self::factory()->post->create(
+			array(
+				'post_author' => $other_user_id,
+				'post_status' => 'publish',
+			)
+		);
+		$other_outbox = add_to_outbox( \get_post( $other_post ), 'Create', $other_user_id );
+
+		$ids = \wp_list_pluck( $this->instance->test_get_new_items( $this->user_id, 'outbox', 0 ), 'ID' );
+		$this->assertContains( $own_outbox, $ids, 'Owner should see their own outbox item.' );
+		$this->assertNotContains( $other_outbox, $ids, "Owner must not see another user's outbox item." );
+
+		$latest = $this->instance->test_get_latest_item_id( $this->user_id, 'outbox' );
+		$this->assertSame( $own_outbox, $latest, "Latest item must be the owner's, not a newer item from another user." );
+	}
+
+	/**
 	 * Test get_event_type_map returns expected mappings.
 	 *
 	 * @covers ::get_event_type_map

--- a/tests/phpunit/tests/includes/rest/class-test-trait-event-stream.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-event-stream.php
@@ -334,6 +334,7 @@ class Test_Trait_Event_Stream extends \WP_UnitTestCase {
 	 */
 	public function test_outbox_stream_is_scoped_to_owner() {
 		$other_user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'ID', $other_user_id )->add_cap( 'activitypub' );
 
 		$own_post   = self::factory()->post->create(
 			array(


### PR DESCRIPTION
## Proposed changes:

The real-time activity event stream (SSE) for an actor's **outbox** was not scoped to that actor. `Event_Stream::get_new_items()` and `get_latest_item_id()` filtered the outbox query only by the `_activitypub_activity_actor` meta, which stores the actor *type* (`user` / `blog` / `application`) — a value shared by every regular user. As a result, an actor's own outbox stream emitted outbox activities authored by *other* local users.

* Scope the outbox branch of both methods with `'author' => $user_id > 0 ? $user_id : null`, exactly as `Outbox_Controller::get_items()` already scopes the public outbox collection. For real users this binds the query to the actor's own items; the retained type clause continues to disambiguate the blog and application actors (which share `post_author` 0).
* The inbox branch is unchanged — it already scopes by `_activitypub_user_id`, matching `Actors_Inbox_Controller::get_items()`.

The stream endpoint's permission callback (OAuth `push` scope + owner check) was already correct; this fixes the query that backs it so it returns only the requesting actor's activities.

## Other information:

- [x] Have you written new tests for your changes, if applicable?

Added `test_outbox_stream_is_scoped_to_owner` (cross-user isolation: one actor's stream excludes another's items, and `get_latest_item_id` returns the owner's item rather than a newer one from another user). It fails against the pre-fix code.

## Testing instructions:

1. With two local actors that both have outbox activity, open the SSE outbox stream for actor A (`/wp-json/activitypub/1.0/actors/<A>/outbox/stream`, `push` scope).
2. Trigger a new outbox item for actor B.
3. Before this change, A's stream emits B's new item; after, it only emits A's own items.

### Changelog entry

Included at `.github/changelog/fix-outbox-stream-scope`.
