### PR TITLE
Verify Accept sender matches the followed actor

### DIFF
--- a/.github/changelog/fix-accept-actor-binding
+++ b/.github/changelog/fix-accept-actor-binding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a follow request being marked as accepted when the confirmation came from a different account than the one being followed.

--- a/includes/handler/class-accept.php
+++ b/includes/handler/class-accept.php
@@ -42,7 +42,18 @@ class Accept {
 			return;
 		}
 
-		$actor_post = Remote_Actors::get_by_uri( object_to_uri( $accept['object']['object'] ) );
+		/*
+		 * For a Follow Accept, the sender must be the actor that was followed.
+		 * Without this, a signed Accept from one actor could confirm a Follow that
+		 * targeted another actor by referencing that pending Follow's outbox GUID.
+		 */
+		$accept_actor   = object_to_uri( $accept['actor'] ?? '' );
+		$followed_actor = object_to_uri( $accept['object']['object'] ?? '' );
+		if ( ! $accept_actor || ! $followed_actor || $accept_actor !== $followed_actor ) {
+			return;
+		}
+
+		$actor_post = Remote_Actors::get_by_uri( $followed_actor );
 
 		if ( \is_wp_error( $actor_post ) ) {
 			return;

--- a/tests/phpunit/tests/includes/collection/class-test-following.php
+++ b/tests/phpunit/tests/includes/collection/class-test-following.php
@@ -387,30 +387,35 @@ class Test_Following extends \WP_UnitTestCase {
 		\wp_publish_post( $outbox_item_5 );
 
 		$accept_1 = array(
+			'actor'  => 'https://example.com/actor/1',
 			'object' => array(
 				'id'     => $outbox_item_1->guid,
 				'object' => 'https://example.com/actor/1',
 			),
 		);
 		$accept_2 = array(
+			'actor'  => 'https://example.com/actor/1',
 			'object' => array(
 				'id'     => $outbox_item_2->guid,
 				'object' => 'https://example.com/actor/1',
 			),
 		);
 		$accept_3 = array(
+			'actor'  => 'https://example.com/actor/1',
 			'object' => array(
 				'id'     => $outbox_item_3->guid,
 				'object' => 'https://example.com/actor/1',
 			),
 		);
 		$accept_4 = array(
+			'actor'  => 'https://example.com/actor/1',
 			'object' => array(
 				'id'     => $outbox_item_4->guid,
 				'object' => 'https://example.com/actor/1',
 			),
 		);
 		$accept_5 = array(
+			'actor'  => 'https://example.com/actor/1',
 			'object' => array(
 				'id'     => $outbox_item_5->guid,
 				'object' => 'https://example.com/actor/1',

--- a/tests/phpunit/tests/includes/handler/class-test-accept.php
+++ b/tests/phpunit/tests/includes/handler/class-test-accept.php
@@ -151,7 +151,7 @@ class Test_Accept extends \WP_UnitTestCase {
 		// Prepare accept array as expected by handle_accept, using the real outbox guid.
 		$accept = array(
 			'type'   => 'Accept',
-			'actor'  => 'https://example.net/actor/123',
+			'actor'  => $object_guid,
 			'object' => array(
 				'id'     => $outbox_guid,
 				'actor'  => 'https://example.com/actor/123',
@@ -172,5 +172,104 @@ class Test_Accept extends \WP_UnitTestCase {
 		// Assert: user_id is no longer in _activitypub_followed_by_pending.
 		$pending = \get_post_meta( $post_id, Following::PENDING_META_KEY, false );
 		$this->assertNotContains( (string) $user_id, $pending );
+	}
+
+	/**
+	 * An Accept whose sender is not the followed actor must be ignored.
+	 *
+	 * Guards against a same-instance actor accepting a Follow that targeted a
+	 * different actor by referencing that pending Follow's outbox GUID.
+	 */
+	public function test_handle_accept_rejects_actor_object_mismatch() {
+		$user_id     = self::$user_id;
+		$object_guid = 'https://example.com/actor/123';
+		$outbox_guid = 'https://example.com/outbox/123';
+
+		$outbox_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'ap_outbox',
+				'post_status' => 'publish',
+				'guid'        => $outbox_guid,
+			)
+		);
+		\add_post_meta( $outbox_post_id, '_activitypub_activity_type', 'Follow' );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Remote_Actors::POST_TYPE,
+				'post_status' => 'publish',
+				'guid'        => $object_guid,
+			)
+		);
+		\add_post_meta( $post_id, Following::PENDING_META_KEY, (string) $user_id );
+
+		// The Accept is sent by a different actor than the one that was followed.
+		$accept = array(
+			'type'   => 'Accept',
+			'actor'  => 'https://example.com/actor/999',
+			'object' => array(
+				'id'     => $outbox_guid,
+				'actor'  => 'https://example.com/actor/123',
+				'type'   => 'Follow',
+				'object' => $object_guid,
+			),
+		);
+
+		Accept::handle_accept( $accept, $user_id );
+
+		\clean_post_cache( $post_id );
+
+		// The relationship must stay pending and must not be marked as followed.
+		$this->assertNotContains( (string) $user_id, \get_post_meta( $post_id, Following::FOLLOWING_META_KEY, false ) );
+		$this->assertContains( (string) $user_id, \get_post_meta( $post_id, Following::PENDING_META_KEY, false ) );
+	}
+
+	/**
+	 * A non-Follow Accept (e.g. a quote request) is left untouched by the Follow logic.
+	 *
+	 * The sender/followed-actor guard is scoped to the Follow branch, so it must not
+	 * affect other Accept types.
+	 */
+	public function test_handle_accept_ignores_non_follow_activity() {
+		$user_id     = self::$user_id;
+		$object_guid = 'https://example.com/actor/456';
+		$outbox_guid = 'https://example.com/outbox/456';
+
+		// The outbox item is a QuoteRequest, not a Follow.
+		$outbox_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'ap_outbox',
+				'post_status' => 'publish',
+				'guid'        => $outbox_guid,
+			)
+		);
+		\add_post_meta( $outbox_post_id, '_activitypub_activity_type', 'QuoteRequest' );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Remote_Actors::POST_TYPE,
+				'post_status' => 'publish',
+				'guid'        => $object_guid,
+			)
+		);
+		\add_post_meta( $post_id, Following::PENDING_META_KEY, (string) $user_id );
+
+		$accept = array(
+			'type'   => 'Accept',
+			'actor'  => $object_guid,
+			'object' => array(
+				'id'     => $outbox_guid,
+				'type'   => 'QuoteRequest',
+				'object' => $object_guid,
+			),
+		);
+
+		Accept::handle_accept( $accept, $user_id );
+
+		\clean_post_cache( $post_id );
+
+		// A non-Follow Accept must not change the following state.
+		$this->assertEmpty( \get_post_meta( $post_id, Following::FOLLOWING_META_KEY, false ) );
+		$this->assertContains( (string) $user_id, \get_post_meta( $post_id, Following::PENDING_META_KEY, false ) );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

