### PR TITLE
Support Starter Kit consent stamps for the blog actor

### DIFF
--- a/.github/changelog/fix-starter-kit-blog-user
+++ b/.github/changelog/fix-starter-kit-blog-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Starter Kit consent now also works for the blog profile, not just for individual authors.

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -474,6 +474,11 @@ class Query {
 
 			$actor_id = (int) $queried->ID;
 		} else {
+			// A non-numeric actor var would cast to 0 and alias the blog actor; reject it.
+			if ( ! \is_numeric( $actor_var ) ) {
+				return false;
+			}
+
 			$actor_id = (int) $actor_var;
 		}
 

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -11,6 +11,7 @@ use Activitypub\Activity\Extended_Object\Feature_Authorization;
 use Activitypub\Activity\Extended_Object\Quote_Authorization;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
+use Activitypub\Handler\Feature_Request;
 use Activitypub\Transformer\Factory;
 
 /**
@@ -145,7 +146,8 @@ class Query {
 				return $this->maybe_get_stamp();
 			}
 
-			if ( $queried_object instanceof \WP_User || \get_query_var( 'actor' ) ) {
+			// Note: the blog actor's `actor` query var is '0', which is falsy but valid.
+			if ( $queried_object instanceof \WP_User || '' !== \get_query_var( 'actor' ) ) {
 				return $this->maybe_get_actor_stamp();
 			}
 		}
@@ -449,34 +451,34 @@ class Query {
 	/**
 	 * Maybe get a FeatureAuthorization object from an actor-scoped stamp.
 	 *
-	 * Resolves URLs of the form `?actor=USER_ID&stamp=UMETA_ID` against the
-	 * `_activitypub_featured_by` user meta. The umeta_id doubles as the stamp
-	 * identifier; ownership is enforced by checking the row's user_id matches
-	 * the queried actor.
+	 * Resolves URLs of the form `?actor=USER_ID&stamp=STAMP_ID` against the
+	 * actor's stamp store, see {@see Feature_Request::get_stamp()}. Ownership
+	 * is enforced by resolving the stamp scoped to the queried actor, which
+	 * includes the blog actor (`actor=0`).
 	 *
 	 * @return bool True if a FeatureAuthorization was prepared, false otherwise.
 	 */
 	private function maybe_get_actor_stamp() {
-		$stamp_id = (int) \get_query_var( 'stamp' );
-		$actor_id = (int) \get_query_var( 'actor' );
+		$stamp_id  = (int) \get_query_var( 'stamp' );
+		$actor_var = \get_query_var( 'actor' );
 
 		if ( ! $stamp_id ) {
 			return false;
 		}
 
-		if ( ! $actor_id ) {
+		if ( '' === $actor_var ) {
 			$queried = $this->get_queried_object();
-			if ( $queried instanceof \WP_User ) {
-				$actor_id = (int) $queried->ID;
+			if ( ! $queried instanceof \WP_User ) {
+				return false;
 			}
+
+			$actor_id = (int) $queried->ID;
+		} else {
+			$actor_id = (int) $actor_var;
 		}
 
-		if ( ! $actor_id ) {
-			return false;
-		}
-
-		$meta = \get_metadata_by_mid( 'user', $stamp_id );
-		if ( ! $meta || '_activitypub_featured_by' !== $meta->meta_key || (int) $meta->user_id !== $actor_id ) {
+		$instrument = Feature_Request::get_stamp( $actor_id, $stamp_id );
+		if ( null === $instrument ) {
 			return false;
 		}
 
@@ -488,7 +490,7 @@ class Query {
 		$stamp_url = \add_query_arg(
 			array(
 				'actor' => $actor_id,
-				'stamp' => $meta->umeta_id,
+				'stamp' => $stamp_id,
 			),
 			\home_url( '/' )
 		);
@@ -496,7 +498,7 @@ class Query {
 		$authorization = new Feature_Authorization();
 		$authorization->set_id( $stamp_url );
 		$authorization->set_attributed_to( $actor->get_id() );
-		$authorization->set_interacting_object( $meta->meta_value );
+		$authorization->set_interacting_object( $instrument );
 		$authorization->set_interaction_target( $actor->get_id() );
 
 		$this->activitypub_object    = $authorization;

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -474,8 +474,9 @@ class Query {
 
 			$actor_id = (int) $queried->ID;
 		} else {
-			// A non-numeric actor var would cast to 0 and alias the blog actor; reject it.
-			if ( ! \is_numeric( $actor_var ) ) {
+			// Values like '0e1' or '1.5' pass is_numeric() but cast to 0/1 and alias
+			// an actor, so require a plain decimal integer before casting.
+			if ( ! \ctype_digit( (string) $actor_var ) ) {
 				return false;
 			}
 

--- a/includes/handler/class-feature-request.php
+++ b/includes/handler/class-feature-request.php
@@ -22,6 +22,17 @@ use function Activitypub\user_can_activitypub;
  * @see https://w3id.org/fep/7aa9
  */
 class Feature_Request {
+
+	/**
+	 * Option name for the blog actor's feature stamps.
+	 *
+	 * The blog actor has no users-table row (its ID is 0), so its stamps
+	 * cannot live in user meta like the stamps of regular users do.
+	 *
+	 * @var string
+	 */
+	const BLOG_STAMPS_OPTION = 'activitypub_blog_featured_by';
+
 	/**
 	 * Initialize the class, registering WordPress hooks.
 	 */
@@ -105,11 +116,11 @@ class Feature_Request {
 	/**
 	 * Send an Accept activity in response to the FeatureRequest, issuing a stamp.
 	 *
-	 * Idempotent: a second call with the same instrument for the same user reuses
-	 * the existing umeta row instead of minting a duplicate stamp.
+	 * Idempotent: a second call with the same instrument for the same actor reuses
+	 * the existing stamp instead of minting a duplicate, see {@see add_stamp()}.
 	 *
 	 * @param array $activity_object The activity object.
-	 * @param int   $user_id         The local user ID being featured.
+	 * @param int   $user_id         The local user ID being featured (0 for the blog actor).
 	 */
 	public static function queue_accept( $activity_object, $user_id ) {
 		if ( ! user_can_activitypub( $user_id ) ) {
@@ -123,21 +134,10 @@ class Feature_Request {
 
 		$activity_object['instrument'] = object_to_uri( $activity_object['instrument'] );
 
-		// Idempotent stamp creation.
-		$existing = \get_user_meta( $user_id, '_activitypub_featured_by', false );
-		if ( \in_array( $activity_object['instrument'], (array) $existing, true ) ) {
-			global $wpdb;
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$umeta_id = $wpdb->get_var(
-				$wpdb->prepare(
-					"SELECT umeta_id FROM {$wpdb->usermeta} WHERE user_id = %d AND meta_key = %s AND meta_value = %s LIMIT 1",
-					$user_id,
-					'_activitypub_featured_by',
-					$activity_object['instrument']
-				)
-			);
-		} else {
-			$umeta_id = \add_user_meta( $user_id, '_activitypub_featured_by', $activity_object['instrument'] );
+		$stamp_id = self::add_stamp( $user_id, $activity_object['instrument'] );
+		if ( ! $stamp_id ) {
+			// Without a stamp there is nothing to consent with — don't send a dangling Accept.
+			return;
 		}
 
 		// Send minimal activity object back.
@@ -155,7 +155,7 @@ class Feature_Request {
 		$stamp_url = \add_query_arg(
 			array(
 				'actor' => $user_id,
-				'stamp' => $umeta_id,
+				'stamp' => $stamp_id,
 			),
 			\home_url( '/' )
 		);
@@ -168,6 +168,81 @@ class Feature_Request {
 		$activity->add_to( object_to_uri( $activity_object['actor'] ) );
 
 		add_to_outbox( $activity, null, $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+	}
+
+	/**
+	 * Create (or reuse) a feature stamp for an actor.
+	 *
+	 * Stamps for users live in user meta, with the umeta_id doubling as the
+	 * stamp ID. The blog actor has no users-table row, so its stamps are
+	 * stored in a keyed option array instead.
+	 *
+	 * Idempotent: an existing stamp for the same instrument is reused.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int    $user_id    The local actor ID (0 for the blog actor).
+	 * @param string $instrument The instrument URI being stamped.
+	 * @return int|false The stamp ID, or false on failure.
+	 */
+	public static function add_stamp( $user_id, $instrument ) {
+		if ( Actors::BLOG_USER_ID === $user_id ) {
+			$stamps = \get_option( self::BLOG_STAMPS_OPTION, array() );
+
+			$existing = \array_search( $instrument, $stamps, true );
+			if ( false !== $existing ) {
+				return $existing;
+			}
+
+			$stamp_id = empty( $stamps ) ? 1 : \max( \array_keys( $stamps ) ) + 1;
+
+			$stamps[ $stamp_id ] = $instrument;
+			if ( ! \update_option( self::BLOG_STAMPS_OPTION, $stamps, false ) ) {
+				return false;
+			}
+
+			return $stamp_id;
+		}
+
+		$existing = \get_user_meta( $user_id, '_activitypub_featured_by', false );
+		if ( \in_array( $instrument, (array) $existing, true ) ) {
+			global $wpdb;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			return (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT umeta_id FROM {$wpdb->usermeta} WHERE user_id = %d AND meta_key = %s AND meta_value = %s LIMIT 1",
+					$user_id,
+					'_activitypub_featured_by',
+					$instrument
+				)
+			);
+		}
+
+		return \add_user_meta( $user_id, '_activitypub_featured_by', $instrument );
+	}
+
+	/**
+	 * Resolve a stamp ID for an actor to the stamped instrument URI.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int $user_id  The local actor ID (0 for the blog actor).
+	 * @param int $stamp_id The stamp ID.
+	 * @return string|null The instrument URI, or null if the stamp does not exist for this actor.
+	 */
+	public static function get_stamp( $user_id, $stamp_id ) {
+		if ( Actors::BLOG_USER_ID === $user_id ) {
+			$stamps = \get_option( self::BLOG_STAMPS_OPTION, array() );
+
+			return $stamps[ $stamp_id ] ?? null;
+		}
+
+		$meta = \get_metadata_by_mid( 'user', $stamp_id );
+		if ( ! $meta || '_activitypub_featured_by' !== $meta->meta_key || (int) $meta->user_id !== $user_id ) {
+			return null;
+		}
+
+		return $meta->meta_value;
 	}
 
 	/**

--- a/includes/handler/class-feature-request.php
+++ b/includes/handler/class-feature-request.php
@@ -34,6 +34,16 @@ class Feature_Request {
 	const BLOG_STAMPS_OPTION = 'activitypub_blog_featured_by';
 
 	/**
+	 * Seconds after which a held blog-stamp lock is treated as abandoned.
+	 *
+	 * A request that dies mid-write would otherwise leave the lock row in place
+	 * forever, deadlocking every future blog-actor accept.
+	 *
+	 * @var int
+	 */
+	const BLOG_STAMPS_LOCK_TTL = 10;
+
+	/**
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
@@ -187,21 +197,7 @@ class Feature_Request {
 	 */
 	public static function add_stamp( $user_id, $instrument ) {
 		if ( Actors::BLOG_USER_ID === $user_id ) {
-			$stamps = \get_option( self::BLOG_STAMPS_OPTION, array() );
-
-			$existing = \array_search( $instrument, $stamps, true );
-			if ( false !== $existing ) {
-				return $existing;
-			}
-
-			$stamp_id = empty( $stamps ) ? 1 : \max( \array_keys( $stamps ) ) + 1;
-
-			$stamps[ $stamp_id ] = $instrument;
-			if ( ! \update_option( self::BLOG_STAMPS_OPTION, $stamps, false ) ) {
-				return false;
-			}
-
-			return $stamp_id;
+			return self::add_blog_stamp( $instrument );
 		}
 
 		$existing = \get_user_meta( $user_id, '_activitypub_featured_by', false );
@@ -219,6 +215,67 @@ class Feature_Request {
 		}
 
 		return \add_user_meta( $user_id, '_activitypub_featured_by', $instrument );
+	}
+
+	/**
+	 * Create (or reuse) a feature stamp for the blog actor.
+	 *
+	 * The blog actor's stamps share a single option array, so the
+	 * read-modify-write that allocates the next ID is guarded by a lock to keep
+	 * concurrent inbox deliveries from minting the same ID or clobbering each
+	 * other's writes.
+	 *
+	 * @param string $instrument The instrument URI being stamped.
+	 * @return int|false The stamp ID, or false on failure.
+	 */
+	private static function add_blog_stamp( $instrument ) {
+		$lock = self::BLOG_STAMPS_OPTION . '_lock';
+
+		/*
+		 * Acquire a short-lived lock. add_option only succeeds when the row is
+		 * absent, which makes it a race-safe mutex (see
+		 * Scheduler\Statistics::send_annual_email()).
+		 */
+		$acquired = false;
+		for ( $attempt = 0; $attempt < 50; $attempt++ ) {
+			if ( \add_option( $lock, \time(), '', false ) ) {
+				$acquired = true;
+				break;
+			}
+
+			// Recover a lock abandoned by a request that died mid-write.
+			$held = (int) \get_option( $lock );
+			if ( $held && \time() - $held > self::BLOG_STAMPS_LOCK_TTL ) {
+				\delete_option( $lock );
+				continue;
+			}
+
+			\usleep( 10000 ); // 10ms.
+		}
+
+		if ( ! $acquired ) {
+			return false;
+		}
+
+		try {
+			// Re-read inside the lock so we observe a prior holder's write.
+			$stamps   = \get_option( self::BLOG_STAMPS_OPTION, array() );
+			$existing = \array_search( $instrument, $stamps, true );
+			if ( false !== $existing ) {
+				return $existing;
+			}
+
+			$stamp_id            = empty( $stamps ) ? 1 : \max( \array_keys( $stamps ) ) + 1;
+			$stamps[ $stamp_id ] = $instrument;
+
+			if ( ! \update_option( self::BLOG_STAMPS_OPTION, $stamps, false ) ) {
+				return false;
+			}
+
+			return $stamp_id;
+		} finally {
+			\delete_option( $lock );
+		}
 	}
 
 	/**

--- a/includes/handler/class-feature-request.php
+++ b/includes/handler/class-feature-request.php
@@ -24,24 +24,16 @@ use function Activitypub\user_can_activitypub;
 class Feature_Request {
 
 	/**
-	 * Option name for the blog actor's feature stamps.
+	 * Option-name prefix for the blog actor's feature stamps.
 	 *
-	 * The blog actor has no users-table row (its ID is 0), so its stamps
-	 * cannot live in user meta like the stamps of regular users do.
+	 * The blog actor has no users-table row (its ID is 0), so its stamps cannot
+	 * live in user meta like the stamps of regular users do. Each stamp is stored
+	 * in its own option row, keyed `{prefix}_{id}`, so a stamp ID can be claimed
+	 * atomically with `add_option()` without a lock.
 	 *
 	 * @var string
 	 */
 	const BLOG_STAMPS_OPTION = 'activitypub_blog_featured_by';
-
-	/**
-	 * Seconds after which a held blog-stamp lock is treated as abandoned.
-	 *
-	 * A request that dies mid-write would otherwise leave the lock row in place
-	 * forever, deadlocking every future blog-actor accept.
-	 *
-	 * @var int
-	 */
-	const BLOG_STAMPS_LOCK_TTL = 10;
 
 	/**
 	 * Initialize the class, registering WordPress hooks.
@@ -184,8 +176,8 @@ class Feature_Request {
 	 * Create (or reuse) a feature stamp for an actor.
 	 *
 	 * Stamps for users live in user meta, with the umeta_id doubling as the
-	 * stamp ID. The blog actor has no users-table row, so its stamps are
-	 * stored in a keyed option array instead.
+	 * stamp ID. The blog actor has no users-table row, so each of its stamps is
+	 * stored in its own option row instead.
 	 *
 	 * Idempotent: an existing stamp for the same instrument is reused.
 	 *
@@ -220,62 +212,48 @@ class Feature_Request {
 	/**
 	 * Create (or reuse) a feature stamp for the blog actor.
 	 *
-	 * The blog actor's stamps share a single option array, so the
-	 * read-modify-write that allocates the next ID is guarded by a lock to keep
-	 * concurrent inbox deliveries from minting the same ID or clobbering each
-	 * other's writes.
+	 * Each blog stamp lives in its own option row (`{prefix}_{id}`), so a slot is
+	 * claimed atomically with `add_option()` — which only inserts when the row is
+	 * absent (see Scheduler\Statistics::send_annual_email()). Concurrent inbox
+	 * deliveries therefore can't mint the same ID or clobber each other's writes,
+	 * and no lock is needed. Stamps are never deleted, so the slots stay gap-free
+	 * and the walk stops at the first empty slot.
 	 *
 	 * @param string $instrument The instrument URI being stamped.
 	 * @return int|false The stamp ID, or false on failure.
 	 */
 	private static function add_blog_stamp( $instrument ) {
-		$lock = self::BLOG_STAMPS_OPTION . '_lock';
+		$stamp_id = 1;
 
 		/*
-		 * Acquire a short-lived lock. add_option only succeeds when the row is
-		 * absent, which makes it a race-safe mutex (see
-		 * Scheduler\Statistics::send_annual_email()).
+		 * Bounded far above any realistic blog stamp count, to guard against a
+		 * pathological object-cache state where a just-claimed slot never becomes
+		 * visible and the re-read would otherwise spin forever.
 		 */
-		$acquired = false;
-		for ( $attempt = 0; $attempt < 50; $attempt++ ) {
-			if ( \add_option( $lock, \time(), '', false ) ) {
-				$acquired = true;
-				break;
+		for ( $attempt = 0; $attempt < 10000; $attempt++ ) {
+			$key     = self::BLOG_STAMPS_OPTION . '_' . $stamp_id;
+			$current = \get_option( $key );
+
+			// Idempotent: an existing stamp for the same instrument is reused.
+			if ( $current === $instrument ) {
+				return $stamp_id;
 			}
 
-			// Recover a lock abandoned by a request that died mid-write.
-			$held = (int) \get_option( $lock );
-			if ( $held && \time() - $held > self::BLOG_STAMPS_LOCK_TTL ) {
-				\delete_option( $lock );
+			if ( false === $current ) {
+				if ( \add_option( $key, $instrument, '', false ) ) {
+					return $stamp_id;
+				}
+
+				// A concurrent accept claimed this slot first; re-read it (no
+				// increment) to see whether it took our instrument or another.
 				continue;
 			}
 
-			\usleep( 10000 ); // 10ms.
+			// Slot holds a different instrument; try the next one.
+			++$stamp_id;
 		}
 
-		if ( ! $acquired ) {
-			return false;
-		}
-
-		try {
-			// Re-read inside the lock so we observe a prior holder's write.
-			$stamps   = \get_option( self::BLOG_STAMPS_OPTION, array() );
-			$existing = \array_search( $instrument, $stamps, true );
-			if ( false !== $existing ) {
-				return $existing;
-			}
-
-			$stamp_id            = empty( $stamps ) ? 1 : \max( \array_keys( $stamps ) ) + 1;
-			$stamps[ $stamp_id ] = $instrument;
-
-			if ( ! \update_option( self::BLOG_STAMPS_OPTION, $stamps, false ) ) {
-				return false;
-			}
-
-			return $stamp_id;
-		} finally {
-			\delete_option( $lock );
-		}
+		return false;
 	}
 
 	/**
@@ -289,9 +267,9 @@ class Feature_Request {
 	 */
 	public static function get_stamp( $user_id, $stamp_id ) {
 		if ( Actors::BLOG_USER_ID === $user_id ) {
-			$stamps = \get_option( self::BLOG_STAMPS_OPTION, array() );
+			$instrument = \get_option( self::BLOG_STAMPS_OPTION . '_' . (int) $stamp_id );
 
-			return $stamps[ $stamp_id ] ?? null;
+			return false === $instrument ? null : $instrument;
 		}
 
 		$meta = \get_metadata_by_mid( 'user', $stamp_id );

--- a/tests/phpunit/tests/includes/class-test-query-feature-stamp.php
+++ b/tests/phpunit/tests/includes/class-test-query-feature-stamp.php
@@ -106,6 +106,45 @@ class Test_Query_Feature_Stamp extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Numeric-looking but non-integer actor values must not alias an actor.
+	 *
+	 * Regression: `(int) 'alice'` casts to 0, and values like '0e1' or '1.5' pass
+	 * is_numeric() but cast to 0/1, so such actor values could resolve another
+	 * actor's stamp store. Only plain decimal integers may reach the resolver.
+	 *
+	 * @covers ::get_activitypub_object
+	 */
+	public function test_actor_stamp_rejects_non_integer_actor() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$stamp_id = Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://other.example.com/users/curator/featured/guard' );
+
+		$reset = function () {
+			$instance_property = new \ReflectionProperty( Query::class, 'instance' );
+			$instance_property->setAccessible( true );
+			$instance_property->setValue( null, null );
+		};
+
+		// Control: the canonical integer actor resolves the stamp.
+		set_query_var( 'actor', '0' );
+		set_query_var( 'stamp', $stamp_id );
+		$this->assertInstanceOf( Feature_Authorization::class, Query::get_instance()->get_activitypub_object(), 'A decimal-integer actor should resolve the stamp.' );
+
+		// alice → 0, 0e1 → 0, 1.5 → 1: none may resolve a stamp.
+		foreach ( array( 'alice', '0e1', '1.5' ) as $bad_actor ) {
+			$reset();
+			set_query_var( 'actor', $bad_actor );
+			set_query_var( 'stamp', $stamp_id );
+
+			$this->assertNotInstanceOf(
+				Feature_Authorization::class,
+				Query::get_instance()->get_activitypub_object(),
+				"Actor '{$bad_actor}' must not resolve an actor stamp."
+			);
+		}
+	}
+
+	/**
 	 * End-to-end: a stamp URL goes through the same lifecycle as a real
 	 * request (go_to → template_redirect → Query) and produces a
 	 * FeatureAuthorization. This guards against the router reverting to

--- a/tests/phpunit/tests/includes/class-test-query-feature-stamp.php
+++ b/tests/phpunit/tests/includes/class-test-query-feature-stamp.php
@@ -8,6 +8,8 @@
 namespace Activitypub\Tests;
 
 use Activitypub\Activity\Extended_Object\Feature_Authorization;
+use Activitypub\Collection\Actors;
+use Activitypub\Handler\Feature_Request;
 use Activitypub\Query;
 use Activitypub\Router;
 
@@ -133,6 +135,82 @@ class Test_Query_Feature_Stamp extends \WP_UnitTestCase {
 		 * exception means the guard fired and let the request through to
 		 * content negotiation.
 		 */
+		Router::template_redirect();
+
+		$object = Query::get_instance()->get_activitypub_object();
+		$this->assertInstanceOf( Feature_Authorization::class, $object );
+		$this->assertSame( $instrument, $object->to_array()['interactingObject'] );
+	}
+
+	/**
+	 * A blog-actor stamp (actor=0) resolves to a FeatureAuthorization object.
+	 *
+	 * Regression test: `0` is falsy as a query var, so the blog actor was
+	 * previously never routed to the stamp resolver.
+	 *
+	 * @covers ::get_activitypub_object
+	 */
+	public function test_blog_actor_stamp_resolves_to_feature_authorization() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$instrument = 'https://other.example.com/users/curator/featured/88';
+		$stamp_id   = Feature_Request::add_stamp( Actors::BLOG_USER_ID, $instrument );
+
+		set_query_var( 'actor', '0' );
+		set_query_var( 'stamp', $stamp_id );
+
+		$object = Query::get_instance()->get_activitypub_object();
+
+		$this->assertInstanceOf( Feature_Authorization::class, $object );
+		$array = $object->to_array();
+		$this->assertSame( 'FeatureAuthorization', $array['type'] );
+		$this->assertSame( $instrument, $array['interactingObject'] );
+		$this->assertSame( Actors::get_by_id( Actors::BLOG_USER_ID )->get_id(), $array['attributedTo'] );
+	}
+
+	/**
+	 * Stamps do not leak across actor types: a user's stamp ID cannot be
+	 * resolved as the blog actor, and vice versa.
+	 *
+	 * @covers \Activitypub\Handler\Feature_Request::get_stamp
+	 */
+	public function test_stamps_do_not_leak_across_actor_types() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$umeta_id      = add_user_meta( self::$user_id, '_activitypub_featured_by', 'https://x/y/user' );
+		$blog_stamp_id = Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://x/y/blog' );
+
+		// A user stamp can never be served from the blog store, and vice versa.
+		$this->assertNotSame( 'https://x/y/user', Feature_Request::get_stamp( Actors::BLOG_USER_ID, $umeta_id ), 'A user stamp must not resolve for the blog actor.' );
+		$this->assertNotSame( 'https://x/y/blog', Feature_Request::get_stamp( self::$user_id, $blog_stamp_id ), 'A blog stamp must not resolve for a user actor.' );
+
+		// Lookups stay scoped to the requested actor.
+		$this->assertSame( 'https://x/y/blog', Feature_Request::get_stamp( Actors::BLOG_USER_ID, $blog_stamp_id ) );
+		$this->assertSame( 'https://x/y/user', Feature_Request::get_stamp( self::$user_id, $umeta_id ) );
+	}
+
+	/**
+	 * End-to-end: a blog-actor stamp URL (?actor=0&stamp=N) goes through the
+	 * request lifecycle and produces a FeatureAuthorization.
+	 *
+	 * @covers ::get_activitypub_object
+	 * @covers \Activitypub\Router::template_redirect
+	 */
+	public function test_blog_stamp_url_routes_and_resolves_end_to_end() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$instrument = 'https://other.example.com/users/curator/featured/blog-integration';
+		$stamp_id   = Feature_Request::add_stamp( Actors::BLOG_USER_ID, $instrument );
+
+		$stamp_url = add_query_arg(
+			array(
+				'actor' => 0,
+				'stamp' => $stamp_id,
+			),
+			home_url( '/' )
+		);
+
+		$this->go_to( $stamp_url );
 		Router::template_redirect();
 
 		$object = Query::get_instance()->get_activitypub_object();

--- a/tests/phpunit/tests/includes/class-test-query.php
+++ b/tests/phpunit/tests/includes/class-test-query.php
@@ -7,7 +7,9 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
+use Activitypub\Handler\Feature_Request;
 use Activitypub\Query;
 use WP_UnitTestCase;
 
@@ -510,6 +512,45 @@ class Test_Query extends \WP_UnitTestCase {
 
 		// Clean up.
 		\delete_post_meta( self::$post_id, '_activitypub_quoted_by' );
+	}
+
+	/**
+	 * Test that a non-numeric actor var does not alias the blog actor's stamp.
+	 *
+	 * Regression: `(int) 'alice'` casts to 0, so a request like `?actor=alice&stamp=1`
+	 * would resolve against the blog actor's stamp store. Only numeric actor values
+	 * may reach the actor-scoped stamp path.
+	 *
+	 * @covers ::maybe_get_actor_stamp
+	 */
+	public function test_actor_stamp_rejects_non_numeric_actor() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$instrument = 'https://remote.example.com/users/curator/featured/7';
+		$stamp_id   = Feature_Request::add_stamp( Actors::BLOG_USER_ID, $instrument );
+
+		// A numeric blog actor resolves the stamp.
+		Query::get_instance()->__destruct();
+		$this->go_to( \home_url( '/?actor=0&stamp=' . $stamp_id ) );
+		\set_query_var( 'actor', '0' );
+		\set_query_var( 'stamp', $stamp_id );
+
+		$object = Query::get_instance()->get_activitypub_object();
+		$this->assertNotNull( $object, 'Numeric blog actor should resolve the stamp.' );
+		$this->assertEquals( 'FeatureAuthorization', $object->get_type(), 'Numeric blog actor should yield a FeatureAuthorization.' );
+
+		// A non-numeric actor must not alias the blog actor.
+		Query::get_instance()->__destruct();
+		$this->go_to( \home_url( '/?actor=alice&stamp=' . $stamp_id ) );
+		\set_query_var( 'actor', 'alice' );
+		\set_query_var( 'stamp', $stamp_id );
+
+		$object = Query::get_instance()->get_activitypub_object();
+		if ( null !== $object ) {
+			$this->assertNotEquals( 'FeatureAuthorization', $object->get_type(), 'Non-numeric actor must not resolve the blog actor stamp.' );
+		}
+
+		\delete_option( Feature_Request::BLOG_STAMPS_OPTION );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-query.php
+++ b/tests/phpunit/tests/includes/class-test-query.php
@@ -7,9 +7,7 @@
 
 namespace Activitypub\Tests;
 
-use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
-use Activitypub\Handler\Feature_Request;
 use Activitypub\Query;
 use WP_UnitTestCase;
 
@@ -512,48 +510,6 @@ class Test_Query extends \WP_UnitTestCase {
 
 		// Clean up.
 		\delete_post_meta( self::$post_id, '_activitypub_quoted_by' );
-	}
-
-	/**
-	 * Test that a non-integer actor var does not alias the blog/user actor's stamp.
-	 *
-	 * Regression: `(int) 'alice'` casts to 0, and values like '0e1' or '1.5' pass
-	 * is_numeric() but cast to 0/1, so requests like `?actor=alice&stamp=1` would
-	 * resolve against an actor's stamp store. Only plain decimal-integer actor
-	 * values may reach the actor-scoped stamp path.
-	 *
-	 * @covers ::maybe_get_actor_stamp
-	 */
-	public function test_actor_stamp_rejects_non_integer_actor() {
-		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
-
-		$instrument = 'https://remote.example.com/users/curator/featured/7';
-		$stamp_id   = Feature_Request::add_stamp( Actors::BLOG_USER_ID, $instrument );
-
-		// A numeric blog actor resolves the stamp.
-		Query::get_instance()->__destruct();
-		$this->go_to( \home_url( '/?actor=0&stamp=' . $stamp_id ) );
-		\set_query_var( 'actor', '0' );
-		\set_query_var( 'stamp', $stamp_id );
-
-		$object = Query::get_instance()->get_activitypub_object();
-		$this->assertNotNull( $object, 'Numeric blog actor should resolve the stamp.' );
-		$this->assertEquals( 'FeatureAuthorization', $object->get_type(), 'Numeric blog actor should yield a FeatureAuthorization.' );
-
-		// Non-integer actor values must not alias an actor (alice → 0, 0e1 → 0, 1.5 → 1).
-		foreach ( array( 'alice', '0e1', '1.5' ) as $bad_actor ) {
-			Query::get_instance()->__destruct();
-			$this->go_to( \home_url( '/?actor=' . $bad_actor . '&stamp=' . $stamp_id ) );
-			\set_query_var( 'actor', $bad_actor );
-			\set_query_var( 'stamp', $stamp_id );
-
-			$object = Query::get_instance()->get_activitypub_object();
-			if ( null !== $object ) {
-				$this->assertNotEquals( 'FeatureAuthorization', $object->get_type(), "Actor '{$bad_actor}' must not resolve an actor stamp." );
-			}
-		}
-
-		\delete_option( Feature_Request::BLOG_STAMPS_OPTION . '_' . $stamp_id );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-query.php
+++ b/tests/phpunit/tests/includes/class-test-query.php
@@ -515,15 +515,16 @@ class Test_Query extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a non-numeric actor var does not alias the blog actor's stamp.
+	 * Test that a non-integer actor var does not alias the blog/user actor's stamp.
 	 *
-	 * Regression: `(int) 'alice'` casts to 0, so a request like `?actor=alice&stamp=1`
-	 * would resolve against the blog actor's stamp store. Only numeric actor values
-	 * may reach the actor-scoped stamp path.
+	 * Regression: `(int) 'alice'` casts to 0, and values like '0e1' or '1.5' pass
+	 * is_numeric() but cast to 0/1, so requests like `?actor=alice&stamp=1` would
+	 * resolve against an actor's stamp store. Only plain decimal-integer actor
+	 * values may reach the actor-scoped stamp path.
 	 *
 	 * @covers ::maybe_get_actor_stamp
 	 */
-	public function test_actor_stamp_rejects_non_numeric_actor() {
+	public function test_actor_stamp_rejects_non_integer_actor() {
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
 
 		$instrument = 'https://remote.example.com/users/curator/featured/7';
@@ -539,18 +540,20 @@ class Test_Query extends \WP_UnitTestCase {
 		$this->assertNotNull( $object, 'Numeric blog actor should resolve the stamp.' );
 		$this->assertEquals( 'FeatureAuthorization', $object->get_type(), 'Numeric blog actor should yield a FeatureAuthorization.' );
 
-		// A non-numeric actor must not alias the blog actor.
-		Query::get_instance()->__destruct();
-		$this->go_to( \home_url( '/?actor=alice&stamp=' . $stamp_id ) );
-		\set_query_var( 'actor', 'alice' );
-		\set_query_var( 'stamp', $stamp_id );
+		// Non-integer actor values must not alias an actor (alice → 0, 0e1 → 0, 1.5 → 1).
+		foreach ( array( 'alice', '0e1', '1.5' ) as $bad_actor ) {
+			Query::get_instance()->__destruct();
+			$this->go_to( \home_url( '/?actor=' . $bad_actor . '&stamp=' . $stamp_id ) );
+			\set_query_var( 'actor', $bad_actor );
+			\set_query_var( 'stamp', $stamp_id );
 
-		$object = Query::get_instance()->get_activitypub_object();
-		if ( null !== $object ) {
-			$this->assertNotEquals( 'FeatureAuthorization', $object->get_type(), 'Non-numeric actor must not resolve the blog actor stamp.' );
+			$object = Query::get_instance()->get_activitypub_object();
+			if ( null !== $object ) {
+				$this->assertNotEquals( 'FeatureAuthorization', $object->get_type(), "Actor '{$bad_actor}' must not resolve an actor stamp." );
+			}
 		}
 
-		\delete_option( Feature_Request::BLOG_STAMPS_OPTION );
+		\delete_option( Feature_Request::BLOG_STAMPS_OPTION . '_' . $stamp_id );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/handler/class-test-feature-request.php
+++ b/tests/phpunit/tests/includes/handler/class-test-feature-request.php
@@ -376,4 +376,121 @@ class Test_Feature_Request extends ActivityPub_Outbox_TestCase {
 		);
 		$this->assertNotEmpty( $outbox, 'Unresolvable target should still produce a Reject activity.' );
 	}
+
+	/**
+	 * Test that queue_accept stores a stamp for the blog actor in the option store.
+	 *
+	 * The blog actor has no users-table row, so its stamps cannot live in
+	 * user meta.
+	 *
+	 * @covers ::queue_accept
+	 * @covers ::add_stamp
+	 */
+	public function test_queue_accept_stores_stamp_for_blog_actor() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$blog_actor         = Actors::get_by_id( Actors::BLOG_USER_ID );
+		$activity           = $this->create_feature_request_activity();
+		$activity['object'] = $blog_actor->get_id();
+
+		Feature_Request::queue_accept( $activity, Actors::BLOG_USER_ID );
+
+		// The stamp is stored in the blog stamp option.
+		$stamps = \get_option( Feature_Request::BLOG_STAMPS_OPTION, array() );
+		$this->assertContains( $activity['instrument'], $stamps, 'Instrument URL should be recorded in the blog stamp option.' );
+
+		$stamp_id = \array_search( $activity['instrument'], $stamps, true );
+
+		// The Accept carries a resolvable stamp URL for actor 0.
+		$outbox = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Accept',
+					),
+				),
+			)
+		);
+		$this->assertNotEmpty( $outbox, 'Accept activity should be queued for the blog actor.' );
+
+		$payload = json_decode( $outbox[0]->post_content, true );
+		$this->assertSame( $blog_actor->get_id(), $payload['actor'], 'The Accept should be sent by the blog actor.' );
+		$this->assertStringContainsString( 'actor=0', $payload['result'] );
+		$this->assertStringContainsString( 'stamp=' . $stamp_id, $payload['result'] );
+	}
+
+	/**
+	 * Test that blog-actor stamps are idempotent: a second FeatureRequest with the
+	 * same instrument reuses the existing stamp.
+	 *
+	 * @covers ::queue_accept
+	 * @covers ::add_stamp
+	 */
+	public function test_queue_accept_idempotent_for_blog_actor() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_AND_BLOG_MODE );
+
+		$activity           = $this->create_feature_request_activity();
+		$activity['object'] = Actors::get_by_id( Actors::BLOG_USER_ID )->get_id();
+
+		Feature_Request::queue_accept( $activity, Actors::BLOG_USER_ID );
+		Feature_Request::queue_accept( $activity, Actors::BLOG_USER_ID );
+
+		$stamps = \get_option( Feature_Request::BLOG_STAMPS_OPTION, array() );
+		$this->assertCount( 1, $stamps, 'Duplicate FeatureRequests for the same instrument must not produce multiple blog stamps.' );
+	}
+
+	/**
+	 * Test that FeatureRequests targeting the Application actor are rejected
+	 * and never accepted, regardless of the site policy.
+	 *
+	 * @covers ::handle_feature_request
+	 */
+	public function test_handle_feature_request_rejects_application_actor() {
+		update_option( 'activitypub_default_feature_policy', ACTIVITYPUB_INTERACTION_POLICY_ANYONE );
+
+		$application        = Actors::get_by_id( Actors::APPLICATION_USER_ID );
+		$activity           = $this->create_feature_request_activity();
+		$activity['object'] = $application->get_id();
+
+		Feature_Request::handle_feature_request( $activity, self::$user_id );
+
+		/*
+		 * The Application actor is not resolvable as a FeatureRequest target
+		 * (Actors::get_by_resource() has no branch for it), so the request
+		 * takes the unresolvable-target path and is rejected.
+		 */
+		$rejects = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Reject',
+					),
+				),
+			)
+		);
+		$this->assertNotEmpty( $rejects, 'FeatureRequests targeting the Application actor should be rejected.' );
+
+		$accepts = get_posts(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'pending',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					array(
+						'key'   => '_activitypub_activity_type',
+						'value' => 'Accept',
+					),
+				),
+			)
+		);
+		$this->assertEmpty( $accepts, 'The Application actor must never accept FeatureRequests, regardless of policy.' );
+	}
 }

--- a/tests/phpunit/tests/includes/handler/class-test-feature-request.php
+++ b/tests/phpunit/tests/includes/handler/class-test-feature-request.php
@@ -395,11 +395,14 @@ class Test_Feature_Request extends ActivityPub_Outbox_TestCase {
 
 		Feature_Request::queue_accept( $activity, Actors::BLOG_USER_ID );
 
-		// The stamp is stored in the blog stamp option.
-		$stamps = \get_option( Feature_Request::BLOG_STAMPS_OPTION, array() );
-		$this->assertContains( $activity['instrument'], $stamps, 'Instrument URL should be recorded in the blog stamp option.' );
-
-		$stamp_id = \array_search( $activity['instrument'], $stamps, true );
+		// The stamp is persisted and resolvable for the blog actor. Re-adding the
+		// same instrument is idempotent and returns its existing stamp ID.
+		$stamp_id = Feature_Request::add_stamp( Actors::BLOG_USER_ID, $activity['instrument'] );
+		$this->assertSame(
+			$activity['instrument'],
+			Feature_Request::get_stamp( Actors::BLOG_USER_ID, $stamp_id ),
+			'Instrument URL should be resolvable for the blog actor.'
+		);
 
 		// The Accept carries a resolvable stamp URL for actor 0.
 		$outbox = get_posts(
@@ -439,49 +442,30 @@ class Test_Feature_Request extends ActivityPub_Outbox_TestCase {
 		Feature_Request::queue_accept( $activity, Actors::BLOG_USER_ID );
 		Feature_Request::queue_accept( $activity, Actors::BLOG_USER_ID );
 
-		$stamps = \get_option( Feature_Request::BLOG_STAMPS_OPTION, array() );
-		$this->assertCount( 1, $stamps, 'Duplicate FeatureRequests for the same instrument must not produce multiple blog stamps.' );
+		// The duplicate reuses the first slot and never allocates a second.
+		$this->assertSame( $activity['instrument'], Feature_Request::get_stamp( Actors::BLOG_USER_ID, 1 ), 'The first blog stamp slot holds the instrument.' );
+		$this->assertNull( Feature_Request::get_stamp( Actors::BLOG_USER_ID, 2 ), 'Duplicate FeatureRequests for the same instrument must not produce a second blog stamp.' );
 	}
 
 	/**
-	 * Test that distinct instruments get distinct blog stamp IDs and that the
-	 * allocation lock is released afterwards.
+	 * Test that distinct instruments get distinct, resolvable blog stamp IDs and
+	 * that re-adding an instrument is idempotent.
 	 *
 	 * @covers ::add_stamp
+	 * @covers ::get_stamp
 	 */
 	public function test_add_stamp_allocates_distinct_ids_for_blog_actor() {
 		$first  = Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://remote.example.com/featured/1' );
 		$second = Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://remote.example.com/featured/2' );
 
-		$this->assertNotFalse( $first, 'First blog stamp should be created.' );
-		$this->assertNotFalse( $second, 'Second blog stamp should be created.' );
 		$this->assertNotSame( $first, $second, 'Distinct instruments must not reuse the same blog stamp ID.' );
 
-		$stamps = \get_option( Feature_Request::BLOG_STAMPS_OPTION, array() );
-		$this->assertCount( 2, $stamps, 'Both instruments should be recorded.' );
+		// Each ID resolves back to its own instrument.
+		$this->assertSame( 'https://remote.example.com/featured/1', Feature_Request::get_stamp( Actors::BLOG_USER_ID, $first ) );
+		$this->assertSame( 'https://remote.example.com/featured/2', Feature_Request::get_stamp( Actors::BLOG_USER_ID, $second ) );
 
-		$this->assertFalse(
-			\get_option( Feature_Request::BLOG_STAMPS_OPTION . '_lock' ),
-			'The allocation lock must be released after add_stamp() returns.'
-		);
-	}
-
-	/**
-	 * Test that a stale blog-stamp lock is recovered instead of deadlocking.
-	 *
-	 * @covers ::add_stamp
-	 */
-	public function test_add_stamp_recovers_stale_blog_lock() {
-		// Simulate a lock abandoned by a request that died mid-write.
-		\add_option( Feature_Request::BLOG_STAMPS_OPTION . '_lock', \time() - ( Feature_Request::BLOG_STAMPS_LOCK_TTL + 5 ), '', false );
-
-		$stamp_id = Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://remote.example.com/featured/stale' );
-
-		$this->assertNotFalse( $stamp_id, 'A stale lock must be recovered so the stamp can still be created.' );
-		$this->assertFalse(
-			\get_option( Feature_Request::BLOG_STAMPS_OPTION . '_lock' ),
-			'The recovered lock must be released after add_stamp() returns.'
-		);
+		// Re-adding the first instrument reuses its slot.
+		$this->assertSame( $first, Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://remote.example.com/featured/1' ), 'Re-adding an instrument must reuse its stamp ID.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/handler/class-test-feature-request.php
+++ b/tests/phpunit/tests/includes/handler/class-test-feature-request.php
@@ -444,6 +444,47 @@ class Test_Feature_Request extends ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test that distinct instruments get distinct blog stamp IDs and that the
+	 * allocation lock is released afterwards.
+	 *
+	 * @covers ::add_stamp
+	 */
+	public function test_add_stamp_allocates_distinct_ids_for_blog_actor() {
+		$first  = Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://remote.example.com/featured/1' );
+		$second = Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://remote.example.com/featured/2' );
+
+		$this->assertNotFalse( $first, 'First blog stamp should be created.' );
+		$this->assertNotFalse( $second, 'Second blog stamp should be created.' );
+		$this->assertNotSame( $first, $second, 'Distinct instruments must not reuse the same blog stamp ID.' );
+
+		$stamps = \get_option( Feature_Request::BLOG_STAMPS_OPTION, array() );
+		$this->assertCount( 2, $stamps, 'Both instruments should be recorded.' );
+
+		$this->assertFalse(
+			\get_option( Feature_Request::BLOG_STAMPS_OPTION . '_lock' ),
+			'The allocation lock must be released after add_stamp() returns.'
+		);
+	}
+
+	/**
+	 * Test that a stale blog-stamp lock is recovered instead of deadlocking.
+	 *
+	 * @covers ::add_stamp
+	 */
+	public function test_add_stamp_recovers_stale_blog_lock() {
+		// Simulate a lock abandoned by a request that died mid-write.
+		\add_option( Feature_Request::BLOG_STAMPS_OPTION . '_lock', \time() - ( Feature_Request::BLOG_STAMPS_LOCK_TTL + 5 ), '', false );
+
+		$stamp_id = Feature_Request::add_stamp( Actors::BLOG_USER_ID, 'https://remote.example.com/featured/stale' );
+
+		$this->assertNotFalse( $stamp_id, 'A stale lock must be recovered so the stamp can still be created.' );
+		$this->assertFalse(
+			\get_option( Feature_Request::BLOG_STAMPS_OPTION . '_lock' ),
+			'The recovered lock must be released after add_stamp() returns.'
+		);
+	}
+
+	/**
 	 * Test that FeatureRequests targeting the Application actor are rejected
 	 * and never accepted, regardless of the site policy.
 	 *


### PR DESCRIPTION
## Proposed changes:

* Starter Kit (FEP-7aa9) consent was broken for the blog actor: its ID is 0, and add_user_meta() rejects object ID 0, so no consent stamp was ever stored — yet the Accept was still sent, with a result URL pointing at the homepage. Remote services received consent that could never be verified.
* Stamps now go through Feature_Request::add_stamp() / get_stamp(): users keep the existing user-meta store (the umeta_id doubles as the stamp ID), while the blog actor stores its stamps in a keyed, non-autoloaded option (activitypub_blog_featured_by). Stamp creation stays idempotent for both.
* queue_accept() no longer sends an Accept when no stamp could be stored — no more unverifiable consent on the wire.
* Two falsy-string fixes in Query: the blog actor's actor query var is '0', which PHP treats as false, so stamp URLs like ?actor=0&stamp=1 were never routed to the resolver and could not have resolved anyway. Both checks now distinguish "absent" from 0, and the resolver delegates to get_stamp() with the lookup scoped to the requested actor.
* FeatureRequests targeting the Application actor are pinned by a test as rejected-never-accepted (they take the unresolvable-target path, since Actors::get_by_resource() has no Application branch).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Enable the blog actor (Settings → ActivityPub → Profiles) and set the Starter Kit policy to Anyone (Settings → ActivityPub → Activities).
* Deliver a FeatureRequest for the blog actor, or create a stamp directly: wp eval 'var_dump( Activitypub\Handler\Feature_Request::add_stamp( 0, "https://curator.example/featured/1" ) );'
* Fetch the stamp URL: curl -H "Accept: application/activity+json" "https://example.com/?actor=0&stamp=1" — expect a FeatureAuthorization attributed to the blog actor with the instrument as interactingObject.
* Run the tests: npm run env-test -- --filter "/Test_Feature_Request|Test_Query_Feature_Stamp/" (6 new tests: blog stamp storage and result URL, blog idempotency, cross-actor stamp isolation in both directions, blog end-to-end routing, Application rejection).