### PR TITLE
Add unit test coverage for the admin app data layer

### DIFF
--- a/src/app/hooks/__tests__/use-feed-filters.test.tsx
+++ b/src/app/hooks/__tests__/use-feed-filters.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockUpdateView = jest.fn();
+let mockView: { filters?: unknown[]; page?: number } = { filters: [] };
+
+jest.mock( '@wordpress/views', () => ( {
+	useView: () => ( { view: mockView, updateView: mockUpdateView } ),
+} ) );
+
+import { renderHook, act } from '@testing-library/react';
+import { useFeedFilters } from '../use-feed-filters';
+
+describe( 'useFeedFilters', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockView = { filters: [] };
+	} );
+
+	describe( 'hasActiveFilters', () => {
+		it( 'should be false when there are no filters', () => {
+			mockView = { filters: [] };
+			const { result } = renderHook( () => useFeedFilters() );
+			expect( result.current.hasActiveFilters ).toBe( false );
+		} );
+
+		it( 'should be false when filters is undefined', () => {
+			mockView = {};
+			const { result } = renderHook( () => useFeedFilters() );
+			expect( result.current.hasActiveFilters ).toBe( false );
+		} );
+
+		it( 'should be true when at least one filter is active', () => {
+			mockView = { filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 1 ] } ] };
+			const { result } = renderHook( () => useFeedFilters() );
+			expect( result.current.hasActiveFilters ).toBe( true );
+		} );
+	} );
+
+	describe( 'clearAllFilters', () => {
+		it( 'should reset filters and return to the first page', () => {
+			mockView = { filters: [ { field: 'ap_tag', value: [ 1 ] } ], page: 3 };
+			const { result } = renderHook( () => useFeedFilters() );
+
+			act( () => {
+				result.current.clearAllFilters();
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [],
+				page: 1,
+			} );
+		} );
+	} );
+} );

--- a/src/app/hooks/__tests__/use-feed.test.tsx
+++ b/src/app/hooks/__tests__/use-feed.test.tsx
@@ -94,6 +94,21 @@ describe( 'useFeed', () => {
 		expect( query.ap_tag ).toBeUndefined();
 	} );
 
