### PR TITLE
Fix fatal error in Stream connector on new follower

### DIFF
--- a/.github/changelog/fix-stream-follower-fatal
+++ b/.github/changelog/fix-stream-follower-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a fatal error when receiving a new follower while the Stream plugin is active.

--- a/integration/stream/class-connector.php
+++ b/integration/stream/class-connector.php
@@ -111,14 +111,14 @@ class Connector extends \WP_Stream\Connector {
 	/**
 	 * Callback for activitypub_handled_follow.
 	 *
-	 * @param array         $activity The ActivityPub activity data.
-	 * @param int|int[]     $user_ids The local user ID(s) of the followed actor(s).
-	 * @param mixed         $state    Status or WP_Error object indicating the result of the follow handling.
-	 * @param \WP_Post|null $context  The WP_Post object representing the remote actor/follower.
+	 * @param array              $activity The ActivityPub activity data.
+	 * @param int|int[]          $user_ids The local user ID(s) of the followed actor(s).
+	 * @param bool               $success  Whether the follow was handled successfully.
+	 * @param \WP_Post|\WP_Error $context  The remote actor/follower, or WP_Error on failure.
 	 */
-	public function callback_activitypub_handled_follow( $activity, $user_ids, $state, $context ) {
-		// The hook passes an array of user IDs; Stream's log() expects a single integer ID.
-		$user_id   = \is_array( $user_ids ) ? \reset( $user_ids ) : $user_ids;
+	public function callback_activitypub_handled_follow( $activity, $user_ids, $success, $context ) {
+		// The hook passes an array of user IDs; Stream's log() builds a WP_User from this, so coerce to a single integer.
+		$user_id   = (int) ( \is_array( $user_ids ) ? \reset( $user_ids ) : $user_ids );
 		$actor_url = \is_object( $context ) && ! \is_wp_error( $context ) ? $context->guid : $activity['actor'];
 
 		$this->log(

--- a/integration/stream/class-connector.php
+++ b/integration/stream/class-connector.php
@@ -111,12 +111,14 @@ class Connector extends \WP_Stream\Connector {
 	/**
 	 * Callback for activitypub_handled_follow.
 	 *
-	 * @param array         $activity     The ActivityPub activity data.
-	 * @param int|null      $user_id      The local user ID, or null if not applicable.
-	 * @param mixed         $state        Status or WP_Error object indicating the result of the follow handling.
-	 * @param \WP_Post|null $context   The WP_Post object representing the remote actor/follower.
+	 * @param array         $activity The ActivityPub activity data.
+	 * @param int|int[]     $user_ids The local user ID(s) of the followed actor(s).
+	 * @param mixed         $state    Status or WP_Error object indicating the result of the follow handling.
+	 * @param \WP_Post|null $context  The WP_Post object representing the remote actor/follower.
 	 */
-	public function callback_activitypub_handled_follow( $activity, $user_id, $state, $context ) {
+	public function callback_activitypub_handled_follow( $activity, $user_ids, $state, $context ) {
+		// The hook passes an array of user IDs; Stream's log() expects a single integer ID.
+		$user_id   = \is_array( $user_ids ) ? \reset( $user_ids ) : $user_ids;
 		$actor_url = \is_object( $context ) && ! \is_wp_error( $context ) ? $context->guid : $activity['actor'];
 
 		$this->log(

--- a/tests/phpunit/tests/integration/class-test-stream-connector.php
+++ b/tests/phpunit/tests/integration/class-test-stream-connector.php
@@ -284,13 +284,16 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 				}
 			);
 
-		$stream_connector->callback_activitypub_handled_follow( $activity, self::$user_id, true, $context );
+		// The "activitypub_handled_follow" hook fires with an array of user IDs (int[]).
+		$stream_connector->callback_activitypub_handled_follow( $activity, array( self::$user_id ), true, $context );
 
 		$this->assertNotNull( $logged_data, 'Should have logged the follow event' );
 		$this->assertStringContainsString( 'New Follower: https://example.com/actor', $logged_data['message'] );
 		$this->assertEquals( 'notification', $logged_data['context_type'] );
 		$this->assertEquals( 'follow', $logged_data['action'] );
-		$this->assertEquals( self::$user_id, $logged_data['user_id'] );
+		// Stream's log() builds a WP_User from this value, so it must be a single integer, not the array.
+		$this->assertIsInt( $logged_data['user_id'], 'Stream log() must receive a single integer user ID, not an array.' );
+		$this->assertSame( self::$user_id, $logged_data['user_id'] );
 		$this->assertArrayHasKey( 'activity', $logged_data['meta'] );
 		$this->assertArrayHasKey( 'remote_actor', $logged_data['meta'] );
 	}
@@ -327,7 +330,8 @@ class Test_Stream_Connector extends \WP_UnitTestCase {
 				}
 			);
 
-		$stream_connector->callback_activitypub_handled_follow( $activity, self::$user_id, false, $context );
+		// The "activitypub_handled_follow" hook fires with an array of user IDs (int[]).
+		$stream_connector->callback_activitypub_handled_follow( $activity, array( self::$user_id ), false, $context );
 
 		$this->assertStringContainsString( 'New Follower: https://example.com/actor', $logged_data['message'] );
 	}


### PR DESCRIPTION
## Proposed changes:

Fixes a **fatal error on every inbound Follow** for any site running the [Stream](https://wordpress.org/plugins/stream/) plugin.

Since 7.5.0, the `activitypub_handled_follow` hook passes its user IDs as an array (`int[]`). The Stream integration's `callback_activitypub_handled_follow()` still treated that argument as a scalar and forwarded the array straight into `WP_Stream\Connector::log()`'s `$user_id` parameter. Stream then built a `WP_User` from the array:

```
PHP Fatal error: Uncaught TypeError: trim(): Argument #1 ($string) must be of type string, array given
  …/class-wp-user.php(160): WP_User::get_data_by('login', Array)
  …/stream/classes/class-log.php(78): WP_User->__construct(0)
  …/activitypub/integration/stream/class-connector.php(122): WP_Stream\Connector->log(…, Array)
  …/activitypub/includes/handler/class-follow.php(83): do_action('activitypub_handled_follow', …)
```

The fix normalizes the user IDs to a single integer in the callback (`\is_array( $user_ids ) ? \reset( $user_ids ) : $user_ids`), mirroring the pattern already used by every other consumer of this hook (`Follow::queue_accept`, `Mailer::new_follower`, `Event_Stream::signal_inbox`). I audited all consumers of the `(array) $user_ids` hooks — the Stream follow callback was the only one mishandling the array.

### Other information:

- [x] Have you written new tests for your changes, if applicable? _(Updated the Stream connector tests to pass the array the hook actually emits; they fail without the fix.)_

## Testing instructions:

* With the Stream plugin active, have a remote account follow your site (or fire `do_action( 'activitypub_handled_follow', $activity, array( 1 ), true, $remote_actor )`).
* Before this change: a fatal `TypeError` in `class-wp-user.php`. After: the follow is logged to Stream as "New Follower" with no error.
* `npm run env-test -- --filter='Follow|Stream'` → all green.

### Changelog entry

A changelog entry is already included in this PR (`.github/changelog/fix-stream-follower-fatal`, patch / fixed), so the automatic entry box is left unchecked.
