### PR TITLE
Gate outbox visibility on strict ownership instead of capability

### DIFF
--- a/.github/changelog/fix-outbox-owner-check
+++ b/.github/changelog/fix-outbox-owner-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Prevent logged-in users from viewing another user's private outbox activities.

--- a/includes/rest/class-outbox-controller.php
+++ b/includes/rest/class-outbox-controller.php
@@ -18,7 +18,6 @@ use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_object_id;
 use function Activitypub\get_rest_url_by_path;
 use function Activitypub\object_to_uri;
-use function Activitypub\user_can_act_as_blog;
 
 /**
  * ActivityPub Outbox Controller.
@@ -180,23 +179,16 @@ class Outbox_Controller extends \WP_REST_Controller {
 		);
 
 		/*
-		 * Whether the current user owns the outbox being queried. Owners see private
-		 * and non-public activity types without the visibility filters below.
+		 * Whether the current user owns the outbox being queried. Owners see private and
+		 * non-public activity types; unauthenticated, federation, and non-owner requests are
+		 * limited to the public subset by the visibility filter below.
 		 *
-		 * For the blog actor (user_id = 0) the identity-equality check is wrong on
-		 * two counts — `get_current_user_id()` returns 0 for anonymous visitors (so
-		 * `0 === 0` would leak everything to the public), and AP-capable authors
-		 * would otherwise pass the `current_user_can( 'activitypub' )` arm and read
-		 * the blog's private Accepts. Delegate to the capability helper instead.
+		 * Reuse the canonical ownership gate (the same check the OAuth C2S path applies via
+		 * maybe_verify_owner()) instead of re-deriving it here: it requires an authenticated
+		 * session, matches the requested user by identity, and handles the blog actor via
+		 * user_can_act_as_blog(). A global capability never stands in for ownership.
 		 */
-		if ( Actors::BLOG_USER_ID === (int) $user_id ) {
-			$is_outbox_owner = user_can_act_as_blog();
-		} else {
-			$is_outbox_owner = \is_user_logged_in() && (
-				\get_current_user_id() === (int) $user_id
-				|| \current_user_can( 'activitypub' )
-			);
-		}
+		$is_outbox_owner = true === $this->verify_owner( $request );
 
 		if ( ! $is_outbox_owner ) {
 			$args['meta_query'][] = array(

--- a/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-outbox-controller.php
@@ -531,6 +531,73 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * Test that a capable non-owner only sees another user's public outbox items.
+	 *
+	 * Regression: ownership was previously satisfied by the global `activitypub`
+	 * capability (held by every author), so any author could read every other user's
+	 * non-public outbox items. Ownership must be a strict identity check.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_hides_non_public_from_capable_non_owner() {
+		$owner = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'ID', $owner )->add_cap( 'activitypub' );
+
+		foreach ( array(
+			array( 'note/pub', \ACTIVITYPUB_CONTENT_VISIBILITY_PUBLIC ),
+			array( 'note/priv', \ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE ),
+		) as $item ) {
+			list( $slug, $visibility ) = $item;
+			self::factory()->post->create(
+				array(
+					'post_author'  => $owner,
+					'post_type'    => Outbox::POST_TYPE,
+					'post_status'  => 'pending',
+					'post_title'   => 'https://example.org/' . $slug,
+					'post_content' => \wp_json_encode(
+						array(
+							'@context' => array( 'https://www.w3.org/ns/activitystreams' ),
+							'id'       => 'https://example.org/' . $slug,
+							'type'     => 'Create',
+							'actor'    => 'https://example.org/user/' . $owner,
+							'object'   => array(
+								'id'      => 'https://example.org/' . $slug,
+								'type'    => 'Note',
+								'content' => 'Test content',
+							),
+						)
+					),
+					'meta_input'   => array(
+						'_activitypub_activity_type'     => 'Create',
+						'_activitypub_activity_actor'    => 'user',
+						'activitypub_content_visibility' => $visibility,
+					),
+				)
+			);
+		}
+
+		// A different user that also holds the activitypub capability.
+		$other = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'ID', $other )->add_cap( 'activitypub' );
+		\wp_set_current_user( $other );
+		$this->assertTrue( \current_user_can( 'activitypub' ) );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $owner . '/outbox' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 10 );
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount(
+			1,
+			$data['orderedItems'],
+			'A capable non-owner must only see the public outbox item, not the private one.'
+		);
+		$this->assertSame( 'https://example.org/note/pub', $data['orderedItems'][0]['id'] );
+	}
+
+	/**
 	 * Test getting items with correct actor type filtering.
 	 *
 	 * @covers ::get_items
@@ -766,7 +833,7 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 		);
 
 		// Test as non-privileged user.
-		wp_set_current_user( $viewer_id );
+		\wp_set_current_user( $viewer_id );
 		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . self::$user_id . '/outbox' );
 		$request->set_param( 'page', 1 ); // Need to request a page to get orderedItems.
 		$response = \rest_get_server()->dispatch( $request );
@@ -775,12 +842,27 @@ class Test_Outbox_Controller extends Test_REST_Controller_Testcase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 10, $data['orderedItems'] );
 
-		// Test as privileged user.
+		/*
+		 * Test as an administrator who is not the actor owner. Site administration
+		 * does not grant access to another user's non-public outbox items: ownership
+		 * is a strict identity check, so the admin sees the same public subset (10).
+		 */
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $admin_id );
+		\wp_set_current_user( $admin_id );
 		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . self::$user_id . '/outbox' );
 		$request->set_param( 'page', 1 ); // Need to request a page to get orderedItems.
 		$request->set_param( 'per_page', 20 ); // Need per_page for pagination calculation.
