### PR TITLE
Fix FEP-8fcf followers-sync authority bypass

### DIFF
--- a/.github/changelog/fix-followers-sync-authority-binding
+++ b/.github/changelog/fix-followers-sync-authority-binding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Prevent a remote server from discovering which of your followers belong to a third-party server it does not control.

--- a/includes/rest/class-followers-controller.php
+++ b/includes/rest/class-followers-controller.php
@@ -10,6 +10,7 @@ namespace Activitypub\Rest;
 use Activitypub\Activity\Base_Object;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Remote_Actors;
+use Activitypub\Signature;
 
 use function Activitypub\get_masked_wp_version;
 use function Activitypub\get_rest_url_by_path;
@@ -259,8 +260,17 @@ class Followers_Controller extends Actors_Controller {
 		 * FEP-8fcf: the responding server MUST ensure the requested authority
 		 * matches the signing peer, so that instances cannot "get tricked
 		 * into requesting the followers list of a third-party individual".
+		 *
+		 * Derive the signer host from the keyId that the verifier actually
+		 * checked (Signature::get_key_id() mirrors the verifier's header
+		 * choice and returns null when several labels make the choice
+		 * ambiguous). Re-parsing the raw headers here would diverge from the
+		 * verified key: a request can carry an RFC 9421 Signature-Input plus a
+		 * Signature header padded with an unrelated keyId, letting an attacker
+		 * sign with their own key yet steer a naive parser at a third-party host.
 		 */
-		$signer_host = self::normalize_host( self::get_signer_host( $request ) );
+		$key_id      = Signature::get_key_id( $request );
+		$signer_host = $key_id ? self::normalize_host( (string) \wp_parse_url( $key_id, \PHP_URL_HOST ) ) : '';
 		$asked_host  = self::normalize_host( (string) \wp_parse_url( $authority, \PHP_URL_HOST ) );
 
 		if ( ! $signer_host || ! $asked_host || $signer_host !== $asked_host ) {
@@ -314,38 +324,6 @@ class Followers_Controller extends Actors_Controller {
 		$host = \strtolower( (string) $host );
 		$host = \trim( $host, '[]' );
 		return \rtrim( $host, '.' );
-	}
-
-	/**
-	 * Resolve the signing peer's host from the request's HTTP Signature header.
-	 *
-	 * Supports both Cavage-style `Signature: keyId="…"` and RFC 9421's
-	 * `Signature-Input: …keyid="…"`. Returns the host component of the key
-	 * ID URI, lowercased, or an empty string when none is present.
-	 *
-	 * @since 8.1.0
-	 *
-	 * @param \WP_REST_Request $request The request object.
-	 * @return string The signer's host, or an empty string.
-	 */
-	private static function get_signer_host( $request ) {
-		$signature = $request->get_header( 'signature' );
-		$key_id    = null;
-
-		if ( $signature && \preg_match( '/keyId="([^"]+)"/i', $signature, $matches ) ) {
-			$key_id = $matches[1];
-		} else {
-			$signature_input = $request->get_header( 'signature-input' );
-			if ( $signature_input && \preg_match( '/keyid="([^"]+)"/i', $signature_input, $matches ) ) {
-				$key_id = $matches[1];
-			}
-		}
-
-		if ( ! $key_id ) {
-			return '';
-		}
-
-		return \strtolower( (string) \wp_parse_url( $key_id, \PHP_URL_HOST ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-followers-controller.php
@@ -481,6 +481,73 @@ class Test_Followers_Controller extends \Activitypub\Tests\Test_REST_Controller_
 	}
 
 	/**
+	 * An RFC 9421 request whose verified key (in Signature-Input) belongs to
+	 * the attacker must not have its authority taken from an unrelated keyId
+	 * padded into the Signature header.
+	 *
+	 * The verifier selects RFC 9421 whenever Signature-Input is present and
+	 * checks the key named there; the lenient structured-field parser ignores
+	 * trailing junk in the Signature header. A handler that re-parsed the raw
+	 * Signature header could be steered to a third-party host, defeating the
+	 * FEP-8fcf authority binding. The signer host must come from the verified
+	 * keyId instead.
+	 *
+	 * @covers ::get_partial_followers
+	 */
+	public function test_sync_ignores_keyid_padded_into_signature_header() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
+		$request->set_param( 'user_id', $user_id );
+		$request->set_param( 'page', 1 );
+		// Attacker asks for the victim host they do not control.
+		$request->set_param( 'authority', 'https://victim.example' );
+		// The verified key lives in Signature-Input and points at the attacker.
+		$request->set_header( 'Signature-Input', 'sig1=("@method" "@authority");created=1700000000;keyid="https://attacker.example/key"' );
+		// The Signature header carries the signature bytes plus an unrelated keyId.
+		$request->set_header( 'Signature', 'sig1=:AAAA:, keyId="https://victim.example/key"' );
+
+		$controller = new \Activitypub\Rest\Followers_Controller();
+		$response   = $controller->get_partial_followers( $request );
+
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'activitypub_authority_mismatch', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * A Signature-Input carrying more than one keyId is ambiguous: the handler
+	 * cannot know which label the verifier accepted, so the authority match
+	 * must fail closed rather than trust the first listed keyId.
+	 *
+	 * @covers ::get_partial_followers
+	 */
+	public function test_sync_rejects_ambiguous_multi_label_signature() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $user_id . '/followers/sync' );
+		$request->set_param( 'user_id', $user_id );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'authority', 'https://victim.example' );
+		// Two labels, two different keyIds: the choice is ambiguous to the handler.
+		$request->set_header( 'Signature-Input', 'sig1=("@method");created=1700000000;keyid="https://victim.example/key", sig2=("@method");created=1700000000;keyid="https://attacker.example/key"' );
+		$request->set_header( 'Signature', 'sig1=:AAAA:, sig2=:BBBB:' );
+
+		$controller = new \Activitypub\Rest\Followers_Controller();
+		$response   = $controller->get_partial_followers( $request );
+
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'activitypub_authority_mismatch', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data()['status'] );
+	}
+
+	/**
 	 * The defer-signature filter receives `$force_signature` as a third
 	 * argument so hooks can preserve mandatory signing on peer-only
 	 * endpoints like `/followers/sync` without touching unrelated requests.


### PR DESCRIPTION
## Proposed changes:

Fixes an authorization-bypass / follower-disclosure vulnerability in the FEP-8fcf `/followers/sync` endpoint.

`get_partial_followers()` enforces FEP-8fcf's rule that "the requested authority MUST match the signing peer," so an instance cannot be tricked into requesting the follower list of a third party. It did this by deriving the signer's host from a private `get_signer_host()` helper that re-parsed the raw HTTP signature headers — and that parser diverged from the key the verifier actually checked in two ways:

1. It read the `Signature` header **before** `Signature-Input`, whereas `Signature::verify_http_signature()` selects the RFC 9421 verifier whenever `Signature-Input` is present.
2. It had no multi-label ambiguity guard and greedily matched the first `keyid`.

### Exploit

`/followers/sync` has no `show_social_graph()` gate — the authority↔signer binding is its *only* access control. An attacker controlling a single federated actor (`attacker.example`) could defeat it:

- `Signature-Input: sig1=("@method" "@authority");created=…;keyid="https://attacker.example/key"` — the attacker's own key, which they can sign with.
- `Signature: sig1=:VALID_ATTACKER_SIG:, keyId="https://victim.example/key"` — the valid signature bytes plus an unrelated, padded `keyId`.

The RFC 9421 parser only extracts `sig1=:…:` and ignores the trailing junk, so the signature verifies cleanly against the attacker's key and the permission check passes (`verify_key_id` is a no-op on a GET with no JSON actor). Then `get_signer_host()` ran its regex over the raw `Signature` header, picked up the padded `keyId="https://victim.example/key"`, and returned `victim.example`. The attacker sent `authority=https://victim.example`, the hosts matched, and the endpoint returned the local user's followers that live on `victim.example`.

A multi-label `Signature-Input` (two `keyid`s, only the attacker's label signed) achieves the same result against the old parser.

Net effect: any federated peer could enumerate a local user's followers on any third-party host it named, bypassing the FEP-8fcf authority binding and the hidden-social-graph setting on this endpoint.

### Fix

Derive the signer host from `Signature::get_key_id()` — the existing helper that mirrors the verifier's header selection (`Signature-Input` → RFC 9421, else draft Cavage with an `Authorization` fallback) and returns `null` when more than one label makes the signer ambiguous. Delete `get_signer_host()`. The authority check now binds to the same key the verifier checked, and fails closed on ambiguity.

This also fixes two latent issues for free: the old parser had no `Authorization`-header fallback (draft-signed peers using `Authorization: Signature …` got a false 403), and only `strtolower`'d the host instead of running it through `normalize_host()`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New regression tests, both of which fail against the old `get_signer_host()`:
- `test_sync_ignores_keyid_padded_into_signature_header` — the padded-`Signature`-header variant.
- `test_sync_rejects_ambiguous_multi_label_signature` — the multi-label variant.

## Testing instructions:

* `npm run env-test -- --filter='test_sync'` — 34/34 pass, including the two new regression tests.
* `npm run env-test -- --filter='Followers_Controller|Signature|Verification'` — 132/132 pass.
* `composer lint` — clean.

### Changelog entry

Changelog file added: `.github/changelog/fix-followers-sync-authority-binding` (Significance: patch, Type: security).
