### PR TITLE
Restrict quote stamps to quote-authorization meta

### DIFF
--- a/.github/changelog/fix-quote-stamp-meta-key
+++ b/.github/changelog/fix-quote-stamp-meta-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Stop the quote-authorization stamp from exposing a post's other metadata.

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -410,8 +410,13 @@ class Query {
 
 		$post = $this->get_queried_object();
 
-		// Ensure the meta belongs to the queried post to prevent arbitrary meta disclosure.
-		if ( (int) $meta->post_id !== $post->ID ) {
+		/*
+		 * Only quote-authorization meta may be reflected as a stamp, and only for the queried
+		 * post. Checking the post id alone would still let an unauthenticated request read any
+		 * of that post's meta rows (e.g. _edit_lock or private custom fields) by guessing a
+		 * meta_id, so the meta key is verified too.
+		 */
+		if ( '_activitypub_quoted_by' !== $meta->meta_key || (int) $meta->post_id !== $post->ID ) {
 			return false;
 		}
 

--- a/tests/phpunit/tests/includes/class-test-query.php
+++ b/tests/phpunit/tests/includes/class-test-query.php
@@ -513,6 +513,33 @@ class Test_Query extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a stamp cannot reflect a post's non-quote meta.
+	 *
+	 * Regression: the stamp only checked that the meta row belonged to the queried post, so
+	 * an unauthenticated request could read any of the post's meta values (e.g. private
+	 * custom fields) by guessing a meta_id. Only `_activitypub_quoted_by` meta may be exposed.
+	 *
+	 * @covers ::maybe_get_stamp
+	 */
+	public function test_maybe_get_stamp_rejects_non_quote_meta() {
+		// A non-quote meta row on the same public post (e.g. a private custom field).
+		$secret_meta_id = \add_post_meta( self::$post_id, '_secret_private_meta', 'super-secret-value' );
+
+		Query::get_instance()->__destruct();
+		$this->go_to( home_url( '/?p=' . self::$post_id . '&stamp=' . $secret_meta_id ) );
+		\set_query_var( 'stamp', $secret_meta_id );
+
+		$query  = Query::get_instance();
+		$object = $query->get_activitypub_object();
+
+		$this->assertNotNull( $object, 'Should fall back to the post object' );
+		$this->assertNotEquals( 'QuoteAuthorization', $object->get_type(), 'A non-quote meta row must not be reflected as a stamp.' );
+		$this->assertStringNotContainsString( 'super-secret-value', \wp_json_encode( $object->to_array() ), 'The private meta value must not be disclosed.' );
+
+		\delete_post_meta( self::$post_id, '_secret_private_meta' );
+	}
+
+	/**
 	 * Test maybe_get_stamp with non-existent meta ID.
 	 *
 	 * @covers ::maybe_get_stamp


### PR DESCRIPTION
## Proposed changes:

The quote-authorization "stamp" endpoint (`?p=POST_ID&stamp=META_ID`, reached unauthenticated) loaded a post meta row by its `meta_id` and reflected the value into a `QuoteAuthorization` object. It checked only that the meta row belonged to the queried post, not that it was a quote-authorization row — so any of that post's meta values (`_edit_lock`, SEO fields, private custom fields, …) could be read by guessing a `meta_id`.

This adds a meta-key check: the row must have key `_activitypub_quoted_by` (the only key the quote handler ever writes for stamps). Anything else falls back to the normal post object. This mirrors the existing `maybe_get_actor_stamp()` sibling, which already gates on `_activitypub_featured_by`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Regression test: a non-quote meta row (`_secret_private_meta`) on the same post is not reflected as a `QuoteAuthorization`, and its value never appears in the response. Verified by negative control — it *is* exposed without the fix.

## Testing instructions:

* On a public post, add a private meta value and note its `meta_id`, plus a real quote authorization (`_activitypub_quoted_by`).
* Request `?p=POST_ID&stamp=<private meta_id>` unauthenticated and confirm you get the normal post object (no `QuoteAuthorization`, no meta value).
* Request `?p=POST_ID&stamp=<quote meta_id>` and confirm the `QuoteAuthorization` is still returned as before.

### Changelog entry

Changelog entry added in `.github/changelog/fix-quote-stamp-meta-key`.
