### PR TITLE
Hide follower/following counts when the social graph is private

### DIFF
--- a/.github/changelog/fix-hidden-social-graph-total
+++ b/.github/changelog/fix-hidden-social-graph-total
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Hide the follower and following counts when the social graph is set to private, not just the lists.

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -191,11 +191,17 @@ class Followers_Controller extends Actors_Controller {
 
 		$data = Followers::query( $user_id, $per_page, $page, array( 'order' => \ucwords( $order ) ) );
 
+		/*
+		 * When the social graph is hidden, expose neither the list nor the count: a
+		 * non-owner would otherwise still learn the follower total via totalItems.
+		 */
+		$show_social_graph = $this->show_social_graph( $request );
+
 		$response = array(
 			'id'         => get_rest_url_by_path( \sprintf( 'actors/%d/followers', $user_id ) ),
 			'generator'  => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'type'       => 'OrderedCollection',
-			'totalItems' => $data['total'],
+			'totalItems' => $show_social_graph ? $data['total'] : 0,
 		);
 
 		if ( 'full' === $context ) {
@@ -203,7 +209,7 @@ class Followers_Controller extends Actors_Controller {
 			$response = array( '@context' => Base_Object::JSON_LD_CONTEXT ) + $response;
 		}
 
-		if ( $this->show_social_graph( $request ) ) {
+		if ( $show_social_graph ) {
 			$response['orderedItems'] = \array_filter(
 				\array_map(
 					static function ( $item ) use ( $context ) {

--- a/includes/rest/class-following-controller.php
+++ b/includes/rest/class-following-controller.php
@@ -103,11 +103,17 @@ class Following_Controller extends Actors_Controller {
 
 		$data = Following::query( $user_id, $per_page, $page, array( 'order' => \ucwords( $order ) ) );
 
+		/*
+		 * When the social graph is hidden, expose neither the list nor the count: a
+		 * non-owner would otherwise still learn the following total via totalItems.
+		 */
+		$show_social_graph = $this->show_social_graph( $request );
+
 		$response = array(
 			'id'         => get_rest_url_by_path( \sprintf( 'actors/%d/following', $user_id ) ),
 			'generator'  => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'type'       => 'OrderedCollection',
-			'totalItems' => $data['total'],
+			'totalItems' => $show_social_graph ? $data['total'] : 0,
 		);
 
 		if ( 'full' === $context ) {
@@ -115,7 +121,7 @@ class Following_Controller extends Actors_Controller {
 			$response = array( '@context' => Base_Object::JSON_LD_CONTEXT ) + $response;
 		}
 
-		if ( $this->show_social_graph( $request ) ) {
+		if ( $show_social_graph ) {
 			$response['orderedItems'] = \array_filter(
 				\array_map(
 					static function ( $item ) use ( $context ) {
@@ -143,7 +149,8 @@ class Following_Controller extends Actors_Controller {
 		 */
 		$items = \apply_filters_deprecated( 'activitypub_rest_following', array( array(), $user ), '7.1.0', 'Please migrate your Followings to the new internal Following structure.' );
 
-		if ( ! empty( $items ) ) {
+		// Honor the hidden social graph here too, or this deprecated path would re-leak the count and list.
+		if ( $show_social_graph && ! empty( $items ) ) {
 			$response['totalItems']   = count( $items );
 			$response['orderedItems'] = $items;
 		}

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -115,6 +115,36 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 	}
 
 	/**
+	 * Test that a hidden social graph does not leak the follower count.
+	 *
+	 * Regression: totalItems was emitted unconditionally, so a non-owner could read
+	 * the follower total even when the social graph was hidden.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_hides_total_when_social_graph_hidden() {
+		$actor_mode = \get_option( 'activitypub_actor_mode' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+		\update_option( 'activitypub_hide_social_graph', '1' );
+		\wp_set_current_user( 0 );
+
+		try {
+			$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/followers' );
+			$request->set_param( 'page', 1 );
+			$request->set_param( 'context', 'simple' );
+			$response = rest_get_server()->dispatch( $request );
+
+			$this->assertEquals( 200, $response->get_status() );
+			$data = $response->get_data();
+			$this->assertSame( 0, $data['totalItems'], 'A hidden social graph must not leak the follower count.' );
+			$this->assertEmpty( $data['orderedItems'] ?? array(), 'A hidden social graph must not expose the follower list.' );
+		} finally {
+			\delete_option( 'activitypub_hide_social_graph' );
+			\update_option( 'activitypub_actor_mode', $actor_mode );
+		}
+	}
+
+	/**
 	 * Test get_items response with full context.
 	 *
 	 * @covers ::get_items

--- a/tests/phpunit/tests/includes/rest/class-test-following-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-following-controller.php
@@ -135,6 +135,70 @@ class Test_Following_Controller extends \Activitypub\Tests\Test_REST_Controller_
 	}
 
 	/**
+	 * Test that a hidden social graph does not leak the following count.
+	 *
+	 * Regression: totalItems was emitted unconditionally, so a non-owner could read
+	 * the following total even when the social graph was hidden.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_hides_total_when_social_graph_hidden() {
+		$actor_mode = \get_option( 'activitypub_actor_mode' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+		\update_option( 'activitypub_hide_social_graph', '1' );
+		\wp_set_current_user( 0 );
+
+		try {
+			$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/following' );
+			$request->set_param( 'page', 1 );
+			$request->set_param( 'context', 'simple' );
+			$response = rest_get_server()->dispatch( $request );
+
+			$this->assertEquals( 200, $response->get_status() );
+			$data = $response->get_data();
+			$this->assertSame( 0, $data['totalItems'], 'A hidden social graph must not leak the following count.' );
+			$this->assertEmpty( $data['orderedItems'] ?? array(), 'A hidden social graph must not expose the following list.' );
+		} finally {
+			\delete_option( 'activitypub_hide_social_graph' );
+			\update_option( 'activitypub_actor_mode', $actor_mode );
+		}
+	}
+
+	/**
+	 * Test that the deprecated activitypub_rest_following filter cannot re-leak a hidden count.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_deprecated_filter_respects_hidden_social_graph() {
+		$this->setExpectedDeprecated( 'activitypub_rest_following' );
+
+		$actor_mode = \get_option( 'activitypub_actor_mode' );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+		\update_option( 'activitypub_hide_social_graph', '1' );
+		\wp_set_current_user( 0 );
+
+		$inject = static function () {
+			return array( 'https://example.org/actor/leak' );
+		};
+		\add_filter( 'activitypub_rest_following', $inject );
+
+		try {
+			$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/following' );
+			$request->set_param( 'page', 1 );
+			$request->set_param( 'context', 'simple' );
+			$response = rest_get_server()->dispatch( $request );
+
+			$data = $response->get_data();
+			$this->assertSame( 0, $data['totalItems'], 'The deprecated filter must not re-leak the count when the graph is hidden.' );
+			$this->assertEmpty( $data['orderedItems'] ?? array(), 'The deprecated filter must not re-expose the list when the graph is hidden.' );
+		} finally {
+			\remove_filter( 'activitypub_rest_following', $inject );
+			\delete_option( 'activitypub_hide_social_graph' );
+			\update_option( 'activitypub_actor_mode', $actor_mode );
+		}
+	}
+
+	/**
 	 * Test get_items response with full context.
 	 *
 	 * @covers ::get_items


### PR DESCRIPTION
## Proposed changes:

The followers and following REST collections emitted `totalItems` (the follower/following count) unconditionally, while only the `orderedItems` list was gated behind `show_social_graph()`. So when a user hid their social graph, a non-owner could still read the count via `totalItems`.

This gates `totalItems` on the same `show_social_graph()` check (emitting `0` when hidden) and reuses the result for `orderedItems`. Because `show_social_graph()` returns true for the resource owner, owners still see the real count. The deprecated `activitypub_rest_following` filter path is gated too, so it cannot re-leak the count for sites still using that hook.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Regression tests for both endpoints: a hidden graph returns `totalItems: 0` and no list to a non-owner; and a dedicated test confirms the deprecated `activitypub_rest_following` filter cannot re-leak the count. Verified by negative control — both fail without the fix.

## Testing instructions:

* Enable "hide social graph" for an actor (or the blog actor via the site setting).
* As an unauthenticated request, fetch `?rest_route=/activitypub/1.0/actors/{id}/followers` (and `/following`).
* Confirm `totalItems` is `0` and no `orderedItems` are present.
* Confirm the owner (logged in, viewing their own) still sees the real count and list.

### Changelog entry

Changelog entry added in `.github/changelog/fix-hidden-social-graph-total`.