Harden the inbound `Accept` handler so a Follow is only confirmed by the account that was actually followed.

`Handler\Accept::handle_accept()` looked up the pending Follow by the `Accept`'s outbox GUID (`object.id`) and resolved the followed actor from `object.object`, but never checked that the **sender** of the `Accept` (`actor`) was that same actor. A signed `Accept` from a different federated actor could therefore confirm a pending Follow that targeted someone else, by referencing that Follow's outbox GUID.

- Add a sender check in the Follow branch: bail unless `object_to_uri( accept.actor )` equals `object_to_uri( accept.object.object )` (and both are non-empty).
- The check is placed **after** the `'Follow' !== activity_type` confirmation, so other `Accept` types (e.g. quote-request Accepts) are completely unaffected.

This mirrors the actor↔object binding already enforced in the Update, Undo, and Delete handlers.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Initiate a Follow from a local user to a remote actor (pending state).
* Simulate an inbound `Accept` whose `actor` does **not** match the followed actor (`object.object`) but references the real pending Follow's outbox GUID — confirm the follow stays pending and is not marked accepted.
* Simulate a legitimate `Accept` where `actor` matches `object.object` — confirm the follow moves to accepted as before.
* Confirm a non-Follow `Accept` (e.g. a quote-request Accept) is unaffected.
* `npm run env-test -- --filter='Test_Accept|Test_Following'` — all green.

### Changelog entry

A changelog entry is included in this PR (`.github/changelog/fix-accept-actor-binding`), so the automatic entry box is left unchecked.
