### PR TITLE
Backfill missing inbox actor from HTTP signature keyId

### DIFF
--- a/.github/changelog/fix-inbox-actor-from-key-id
+++ b/.github/changelog/fix-inbox-actor-from-key-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Requests from other platforms to feature your posts are now handled correctly instead of being ignored.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -74,6 +74,37 @@ class Signature {
 	}
 
 	/**
+	 * Extract the signing keyId from a request's HTTP Signature headers.
+	 *
+	 * Supports both the draft HTTP Signatures `Signature` header and the RFC 9421
+	 * `Signature-Input` header.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return string|null The keyId, or null when no signature is present.
+	 */
+	public static function get_key_id( $request ) {
+		$signature = $request->get_header( 'signature' );
+		if ( $signature && \preg_match( '/keyId="([^"]+)"/i', $signature, $matches ) ) {
+			return $matches[1];
+		}
+
+		/*
+		 * RFC 9421 Signature-Input: keyid is a `;`-delimited parameter whose value may be
+		 * quoted or unquoted. Anchoring on `;` (or string start) avoids matching a `keyid=`
+		 * substring inside another parameter's value.
+		 */
+		$signature_input = $request->get_header( 'signature-input' );
+		if ( $signature_input && \preg_match( '/(?:^|;)\s*keyid="?([^";,\s]+)/i', $signature_input, $matches ) ) {
+			return $matches[1];
+		}
+
+		return null;
+	}
+
+	/**
 	 * If a request with RFC-9421 signature fails, we try again with the Draft Cavage signature.
 	 *
 	 * @param array  $response HTTP response.

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -74,30 +74,41 @@ class Signature {
 	}
 
 	/**
-	 * Extract the signing keyId from a request's HTTP Signature headers.
+	 * Extract the signing keyId that {@see Signature::verify_http_signature()} would verify against.
 	 *
-	 * Supports both the draft HTTP Signatures `Signature` header and the RFC 9421
-	 * `Signature-Input` header.
+	 * The returned keyId is only trustworthy if it identifies the key the signature is
+	 * actually checked with, so this mirrors the verifier's header choice rather than
+	 * scanning headers in an arbitrary order:
+	 *
+	 * - When a `Signature-Input` header is present the RFC 9421 verifier is used, so the
+	 *   keyId is taken from there and a draft `Signature` header (which the verifier ignores)
+	 *   is not consulted. The RFC 9421 verifier accepts whichever of several signature labels
+	 *   validates, so a `Signature-Input` carrying more than one keyId is ambiguous: we cannot
+	 *   know in advance which key will verify and must not guess, so `null` is returned.
+	 * - Otherwise the draft HTTP Signatures `Signature` header is used, matching the draft
+	 *   verifier, which takes the first `keyId`.
 	 *
 	 * @since unreleased
 	 *
 	 * @param \WP_REST_Request $request The request object.
 	 *
-	 * @return string|null The keyId, or null when no signature is present.
+	 * @return string|null The keyId, or null when none is present or the choice is ambiguous.
 	 */
 	public static function get_key_id( $request ) {
-		$signature = $request->get_header( 'signature' );
-		if ( $signature && \preg_match( '/keyId="([^"]+)"/i', $signature, $matches ) ) {
-			return $matches[1];
+		$signature_input = $request->get_header( 'signature-input' );
+		if ( $signature_input ) {
+			/*
+			 * keyid is a `;`-delimited parameter whose value may be quoted or unquoted.
+			 * Anchoring on `;` (or string start) avoids matching a `keyid=` substring inside
+			 * another parameter's value. Count every label's keyId: more than one is ambiguous.
+			 */
+			$count = \preg_match_all( '/(?:^|;)\s*keyid="?([^";,\s]+)/i', $signature_input, $matches );
+
+			return 1 === $count ? $matches[1][0] : null;
 		}
 
-		/*
-		 * RFC 9421 Signature-Input: keyid is a `;`-delimited parameter whose value may be
-		 * quoted or unquoted. Anchoring on `;` (or string start) avoids matching a `keyid=`
-		 * substring inside another parameter's value.
-		 */
-		$signature_input = $request->get_header( 'signature-input' );
-		if ( $signature_input && \preg_match( '/(?:^|;)\s*keyid="?([^";,\s]+)/i', $signature_input, $matches ) ) {
+		$signature = $request->get_header( 'signature' );
+		if ( $signature && \preg_match( '/keyId="([^"]+)"/i', $signature, $matches ) ) {
 			return $matches[1];
 		}
 

--- a/includes/class-signature.php
+++ b/includes/class-signature.php
@@ -54,9 +54,15 @@ class Signature {
 	/**
 	 * Verifies the http signatures
 	 *
+	 * On success the verified keyId is returned (a truthy string), so callers can bind it to
+	 * the activity actor without re-parsing headers, which cannot tell which signature label
+	 * actually validated. Pass/fail callers should branch on {@see is_wp_error()} as before.
+	 *
+	 * @since unreleased Returns the verified keyId on success instead of `true`.
+	 *
 	 * @param \WP_REST_Request|array $request The request object or $_SERVER array.
 	 *
-	 * @return bool|\WP_Error A boolean or WP_Error.
+	 * @return string|\WP_Error The verified keyId on success, WP_Error on failure.
 	 */
 	public static function verify_http_signature( $request ) {
 		if ( is_object( $request ) ) { // REST Request object.
@@ -85,8 +91,9 @@ class Signature {
 	 *   is not consulted. The RFC 9421 verifier accepts whichever of several signature labels
 	 *   validates, so a `Signature-Input` carrying more than one keyId is ambiguous: we cannot
 	 *   know in advance which key will verify and must not guess, so `null` is returned.
-	 * - Otherwise the draft HTTP Signatures `Signature` header is used, matching the draft
-	 *   verifier, which takes the first `keyId`.
+	 * - Otherwise the draft HTTP Signatures form is used, taking the first `keyId` from the
+	 *   `Signature` header or, failing that, the `Authorization` header — matching the draft
+	 *   verifier, which reads `signature ?? authorization`.
 	 *
 	 * @since unreleased
 	 *
@@ -107,7 +114,12 @@ class Signature {
 			return 1 === $count ? $matches[1][0] : null;
 		}
 
+		// A draft signature may arrive in the Signature header or, less commonly, Authorization.
 		$signature = $request->get_header( 'signature' );
+		if ( ! $signature ) {
+			$signature = $request->get_header( 'authorization' );
+		}
+
 		if ( $signature && \preg_match( '/keyId="([^"]+)"/i', $signature, $matches ) ) {
 			return $matches[1];
 		}

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -7,6 +7,8 @@
 
 namespace Activitypub\Rest;
 
+use Activitypub\Signature;
+
 /**
  * ActivityPub Server REST-Class.
  *
@@ -106,22 +108,24 @@ class Server {
 	}
 
 	/**
-	 * Backfill a missing `actor` on incoming inbox activities from the HTTP signature.
+	 * Backfill a missing `actor` on incoming FeatureRequest activities from the signature.
 	 *
-	 * Some implementations convey the sending actor only through the HTTP signature
-	 * and omit the `actor` property from the activity body. Mastodon does this for
-	 * FeatureRequest activities (FEP-7aa9), for example. Because our inbox routes
-	 * require `actor`, those activities are rejected during parameter validation
-	 * before they can be stored or handed to a handler.
+	 * Mastodon (FEP-7aa9) omits `actor` from the FeatureRequest body and conveys the
+	 * requesting actor only through the HTTP signature keyId. Our inbox routes require
+	 * `actor`, so such a request is rejected during parameter validation before it can
+	 * reach the inbox or its handler, which is why no Accept is ever sent.
 	 *
-	 * The signature is the authoritative sender identity anyway, so derive the actor
-	 * from the keyId and inject it into the request body. Validation, signature
-	 * verification, and the handlers then see a normal `actor`. This is purely
-	 * additive: a well-formed activity already carries an `actor` and is left
-	 * untouched, and the injected value still has to survive signature verification.
+	 * Derive the actor from the keyId and add it as a request parameter. The actor is
+	 * injected with `set_param()` rather than by rewriting the request body, so the raw
+	 * body stays byte-identical and the signed `Digest` still verifies. Inbox POSTs read
+	 * JSON parameters first (see `request_parameter_order()`), so the value is visible to
+	 * both parameter validation and the handler via `get_json_params()`.
 	 *
-	 * Runs on `rest_pre_dispatch` because that is the only hook that fires before
-	 * required-parameter validation.
+	 * Scoped to FeatureRequest, the only activity type known to address this way. Runs on
+	 * `rest_pre_dispatch` because that is the only hook that fires before required-parameter
+	 * validation. Signature verification still runs afterwards and remains authoritative:
+	 * the injected actor is derived from the very keyId the signature is checked against, so
+	 * it cannot be used to impersonate another actor.
 	 *
 	 * @since unreleased
 	 *
@@ -150,47 +154,18 @@ class Server {
 		}
 
 		$json = $request->get_json_params();
-		if ( ! \is_array( $json ) || ! empty( $json['actor'] ) ) {
+		if ( ! \is_array( $json ) || 'FeatureRequest' !== ( $json['type'] ?? '' ) || ! empty( $json['actor'] ) ) {
 			return $result;
 		}
 
-		$key_id = self::get_key_id_from_request( $request );
+		$key_id = Signature::get_key_id( $request );
 		if ( ! $key_id ) {
 			return $result;
 		}
 
-		$json['actor'] = \strip_fragment_from_url( $key_id );
-		$request->set_body( \wp_json_encode( $json ) );
+		$request->set_param( 'actor', \strip_fragment_from_url( $key_id ) );
 
 		return $result;
-	}
-
-	/**
-	 * Extract the signing keyId from a request's HTTP Signature headers.
-	 *
-	 * Supports both the draft HTTP Signatures `Signature` header and the RFC 9421
-	 * `Signature-Input` header, matching the keyId the same way the signature
-	 * verifier does.
-	 *
-	 * @since unreleased
-	 *
-	 * @param \WP_REST_Request $request The request object.
-	 *
-	 * @return string|null The keyId, or null when no signature is present.
-	 */
-	private static function get_key_id_from_request( $request ) {
-		$signature = $request->get_header( 'signature' );
-		if ( $signature && \preg_match( '/keyId="([^"]+)"/i', $signature, $matches ) ) {
-			return $matches[1];
-		}
-
-		// RFC 9421: keyid is a `;`-delimited parameter whose value may be quoted or unquoted.
-		$signature_input = $request->get_header( 'signature-input' );
-		if ( $signature_input && \preg_match( '/(?:^|;)\s*keyid="?([^";,\s]+)/i', $signature_input, $matches ) ) {
-			return $matches[1];
-		}
-
-		return null;
 	}
 
 	/**

--- a/includes/rest/class-server.php
+++ b/includes/rest/class-server.php
@@ -19,6 +19,7 @@ class Server {
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
+		\add_filter( 'rest_pre_dispatch', array( self::class, 'maybe_add_actor_from_signature' ), 10, 3 );
 		\add_filter( 'rest_request_before_callbacks', array( self::class, 'validate_requests' ), 9, 3 );
 		\add_filter( 'rest_request_parameter_order', array( self::class, 'request_parameter_order' ), 10, 2 );
 
@@ -102,6 +103,94 @@ class Server {
 			'URL',
 			'defaults',
 		);
+	}
+
+	/**
+	 * Backfill a missing `actor` on incoming inbox activities from the HTTP signature.
+	 *
+	 * Some implementations convey the sending actor only through the HTTP signature
+	 * and omit the `actor` property from the activity body. Mastodon does this for
+	 * FeatureRequest activities (FEP-7aa9), for example. Because our inbox routes
+	 * require `actor`, those activities are rejected during parameter validation
+	 * before they can be stored or handed to a handler.
+	 *
+	 * The signature is the authoritative sender identity anyway, so derive the actor
+	 * from the keyId and inject it into the request body. Validation, signature
+	 * verification, and the handlers then see a normal `actor`. This is purely
+	 * additive: a well-formed activity already carries an `actor` and is left
+	 * untouched, and the injected value still has to survive signature verification.
+	 *
+	 * Runs on `rest_pre_dispatch` because that is the only hook that fires before
+	 * required-parameter validation.
+	 *
+	 * @since unreleased
+	 *
+	 * @param mixed            $result  Response to replace the request with, or null to continue.
+	 * @param \WP_REST_Server  $server  Server instance.
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return mixed The unmodified `$result`.
+	 */
+	public static function maybe_add_actor_from_signature( $result, $server, $request ) {
+		// Respect an earlier short-circuit.
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		if ( \WP_REST_Server::CREATABLE !== $request->get_method() ) {
+			return $result;
+		}
+
+		$route = $request->get_route();
+		if (
+			! \str_starts_with( $route, '/' . ACTIVITYPUB_REST_NAMESPACE ) ||
+			! \str_ends_with( $route, '/inbox' )
+		) {
+			return $result;
+		}
+
+		$json = $request->get_json_params();
+		if ( ! \is_array( $json ) || ! empty( $json['actor'] ) ) {
+			return $result;
+		}
+
+		$key_id = self::get_key_id_from_request( $request );
+		if ( ! $key_id ) {
+			return $result;
+		}
+
+		$json['actor'] = \strip_fragment_from_url( $key_id );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		return $result;
+	}
+
+	/**
+	 * Extract the signing keyId from a request's HTTP Signature headers.
+	 *
+	 * Supports both the draft HTTP Signatures `Signature` header and the RFC 9421
+	 * `Signature-Input` header, matching the keyId the same way the signature
+	 * verifier does.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return string|null The keyId, or null when no signature is present.
+	 */
+	private static function get_key_id_from_request( $request ) {
+		$signature = $request->get_header( 'signature' );
+		if ( $signature && \preg_match( '/keyId="([^"]+)"/i', $signature, $matches ) ) {
+			return $matches[1];
+		}
+
+		// RFC 9421: keyid is a `;`-delimited parameter whose value may be quoted or unquoted.
+		$signature_input = $request->get_header( 'signature-input' );
+		if ( $signature_input && \preg_match( '/(?:^|;)\s*keyid="?([^";,\s]+)/i', $signature_input, $matches ) ) {
+			return $matches[1];
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -99,23 +99,12 @@ trait Verification {
 	 * @return true|\WP_Error True if valid, WP_Error on mismatch.
 	 */
 	private function verify_key_id( $request ) {
-		$sig = $request->get_header( 'signature' );
-		if ( ! $sig || ! \preg_match( '/keyId="([^"]+)"/i', $sig, $m ) ) {
-			/*
-			 * RFC 9421 Signature-Input. Match the keyid the same way the RFC 9421 verifier
-			 * parses it: as a `;`-delimited parameter whose value may be quoted or unquoted.
-			 * Anchoring on `;` (or string start) is required — a bare `keyid=` search would
-			 * also match a `keyid=` substring inside another parameter's quoted value (or a
-			 * param named `…keyid`), letting an attacker point this binding at a different
-			 * host than the one the verifier actually used.
-			 */
-			$sig = $request->get_header( 'signature-input' );
-			if ( ! $sig || ! \preg_match( '/(?:^|;)\s*keyid="?([^";,\s]+)/i', $sig, $m ) ) {
-				return true;
-			}
+		$key_id = Signature::get_key_id( $request );
+		if ( ! $key_id ) {
+			return true;
 		}
 
-		$key_host = \strtolower( (string) \wp_parse_url( $m[1], \PHP_URL_HOST ) );
+		$key_host = \strtolower( (string) \wp_parse_url( $key_id, \PHP_URL_HOST ) );
 		$json     = $request->get_json_params();
 		$actor    = isset( $json['actor'] ) ? object_to_uri( $json['actor'] ) : null;
 

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -71,17 +71,17 @@ trait Verification {
 
 		// POST-Requests always have to be signed, GET-Requests only require a signature in secure mode or when forced.
 		if ( 'GET' !== $request->get_method() || use_authorized_fetch() || $force_signature ) {
-			$verified_request = Signature::verify_http_signature( $request );
-			if ( \is_wp_error( $verified_request ) ) {
+			$verified_key_id = Signature::verify_http_signature( $request );
+			if ( \is_wp_error( $verified_key_id ) ) {
 				return new \WP_Error(
 					'activitypub_signature_verification',
-					$verified_request->get_error_message(),
+					$verified_key_id->get_error_message(),
 					array( 'status' => 401 )
 				);
 			}
 
 			// Verify the signing key's host matches the activity actor's host.
-			$key_id_check = $this->verify_key_id( $request );
+			$key_id_check = $this->verify_key_id( $request, $verified_key_id );
 			if ( \is_wp_error( $key_id_check ) ) {
 				return $key_id_check;
 			}
@@ -93,13 +93,19 @@ trait Verification {
 	/**
 	 * Check that the signature keyId and activity actor share the same host.
 	 *
+	 * Binds against the keyId that {@see Signature::verify_http_signature()} actually
+	 * verified, passed in by the caller. Re-parsing the headers here would be unsafe: a
+	 * request can present several signature labels (or a draft and an RFC 9421 header) with
+	 * different keyIds, and only the verifier knows which one validated.
+	 *
 	 * @since 8.1.0
+	 * @since unreleased Added the `$key_id` parameter; binds against the verified keyId.
 	 *
 	 * @param \WP_REST_Request $request The request object.
+	 * @param string|null      $key_id  The keyId that verified the signature.
 	 * @return true|\WP_Error True if valid, WP_Error on mismatch.
 	 */
-	private function verify_key_id( $request ) {
-		$key_id = Signature::get_key_id( $request );
+	private function verify_key_id( $request, $key_id ) {
 		if ( ! $key_id ) {
 			return true;
 		}

--- a/includes/signature/class-http-message-signature.php
+++ b/includes/signature/class-http-message-signature.php
@@ -133,9 +133,11 @@ class Http_Message_Signature implements Http_Signature {
 	/**
 	 * Verify the HTTP Signature against a request.
 	 *
+	 * @since unreleased Returns the verified keyId on success instead of `true`.
+	 *
 	 * @param array       $headers The HTTP headers.
 	 * @param string|null $body    The request body, if applicable.
-	 * @return bool|\WP_Error True, if the signature is valid, WP_Error on failure.
+	 * @return string|\WP_Error The verified keyId on success, WP_Error on failure.
 	 */
 	public function verify( array $headers, $body = null ) {
 		$parsed = $this->parse_signature_labels( $headers );
@@ -147,7 +149,11 @@ class Http_Message_Signature implements Http_Signature {
 		foreach ( $parsed as $data ) {
 			$result = $this->verify_signature_label( $data, $headers, $body );
 			if ( true === $result ) {
-				return true;
+				/*
+				 * Return the keyId of the label that actually verified, so the caller binds
+				 * against the real signer instead of guessing among several labels.
+				 */
+				return $data['params']['keyid'];
 			}
 
 			if ( \is_wp_error( $result ) ) {

--- a/includes/signature/class-http-signature-draft.php
+++ b/includes/signature/class-http-signature-draft.php
@@ -87,9 +87,11 @@ class Http_Signature_Draft implements Http_Signature {
 	/**
 	 * Verify the HTTP Signature against a request.
 	 *
+	 * @since unreleased Returns the verified keyId on success instead of `true`.
+	 *
 	 * @param array       $headers The HTTP headers.
 	 * @param string|null $body    The request body, if applicable.
-	 * @return bool|\WP_Error True, if the signature is valid, WP_Error on failure.
+	 * @return string|\WP_Error The verified keyId on success, WP_Error on failure.
 	 */
 	public function verify( array $headers, $body = null ) {
 		if ( ! isset( $headers['signature'] ) && ! isset( $headers['authorization'] ) ) {
@@ -129,7 +131,8 @@ class Http_Signature_Draft implements Http_Signature {
 			return new \WP_Error( 'activitypub_signature', 'Invalid signature', array( 'status' => 401 ) );
 		}
 
-		return true;
+		// Return the verified keyId so the caller can bind it to the activity actor.
+		return $parsed['keyId'];
 	}
 
 	/**

--- a/includes/signature/interface-http-signature.php
+++ b/includes/signature/interface-http-signature.php
@@ -28,9 +28,11 @@ interface Http_Signature {
 	/**
 	 * Verify the HTTP Signature against a request.
 	 *
+	 * @since unreleased Returns the verified keyId on success instead of `true`.
+	 *
 	 * @param array       $headers The HTTP headers.
 	 * @param string|null $body    The request body, if applicable.
-	 * @return bool|\WP_Error
+	 * @return string|\WP_Error The verified keyId on success, WP_Error on failure.
 	 */
 	public function verify( array $headers, $body = null );
 

--- a/tests/phpunit/tests/includes/class-test-signature.php
+++ b/tests/phpunit/tests/includes/class-test-signature.php
@@ -100,7 +100,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		};
 		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 
-		$this->assertTrue( Signature::verify_http_signature( $request ), "Valid hs2019 signature for curve {$curve} should verify" );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ), "Valid hs2019 signature for curve {$curve} should verify" );
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 	}
 
@@ -198,7 +198,7 @@ class Test_Signature extends \WP_UnitTestCase {
 			);
 		};
 		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
-		$this->assertTrue( Signature::verify_http_signature( $request ), "Valid hs2019 signature for RSA {$bits} bits should verify" );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ), "Valid hs2019 signature for RSA {$bits} bits should verify" );
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 	}
 
@@ -329,7 +329,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		$request->set_body( $args['body'] );
 		$request->set_headers( $args['headers'] );
 
-		$this->assertTrue( Signature::verify_http_signature( $request ) );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ) );
 
 		// Create a request with a modified body but the original digest.
 		$request->set_body( '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Modified content."}}' );
@@ -349,7 +349,7 @@ class Test_Signature extends \WP_UnitTestCase {
 			'HTTP_SIGNATURE' => $args['headers']['Signature'],
 		);
 
-		$this->assertTrue( Signature::verify_http_signature( $request ) );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ) );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 	}
@@ -415,7 +415,7 @@ class Test_Signature extends \WP_UnitTestCase {
 
 		$this->assertWPError( $sign( $far_past ), 'Signatures more than an hour old must be rejected.' );
 		$this->assertWPError( $sign( $far_future ), 'Signatures more than five minutes in the future must be rejected.' );
-		$this->assertTrue( $sign( $within ), 'Signatures within the skew window must verify.' );
+		$this->assertNotWPError( $sign( $within ), 'Signatures within the skew window must verify.' );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 		\remove_filter( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
@@ -536,7 +536,7 @@ class Test_Signature extends \WP_UnitTestCase {
 			)
 		);
 
-		$this->assertTrue( Signature::verify_http_signature( $request ), 'Signed GET requests with a query string must verify.' );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ), 'Signed GET requests with a query string must verify.' );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 	}
@@ -588,7 +588,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		$request->set_query_params( array( 'authority' => 'https://mastodon.example' ) );
 		$request->set_headers( $args['headers'] );
 
-		$this->assertTrue( Signature::verify_http_signature( $request ), 'Signatures created by the plugin for query-string URLs must round-trip.' );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ), 'Signatures created by the plugin for query-string URLs must round-trip.' );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 		\remove_filter( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
@@ -638,7 +638,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/0/outbox' );
 		$request->set_headers( $args['headers'] );
 
-		$this->assertTrue( Signature::verify_http_signature( $request ), 'Signed GET requests without a query string must still verify.' );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ), 'Signed GET requests without a query string must still verify.' );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 		\remove_filter( 'pre_option_activitypub_rfc9421_signature', $force_cavage );
@@ -1079,7 +1079,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		$request->set_headers( $args['headers'] );
 
 		// The verification should succeed.
-		$this->assertTrue( Signature::verify_http_signature( $request ) );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ) );
 
 		// Create a request with a modified body but the original digest.
 		$request->set_body( '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Modified content."}}' );
@@ -1101,7 +1101,83 @@ class Test_Signature extends \WP_UnitTestCase {
 		);
 
 		// The verification should succeed.
-		$this->assertTrue( Signature::verify_http_signature( $request ) );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ) );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+		\delete_option( 'activitypub_rfc9421_signature' );
+	}
+
+	/**
+	 * RFC 9421: the keyId returned is the label that actually verified, not merely the first.
+	 *
+	 * A request can carry several signature labels and the verifier accepts whichever validates.
+	 * An attacker pairing a victim-keyed invalid label with their own valid label must not get
+	 * the victim keyId surfaced, or the actor host-binding could be bypassed.
+	 *
+	 * @covers ::verify_http_signature
+	 * @covers \Activitypub\Signature\Http_Message_Signature::verify
+	 */
+	public function test_verify_http_signature_rfc9421_returns_verifying_label_key_id() {
+		\update_option( 'activitypub_rfc9421_signature', '1' );
+		$keys = self::$test_keys['rsa']['4096'];
+
+		$mock_remote_key_retrieval = function () use ( $keys ) {
+			return array(
+				'name'      => 'Admin',
+				'url'       => 'https://example.org/author/admin',
+				'publicKey' => array(
+					'id'           => 'https://example.org/author/admin#main-key',
+					'owner'        => 'https://example.org/author/admin',
+					'publicKeyPem' => $keys['public_key'],
+				),
+			);
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+
+		$args = \apply_filters(
+			'http_request_args',
+			array(
+				'method'      => 'POST',
+				'body'        => '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}',
+				'headers'     => array(
+					'Date' => \gmdate( 'D, d M Y H:i:s T' ),
+					'Host' => 'example.org',
+				),
+				'key_id'      => 'https://example.org/author/admin#main-key',
+				'private_key' => \openssl_pkey_get_private( $keys['private_key'] ),
+				'user_id'     => 1,
+			),
+			'https://example.org/wp-json/activitypub/1.0/inbox'
+		);
+
+		/*
+		 * Prepend a second label naming a different-host keyId but carrying an invalid signature.
+		 * The verifier should skip it and report the keyId of the label that actually validated.
+		 */
+		$created                    = \time();
+		$headers                    = $args['headers'];
+		$headers['Signature-Input'] = \sprintf(
+			'sig0=("@method");created=%d;keyid="https://victim.example/users/victim#main-key";alg="rsa-v1_5-sha256", ',
+			$created
+		) . $headers['Signature-Input'];
+		$headers['Signature']       = 'sig0=:' . \base64_encode( 'not-a-valid-signature' ) . ':, ' . $headers['Signature'];
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp-json/activitypub/1.0/inbox';
+		$_SERVER['HTTP_HOST']      = 'example.org';
+		$_SERVER['HTTPS']          = 'on';
+
+		$request = new \WP_REST_Request( 'POST', ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_body( $args['body'] );
+		$request->set_headers( $headers );
+
+		$result = Signature::verify_http_signature( $request );
+
+		$this->assertSame(
+			'https://example.org/author/admin#main-key',
+			$result,
+			'The keyId of the label that actually verified must be returned, not the first label.'
+		);
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 		\delete_option( 'activitypub_rfc9421_signature' );
@@ -1216,7 +1292,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		$request->set_header( 'Signature', $signature_header );
 
 		// The verification should succeed.
-		$this->assertTrue( Signature::verify_http_signature( $request ) );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ) );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 	}
@@ -1321,7 +1397,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		$request->set_header( 'Signature', $signature_header );
 
 		// The verification should succeed.
-		$this->assertTrue( Signature::verify_http_signature( $request ) );
+		$this->assertNotWPError( Signature::verify_http_signature( $request ) );
 
 		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 	}
@@ -1432,7 +1508,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_retrieval, 10, 2 );
 
 		try {
-			$this->assertTrue( Signature::verify_http_signature( $request ), 'Valid signature with standalone key object should verify' );
+			$this->assertNotWPError( Signature::verify_http_signature( $request ), 'Valid signature with standalone key object should verify' );
 		} finally {
 			\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_retrieval, 10 );
 		}