+	it( 'should request a limited set of _fields', () => {
+		renderHook( () => useFeed( { userId: 1 } ) );
+		const fields = lastCall().query._fields as string[];
+		expect( Array.isArray( fields ) ).toBe( true );
+		// A few representative fields the feed list and inspector rely on.
+		expect( fields ).toEqual(
+			expect.arrayContaining( [ 'id', 'title', 'actor_info', 'ap_object_type', 'ap_tag' ] )
+		);
+	} );
+
+	it( 'should pass custom fields through to the query', () => {
+		renderHook( () => useFeed( { userId: 1, fields: [ 'id', 'title' ] } ) );
+		expect( lastCall().query._fields ).toEqual( [ 'id', 'title' ] );
+	} );
+
 	it( 'should return the resolved records when enabled', () => {
 		const records = [ { id: 1 }, { id: 2 } ];
 		mockUseEntityRecords.mockReturnValue( {

--- a/src/app/hooks/__tests__/use-feed.test.tsx
+++ b/src/app/hooks/__tests__/use-feed.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockUseEntityRecords = jest.fn();
+
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityRecords: ( ...args: unknown[] ) => mockUseEntityRecords( ...args ),
+} ) );
+
+import { renderHook } from '@testing-library/react';
+import { useFeed } from '../use-feed';
+
+/**
+ * Returns the arguments the hook passed to `useEntityRecords` on its last call.
+ */
+function lastCall(): { kind: string; name: string; query: Record< string, unknown >; options: { enabled: boolean } } {
+	const call = mockUseEntityRecords.mock.calls[ mockUseEntityRecords.mock.calls.length - 1 ];
+	return { kind: call[ 0 ], name: call[ 1 ], query: call[ 2 ], options: call[ 3 ] };
+}
+
+describe( 'useFeed', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseEntityRecords.mockReturnValue( {
+			records: [],
+			hasResolved: true,
+			isResolving: false,
+			totalItems: 0,
+			totalPages: 0,
+		} );
+	} );
+
+	it( 'should query the ap_post post type', () => {
+		renderHook( () => useFeed( { userId: 1 } ) );
+		const { kind, name } = lastCall();
+		expect( kind ).toBe( 'postType' );
+		expect( name ).toBe( 'ap_post' );
+	} );
+
+	it( 'should be disabled and return empty data when userId is missing', () => {
+		const { result } = renderHook( () => useFeed() );
+		const { query, options } = lastCall();
+
+		expect( options.enabled ).toBe( false );
+		expect( query.user_id ).toBeUndefined();
+		expect( result.current.feed ).toEqual( [] );
+		expect( result.current.totalItems ).toBeNull();
+		expect( result.current.totalPages ).toBeNull();
+	} );
+
+	it( 'should be enabled and pass user_id when userId is provided', () => {
+		renderHook( () => useFeed( { userId: 0 } ) );
+		const { query, options } = lastCall();
+		expect( options.enabled ).toBe( true );
+		expect( query.user_id ).toBe( 0 );
+	} );
+
+	it( 'should map pagination and ordering params to REST query args', () => {
+		renderHook( () =>
+			useFeed( { userId: 1, perPage: 5, page: 2, orderBy: 'title', order: 'asc', search: 'hello' } )
+		);
+		const { query } = lastCall();
+		expect( query.per_page ).toBe( 5 );
+		expect( query.page ).toBe( 2 );
+		expect( query.orderby ).toBe( 'title' );
+		expect( query.order ).toBe( 'asc' );
+		expect( query.search ).toBe( 'hello' );
+	} );
+
+	it( 'should wrap a single ap_object_type filter value in an array', () => {
+		renderHook( () =>
+			useFeed( { userId: 1, filters: [ { field: 'ap_object_type', operator: 'is', value: 4 } ] } )
+		);
+		expect( lastCall().query.ap_object_type ).toEqual( [ 4 ] );
+	} );
+
+	it( 'should pass an array ap_object_type filter value through unchanged', () => {
+		renderHook( () =>
+			useFeed( { userId: 1, filters: [ { field: 'ap_object_type', operator: 'isAny', value: [ 4, 5 ] } ] } )
+		);
+		expect( lastCall().query.ap_object_type ).toEqual( [ 4, 5 ] );
+	} );
+
+	it( 'should pass the ap_tag filter value through as-is', () => {
+		renderHook( () => useFeed( { userId: 1, filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 7 ] } ] } ) );
+		expect( lastCall().query.ap_tag ).toEqual( [ 7 ] );
+	} );
+
+	it( 'should not add filter args when no filters are provided', () => {
+		renderHook( () => useFeed( { userId: 1 } ) );
+		const { query } = lastCall();
+		expect( query.ap_object_type ).toBeUndefined();
+		expect( query.ap_tag ).toBeUndefined();
+	} );
+
+	it( 'should return the resolved records when enabled', () => {
+		const records = [ { id: 1 }, { id: 2 } ];
+		mockUseEntityRecords.mockReturnValue( {
+			records,
+			hasResolved: true,
+			isResolving: false,
+			totalItems: 2,
+			totalPages: 1,
+		} );
+
+		const { result } = renderHook( () => useFeed( { userId: 1 } ) );
+		expect( result.current.feed ).toBe( records );
+		expect( result.current.totalItems ).toBe( 2 );
+		expect( result.current.totalPages ).toBe( 1 );
+	} );
+
+	it( 'should fall back to an empty feed when records is null', () => {
+		mockUseEntityRecords.mockReturnValue( {
+			records: null,
+			hasResolved: true,
+			isResolving: false,
+			totalItems: null,
+			totalPages: null,
+		} );
+
+		const { result } = renderHook( () => useFeed( { userId: 1 } ) );
+		expect( result.current.feed ).toEqual( [] );
+	} );
+} );

--- a/src/app/hooks/__tests__/use-object-type-filter.test.tsx
+++ b/src/app/hooks/__tests__/use-object-type-filter.test.tsx
@@ -59,6 +59,23 @@ describe( 'useObjectTypeFilter', () => {
 			} );
 		} );
 
