### PR TITLE
Bind the signing-key host to the actor for RFC 9421 keyIds

### DIFF
--- a/.github/changelog/fix-signature-keyid-binding
+++ b/.github/changelog/fix-signature-keyid-binding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Enforce the signing-key host check on incoming federated activities regardless of how the key identifier is formatted.

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -101,9 +101,16 @@ trait Verification {
 	private function verify_key_id( $request ) {
 		$sig = $request->get_header( 'signature' );
 		if ( ! $sig || ! \preg_match( '/keyId="([^"]+)"/i', $sig, $m ) ) {
-			// RFC 9421 Signature-Input.
+			/*
+			 * RFC 9421 Signature-Input. Match the keyid the same way the RFC 9421 verifier
+			 * parses it: as a `;`-delimited parameter whose value may be quoted or unquoted.
+			 * Anchoring on `;` (or string start) is required — a bare `keyid=` search would
+			 * also match a `keyid=` substring inside another parameter's quoted value (or a
+			 * param named `…keyid`), letting an attacker point this binding at a different
+			 * host than the one the verifier actually used.
+			 */
 			$sig = $request->get_header( 'signature-input' );
-			if ( ! $sig || ! \preg_match( '/keyid="([^"]+)"/i', $sig, $m ) ) {
+			if ( ! $sig || ! \preg_match( '/(?:^|;)\s*keyid="?([^";,\s]+)/i', $sig, $m ) ) {
 				return true;
 			}
 		}

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -637,4 +637,92 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 		$this->assertEquals( 'activitypub_signature_verification', $result->get_error_code() );
 		$this->assertEquals( 401, $result->get_error_data()['status'] );
 	}
+
+	/**
+	 * Invoke the private verify_key_id() with a crafted Signature-Input header and actor.
+	 *
+	 * @param string $signature_input The Signature-Input header value.
+	 * @param string $actor           The activity actor URI.
+	 * @return true|\WP_Error
+	 */
+	private function invoke_verify_key_id( $signature_input, $actor ) {
+		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/inbox' );
+		$request->set_header( 'signature-input', $signature_input );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( \wp_json_encode( array( 'actor' => $actor ) ) );
+
+		$method = new \ReflectionMethod( $this->instance, 'verify_key_id' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->instance, $request );
+	}
+
+	/**
+	 * Test that an unquoted RFC 9421 keyid on a different host is rejected.
+	 *
+	 * Regression: the keyid binding previously matched quotes only, so an unquoted
+	 * keyid (which the RFC 9421 verifier accepts) skipped the host-equality check.
+	 *
+	 * @covers ::verify_key_id
+	 */
+	public function test_verify_key_id_unquoted_mismatched_host_is_rejected() {
+		$result = $this->invoke_verify_key_id(
+			'sig1=("@method");keyid=https://evil.example/actor#key;alg="rsa-v1_5-sha256"',
+			'https://victim.example/users/alice'
+		);
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_key_actor_mismatch', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test that an unquoted RFC 9421 keyid on the same host passes.
+	 *
+	 * @covers ::verify_key_id
+	 */
+	public function test_verify_key_id_unquoted_same_host_passes() {
+		$result = $this->invoke_verify_key_id(
+			'sig1=("@method");keyid=https://example.org/actor#key;alg="rsa-v1_5-sha256"',
+			'https://example.org/users/bob'
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that a quoted RFC 9421 keyid on a different host is still rejected.
+	 *
+	 * @covers ::verify_key_id
+	 */
+	public function test_verify_key_id_quoted_mismatched_host_is_rejected() {
+		$result = $this->invoke_verify_key_id(
+			'sig1=("@method");keyid="https://evil.example/actor#key";alg="rsa-v1_5-sha256"',
+			'https://victim.example/users/alice'
+		);
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_key_actor_mismatch', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test that a keyid injected into another parameter's value does not fool the binding.
+	 *
+	 * The real `keyid` parameter (evil host) is what the RFC 9421 verifier uses; a
+	 * `keyid=<victim host>` string smuggled inside an earlier quoted parameter value must
+	 * not be picked up instead, which would make the host check pass against the wrong host.
+	 *
+	 * @covers ::verify_key_id
+	 */
+	public function test_verify_key_id_ignores_keyid_inside_other_param() {
+		$result = $this->invoke_verify_key_id(
+			'sig1=("@method");tag="keyid=https://victim.example/key";keyid=https://evil.example/key',
+			'https://victim.example/users/alice'
+		);
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_key_actor_mismatch', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
 }


### PR DESCRIPTION
## Proposed changes:

`Verification::verify_key_id()` binds an incoming activity's HTTP-signature signing-key host to the activity actor host (so a key on one host can't sign for an actor on another). For RFC 9421 requests it read the `keyid` from the `Signature-Input` header with a quote-**required** pattern, but the RFC 9421 verifier (`parse_signature_labels()`) parses `keyid` with the quotes **optional**. An unquoted `keyid` therefore verified cryptographically yet was missed by the binding's regex — the function fell through to its lenient "no keyid" return and the host check never ran.

* Parse the `keyid` the same way the verifier does: a `;`-delimited parameter whose value may be quoted or unquoted. The match is anchored on `;` (or string start), so a `keyid=` substring smuggled inside another parameter's quoted value — or a parameter named `…keyid` — can't redirect the binding to a different host than the one the verifier actually used.
* The Draft (`keyId="…"`) path and the deliberate "no keyid present → pass" behavior (this check is supplementary to `verify_http_signature`, which is the cryptographic gate) are unchanged.

## Other information:

- [x] Have you written new tests for your changes, if applicable?

Four new `verify_key_id` cases in `Test_Trait_Verification`: unquoted + mismatched host → rejected (403); unquoted + same host → pass; quoted + mismatched host → rejected; and a `keyid` injected into another parameter's value → still bound to the real (verifier-used) host. They fail against the pre-fix regex.

## Testing instructions:

This is covered by the unit tests (`--filter=Test_Trait_Verification`). The check only runs on signed S2S requests, so end-to-end reproduction requires a federated peer sending an RFC 9421 signature with an unquoted `keyid` whose host differs from the activity `actor`.

### Changelog entry

Included at `.github/changelog/fix-signature-keyid-binding`.
