### PR TITLE
Use wp_safe_remote_get() for the Site Health REST API check

### DIFF
--- a/.github/changelog/fix-health-check-safe-remote-get
+++ b/.github/changelog/fix-health-check-safe-remote-get
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Harden the Site Health connectivity check so it cannot be used to reach unsafe network addresses.

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -968,8 +968,12 @@ class Health_Check {
 		$actor = Actors::get_by_id( Actors::APPLICATION_USER_ID );
 		$url   = $actor->get_inbox();
 
-		// Make an unauthenticated request.
-		$response = \wp_remote_get(
+		/*
+		 * Make an unauthenticated request. wp_safe_remote_get() guards against
+		 * SSRF should the inbox URL ever resolve off-site; requests to the
+		 * site's own host are still allowed by wp_http_validate_url().
+		 */
+		$response = \wp_safe_remote_get(
 			$url,
 			array(
 				'timeout' => 5,


### PR DESCRIPTION
## Proposed changes:

Hardens the Site Health REST API connectivity check against SSRF.

`Health_Check::is_rest_api_accessible()` fetched the application actor's inbox with `wp_remote_get()`, which performs no URL validation. This swaps it for `wp_safe_remote_get()` as defense in depth.

The target URL is derived from the application actor's inbox (the site's own host), not from per-request user input, so this is a low-risk, admin-only code path today — but `wp_remote_get()` here is SSRF-shaped if the inbox URL ever resolves off-site.

`wp_safe_remote_get()` runs the URL through `wp_http_validate_url()`, which blocks private/reserved IP ranges **except** when the host matches the site's own host (its `$same_host` short-circuit). Because the inbox URL is built from the site's REST URL, localhost and intranet installs keep working — the check still reaches the site itself.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

No new tests: this is a one-line swap to a safer stdlib wrapper with no behavior change for the existing code paths. The existing Site Health suite (33 tests) still passes.

## Testing instructions:

* `npm run env-test -- --filter='Health_Check'` — 33/33 pass.
* `composer lint` — clean.
* On a production (public) install, Site Health → the ActivityPub REST API check behaves exactly as before. On a localhost/intranet install it also still works, because the request goes to the site's own host.

### Changelog entry

Changelog file added: `.github/changelog/fix-health-check-safe-remote-get` (Significance: patch, Type: security).