@@ -1559,7 +1635,7 @@ class Test_Signature extends \WP_UnitTestCase {
 		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_retrieval, 10, 2 );
 
 		try {
-			$this->assertTrue( Signature::verify_http_signature( $request ), 'Same-host standalone key following owner should verify' );
+			$this->assertNotWPError( Signature::verify_http_signature( $request ), 'Same-host standalone key following owner should verify' );
 		} finally {
 			\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_retrieval, 10 );
 		}
@@ -1637,35 +1713,121 @@ class Test_Signature extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A draft signature carried in the Authorization header is also recognized, matching the
+	 * verifier's `signature ?? authorization` fallback.
+	 *
+	 * @covers ::get_key_id
+	 */
+	public function test_get_key_id_reads_authorization_header() {
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'authorization', 'Signature keyId="https://remote.example/users/curator#main-key",algorithm="rsa-sha256",signature="abc"' );
+
+		$this->assertSame( 'https://remote.example/users/curator#main-key', Signature::get_key_id( $request ) );
+	}
+
+	/**
+	 * An OAuth Bearer token in the Authorization header carries no keyId and must not match.
+	 *
+	 * @covers ::get_key_id
+	 */
+	public function test_get_key_id_ignores_bearer_authorization() {
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'authorization', 'Bearer some-oauth-token' );
+
+		$this->assertNull( Signature::get_key_id( $request ) );
+	}
+
+	/**
 	 * Data provider for test_get_key_id.
 	 *
 	 * @return array[]
 	 */
 	public function get_key_id_provider() {
 		return array(
-			'draft Signature header'        => array(
+			'draft Signature header'           => array(
 				'keyId="https://remote.example/users/curator#main-key",algorithm="rsa-sha256",signature="abc"',
 				null,
 				'https://remote.example/users/curator#main-key',
 			),
-			'RFC 9421 Signature-Input'      => array(
+			'RFC 9421 Signature-Input'         => array(
 				null,
 				'sig1=("@method" "@target-uri");keyid="https://remote.example/users/curator#main-key";created=1700000000',
 				'https://remote.example/users/curator#main-key',
 			),
-			'no signature headers'          => array( null, null, null ),
+			'no signature headers'             => array( null, null, null ),
 			// Signature-Input wins over a draft Signature header, matching the verifier's choice.
-			'mixed headers prefer RFC 9421' => array(
+			'mixed headers prefer RFC 9421'    => array(
 				'keyId="https://victim.example/users/victim#main-key",signature="abc"',
 				'sig1=("@method");keyid="https://attacker.example/users/attacker#main-key";created=1700000000',
 				'https://attacker.example/users/attacker#main-key',
 			),
 			// The verifier accepts whichever label validates, so multiple keyIds are ambiguous.
-			'ambiguous multiple keyIds'     => array(
+			'ambiguous multiple keyIds'        => array(
 				null,
 				'sig1=("@method");keyid="https://victim.example/users/victim#main-key", sig2=("@method");keyid="https://attacker.example/users/attacker#main-key";created=1700000000',
 				null,
 			),
+			// RFC 9421 allows an unquoted keyid value.
+			'RFC 9421 unquoted keyid'          => array(
+				null,
+				'sig1=("@method");keyid=https://evil.example/actor#key;alg="rsa-v1_5-sha256"',
+				'https://evil.example/actor#key',
+			),
+			// A `keyid=` smuggled inside another parameter's quoted value must not be picked up.
+			'keyid inside other param ignored' => array(
+				null,
+				'sig1=("@method");tag="keyid=https://victim.example/key";keyid=https://evil.example/key',
+				'https://evil.example/key',
+			),
 		);
+	}
+
+	/**
+	 * A successful verification returns the keyId it validated against, so callers can bind it.
+	 *
+	 * @covers ::verify_http_signature
+	 */
+	public function test_verify_http_signature_returns_verified_key_id() {
+		$keys = Actors::get_keypair( 1 );
+
+		$mock_remote_key_retrieval = function () use ( $keys ) {
+			return array(
+				'name'      => 'Admin',
+				'url'       => 'https://example.org/author/admin',
+				'publicKey' => array(
+					'id'           => 'https://example.org/author/admin#main-key',
+					'owner'        => 'https://example.org/author/admin',
+					'publicKeyPem' => $keys['public_key'],
+				),
+			);
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
+
+		$args = \apply_filters(
+			'http_request_args',
+			array(
+				'method'      => 'POST',
+				'body'        => '{"type":"Create","actor":"https://example.org/author/admin","object":{"type":"Note","content":"Test content."}}',
+				'key_id'      => 'https://example.org/author/admin#main-key',
+				'private_key' => Actors::get_private_key( 1 ),
+				'user_id'     => 1,
+				'headers'     => array(
+					'Content-Type' => 'application/activity+json',
+					'Date'         => \gmdate( 'D, d M Y H:i:s T' ),
+					'Host'         => 'example.org',
+				),
+			),
+			'https://example.org/wp-json/activitypub/1.0/inbox'
+		);
+
+		$request = new \WP_REST_Request( 'POST', ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_body( $args['body'] );
+		$request->set_headers( $args['headers'] );
+
+		$result = Signature::verify_http_signature( $request );
+
+		$this->assertSame( 'https://example.org/author/admin#main-key', $result, 'The verified keyId is returned on success.' );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $mock_remote_key_retrieval );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-signature.php
+++ b/tests/phpunit/tests/includes/class-test-signature.php
@@ -1611,4 +1611,49 @@ class Test_Signature extends \WP_UnitTestCase {
 		\delete_option( 'activitypub_rfc9421_signature' );
 		\remove_filter( 'pre_http_request', $mock_callback );
 	}
+
+	/**
+	 * The keyId is extracted from both the draft Signature header and the RFC 9421
+	 * Signature-Input header, and is null when neither is present.
+	 *
+	 * @covers ::get_key_id
+	 *
+	 * @dataProvider get_key_id_provider
+	 *
+	 * @param string|null $signature       The draft Signature header value, or null.
+	 * @param string|null $signature_input The RFC 9421 Signature-Input header value, or null.
+	 * @param string|null $expected        The expected keyId.
+	 */
+	public function test_get_key_id( $signature, $signature_input, $expected ) {
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		if ( null !== $signature ) {
+			$request->set_header( 'signature', $signature );
+		}
+		if ( null !== $signature_input ) {
+			$request->set_header( 'signature-input', $signature_input );
+		}
+
+		$this->assertSame( $expected, Signature::get_key_id( $request ) );
+	}
+
+	/**
+	 * Data provider for test_get_key_id.
+	 *
+	 * @return array[]
+	 */
+	public function get_key_id_provider() {
+		return array(
+			'draft Signature header'   => array(
+				'keyId="https://remote.example/users/curator#main-key",algorithm="rsa-sha256",signature="abc"',
+				null,
+				'https://remote.example/users/curator#main-key',
+			),
+			'RFC 9421 Signature-Input' => array(
+				null,
+				'sig1=("@method" "@target-uri");keyid="https://remote.example/users/curator#main-key";created=1700000000',
+				'https://remote.example/users/curator#main-key',
+			),
+			'no signature headers'     => array( null, null, null ),
+		);
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-signature.php
+++ b/tests/phpunit/tests/includes/class-test-signature.php
@@ -1643,17 +1643,29 @@ class Test_Signature extends \WP_UnitTestCase {
 	 */
 	public function get_key_id_provider() {
 		return array(
-			'draft Signature header'   => array(
+			'draft Signature header'        => array(
 				'keyId="https://remote.example/users/curator#main-key",algorithm="rsa-sha256",signature="abc"',
 				null,
 				'https://remote.example/users/curator#main-key',
 			),
-			'RFC 9421 Signature-Input' => array(
+			'RFC 9421 Signature-Input'      => array(
 				null,
 				'sig1=("@method" "@target-uri");keyid="https://remote.example/users/curator#main-key";created=1700000000',
 				'https://remote.example/users/curator#main-key',
 			),
-			'no signature headers'     => array( null, null, null ),
+			'no signature headers'          => array( null, null, null ),
+			// Signature-Input wins over a draft Signature header, matching the verifier's choice.
+			'mixed headers prefer RFC 9421' => array(
+				'keyId="https://victim.example/users/victim#main-key",signature="abc"',
+				'sig1=("@method");keyid="https://attacker.example/users/attacker#main-key";created=1700000000',
+				'https://attacker.example/users/attacker#main-key',
+			),
+			// The verifier accepts whichever label validates, so multiple keyIds are ambiguous.
+			'ambiguous multiple keyIds'     => array(
+				null,
+				'sig1=("@method");keyid="https://victim.example/users/victim#main-key", sig2=("@method");keyid="https://attacker.example/users/attacker#main-key";created=1700000000',
+				null,
+			),
 		);
 	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-actors-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-actors-inbox-controller.php
@@ -9,6 +9,8 @@ namespace Activitypub\Tests\Rest;
 
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Inbox as Inbox_Collection;
+use Activitypub\Collection\Outbox;
+use Activitypub\Handler\Feature_Request;
 use Activitypub\Rest\Server;
 
 /**
@@ -121,6 +123,69 @@ class Test_Actors_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controll
 		$this->assertEquals( 'object', $response->get_data()['data']['params'][0] );
 
 		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+	}
+
+	/**
+	 * An inbox activity that omits `actor` but is signed (e.g. Mastodon's FeatureRequest,
+	 * FEP-7aa9) must be accepted: the actor is backfilled from the signature keyId, the
+	 * activity is stored, and the handler can respond.
+	 *
+	 * Without the backfill this 400s as a missing `actor` parameter and never reaches the
+	 * inbox or the handler, so no Accept is ever sent.
+	 */
+	public function test_actorless_signed_feature_request_is_stored_and_accepted() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\update_option( 'activitypub_default_feature_policy', ACTIVITYPUB_INTERACTION_POLICY_ANYONE );
+		Feature_Request::init();
+
+		$object_uri = Actors::get_by_id( self::$user_id )->get_id();
+		$actor_uri  = 'https://remote.example/users/curator';
+		$json       = array(
+			'id'         => 'https://remote.example/activities/feat-1',
+			'type'       => 'FeatureRequest',
+			'object'     => $object_uri,
+			'instrument' => 'https://remote.example/users/curator/featured',
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/users/' . self::$user_id . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_header( 'Signature', \sprintf( 'keyId="%s#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="abc"', $actor_uri ) );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+
+		$this->assertEquals( 202, $response->get_status(), 'Signed actor-less FeatureRequest should be accepted, not rejected as a missing parameter.' );
+
+		// The activity was stored with the signature-derived actor.
+		$inbox_item = Inbox_Collection::get_by_guid( 'https://remote.example/activities/feat-1' );
+		$this->assertInstanceOf( \WP_Post::class, $inbox_item );
+		$this->assertSame( $actor_uri, \get_post_meta( $inbox_item->ID, '_activitypub_activity_remote_actor', true ) );
+
+		// An Accept was queued, addressed to the keyId-derived curator.
+		$outbox = \get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				'author'      => self::$user_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Accept',
+					),
+				),
+			)
+		);
+		$this->assertNotEmpty( $outbox, 'An Accept should be queued for the FeatureRequest.' );
+
+		$payload = \json_decode( $outbox[0]->post_content, true );
+		$this->assertContains( $actor_uri, (array) $payload['to'], 'The Accept must be addressed to the requesting curator.' );
+
+		\delete_option( 'activitypub_default_feature_policy' );
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\remove_action( 'activitypub_inbox_feature_request', array( Feature_Request::class, 'handle_feature_request' ) );
+		\remove_action( 'activitypub_rest_inbox_disallowed', array( Feature_Request::class, 'handle_blocked_request' ) );
+		\remove_filter( 'activitypub_validate_object', array( Feature_Request::class, 'validate_object' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-server.php
+++ b/tests/phpunit/tests/includes/rest/class-test-server.php
@@ -189,6 +189,46 @@ class Test_Server extends \WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * A spoofed draft Signature header must not win over the RFC 9421 keyId the request is
+	 * actually verified with. The verifier uses Signature-Input when present, so the injected
+	 * actor must be derived from there, not from the (ignored) draft Signature header.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_uses_verified_keyid_over_spoofed_header() {
+		Server::init();
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'content-type', 'application/activity+json' );
+		$request->set_header( 'signature', 'keyId="https://victim.example/users/victim#main-key",signature="abc"' );
+		$request->set_header( 'signature-input', 'sig1=("@method");keyid="https://attacker.example/users/attacker#main-key";created=1700000000' );
+		$request->set_body( \wp_json_encode( array( 'type' => 'FeatureRequest' ) ) );
+
+		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertSame( 'https://attacker.example/users/attacker', $request->get_json_params()['actor'] );
+	}
+
+	/**
+	 * When the signature carries more than one keyId the verifier may validate any label,
+	 * so we cannot know which key will verify. The actor must not be backfilled.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_skips_ambiguous_keyids() {
+		Server::init();
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'content-type', 'application/activity+json' );
+		$request->set_header( 'signature-input', 'sig1=("@method");keyid="https://victim.example/users/victim#main-key", sig2=("@method");keyid="https://attacker.example/users/attacker#main-key";created=1700000000' );
+		$request->set_body( \wp_json_encode( array( 'type' => 'FeatureRequest' ) ) );
+
+		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertArrayNotHasKey( 'actor', $request->get_json_params() );
+	}
+
+	/**
 	 * A prior short-circuit result must be respected and left intact.
 	 *
 	 * @covers ::maybe_add_actor_from_signature

--- a/tests/phpunit/tests/includes/rest/class-test-server.php
+++ b/tests/phpunit/tests/includes/rest/class-test-server.php
@@ -36,6 +36,153 @@ class Test_Server extends \WP_Test_REST_TestCase {
 		$this->assertEquals( 10, \has_filter( 'rest_post_dispatch', array( Server::class, 'filter_output' ) ) );
 		$this->assertEquals( 10, \has_filter( 'rest_post_dispatch', array( Server::class, 'add_cors_headers' ) ) );
 		$this->assertEquals( 10, \has_filter( 'rest_allowed_cors_headers', array( Server::class, 'allow_cors_headers' ) ) );
+		$this->assertEquals( 10, \has_filter( 'rest_pre_dispatch', array( Server::class, 'maybe_add_actor_from_signature' ) ) );
+	}
+
+	/**
+	 * Build an inbox request that omits the actor but carries a signature keyId.
+	 *
+	 * @param array  $body    The activity body.
+	 * @param string $key_id  The keyId to advertise via the HTTP Signature header.
+	 * @param string $route   Optional. The request route. Default the shared inbox.
+	 * @return \WP_REST_Request The prepared request.
+	 */
+	private function build_signed_inbox_request( $body, $key_id, $route = null ) {
+		$route   = $route ?? '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox';
+		$request = new \WP_REST_Request( 'POST', $route );
+		$request->set_header( 'content-type', 'application/activity+json' );
+		$request->set_header( 'signature', sprintf( 'keyId="%s",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="abc"', $key_id ) );
+		$request->set_body( wp_json_encode( $body ) );
+
+		return $request;
+	}
+
+	/**
+	 * An actor-less inbox activity gets its actor backfilled from the signature keyId.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_backfills_missing_actor() {
+		$request = $this->build_signed_inbox_request(
+			array(
+				'id'         => 'https://remote.example.com/activities/feat-1',
+				'type'       => 'FeatureRequest',
+				'object'     => 'https://example.org/author/1',
+				'instrument' => 'https://remote.example.com/users/curator/featured',
+			),
+			'https://remote.example.com/users/curator#main-key'
+		);
+
+		$result = Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertNull( $result, 'The filter must not hijack the request.' );
+		$this->assertSame(
+			'https://remote.example.com/users/curator',
+			$request->get_json_params()['actor'],
+			'Actor should be derived from the keyId with the fragment stripped.'
+		);
+	}
+
+	/**
+	 * The actor is also derived from an RFC 9421 Signature-Input keyid.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_supports_signature_input() {
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'content-type', 'application/activity+json' );
+		$request->set_header( 'signature-input', 'sig1=("@method" "@target-uri");keyid="https://remote.example.com/users/curator#main-key";created=1700000000' );
+		$request->set_body( wp_json_encode( array( 'type' => 'FeatureRequest' ) ) );
+
+		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertSame( 'https://remote.example.com/users/curator', $request->get_json_params()['actor'] );
+	}
+
+	/**
+	 * An activity that already carries an actor is left untouched.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_keeps_existing_actor() {
+		$request = $this->build_signed_inbox_request(
+			array(
+				'type'  => 'Follow',
+				'actor' => 'https://remote.example.com/users/someone-else',
+			),
+			'https://remote.example.com/users/curator#main-key'
+		);
+
+		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertSame( 'https://remote.example.com/users/someone-else', $request->get_json_params()['actor'] );
+	}
+
+	/**
+	 * Non-inbox routes must never be rewritten.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_skips_non_inbox_route() {
+		$request = $this->build_signed_inbox_request(
+			array( 'type' => 'FeatureRequest' ),
+			'https://remote.example.com/users/curator#main-key',
+			'/' . ACTIVITYPUB_REST_NAMESPACE . '/outbox'
+		);
+
+		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertArrayNotHasKey( 'actor', $request->get_json_params() );
+	}
+
+	/**
+	 * Without a signature there is no authoritative actor to derive, so nothing changes.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_skips_without_signature() {
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'content-type', 'application/activity+json' );
+		$request->set_body( wp_json_encode( array( 'type' => 'FeatureRequest' ) ) );
+
+		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertArrayNotHasKey( 'actor', $request->get_json_params() );
+	}
+
+	/**
+	 * A non-POST request is ignored.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_skips_non_post() {
+		$request = $this->build_signed_inbox_request(
+			array( 'type' => 'FeatureRequest' ),
+			'https://remote.example.com/users/curator#main-key'
+		);
+		$request->set_method( 'GET' );
+
+		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertArrayNotHasKey( 'actor', $request->get_json_params() );
+	}
+
+	/**
+	 * A prior short-circuit result must be respected and left intact.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_respects_short_circuit() {
+		$request = $this->build_signed_inbox_request(
+			array( 'type' => 'FeatureRequest' ),
+			'https://remote.example.com/users/curator#main-key'
+		);
+
+		$response = new \WP_REST_Response( array( 'handled' => true ) );
+		$result   = Server::maybe_add_actor_from_signature( $response, new \WP_REST_Server(), $request );
+
+		$this->assertSame( $response, $result );
+		$this->assertArrayNotHasKey( 'actor', $request->get_json_params() );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-server.php
+++ b/tests/phpunit/tests/includes/rest/class-test-server.php
@@ -40,40 +40,42 @@ class Test_Server extends \WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * Build an inbox request that omits the actor but carries a signature keyId.
+	 * Build an actor-less, signed inbox request for the actor-backfill tests.
 	 *
-	 * @param array  $body    The activity body.
-	 * @param string $key_id  The keyId to advertise via the HTTP Signature header.
-	 * @param string $route   Optional. The request route. Default the shared inbox.
+	 * @param array  $body   The activity body.
+	 * @param string $key_id The keyId to advertise via the HTTP Signature header.
+	 * @param string $route  Optional. The request route. Default the shared inbox.
 	 * @return \WP_REST_Request The prepared request.
 	 */
 	private function build_signed_inbox_request( $body, $key_id, $route = null ) {
 		$route   = $route ?? '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox';
 		$request = new \WP_REST_Request( 'POST', $route );
 		$request->set_header( 'content-type', 'application/activity+json' );
-		$request->set_header( 'signature', sprintf( 'keyId="%s",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="abc"', $key_id ) );
-		$request->set_body( wp_json_encode( $body ) );
+		$request->set_header( 'signature', \sprintf( 'keyId="%s",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="abc"', $key_id ) );
+		$request->set_body( \wp_json_encode( $body ) );
 
 		return $request;
 	}
 
 	/**
-	 * An actor-less inbox activity gets its actor backfilled from the signature keyId.
+	 * An actor-less FeatureRequest gets its actor backfilled from the signature keyId,
+	 * without altering the raw body (so the signed Digest still verifies).
 	 *
 	 * @covers ::maybe_add_actor_from_signature
 	 */
 	public function test_maybe_add_actor_from_signature_backfills_missing_actor() {
-		$request = $this->build_signed_inbox_request(
-			array(
-				'id'         => 'https://remote.example.com/activities/feat-1',
-				'type'       => 'FeatureRequest',
-				'object'     => 'https://example.org/author/1',
-				'instrument' => 'https://remote.example.com/users/curator/featured',
-			),
-			'https://remote.example.com/users/curator#main-key'
-		);
+		Server::init(); // Inbox POSTs read JSON params first; that order makes set_param() land in JSON.
 
-		$result = Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+		$body    = array(
+			'id'         => 'https://remote.example.com/activities/feat-1',
+			'type'       => 'FeatureRequest',
+			'object'     => 'https://example.org/author/1',
+			'instrument' => 'https://remote.example.com/users/curator/featured',
+		);
+		$request = $this->build_signed_inbox_request( $body, 'https://remote.example.com/users/curator#main-key' );
+
+		$original_body = $request->get_body();
+		$result        = Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
 
 		$this->assertNull( $result, 'The filter must not hijack the request.' );
 		$this->assertSame(
@@ -81,6 +83,7 @@ class Test_Server extends \WP_Test_REST_TestCase {
 			$request->get_json_params()['actor'],
 			'Actor should be derived from the keyId with the fragment stripped.'
 		);
+		$this->assertSame( $original_body, $request->get_body(), 'The raw body must be untouched so the signed Digest still verifies.' );
 	}
 
 	/**
@@ -89,10 +92,12 @@ class Test_Server extends \WP_Test_REST_TestCase {
 	 * @covers ::maybe_add_actor_from_signature
 	 */
 	public function test_maybe_add_actor_from_signature_supports_signature_input() {
+		Server::init();
+
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
 		$request->set_header( 'content-type', 'application/activity+json' );
 		$request->set_header( 'signature-input', 'sig1=("@method" "@target-uri");keyid="https://remote.example.com/users/curator#main-key";created=1700000000' );
-		$request->set_body( wp_json_encode( array( 'type' => 'FeatureRequest' ) ) );
+		$request->set_body( \wp_json_encode( array( 'type' => 'FeatureRequest' ) ) );
 
 		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
 
@@ -107,7 +112,7 @@ class Test_Server extends \WP_Test_REST_TestCase {
 	public function test_maybe_add_actor_from_signature_keeps_existing_actor() {
 		$request = $this->build_signed_inbox_request(
 			array(
-				'type'  => 'Follow',
+				'type'  => 'FeatureRequest',
 				'actor' => 'https://remote.example.com/users/someone-else',
 			),
 			'https://remote.example.com/users/curator#main-key'
@@ -119,7 +124,23 @@ class Test_Server extends \WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * Non-inbox routes must never be rewritten.
+	 * Only FeatureRequest activities are backfilled; other actor-less types are left alone.
+	 *
+	 * @covers ::maybe_add_actor_from_signature
+	 */
+	public function test_maybe_add_actor_from_signature_skips_other_activity_types() {
+		$request = $this->build_signed_inbox_request(
+			array( 'type' => 'Follow' ),
+			'https://remote.example.com/users/curator#main-key'
+		);
+
+		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
+
+		$this->assertArrayNotHasKey( 'actor', $request->get_json_params() );
+	}
+
+	/**
+	 * Non-inbox routes must never be touched.
 	 *
 	 * @covers ::maybe_add_actor_from_signature
 	 */
@@ -143,7 +164,7 @@ class Test_Server extends \WP_Test_REST_TestCase {
 	public function test_maybe_add_actor_from_signature_skips_without_signature() {
 		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
 		$request->set_header( 'content-type', 'application/activity+json' );
-		$request->set_body( wp_json_encode( array( 'type' => 'FeatureRequest' ) ) );
+		$request->set_body( \wp_json_encode( array( 'type' => 'FeatureRequest' ) ) );
 
 		Server::maybe_add_actor_from_signature( null, new \WP_REST_Server(), $request );
 

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -467,42 +467,42 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 	/**
 	 * Data provider for verify_key_id tests.
 	 *
-	 * @return array[] Test cases: [ signature_header, actor, expected_pass ].
+	 * @return array[] Test cases: [ verified_key_id, actor, expected_pass ].
 	 */
 	public function data_verify_key_id() {
 		return array(
 			'matching hosts'          => array(
-				'keyId="https://remote.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://remote.example/users/alice#main-key',
 				'https://remote.example/users/alice',
 				true,
 			),
 			'mismatched hosts'        => array(
-				'keyId="https://evil.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://evil.example/users/alice#main-key',
 				'https://remote.example/users/alice',
 				false,
 			),
 			'no actor in body'        => array(
-				'keyId="https://remote.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://remote.example/users/alice#main-key',
 				null,
 				true,
 			),
-			'no signature header'     => array(
+			'no verified key id'      => array(
 				null,
 				'https://remote.example/users/alice',
 				true,
 			),
 			'actor as object with id' => array(
-				'keyId="https://remote.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://remote.example/users/alice#main-key',
 				array( 'id' => 'https://remote.example/users/alice' ),
 				true,
 			),
 			'actor object mismatch'   => array(
-				'keyId="https://evil.example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://evil.example/users/alice#main-key',
 				array( 'id' => 'https://remote.example/users/alice' ),
 				false,
 			),
 			'case-insensitive hosts'  => array(
-				'keyId="https://Remote.Example/users/alice#main-key",algorithm="rsa-sha256",signature="abc"',
+				'https://Remote.Example/users/alice#main-key',
 				'https://remote.example/users/alice',
 				true,
 			),
@@ -510,21 +510,17 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that verify_key_id checks keyId host against actor host.
+	 * Test that verify_key_id checks the verified keyId's host against the actor host.
 	 *
 	 * @dataProvider data_verify_key_id
 	 * @covers ::verify_key_id
 	 *
-	 * @param string|null       $signature The Signature header value.
-	 * @param string|array|null $actor     The actor value in the JSON body.
+	 * @param string|null       $key_id      The keyId that verified the signature.
+	 * @param string|array|null $actor       The actor value in the JSON body.
 	 * @param bool              $should_pass Whether the check should pass.
 	 */
-	public function test_verify_key_id( $signature, $actor, $should_pass ) {
+	public function test_verify_key_id( $key_id, $actor, $should_pass ) {
 		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/inbox' );
-
-		if ( null !== $signature ) {
-			$request->set_header( 'Signature', $signature );
-		}
 
 		$body = array(
 			'type' => 'Like',
@@ -542,7 +538,7 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 		 */
 		$method = new \ReflectionMethod( $this->instance, 'verify_key_id' );
 		$method->setAccessible( true );
-		$result = $method->invoke( $this->instance, $request );
+		$result = $method->invoke( $this->instance, $request, $key_id );
 
 		if ( $should_pass ) {
 			$this->assertTrue( $result );
@@ -636,93 +632,5 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 		$this->assertWPError( $result );
 		$this->assertEquals( 'activitypub_signature_verification', $result->get_error_code() );
 		$this->assertEquals( 401, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * Invoke the private verify_key_id() with a crafted Signature-Input header and actor.
-	 *
-	 * @param string $signature_input The Signature-Input header value.
-	 * @param string $actor           The activity actor URI.
-	 * @return true|\WP_Error
-	 */
-	private function invoke_verify_key_id( $signature_input, $actor ) {
-		$request = new \WP_REST_Request( 'POST', '/activitypub/1.0/inbox' );
-		$request->set_header( 'signature-input', $signature_input );
-		$request->set_header( 'content-type', 'application/json' );
-		$request->set_body( \wp_json_encode( array( 'actor' => $actor ) ) );
-
-		$method = new \ReflectionMethod( $this->instance, 'verify_key_id' );
-		$method->setAccessible( true );
-
-		return $method->invoke( $this->instance, $request );
-	}
-
-	/**
-	 * Test that an unquoted RFC 9421 keyid on a different host is rejected.
-	 *
-	 * Regression: the keyid binding previously matched quotes only, so an unquoted
-	 * keyid (which the RFC 9421 verifier accepts) skipped the host-equality check.
-	 *
-	 * @covers ::verify_key_id
-	 */
-	public function test_verify_key_id_unquoted_mismatched_host_is_rejected() {
-		$result = $this->invoke_verify_key_id(
-			'sig1=("@method");keyid=https://evil.example/actor#key;alg="rsa-v1_5-sha256"',
-			'https://victim.example/users/alice'
-		);
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'activitypub_key_actor_mismatch', $result->get_error_code() );
-		$this->assertEquals( 403, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * Test that an unquoted RFC 9421 keyid on the same host passes.
-	 *
-	 * @covers ::verify_key_id
-	 */
-	public function test_verify_key_id_unquoted_same_host_passes() {
-		$result = $this->invoke_verify_key_id(
-			'sig1=("@method");keyid=https://example.org/actor#key;alg="rsa-v1_5-sha256"',
-			'https://example.org/users/bob'
-		);
-
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test that a quoted RFC 9421 keyid on a different host is still rejected.
-	 *
-	 * @covers ::verify_key_id
-	 */
-	public function test_verify_key_id_quoted_mismatched_host_is_rejected() {
-		$result = $this->invoke_verify_key_id(
-			'sig1=("@method");keyid="https://evil.example/actor#key";alg="rsa-v1_5-sha256"',
-			'https://victim.example/users/alice'
-		);
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'activitypub_key_actor_mismatch', $result->get_error_code() );
-		$this->assertEquals( 403, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * Test that a keyid injected into another parameter's value does not fool the binding.
-	 *
-	 * The real `keyid` parameter (evil host) is what the RFC 9421 verifier uses; a
-	 * `keyid=<victim host>` string smuggled inside an earlier quoted parameter value must
-	 * not be picked up instead, which would make the host check pass against the wrong host.
-	 *
-	 * @covers ::verify_key_id
-	 */
-	public function test_verify_key_id_ignores_keyid_inside_other_param() {
-		$result = $this->invoke_verify_key_id(
-			'sig1=("@method");tag="keyid=https://victim.example/key";keyid=https://evil.example/key',
-			'https://victim.example/users/alice'
-		);
-
-		$this->assertWPError( $result );
-		$this->assertEquals( 'activitypub_key_actor_mismatch', $result->get_error_code() );
-		$this->assertEquals( 403, $result->get_error_data()['status'] );
 	}
 }


### PR DESCRIPTION
## The problem

Incoming `FeatureRequest` activities (FEP-7aa9, "canFeature") from Mastodon are silently rejected. They never get stored in the inbox, and the `Accept`/`Reject` we are supposed to send back is never queued. From the curator's side it looks like our server simply ignored the request.

The root cause is an addressing mismatch. Mastodon's `FeatureRequestSerializer` emits only `id`, `type`, `object`, and `instrument`, and signs the delivery with the curator's key. It does **not** put an `actor` in the activity body, the requesting actor is conveyed solely through the HTTP signature keyId. This is intentional per FEP-7aa9, and FeatureRequest is the only request type Mastodon serializes this way (QuoteRequest, for example, includes `actor`).

Our inbox routes declare `actor` as a **required** REST parameter, and `Feature_Request::validate_object()` also requires it. WordPress validates required parameters in `WP_REST_Server::dispatch()` *before* the `permission_callback` (where signature verification, and therefore keyId resolution, happens). So the request is rejected with `400 rest_missing_callback_param` before it ever reaches storage, the activity dispatch, or the handler. No inbox item, no Accept.

## Proposed changes:

* Add a `rest_pre_dispatch` filter, `Server::maybe_add_actor_from_signature()`, scoped to actor-less `FeatureRequest` POSTs on inbox endpoints. It reads the keyId from the signature, derives the actor URI (fragment stripped, matching the convention `Remote_Actors::get_public_key()` already uses), and adds it to the request.
* The actor is injected with `set_param()`, **not** by rewriting the request body. Inbox POSTs read JSON parameters first (`Server::request_parameter_order()`), so the value is visible to both required-parameter validation and the handler via `get_json_params()`, while the raw body stays byte-identical.
* `rest_pre_dispatch` is the only hook that fires before required-parameter validation, so by the time `actor` is checked it is present. No changes to route args, validators, or the handler.
* Extract the keyId parsing into a shared `Signature::get_key_id()` and reuse it in `verify_key_id()` (which previously parsed the same headers inline).

### Why the body is not rewritten

An earlier revision rewrote the request body to inject the actor. That broke HTTP Signature verification: `Http_Signature_Draft::verify_content_digest()` recomputes `base64( sha256( body ) )` and compares it to the signed `Digest` header, so any change to the body (which Mastodon always digests) turns into a `401 digest_mismatch`. Injecting via `set_param()` leaves the body untouched, so the digest still verifies. A unit test asserts the raw body is unchanged after the filter runs.

### Why this is safe

The injected actor is not trusted on its own. After injection, the request still goes through `Signature::verify_http_signature()` (proving the sender holds the private key for that keyId) and `verify_key_id()` (binding key host to actor host). Because the actor is derived *from* the keyId, the host check is satisfied by construction, and an attacker cannot inject a different actor than the key they actually control.

Crucially, the keyId is the one the request is *actually verified against*. `Signature::get_key_id()` mirrors `verify_http_signature()`'s selection: it takes the keyId from `Signature-Input` when present (RFC 9421, which the verifier prefers) rather than a possibly-spoofed draft `Signature` header, and it refuses to backfill when the signature carries more than one keyId, since the verifier accepts whichever label validates and the verifying key cannot be known in advance. That closes the gap where an actor could be injected from a key that did not sign the request.

The change is purely additive and narrowly scoped: only actor-less FeatureRequests are affected, and a well-formed activity that already carries an `actor` is left untouched.


### Other information:

- [x] Have you written new tests for your changes, if applicable?

Unit tests cover the filter in isolation (backfill from both signature header formats, raw-body-unchanged/digest-preserved, existing-actor passthrough, non-FeatureRequest type, non-inbox route, missing signature, non-POST, short-circuit), the shared `Signature::get_key_id()` helper, and an integration test that drives a signed actor-less `FeatureRequest` through the full REST stack and asserts the inbox item is stored and the `Accept` is queued, addressed to the keyId-derived curator.

## Testing instructions:

* From a Mastodon account, feature/endorse a post authored by a user on the test site (or replay a signed `FeatureRequest` to `/wp-json/activitypub/1.0/users/{id}/inbox` with an `actor`-less body and valid `Signature` + `Digest` headers).
* Confirm the request returns `202` instead of `400`.
* Confirm an inbox item is recorded for the activity.
* With the feature policy set to allow it, confirm an `Accept` is queued in the outbox, addressed to the requesting actor.

The changelog entry is already included in this branch.

