### PR TITLE
Add FAQ section with troubleshooting checklists

### DIFF
--- a/.github/changelog/add-troubleshooting-faq
+++ b/.github/changelog/add-troubleshooting-faq
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add FAQ guides that help solve follow requests stuck on "pending" and comments from the Fediverse not showing up.

--- a/docs/faq/missing-comments.md
+++ b/docs/faq/missing-comments.md
@@ -1,0 +1,73 @@
+# Why don't comments from the Fediverse show up?
+
+People reply to your posts on Mastodon (or another Fediverse platform), but the replies never appear as comments on your WordPress site.
+
+Federated replies are inserted as **regular WordPress comments**, through the same pipeline a visitor's comment-form submission goes through. That is by design — moderation, notifications, and spam handling all work as usual — but it also means **every plugin and setting that gatekeeps comments applies to federated replies too**. A reply from Mastodon cannot solve a captcha, so a captcha plugin that checks all comments will reject every single one.
+
+The plugin already exempts federated comments from flood control and the "name and email required" setting, but it cannot bypass third-party comment validation.
+
+Work through this checklist in order:
+
+### 1. The comment is not missing — look in Spam, Pending, and Trash
+
+The most common "missing" comment is sitting in a queue:
+
+- **Comments → Spam**: Akismet and friends regularly misclassify federated comments (see below).
+- **Comments → Pending**: **Settings → Discussion → "Comment must be manually approved"** or **"must have a previously approved comment"** holds federated replies like any other comment. If you want Fediverse interactions to skip moderation, use the official [auto-approve-reactions snippet](https://github.com/Automattic/wordpress-activitypub/tree/trunk/snippets/auto-approve-reactions).
+- **Comments → Trash**: entries on the Disallowed Comment Keys list land here (see below).
+
+⚠ **Beware of "silently discard" options.** Akismet's "Silently discard the worst and most pervasive spam" and similar auto-delete settings (e.g. Antispam Bee's honeypot delete) remove comments without a trace — it looks exactly like they never arrived. Switch such options to "mark as spam" at least while debugging.
+
+### 2. Captcha and honeypot plugins
+
+**The headline cause.** Captcha plugins usually do not distinguish between a comment submitted via the form and one created via an API — and a federated reply can never pass a captcha. Confirmed examples from support threads and issues:
+
+- **hCaptcha**: the comment-form integration blocks all federated replies. Disable hCaptcha for the comment form (keep it for login etc.).
+- **Advanced Google reCAPTCHA**: blocked all incoming replies; a telltale sign was that comment **notification emails still arrived** while the comments themselves never materialized.
+- **WP Armour (honeypot)**: caused the inbox request to fail with an HTTP 500, blocking replies (and more).
+- **CleanTalk**: has flagged every Fediverse comment as spam.
+
+Fix: disable the plugin's comment-form protection, or deactivate the plugin briefly to confirm it is the culprit, then ask its developers for an exemption. Plugin authors can use the ActivityPub plugin's `\Activitypub\is_activitypub_request()` helper to skip validation for federated comments — please report incompatibilities upstream so they do.
+
+### 3. Akismet specifics
+
+Akismet generally works alongside ActivityPub, but federated comments score worse than form comments and some patterns are misjudged reliably — for example **emoji in the commenter's display name** has repeatedly sent replies straight to spam.
+
+- Check the Spam folder and click **Not Spam** — recent plugin versions submit the commenter's Fediverse address (`user@instance.example`) as the author email, so Akismet can learn per-author reputation.
+- Make sure "Silently discard the worst spam" is off (see step 1).
+
+### 4. The Disallowed Comment Keys list
+
+**Settings → Discussion → Disallowed Comment Keys** is applied to the **full JSON of every incoming activity**, not just the comment text. A broad entry like `.com`, `.ru`, or `http` matches the commenter's profile URL inside the activity and trashes (or silently drops) every reply — and blocks follows too.
+
+Review the list for broad patterns, including leftovers from block-list plugins.
+
+### 5. Security plugins and host firewalls blocking the inbox
+
+Everything that blocks your ActivityPub inbox blocks replies exactly like follow requests: mod_security rules on shared hosts, REST-API-restricting security plugins (Wordfence's username-discovery option, All In One WP Security's REST/6G rules, "Disable REST API" plugins), and similar.
+
+Check your server access log for the `POST` to `/wp-json/activitypub/1.0/…/inbox`:
+
+- **`202`** — the activity arrived; the comment is being filtered locally (steps 1-4).
+- **`400`/`403`** — firewall or security plugin.
+- **`500`** — a plugin conflict during processing (WP Armour was one confirmed case).
+- **Nothing** — blocked upstream; work through the same inbound checks as in [Why is a follow request stuck on "pending"?](pending-follow-requests.md#inbound-checks).
+
+### 6. Caching
+
+If a caching layer serves cached HTML where the remote server expects JSON ([content negotiation](../how-to/caching.md)), reply delivery breaks before the comment is ever created. W3 Total Cache (without its Vary-header option), WP Fastest Cache, WP Rocket, and Breeze have all been confirmed culprits. See the [Caching guide](../how-to/caching.md) for compatible configurations.
+
+### 7. It was never a reply
+
+Some "missing comments" are protocol semantics, not bugs:
+
+- **Only actual replies become comments.** A post that merely @-mentions you — written from scratch instead of using the Reply button — has no `inReplyTo` and cannot be matched to a post.
+- **Visibility matters.** Replies with "mentioned people only" visibility are treated as private messages, not public comments.
+- **Deep threads:** replies to *other people's* replies arrive via the thread; in some setups replies addressed to a local WordPress comment rather than the post are still not imported — a known limitation under investigation.
+- **Companion plugins:** if you run the [Friends plugin](https://wordpress.org/plugins/friends/), mention-only posts appear there as feed items rather than as comments — that is intentional routing.
+
+## Still stuck?
+
+Update the plugin first to rule out long-fixed bugs. Then test with all antispam/captcha/security plugins temporarily disabled — if the reply arrives, re-enable them one at a time to find the culprit.
+
+If none of this helps, open a thread in the [support forum](https://wordpress.org/support/plugin/activitypub/) and include: which antispam/captcha/caching/security plugins you run, whether comment notification emails arrive, and the status code your server log shows for the inbox POST.

--- a/docs/faq/pending-follow-requests.md
+++ b/docs/faq/pending-follow-requests.md
@@ -1,0 +1,118 @@
+# Why is a follow request stuck on "pending"?
+
+Someone tries to follow your site from Mastodon (or another Fediverse platform) and the request stays on "Follow requested" / "Cancel request" forever.
+
+The plugin **always accepts follow requests automatically** — there is no manual approval step. A follow that stays pending therefore always means the technical round-trip broke somewhere:
+
+1. The remote server sends a `Follow` activity to your site's inbox (`/wp-json/activitypub/1.0/actors/…/inbox`).
+2. Your site stores the follower and queues an `Accept` activity.
+3. WP-Cron delivers the `Accept` back to the remote server.
+
+If step 1 is blocked, your site never learns about the follow. If step 2 or 3 fails, your site knows about the follower but the remote server never hears back. The first thing to check tells you which half is broken:
+
+> **Does the follower appear in WordPress?** Check **Users → Followers** (or **Settings → ActivityPub → Followers** for the blog profile).
+>
+> - **No** → the follow request never reached your site. Work through [Inbound checks](#inbound-checks).
+> - **Yes, but still pending on the remote side** → the `Accept` is not being delivered. Work through [Outbound checks](#outbound-checks).
+
+Also run **Tools → Site Health** first — the plugin ships its own checks (author URL reachable, WebFinger, System Task Scheduler) that catch several of the causes below.
+
+## Inbound checks
+
+These block the follow request before your site ever sees it. Your server's access log is the best diagnostic: look for `POST` requests to `/wp-json/activitypub/1.0/` paths and note the status code.
+
+| Status in log | Likely cause |
+|---|---|
+| No request at all | Blocked upstream (firewall, Cloudflare) or the remote server gave up ([see below](#the-remote-server-stopped-trying)) |
+| `403` | Host firewall (mod_security) or security plugin |
+| `401` | Signature verification failure |
+| `404` | Permalink / REST API routing problem |
+| `202` | The request arrived — continue with [Outbound checks](#outbound-checks) |
+
+### 1. Host firewall (mod_security)
+
+**The most common cause on shared hosting.** Many hosts (HostGator, Bluehost, OVH, Strato, and other cPanel-based hosts are recurring examples) run mod_security rules that block `POST` requests with the `application/activity+json` content type.
+
+There is nothing the plugin can do about this — only your host can fix it. Contact their support with something like:
+
+> My WordPress site uses the ActivityPub plugin. Please allow POST requests with the Content-Type `application/activity+json` to paths under `/wp-json/activitypub/`. Your mod_security configuration is currently rejecting them (often OWASP rule 920420). Other customers of yours have had this rule adjusted successfully.
+
+After the host fixes it, ask followers to **cancel the pending request and follow again**.
+
+### 2. Security plugins restricting the REST API
+
+Security plugins that restrict the WordPress REST API to logged-in users break federation completely — the inbox returns `401 rest_login_required`.
+
+Known options to look for:
+
+- **Wordfence**: "Prevent discovery of usernames through `/?author=N` scans, the oEmbed API, the WordPress REST API…" — also breaks author URLs (Site Health shows "Author URL is not accessible").
+- **All In One WP Security**: REST API restriction, "Deny bad query strings", "Advanced character string filter", and the 6G blacklist have all been reported to block ActivityPub traffic.
+- **Patchstack / Solid Security / Sucuri / "Disable WP REST API"-type plugins**: any "restrict REST API to authenticated users" toggle.
+
+Allowlist the `activitypub` REST namespace or disable the restriction.
+
+### 3. Caching and Cloudflare
+
+ActivityPub serves JSON and HTML from the same URLs ([content negotiation](../how-to/caching.md)). A cache that ignores the `Accept` header serves cached HTML to the remote server, which then cannot fetch or verify your profile. Test it:
+
+```
+curl -sL -H "Accept: application/activity+json" https://example.com/author/your-name/
+```
+
+You should get JSON, not HTML. If you get HTML, work through the [Caching guide](../how-to/caching.md). Quick fixes that have resolved real cases:
+
+- Enable the **Vary Header** setting (**Settings → ActivityPub → [Advanced](../how-to/advanced-settings.md)**) — this fixed Cloudflare setups.
+- In **W3 Total Cache**, enable its Vary-header option; **WP Rocket** and **Breeze** are known to ignore `Vary: Accept`.
+- Cloudflare has also been reported to strip the `date` header on proxied requests, which breaks signature verification (`401`). Try grey-clouding the DNS record to confirm.
+
+### 4. The Disallowed Comment Keys list
+
+Surprising but real: the plugin checks **every incoming activity** against **Settings → Discussion → Disallowed Comment Keys**. A broad entry like `.com`, `.ru`, or `http` matches the JSON of every follow request (the actor URL contains it) and silently drops it.
+
+Check the list for overly broad patterns — including ones added by block-list plugins. Deactivating such a plugin is not enough; the entries it added must be deleted manually.
+
+### 5. Signature verification failures (401)
+
+If the log shows `401` for inbox POSTs:
+
+- **WordPress in a subdirectory** (`example.com/blog/`): see [WordPress in a Subdirectory](../how-to/wordpress-in-a-subdir.md). Fixed in current plugin versions — update first.
+- **"Plain" permalinks** with `index.php/` in URLs: switch to a pretty permalink structure (**Settings → Permalinks**).
+- **Reverse proxy / Docker**: the proxy must pass the public hostname through (`ProxyPreserveHost On` for Apache) — see [Reverse Proxy](../how-to/reverse-proxy.md). Also make sure the container clock is synced; signatures embed timestamps and clock skew makes them invalid.
+
+### The remote server stopped trying
+
+If your logs show no inbox requests at all even though the firewall is clean, the remote server may have given up on your domain: after repeated failures, Mastodon marks a domain "unavailable" and stops delivering *anything* — including new follow attempts. This persists even after you fix the original problem.
+
+- Any activity sent *from* your site to that server (for example replying to one of its users) resets the status.
+- The instance admin can also reset it manually (`DeliveryFailureTracker.reset!('example.com')`).
+- Ask followers to cancel the pending request and follow again afterwards.
+
+## Outbound checks
+
+The follower shows up in WordPress, but the remote side still says pending — the `Accept` is queued but not delivered.
+
+### 6. WP-Cron is not running
+
+The `Accept` is sent asynchronously via WP-Cron. If cron never fires, the reply never leaves:
+
+- `define( 'DISABLE_WP_CRON', true );` in `wp-config.php` without a real system cron job.
+- A system cron configured to run rarely (e.g. once a day) — accepts are delayed by up to that interval.
+- Very low-traffic sites where WP-Cron (which piggybacks on visits) rarely triggers.
+
+Check **Tools → Site Health** for scheduler warnings, or inspect pending `activitypub_*` events with [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) or `wp cron event list`. The fix is a system cron job hitting `wp-cron.php` every few minutes.
+
+### 7. Outbound requests blocked
+
+Some hosts block outgoing HTTP requests or specific ports. Test with:
+
+```
+wp eval 'var_dump( wp_remote_get( "https://mastodon.social/.well-known/nodeinfo" ) );'
+```
+
+If outbound requests fail, contact your host.
+
+## Still stuck?
+
+Update the plugin first — several historic causes (subdirectory signatures, the 4.0.0 inbox regression, Pixelfed follows without addressing) were plugin bugs that are long fixed.
+
+If none of this helps, open a thread in the [support forum](https://wordpress.org/support/plugin/activitypub/) and include: your hosting provider, active security/caching/antispam plugins, whether the follower appears in WordPress, and the status code your server log shows for inbox POSTs.

--- a/docs/faq/readme.md
+++ b/docs/faq/readme.md
@@ -1,0 +1,10 @@
+# Frequently Asked Questions
+
+Answers to questions and problems that come up regularly in the [support forum](https://wordpress.org/support/plugin/activitypub/) and on [GitHub](https://github.com/Automattic/wordpress-activitypub/issues). Each answer is a checklist, ordered by how often the cause turns out to be the culprit.
+
+If your question is missing, please [open an issue](https://github.com/Automattic/wordpress-activitypub/issues/new/choose) or [submit a pull request](https://github.com/Automattic/wordpress-activitypub/pulls). For guides on configuring specific setups, see the [How-To section](../how-to/readme.md).
+
+## Table of Contents
+
+- [Why is a follow request stuck on "pending"?](pending-follow-requests.md) — The remote side shows "Follow requested" / "Cancel request" forever.
+- [Why don't comments from the Fediverse show up?](missing-comments.md) — Replies on Mastodon & Co. never appear as WordPress comments, often caused by captcha and antispam plugins.

--- a/docs/how-to/readme.md
+++ b/docs/how-to/readme.md
@@ -2,6 +2,8 @@
 
 This folder contains How-To guides for common problems or edge cases. If you miss a guide, please [open an issue](https://github.com/Automattic/wordpress-activitypub/issues/new/choose) or [submit a pull request](https://github.com/Automattic/wordpress-activitypub/pulls).
 
+Troubleshooting something that is broken rather than configuring a setup? Check the [FAQ section](../faq/readme.md) first.
+
 ## Table of Contents
 
 - [Account Migration](account-migration.md) — Moving between Mastodon, WordPress, and other Fediverse platforms.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,7 +2,11 @@
 
 In this directory you will find the documentation for the ActivityPub plugin.
 
+## FAQ
+
+If something is not working — follow requests stuck on "pending", missing comments — check the [FAQ section](./faq) for checklists covering the most common causes.
+
 ## How-To
 
-If you need help, check out the [How-To section](./how-to) or use [the support forums on WordPress.org](https://wordpress.org/support/plugin/activitypub/).
+For guides on configuring specific setups (caching, reverse proxies, subdirectory installs), check out the [How-To section](./how-to) or use [the support forums on WordPress.org](https://wordpress.org/support/plugin/activitypub/).
 

--- a/readme.txt
+++ b/readme.txt
@@ -72,7 +72,7 @@ Put together, ActivityPub is a protocol for publishing and subscribing to activi
 
 = How do I solve… =
 
-We have a **How-To** section in the [docs](https://github.com/Automattic/wordpress-activitypub/tree/trunk/docs/how-to) directory that can help you troubleshoot common issues.
+We have an **FAQ** section in the [docs](https://github.com/Automattic/wordpress-activitypub/tree/trunk/docs/faq) directory with checklists for the most common problems — for example [follow requests stuck on "pending"](https://github.com/Automattic/wordpress-activitypub/blob/trunk/docs/faq/pending-follow-requests.md) and [comments from the Fediverse not showing up](https://github.com/Automattic/wordpress-activitypub/blob/trunk/docs/faq/missing-comments.md) — and a **How-To** section in the [docs](https://github.com/Automattic/wordpress-activitypub/tree/trunk/docs/how-to) directory for configuring specific setups.
 
 = Constants =
 


### PR DESCRIPTION
## Proposed changes:

* Add a new docs/faq/ section with checklists for the two most common support topics, distilled from recurring wordpress.org support threads and GitHub issues:
  * [Why is a follow request stuck on "pending"?](https://github.com/Automattic/wordpress-activitypub/blob/add/troubleshooting-faq/docs/faq/pending-follow-requests.md) — splits triage into inbound causes (host mod_security rules, REST-restricting security plugins, caching/Cloudflare, signature 401s, the Disallowed Comment Keys list) and outbound causes (WP-Cron, blocked outgoing requests), including a ready-to-send host-escalation template and Mastodon delivery-failure-tracking recovery.
  * [Why don't comments from the Fediverse show up?](https://github.com/Automattic/wordpress-activitypub/blob/add/troubleshooting-faq/docs/faq/missing-comments.md) — Spam/Pending/Trash first, then the captcha/antispam plugin class (hCaptcha, Advanced Google reCAPTCHA, WP Armour, CleanTalk, Akismet quirks), silently-discard options, and protocol semantics (mentions without inReplyTo).
* Cross-link the new section from docs/readme.md, docs/how-to/readme.md and the readme.txt FAQ.
* Every cause listed is backed by maintainer-confirmed forum threads or GitHub issues and was verified against the current code paths (Moderation disallowed-list check, Interactions::persist() comment pipeline, auto-accepted follows).

### Other information:

- [x] Have you written new tests for your changes, if applicable? (not applicable, documentation only)

## Testing instructions:

* Read both new guides in docs/faq/ and check the advice against your support-thread experience.
* Verify the relative links between docs/faq/, docs/how-to/ and the GitHub links in readme.txt resolve.