+		$response = \rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 10, $data['orderedItems'] );
+
+		// The actor owner still sees the full set, including the private item.
+		\wp_set_current_user( self::$user_id );
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . self::$user_id . '/outbox' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 20 );
 		$response = \rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION
## Proposed changes:

The outbox controller treated the global `activitypub` capability as proof of outbox ownership. Since every author-level user holds that capability, any logged-in author (or administrator) could read another user's private and non-public outbox activities simply by changing the actor ID in the request URL.

This replaces the hand-rolled ownership check in `Outbox_Controller::get_items()` with the canonical `verify_owner()` gate from the `Verification` trait — the same gate the OAuth client-to-server path uses via `maybe_verify_owner()`. It requires an authenticated session, matches the requested actor by strict identity, and delegates blog-actor access to `user_can_act_as_blog()`. A global capability no longer stands in for ownership.

Behavior after the fix:

* Unauthenticated and federation requests still see the public subset of any actor's outbox (matching Mastodon, where the public outbox is readable by ID).
* Authenticated requests have ownership verified before the full, unfiltered set is returned.
* Site administration does not grant access to another user's non-public outbox items.

The now-unused `user_can_act_as_blog` import was removed (the trait imports it internally).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Both regression tests fail against the pre-fix code and pass with the fix:

* New `test_get_items_hides_non_public_from_capable_non_owner`: a different capable user reading the owner's outbox sees only the public item, not the private one.
* Updated `test_get_items_meta_query_for_non_privileged_users`: the existing test previously asserted that an administrator (a non-owner) saw the private item; that assertion encoded the bug. It now asserts the admin sees only the public subset, plus a follow-up that the actual owner still sees the full set.

## Testing instructions:

* Create two posts as user A with different visibility (one Public, one set to a non-public visibility such as "Local").
* As user B (a different author, or an administrator), request `?rest_route=/activitypub/1.0/actors/{A_user_id}/outbox&page=1`.
* Before this change, B sees A's non-public activities. After this change, B sees only the public subset.
* As user A, request the same endpoint and confirm the full set (including non-public activities) is still returned.

### Changelog entry

Changelog entry added in `.github/changelog/fix-outbox-owner-check`.
