### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install subversion
       - name: WordPress Plugin Deploy
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/extract-wp-hooks.yml
+++ b/.github/workflows/extract-wp-hooks.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write # Required to push to wiki repository
     steps:
       - uses: actions/checkout@v6
-      - uses: akirk/extract-wp-hooks@1.4.0
+      - uses: akirk/extract-wp-hooks@c0b59d9607347a0390627756c095c52d5f98016a # 1.4.0
         with:
           namespace: 'Activitypub'
           wiki-directory: '../activitypub.wiki'

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: lts/*
 
       - name: Wait for prior instances of the workflow to finish
-        uses: softprops/turnstyle@v3
+        uses: softprops/turnstyle@e15e934b3f69ee283ba389ea05c8886baa656d93 # v3.2.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '7.4'
           coverage: none
           tools: composer, cs2pr
       - name: Install Composer dependencies for PHP
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
       - name: Detect coding standard violations
         run: ./vendor/bin/phpcs

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none
@@ -57,7 +57,7 @@ jobs:
           extensions: mysql
 
       - name: Install Composer dependencies for PHP
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
 
       - name: Setup Test Environment
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wp-version }}
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup PHP with Xdebug
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.4'
           coverage: xdebug
@@ -95,7 +95,7 @@ jobs:
           extensions: mysql
 
       - name: Install Composer dependencies for PHP
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
 
       - name: Setup Test Environment
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

Tracking: DEVPROD-1072

Changes:
- Pins 5 distinct third-party action refs to full commit SHAs with readable version comments.
- Updates: .github/workflows/deploy.yml, .github/workflows/extract-wp-hooks.yml, .github/workflows/gardening.yml, .github/workflows/phpcs.yml, .github/workflows/phpunit.yml
- Dependabot GitHub Actions coverage: already_present (.github/dependabot.yml)

Notes:
- `ramsey/composer-install` keeps `# v4` because the existing `@v4` branch resolves to this commit; the `4.0.0` release tag points to a different commit.

Verification commands:

```bash
# 10up/action-wordpress-plugin-deploy # 2.3.0 -> 54bd289b8525fd23a5c365ec369185f2966529c2
gh api repos/10up/action-wordpress-plugin-deploy/commits/2.3.0 --jq '.sha'
# expected: 54bd289b8525fd23a5c365ec369185f2966529c2

# akirk/extract-wp-hooks # 1.4.0 -> c0b59d9607347a0390627756c095c52d5f98016a
gh api repos/akirk/extract-wp-hooks/commits/1.4.0 --jq '.sha'
# expected: c0b59d9607347a0390627756c095c52d5f98016a

# ramsey/composer-install # v4 -> 5c2bcf28d7b060ef3c601d7b476d5430a7b46c27
gh api repos/ramsey/composer-install/commits/v4 --jq '.sha'
# expected: 5c2bcf28d7b060ef3c601d7b476d5430a7b46c27

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# softprops/turnstyle # v3.2.4 -> e15e934b3f69ee283ba389ea05c8886baa656d93
gh api repos/softprops/turnstyle/commits/v3.2.4 --jq '.sha'
# expected: e15e934b3f69ee283ba389ea05c8886baa656d93
```
