### PR TITLE
Send profile updates when the Starter Kit policy changes

### DIFF
--- a/.github/changelog/update-starter-kit-policy-profile-updates
+++ b/.github/changelog/update-starter-kit-policy-profile-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Notify followers about your new preference when the Starter Kit policy setting changes, so other servers no longer act on an outdated one.

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -146,22 +146,7 @@ class Actor {
 	 * @since unreleased
 	 */
 	public static function schedule_all_profile_updates() {
-		if ( ! is_user_type_disabled( 'blog' ) ) {
-			self::schedule_profile_update( Actors::BLOG_USER_ID );
-		}
-
-		if ( is_user_type_disabled( 'user' ) ) {
-			return;
-		}
-
-		$user_ids = \get_users(
-			array(
-				'capability__in' => array( 'activitypub' ),
-				'fields'         => 'ID',
-			)
-		);
-
-		foreach ( $user_ids as $user_id ) {
+		foreach ( Actors::get_all_ids() as $user_id ) {
 			self::schedule_profile_update( $user_id );
 		}
 	}

--- a/includes/scheduler/class-actor.php
+++ b/includes/scheduler/class-actor.php
@@ -49,6 +49,10 @@ class Actor {
 		\add_action( 'add_option_activitypub_actor_mode', array( self::class, 'blog_user_update' ) );
 		\add_action( 'update_option_activitypub_actor_mode', array( self::class, 'blog_user_update' ) );
 
+		// The Starter Kit policy is part of every actor profile.
+		\add_action( 'add_option_activitypub_default_feature_policy', array( self::class, 'schedule_all_profile_updates' ) );
+		\add_action( 'update_option_activitypub_default_feature_policy', array( self::class, 'schedule_all_profile_updates' ) );
+
 		\add_action( 'transition_post_status', array( self::class, 'schedule_post_activity' ), 33, 3 );
 
 		\add_action( 'post_stuck', array( self::class, 'sticky_post_update' ) );
@@ -129,6 +133,36 @@ class Actor {
 			} elseif ( Extra_Fields::BLOG_POST_TYPE === $post->post_type ) {
 				self::schedule_profile_update( Actors::BLOG_USER_ID );
 			}
+		}
+	}
+
+	/**
+	 * Send profile updates for all local actors.
+	 *
+	 * Used when a site-wide setting that is part of every actor profile
+	 * changes, like the Starter Kit policy (FEP-7aa9 `canFeature`), so
+	 * followers of the blog actor and of every author receive the change.
+	 *
+	 * @since unreleased
+	 */
+	public static function schedule_all_profile_updates() {
+		if ( ! is_user_type_disabled( 'blog' ) ) {
+			self::schedule_profile_update( Actors::BLOG_USER_ID );
+		}
+
+		if ( is_user_type_disabled( 'user' ) ) {
+			return;
+		}
+
+		$user_ids = \get_users(
+			array(
+				'capability__in' => array( 'activitypub' ),
+				'fields'         => 'ID',
+			)
+		);
+
+		foreach ( $user_ids as $user_id ) {
+			self::schedule_profile_update( $user_id );
 		}
 	}
 

--- a/tests/phpunit/tests/includes/scheduler/class-test-actor.php
+++ b/tests/phpunit/tests/includes/scheduler/class-test-actor.php
@@ -9,6 +9,7 @@ namespace Activitypub\Tests\Scheduler;
 
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
+use Activitypub\Collection\Outbox;
 use Activitypub\Scheduler\Actor;
 
 /**
@@ -131,6 +132,62 @@ class Test_Actor extends \Activitypub\Tests\ActivityPub_Outbox_TestCase {
 		$id            = \get_post_meta( $post->ID, '_activitypub_object_id', true );
 		$this->assertSame( $activitpub_id, $id );
 		$this->assertSame( $test_value, $result );
+	}
+
+	/**
+	 * Test that changing the Starter Kit policy schedules profile updates for all actors.
+	 *
+	 * @covers ::schedule_all_profile_updates
+	 */
+	public function test_feature_policy_update_schedules_all_profile_updates() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		// Reset outbox state before testing the feature-policy hook in isolation.
+		_delete_all_posts();
+
+		\update_option( 'activitypub_default_feature_policy', ACTIVITYPUB_INTERACTION_POLICY_ANYONE );
+
+		$outbox_items = \get_posts(
+			array(
+				'post_type'      => Outbox::POST_TYPE,
+				'posts_per_page' => -1,
+				'post_status'    => 'pending',
+			)
+		);
+
+		$object_ids = array();
+		foreach ( $outbox_items as $outbox_item ) {
+			$object_ids[] = \get_post_meta( $outbox_item->ID, '_activitypub_object_id', true );
+		}
+
+		$this->assertContains( Actors::get_by_id( Actors::BLOG_USER_ID )->get_id(), $object_ids, 'The blog actor should receive a profile update.' );
+		$this->assertContains( Actors::get_by_id( self::$user_id )->get_id(), $object_ids, 'User actors should receive a profile update.' );
+	}
+
+	/**
+	 * Test that disabled actor types are skipped when the Starter Kit policy changes.
+	 *
+	 * @covers ::schedule_all_profile_updates
+	 */
+	public function test_feature_policy_update_respects_disabled_user_actors() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+
+		// Reset outbox state before testing the feature-policy hook in isolation.
+		_delete_all_posts();
+
+		\update_option( 'activitypub_default_feature_policy', ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS );
+
+		$outbox_items = \get_posts(
+			array(
+				'post_type'      => Outbox::POST_TYPE,
+				'posts_per_page' => -1,
+				'post_status'    => 'pending',
+			)
+		);
+
+		$blog_actor_id = Actors::get_by_id( Actors::BLOG_USER_ID )->get_id();
+		$this->assertCount( 1, $outbox_items, 'Only the blog actor should receive a profile update when user actors are disabled.' );
+		$this->assertSame( $blog_actor_id, \get_post_meta( $outbox_items[0]->ID, '_activitypub_object_id', true ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* The Default Starter Kit policy setting (activitypub_default_feature_policy) is part of every actor profile as the FEP-7aa9 canFeature interaction policy, but changing it never federated an update — remote servers kept evaluating Starter Kit requests against the stale policy until an unrelated profile edit happened to trigger one.
* Changing (or first saving) the setting now schedules an Update activity for the blog actor and for every user with the activitypub capability, honoring the actor mode: disabled actor types are skipped.
* Reuses the existing profile-update scheduling in the Actor scheduler; the fan-out only runs on an admin settings save, and the capability query matches the established pattern used elsewhere.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Enable both the blog actor and author profiles (Settings → ActivityPub → Profiles).
* Follow the blog actor and an author from a Mastodon account.
* Change Settings → ActivityPub → Activities → Default Starter Kit policy and save.
* Run the outbox cron (or wait), then verify both remote profiles received an Update (e.g. via the outbox endpoint or a debug log on the receiving instance): the actors' interactionPolicy.canFeature.automaticApproval reflects the new policy.
* Switch the actor mode to blog-only and change the policy again: only the blog actor gets an Update.