### PR TITLE
Append the query string when rebuilding (request-target) for signature verification

### DIFF
--- a/.github/changelog/fix-signature-request-target-query
+++ b/.github/changelog/fix-signature-request-target-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Follower synchronization with Mastodon no longer fails, signed requests with query strings now verify correctly.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -148,6 +148,20 @@ class Signature {
 			$route = '/' . $path . $route;
 		}
 
+		/*
+		 * Append the query string. Peers sign the full request-target including
+		 * the query (see Http_Signature_Draft::sign()), so the reconstructed
+		 * value has to match byte-for-byte. Use the raw REQUEST_URI instead of
+		 * re-encoding the parsed query params, re-encoding could change the
+		 * percent-encoding or parameter order and break the signature.
+		 */
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$query = \wp_parse_url( $_SERVER['REQUEST_URI'] ?? '', \PHP_URL_QUERY );
+
+		if ( $query ) {
+			$route .= '?' . $query;
+		}
+
 		return $route;
 	}
 

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -156,9 +156,9 @@ class Signature {
 		 * percent-encoding or parameter order and break the signature.
 		 */
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$query = \wp_parse_url( $_SERVER['REQUEST_URI'] ?? '', \PHP_URL_QUERY );
+		$query = (string) \wp_parse_url( $_SERVER['REQUEST_URI'] ?? '', \PHP_URL_QUERY );
 
-		if ( $query ) {
+		if ( '' !== $query ) {
 			$route .= '?' . $query;
 		}
 

--- a/tests/phpunit/tests/includes/class-test-signature.php
+++ b/tests/phpunit/tests/includes/class-test-signature.php
@@ -483,6 +483,168 @@ class Test_Signature extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A signed GET request whose URL contains a query string must verify.
+	 *
+	 * Draft Cavage peers (e.g. Mastodon) sign the full request-target
+	 * including the query string. The REST branch of the verifier has to
+	 * reconstruct the same value, otherwise endpoints that require query
+	 * parameters — like FEP-8fcf's `/followers/sync?authority=…` — always
+	 * fail with a 401.
+	 *
+	 * @covers ::verify_http_signature
+	 */
+	public function test_verify_http_signature_get_with_query_string() {
+		$keys = Actors::get_keypair( 1 );
+
+		$mock_remote_key_retrieval = function () use ( $keys ) {
+			return array(
+				'name'      => 'Admin',
+				'url'       => 'https://example.org/author/admin',
+				'publicKey' => array(
+					'id'           => 'https://example.org/author/admin#main-key',
+					'owner'        => 'https://example.org/author/admin',
+					'publicKeyPem' => $keys['public_key'],
+				),
+			);
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+
+		/*
+		 * Sign the way Mastodon does: the request-target includes the query
+		 * string. Forcing Cavage mode is not needed here, the verifier picks
+		 * the draft verifier based on the plain `Signature` header.
+		 */
+		$date           = \gmdate( 'D, d M Y H:i:s T' );
+		$target         = '/wp-json/activitypub/1.0/actors/0/followers/sync?authority=https://mastodon.example';
+		$string_to_sign = "(request-target): get {$target}\nhost: example.org\ndate: {$date}";
+
+		$signature = '';
+		\openssl_sign( $string_to_sign, $signature, Actors::get_private_key( 1 ), \OPENSSL_ALGO_SHA256 );
+
+		$_SERVER['REQUEST_URI'] = $target;
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/followers/sync' );
+		$request->set_query_params( array( 'authority' => 'https://mastodon.example' ) );
+		$request->set_headers(
+			array(
+				'Host'      => 'example.org',
+				'Date'      => $date,
+				'Signature' => \sprintf(
+					'keyId="https://example.org/author/admin#main-key",algorithm="rsa-sha256",headers="(request-target) host date",signature="%s"',
+					\base64_encode( $signature )
+				),
+			)
+		);
+
+		$this->assertTrue( Signature::verify_http_signature( $request ), 'Signed GET requests with a query string must verify.' );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+	}
+
+	/**
+	 * A signature created by the plugin's own signer for a query-string URL
+	 * must round-trip through the verifier.
+	 *
+	 * @covers ::verify_http_signature
+	 */
+	public function test_verify_http_signature_round_trip_with_query_string() {
+		$keys = Actors::get_keypair( 1 );
+
+		$force_cavage = '__return_zero';
+		\add_filter( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
+
+		$mock_remote_key_retrieval = function () use ( $keys ) {
+			return array(
+				'name'      => 'Admin',
+				'url'       => 'https://example.org/author/admin',
+				'publicKey' => array(
+					'id'           => 'https://example.org/author/admin#main-key',
+					'owner'        => 'https://example.org/author/admin',
+					'publicKeyPem' => $keys['public_key'],
+				),
+			);
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+
+		$args = \apply_filters(
+			'http_request_args',
+			array(
+				'method'      => 'GET',
+				'key_id'      => 'https://example.org/author/admin#main-key',
+				'private_key' => Actors::get_private_key( 1 ),
+				'user_id'     => 1,
+				'headers'     => array(
+					'Date' => \gmdate( 'D, d M Y H:i:s T' ),
+					'Host' => 'example.org',
+				),
+			),
+			'https://example.org/wp-json/activitypub/1.0/actors/0/followers/sync?authority=https://mastodon.example'
+		);
+
+		// Only the verifier reads REQUEST_URI; the signer above works off the URL.
+		$_SERVER['REQUEST_URI'] = '/wp-json/activitypub/1.0/actors/0/followers/sync?authority=https://mastodon.example';
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/followers/sync' );
+		$request->set_query_params( array( 'authority' => 'https://mastodon.example' ) );
+		$request->set_headers( $args['headers'] );
+
+		$this->assertTrue( Signature::verify_http_signature( $request ), 'Signatures created by the plugin for query-string URLs must round-trip.' );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+		\remove_filter( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
+	}
+
+	/**
+	 * A signed GET request without a query string must still verify.
+	 *
+	 * @covers ::verify_http_signature
+	 */
+	public function test_verify_http_signature_get_without_query_string() {
+		$keys = Actors::get_keypair( 1 );
+
+		$force_cavage = '__return_zero';
+		\add_filter( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
+
+		$mock_remote_key_retrieval = function () use ( $keys ) {
+			return array(
+				'name'      => 'Admin',
+				'url'       => 'https://example.org/author/admin',
+				'publicKey' => array(
+					'id'           => 'https://example.org/author/admin#main-key',
+					'owner'        => 'https://example.org/author/admin',
+					'publicKeyPem' => $keys['public_key'],
+				),
+			);
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+
+		$args = \apply_filters(
+			'http_request_args',
+			array(
+				'method'      => 'GET',
+				'key_id'      => 'https://example.org/author/admin#main-key',
+				'private_key' => Actors::get_private_key( 1 ),
+				'user_id'     => 1,
+				'headers'     => array(
+					'Date' => \gmdate( 'D, d M Y H:i:s T' ),
+					'Host' => 'example.org',
+				),
+			),
+			'https://example.org/wp-json/activitypub/1.0/actors/0/outbox'
+		);
+
+		$_SERVER['REQUEST_URI'] = '/wp-json/activitypub/1.0/actors/0/outbox';
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
+		$request->set_headers( $args['headers'] );
+
+		$this->assertTrue( Signature::verify_http_signature( $request ), 'Signed GET requests without a query string must still verify.' );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+		\remove_filter( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
+	}
+
+	/**
 	 * Signed headers that include neither Date nor (created) must be rejected.
 	 *
 	 * A captured signed request with no time anchor can otherwise be


### PR DESCRIPTION
Signed GET requests whose URL contains a query string always fail draft Cavage signature verification with a 401. In practice this breaks the FEP-8fcf follower synchronization endpoint (`/actors/{id}/followers/sync?authority=…`), which requires the `authority` query parameter and forces signature verification — so Mastodon's follower sync against WordPress sites can never succeed.

## Proposed changes:

* `Signature::verify_http_signature()` rebuilds the `(request-target)` pseudo-header for REST requests from `get_route()`, which only returns the route path and never the query string. Draft Cavage peers (Mastodon among them) sign the full request-target *including* the query, so the reconstructed base string never matches and `openssl_verify()` deterministically fails.
* The plugin's own signer (`Http_Signature_Draft::sign()`) already appends the query string, so signing and verifying were asymmetric.
* This PR appends the query string from the raw `REQUEST_URI` to the rebuilt route, the same source the RFC 9421 verifier already uses for `@request-target`/`@query`. The raw value is used on purpose, re-encoding the parsed query params could change percent-encoding or parameter order and break the byte-for-byte comparison.
* The RFC 9421 path and the `$_SERVER`-array branch are unaffected, both already handle the query correctly. Mastodon signs with draft Cavage, hence the real-world impact.

Real-world data point: a production site running 8.3.0 logged 42 signed GETs from mastodon.social to `/followers/sync?authority=…` over 8 days — every single one was answered with 401, while inbox POSTs from the same instance verified fine (no query string involved). The fix was validated on that install: a draft-Cavage-signed GET against the sync endpoint returned 401 before the patch and 200 after, and signed inbox deliveries from mastodon.social and fosstodon.org kept verifying fine afterwards.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run env-test -- --filter=test_verify_http_signature` — the two new query-string tests fail with a 401 `activitypub_signature` error before the patch and pass after it, the no-query test passes in both cases.
* For a real-world check: follow a WordPress user from a Mastodon account and watch the access log, the periodic signed GET to `/wp-json/activitypub/1.0/actors/{id}/followers/sync?authority=…` returns 401 before and 200 after.

### Changelog entry

A changelog entry is included in the PR (`.github/changelog/fix-signature-request-target-query`).