+		it( 'should preserve other filters when adding an object type filter', () => {
+			mockView = { filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 1 ] } ] };
+			const { result } = renderHook( () => useObjectTypeFilter() );
+
+			act( () => {
+				result.current.updateObjectTypeFilter( 4 );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [
+					{ field: 'ap_tag', operator: 'isAny', value: [ 1 ] },
+					{ field: 'ap_object_type', operator: 'is', value: 4 },
+				],
+				page: 1,
+			} );
+		} );
+
 		it( 'should remove the filter when toggling the same object type', () => {
 			mockView = { filters: [ { field: 'ap_object_type', operator: 'is', value: 4 } ] };
 			const { result } = renderHook( () => useObjectTypeFilter() );

--- a/src/app/hooks/__tests__/use-object-type-filter.test.tsx
+++ b/src/app/hooks/__tests__/use-object-type-filter.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockUpdateView = jest.fn();
+const mockNavigate = jest.fn();
+let mockView: { filters?: Array< { field: string; operator?: string; value: unknown } >; page?: number } = {
+	filters: [],
+};
+
+jest.mock( '@wordpress/views', () => ( {
+	useView: () => ( { view: mockView, updateView: mockUpdateView } ),
+} ) );
+
+jest.mock( '../../router', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
+
+import { renderHook, act } from '@testing-library/react';
+import { useObjectTypeFilter } from '../use-object-type-filter';
+
+describe( 'useObjectTypeFilter', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockView = { filters: [] };
+	} );
+
+	describe( 'selectedObjectTypeId', () => {
+		it( 'should be null when no object type filter is set', () => {
+			const { result } = renderHook( () => useObjectTypeFilter() );
+			expect( result.current.selectedObjectTypeId ).toBeNull();
+		} );
+
+		it( 'should return the filter value when an object type filter is set', () => {
+			mockView = { filters: [ { field: 'ap_object_type', operator: 'is', value: 4 } ] };
+			const { result } = renderHook( () => useObjectTypeFilter() );
+			expect( result.current.selectedObjectTypeId ).toBe( 4 );
+		} );
+
+		it( 'should ignore unrelated filters', () => {
+			mockView = { filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 1 ] } ] };
+			const { result } = renderHook( () => useObjectTypeFilter() );
+			expect( result.current.selectedObjectTypeId ).toBeNull();
+		} );
+	} );
+
+	describe( 'updateObjectTypeFilter', () => {
+		it( 'should add a filter when none exists', () => {
+			mockView = { filters: [] };
+			const { result } = renderHook( () => useObjectTypeFilter() );
+
+			act( () => {
+				result.current.updateObjectTypeFilter( 4 );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [ { field: 'ap_object_type', operator: 'is', value: 4 } ],
+				page: 1,
+			} );
+		} );
+
+		it( 'should remove the filter when toggling the same object type', () => {
+			mockView = { filters: [ { field: 'ap_object_type', operator: 'is', value: 4 } ] };
+			const { result } = renderHook( () => useObjectTypeFilter() );
+
+			act( () => {
+				result.current.updateObjectTypeFilter( 4 );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [],
+				page: 1,
+			} );
+		} );
+
+		it( 'should replace the value when a different object type is selected', () => {
+			mockView = { filters: [ { field: 'ap_object_type', operator: 'is', value: 4 } ] };
+			const { result } = renderHook( () => useObjectTypeFilter() );
+
+			act( () => {
+				result.current.updateObjectTypeFilter( 9 );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [ { field: 'ap_object_type', operator: 'is', value: 9 } ],
+				page: 1,
+			} );
+		} );
+
+		it( 'should clear the object type filter when called with null', () => {
+			mockView = {
+				filters: [
+					{ field: 'ap_object_type', operator: 'is', value: 4 },
+					{ field: 'ap_tag', operator: 'isAny', value: [ 1 ] },
+				],
+			};
+			const { result } = renderHook( () => useObjectTypeFilter() );
+
+			act( () => {
+				result.current.updateObjectTypeFilter( null );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 1 ] } ],
+				page: 1,
+			} );
+		} );
+
+		it( 'should close the inspector by removing postId from the URL', () => {
+			const { result } = renderHook( () => useObjectTypeFilter() );
+
+			act( () => {
+				result.current.updateObjectTypeFilter( 4 );
+			} );
+
+			expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
+			const searchFn = mockNavigate.mock.calls[ 0 ][ 0 ].search;
+			expect( searchFn( { postId: 1, foo: 'bar' } ) ).toEqual( { foo: 'bar' } );
+		} );
+
+		it( 'should call the onComplete callback when provided', () => {
+			const onComplete = jest.fn();
+			const { result } = renderHook( () => useObjectTypeFilter() );
+
+			act( () => {
+				result.current.updateObjectTypeFilter( 4, { onComplete } );
+			} );
+
+			expect( onComplete ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/src/app/hooks/__tests__/use-tag-filter.test.tsx
+++ b/src/app/hooks/__tests__/use-tag-filter.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockUpdateView = jest.fn();
+const mockNavigate = jest.fn();
+let mockView: { filters?: Array< { field: string; operator?: string; value: unknown } >; page?: number } = {
+	filters: [],
+};
+
+jest.mock( '@wordpress/views', () => ( {
+	useView: () => ( { view: mockView, updateView: mockUpdateView } ),
+} ) );
+
+jest.mock( '../../router', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
+
+import { renderHook, act } from '@testing-library/react';
+import { useTagFilter } from '../use-tag-filter';
+
+describe( 'useTagFilter', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockView = { filters: [] };
+	} );
+
+	describe( 'selectedTagId', () => {
+		it( 'should be null when no tag filter is set', () => {
+			const { result } = renderHook( () => useTagFilter() );
+			expect( result.current.selectedTagId ).toBeNull();
+		} );
+
+		it( 'should return the tag id when exactly one tag is selected', () => {
+			mockView = { filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 5 ] } ] };
+			const { result } = renderHook( () => useTagFilter() );
+			expect( result.current.selectedTagId ).toBe( 5 );
+		} );
+
+		it( 'should be null when multiple tags are selected', () => {
+			mockView = { filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 5, 6 ] } ] };
+			const { result } = renderHook( () => useTagFilter() );
+			expect( result.current.selectedTagId ).toBeNull();
+		} );
+	} );
+
+	describe( 'updateTagFilter', () => {
+		it( 'should add a tag filter when none exists', () => {
+			mockView = { filters: [] };
+			const { result } = renderHook( () => useTagFilter() );
+
+			act( () => {
+				result.current.updateTagFilter( 5 );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 5 ] } ],
+				page: 1,
+			} );
+		} );
+
+		it( 'should remove the filter when toggling the same tag', () => {
+			mockView = { filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 5 ] } ] };
+			const { result } = renderHook( () => useTagFilter() );
+
+			act( () => {
+				result.current.updateTagFilter( 5 );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [],
+				page: 1,
+			} );
+		} );
+
+		it( 'should replace the tag when a different tag is selected', () => {
+			mockView = { filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 5 ] } ] };
+			const { result } = renderHook( () => useTagFilter() );
+
+			act( () => {
+				result.current.updateTagFilter( 9 );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [ { field: 'ap_tag', operator: 'isAny', value: [ 9 ] } ],
+				page: 1,
+			} );
+		} );
+
+		it( 'should clear the tag filter when called with null', () => {
+			mockView = {
+				filters: [
+					{ field: 'ap_tag', operator: 'isAny', value: [ 5 ] },
+					{ field: 'ap_object_type', operator: 'is', value: 4 },
+				],
+			};
+			const { result } = renderHook( () => useTagFilter() );
+
+			act( () => {
+				result.current.updateTagFilter( null );
+			} );
+
+			expect( mockUpdateView ).toHaveBeenCalledWith( {
+				filters: [ { field: 'ap_object_type', operator: 'is', value: 4 } ],
+				page: 1,
+			} );
+		} );
+
+		it( 'should close the inspector by removing postId from the URL', () => {
+			const { result } = renderHook( () => useTagFilter() );
+
+			act( () => {
+				result.current.updateTagFilter( 5 );
+			} );
+
+			expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
+			const searchFn = mockNavigate.mock.calls[ 0 ][ 0 ].search;
+			expect( searchFn( { postId: 1, foo: 'bar' } ) ).toEqual( { foo: 'bar' } );
+		} );
+
+		it( 'should call the onComplete callback when provided', () => {
+			const onComplete = jest.fn();
+			const { result } = renderHook( () => useTagFilter() );
+
+			act( () => {
+				result.current.updateTagFilter( 5, { onComplete } );
+			} );
+
+			expect( onComplete ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/src/app/routes/feed/__tests__/utils.test.ts
+++ b/src/app/routes/feed/__tests__/utils.test.ts
@@ -1,5 +1,3 @@
-jest.mock( '@wordpress/views', () => ( {} ) );
-
 import { normalizeFieldOrder } from '../utils';
 
 const FIELDS = [ { id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' } ];

--- a/src/app/routes/feed/__tests__/utils.test.ts
+++ b/src/app/routes/feed/__tests__/utils.test.ts
@@ -1,0 +1,38 @@
+jest.mock( '@wordpress/views', () => ( {} ) );
+
+import { normalizeFieldOrder } from '../utils';
+
+const FIELDS = [ { id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' } ];
+
+describe( 'normalizeFieldOrder', () => {
+	it( 'should return the view unchanged when it has no fields', () => {
+		const view = { type: 'list' } as never;
+		expect( normalizeFieldOrder( view, FIELDS ) ).toBe( view );
+	} );
+
+	it( 'should sort fields into the canonical order', () => {
+		const view = { type: 'list', fields: [ 'c', 'a', 'd', 'b' ] } as never;
+		const result = normalizeFieldOrder( view, FIELDS ) as { fields: string[] };
+		expect( result.fields ).toEqual( [ 'a', 'b', 'c', 'd' ] );
+	} );
+
+	it( 'should place unknown fields at the end', () => {
+		const view = { type: 'list', fields: [ 'unknown', 'b', 'a' ] } as never;
+		const result = normalizeFieldOrder( view, FIELDS ) as { fields: string[] };
+		expect( result.fields ).toEqual( [ 'a', 'b', 'unknown' ] );
+	} );
+
+	it( 'should not mutate the original view fields array', () => {
+		const original = [ 'c', 'a' ];
+		const view = { type: 'list', fields: original } as never;
+		normalizeFieldOrder( view, FIELDS );
+		expect( original ).toEqual( [ 'c', 'a' ] );
+	} );
+
+	it( 'should preserve other view properties', () => {
+		const view = { type: 'table', page: 2, fields: [ 'b', 'a' ] } as never;
+		const result = normalizeFieldOrder( view, FIELDS ) as { type: string; page: number; fields: string[] };
+		expect( result.type ).toBe( 'table' );
+		expect( result.page ).toBe( 2 );
+	} );
+} );

--- a/src/app/store/__tests__/actions.test.ts
+++ b/src/app/store/__tests__/actions.test.ts
@@ -1,0 +1,32 @@
+const mockSet = jest.fn();
+const mockDispatch = jest.fn( ( _store: unknown ) => ( { set: mockSet } ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: ( store: unknown ) => mockDispatch( store ),
+} ) );
+
+jest.mock( '@wordpress/preferences', () => ( {
+	store: 'core/preferences',
+} ) );
+
+import { actions } from '../actions';
+import { SET_ACTIVE_ACTOR } from '../types';
+
+describe( 'store actions', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'setActiveActor', () => {
+		it( 'should return a SET_ACTIVE_ACTOR action with the actor id', () => {
+			const action = actions.setActiveActor( 5 );
+			expect( action ).toEqual( { type: SET_ACTIVE_ACTOR, actorId: 5 } );
+		} );
+
+		it( 'should persist the actor id to preferences', () => {
+			actions.setActiveActor( 12 );
+			expect( mockDispatch ).toHaveBeenCalledWith( 'core/preferences' );
+			expect( mockSet ).toHaveBeenCalledWith( 'activitypub/app', 'activeActorId', 12 );
+		} );
+	} );
+} );

--- a/src/app/store/__tests__/reducer.test.ts
+++ b/src/app/store/__tests__/reducer.test.ts
@@ -1,0 +1,42 @@
+import { reducer } from '../reducer';
+import { DEFAULT_STATE, SET_ACTIVE_ACTOR } from '../types';
+import type { Action } from '../types';
+
+describe( 'store reducer', () => {
+	it( 'should return the default state when called with undefined', () => {
+		// @ts-expect-error -- testing the runtime default for an unknown action.
+		const state = reducer( undefined, { type: 'UNKNOWN' } );
+		expect( state ).toEqual( DEFAULT_STATE );
+		expect( state.activeActorId ).toBeNull();
+	} );
+
+	it( 'should return the same state for an unknown action', () => {
+		const initial = { activeActorId: 7 };
+		// @ts-expect-error -- intentionally passing an unhandled action type.
+		const state = reducer( initial, { type: 'NOPE' } );
+		expect( state ).toBe( initial );
+	} );
+
+	it( 'should set the active actor on SET_ACTIVE_ACTOR', () => {
+		const action: Action = { type: SET_ACTIVE_ACTOR, actorId: 42 };
+		const state = reducer( DEFAULT_STATE, action );
+		expect( state.activeActorId ).toBe( 42 );
+	} );
+
+	it( 'should not mutate the previous state', () => {
+		const initial = { activeActorId: 1 };
+		const action: Action = { type: SET_ACTIVE_ACTOR, actorId: 2 };
+		const state = reducer( initial, action );
+		expect( state ).not.toBe( initial );
+		expect( initial.activeActorId ).toBe( 1 );
+		expect( state.activeActorId ).toBe( 2 );
+	} );
+
+	it( 'should preserve unrelated state fields', () => {
+		const initial = { activeActorId: 1, extra: 'keep-me' } as never;
+		const action: Action = { type: SET_ACTIVE_ACTOR, actorId: 9 };
+		const state = reducer( initial, action ) as { activeActorId: number; extra: string };
+		expect( state.extra ).toBe( 'keep-me' );
+		expect( state.activeActorId ).toBe( 9 );
+	} );
+} );

--- a/src/app/store/__tests__/resolvers.test.ts
+++ b/src/app/store/__tests__/resolvers.test.ts
@@ -1,0 +1,72 @@
+const mockGet = jest.fn();
+const mockSet = jest.fn();
+const mockGetCurrentUser = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	select: () => ( { get: mockGet } ),
+	dispatch: () => ( { set: mockSet } ),
+	resolveSelect: () => ( { getCurrentUser: mockGetCurrentUser } ),
+} ) );
+
+jest.mock( '@wordpress/preferences', () => ( { store: 'core/preferences' } ) );
+jest.mock( '@wordpress/core-data', () => ( { store: 'core' } ) );
+
+import { getActiveActorId } from '../resolvers';
+import { SET_ACTIVE_ACTOR } from '../types';
+
+describe( 'store resolvers', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'getActiveActorId', () => {
+		it( 'should return an action from a saved preference without fetching the user', () => {
+			mockGet.mockReturnValue( 5 );
+
+			const generator = getActiveActorId();
+			const result = generator.next();
+
+			expect( result.done ).toBe( true );
+			expect( result.value ).toEqual( { type: SET_ACTIVE_ACTOR, actorId: 5 } );
+			expect( mockGetCurrentUser ).not.toHaveBeenCalled();
+			expect( mockSet ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should fall back to the current user and persist it when no preference exists', () => {
+			mockGet.mockReturnValue( undefined );
+
+			const generator = getActiveActorId();
+			// First step yields the resolveSelect( coreStore ).getCurrentUser() control.
+			const first = generator.next();
+			expect( first.done ).toBe( false );
+
+			// Resume with the resolved current user.
+			const second = generator.next( { id: 7 } );
+			expect( second.done ).toBe( true );
+			expect( second.value ).toEqual( { type: SET_ACTIVE_ACTOR, actorId: 7 } );
+			expect( mockSet ).toHaveBeenCalledWith( 'activitypub/app', 'activeActorId', 7 );
+		} );
+
+		it( 'should treat null preference the same as undefined', () => {
+			mockGet.mockReturnValue( null );
+
+			const generator = getActiveActorId();
+			generator.next();
+			const second = generator.next( { id: 3 } );
+
+			expect( second.value ).toEqual( { type: SET_ACTIVE_ACTOR, actorId: 3 } );
+		} );
+
+		it( 'should return nothing when no preference and no current user id', () => {
+			mockGet.mockReturnValue( undefined );
+
+			const generator = getActiveActorId();
+			generator.next();
+			const second = generator.next( {} );
+
+			expect( second.done ).toBe( true );
+			expect( second.value ).toBeUndefined();
+			expect( mockSet ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/src/app/store/__tests__/resolvers.test.ts
+++ b/src/app/store/__tests__/resolvers.test.ts
@@ -1,11 +1,14 @@
 const mockGet = jest.fn();
 const mockSet = jest.fn();
 const mockGetCurrentUser = jest.fn();
+const mockSelect = jest.fn( ( _store: unknown ) => ( { get: mockGet } ) );
+const mockDispatch = jest.fn( ( _store: unknown ) => ( { set: mockSet } ) );
+const mockResolveSelect = jest.fn( ( _store: unknown ) => ( { getCurrentUser: mockGetCurrentUser } ) );
 
 jest.mock( '@wordpress/data', () => ( {
-	select: () => ( { get: mockGet } ),
-	dispatch: () => ( { set: mockSet } ),
-	resolveSelect: () => ( { getCurrentUser: mockGetCurrentUser } ),
+	select: ( store: unknown ) => mockSelect( store ),
+	dispatch: ( store: unknown ) => mockDispatch( store ),
+	resolveSelect: ( store: unknown ) => mockResolveSelect( store ),
 } ) );
 
 jest.mock( '@wordpress/preferences', () => ( { store: 'core/preferences' } ) );
@@ -30,6 +33,8 @@ describe( 'store resolvers', () => {
 			expect( result.value ).toEqual( { type: SET_ACTIVE_ACTOR, actorId: 5 } );
 			expect( mockGetCurrentUser ).not.toHaveBeenCalled();
 			expect( mockSet ).not.toHaveBeenCalled();
+			// The preference is read from the preferences store.
+			expect( mockSelect ).toHaveBeenCalledWith( 'core/preferences' );
 		} );
 
 		it( 'should fall back to the current user and persist it when no preference exists', () => {
@@ -45,6 +50,9 @@ describe( 'store resolvers', () => {
 			expect( second.done ).toBe( true );
 			expect( second.value ).toEqual( { type: SET_ACTIVE_ACTOR, actorId: 7 } );
 			expect( mockSet ).toHaveBeenCalledWith( 'activitypub/app', 'activeActorId', 7 );
+			// The current user comes from core-data and the value is persisted to preferences.
+			expect( mockResolveSelect ).toHaveBeenCalledWith( 'core' );
+			expect( mockDispatch ).toHaveBeenCalledWith( 'core/preferences' );
 		} );
 
 		it( 'should treat null preference the same as undefined', () => {

--- a/src/app/store/__tests__/selectors.test.ts
+++ b/src/app/store/__tests__/selectors.test.ts
@@ -1,0 +1,60 @@
+// Use the real createRegistrySelector from @wordpress/data, but stub core-data
+// so we don't pull in the full entity layer. The selector reads
+// `select( coreStore ).getCurrentUser()`, so we only need a store handle.
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+import { selectors } from '../selectors';
+import type { State } from '../types';
+
+const mockGetCurrentUser = jest.fn();
+
+/**
+ * Registry selectors created with `createRegistrySelector` resolve their
+ * `select` from `selector.registry`. Override it so the inner `select( coreStore )`
+ * returns our mocked core-data selectors.
+ *
+ * @param currentUser The value `getCurrentUser()` should return.
+ */
+function withRegistry( currentUser: unknown ): void {
+	mockGetCurrentUser.mockReturnValue( currentUser );
+	( selectors.getActiveActorId as unknown as { registry: unknown } ).registry = {
+		select: () => ( { getCurrentUser: mockGetCurrentUser } ),
+	};
+}
+
+describe( 'store selectors', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'getActiveActorId', () => {
+		it( 'should return the stored actor id when set', () => {
+			withRegistry( { id: 99 } );
+			const state: State = { activeActorId: 3 };
+			expect( selectors.getActiveActorId( state ) ).toBe( 3 );
+			// Should not need the current user when state already has a value.
+			expect( mockGetCurrentUser ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should fall back to the current user id when not set', () => {
+			withRegistry( { id: 7 } );
+			const state: State = { activeActorId: null };
+			expect( selectors.getActiveActorId( state ) ).toBe( 7 );
+		} );
+
+		it( 'should return null when not set and there is no current user', () => {
+			withRegistry( undefined );
+			const state: State = { activeActorId: null };
+			expect( selectors.getActiveActorId( state ) ).toBeNull();
+		} );
+
+		it( 'should return the stored id even when it is 0', () => {
+			withRegistry( { id: 7 } );
+			const state: State = { activeActorId: 0 };
+			expect( selectors.getActiveActorId( state ) ).toBe( 0 );
+			expect( mockGetCurrentUser ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/src/app/store/__tests__/selectors.test.ts
+++ b/src/app/store/__tests__/selectors.test.ts
@@ -1,60 +1,53 @@
-// Use the real createRegistrySelector from @wordpress/data, but stub core-data
-// so we don't pull in the full entity layer. The selector reads
-// `select( coreStore ).getCurrentUser()`, so we only need a store handle.
+// Stub core-data so we only need a store handle ('core'); the selector reads
+// `select( coreStore ).getCurrentUser()`.
 jest.mock( '@wordpress/core-data', () => ( {
 	store: 'core',
 } ) );
 
+import { createRegistry } from '@wordpress/data';
 import { selectors } from '../selectors';
-import type { State } from '../types';
-
-const mockGetCurrentUser = jest.fn();
 
 /**
- * Registry selectors created with `createRegistrySelector` resolve their
- * `select` from `selector.registry`. Override it so the inner `select( coreStore )`
- * returns our mocked core-data selectors.
+ * Builds a real, isolated data registry with a stub core store and the app
+ * selectors registered, then resolves `getActiveActorId` through it. This
+ * exercises the registry-selector wiring the way `@wordpress/data` does at
+ * runtime, without coupling to `createRegistrySelector` internals.
  *
- * @param currentUser The value `getCurrentUser()` should return.
+ * @param activeActorId The app store's stored actor id.
+ * @param currentUser   The value the core store's `getCurrentUser` returns.
  */
-function withRegistry( currentUser: unknown ): void {
-	mockGetCurrentUser.mockReturnValue( currentUser );
-	( selectors.getActiveActorId as unknown as { registry: unknown } ).registry = {
-		select: () => ( { getCurrentUser: mockGetCurrentUser } ),
-	};
+function resolveActiveActorId( activeActorId: number | null, currentUser: unknown ): number | null {
+	const registry = createRegistry();
+
+	registry.registerStore( 'core', {
+		reducer: ( state = {} ) => state,
+		selectors: { getCurrentUser: () => currentUser },
+	} );
+
+	registry.registerStore( 'activitypub/app', {
+		reducer: ( state = { activeActorId } ) => state,
+		selectors,
+	} );
+
+	return registry.select( 'activitypub/app' ).getActiveActorId();
 }
 
 describe( 'store selectors', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'getActiveActorId', () => {
 		it( 'should return the stored actor id when set', () => {
-			withRegistry( { id: 99 } );
-			const state: State = { activeActorId: 3 };
-			expect( selectors.getActiveActorId( state ) ).toBe( 3 );
-			// Should not need the current user when state already has a value.
-			expect( mockGetCurrentUser ).not.toHaveBeenCalled();
+			expect( resolveActiveActorId( 3, { id: 99 } ) ).toBe( 3 );
 		} );
 
 		it( 'should fall back to the current user id when not set', () => {
-			withRegistry( { id: 7 } );
-			const state: State = { activeActorId: null };
-			expect( selectors.getActiveActorId( state ) ).toBe( 7 );
+			expect( resolveActiveActorId( null, { id: 7 } ) ).toBe( 7 );
 		} );
 
 		it( 'should return null when not set and there is no current user', () => {
-			withRegistry( undefined );
-			const state: State = { activeActorId: null };
-			expect( selectors.getActiveActorId( state ) ).toBeNull();
+			expect( resolveActiveActorId( null, undefined ) ).toBeNull();
 		} );
 
 		it( 'should return the stored id even when it is 0', () => {
-			withRegistry( { id: 7 } );
-			const state: State = { activeActorId: 0 };
-			expect( selectors.getActiveActorId( state ) ).toBe( 0 );
-			expect( mockGetCurrentUser ).not.toHaveBeenCalled();
+			expect( resolveActiveActorId( 0, { id: 7 } ) ).toBe( 0 );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Proposed changes:

Adds unit-test coverage for the finished-but-untested parts of the admin app data layer. Before this, the app had only two test files; this adds nine more, covering the core core-data wiring and the feed filtering hooks.

- **Store** (`src/app/store/__tests__/`): `reducer`, `actions`, `selectors`, `resolvers`. Selectors are exercised through a real `@wordpress/data` registry (no coupling to `createRegistrySelector` internals); resolvers are driven step-by-step through the generator and assert which store each `select`/`dispatch`/`resolveSelect` targets.
- **Feed hooks** (`src/app/hooks/__tests__/`): `use-feed` (REST query-arg mapping, `enabled` gating, single-value-to-array wrapping, `_fields` selection, record fallback), `use-feed-filters`, `use-object-type-filter`, and `use-tag-filter` (add / toggle / replace / clear, other-filter preservation, inspector close, `onComplete`).
- **View util** (`src/app/routes/feed/__tests__/utils.test.ts`): `normalizeFieldOrder` canonical ordering, unknown-field placement, immutability, and property preservation.

No production code changed. Full unit suite goes from 244 to 288 passing tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run test:unit -- src/app` and confirm all suites pass.

### Changelog entry

No changelog entry required (test-only, not shipped in the plugin zip). "Skip Changelog" label applied.
