### PR TITLE
Fix Scheduler::update_remote_actors to actually re-fetch from remote

### DIFF
--- a/.github/changelog/fix-scheduler-real-remote-fetch
+++ b/.github/changelog/fix-scheduler-real-remote-fetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the scheduled refresh of remote profiles so it actually re-fetches from the remote server. Previously, stale avatars and bios for commenters never updated until they sent a new activity to your site.

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -280,9 +280,17 @@ class Scheduler {
 		$actors = Remote_Actors::get_outdated( $number );
 
 		foreach ( $actors as $actor ) {
-			$meta = get_remote_metadata_by_actor( $actor->guid, false );
+			/*
+			 * Use Http::get_remote_object() directly here.
+			 * get_remote_metadata_by_actor() short-circuits to the locally
+			 * cached ap_actor CPT via Remote_Actors::fetch_by_uri() and never
+			 * makes an HTTP request when the actor is already cached, so the
+			 * upsert would just rewrite the same stale data and this refresh
+			 * would be a no-op. The Update handler documents the same trap.
+			 */
+			$meta = Http::get_remote_object( $actor->guid, false );
 
-			if ( empty( $meta ) || ! is_array( $meta ) || is_wp_error( $meta ) ) {
+			if ( empty( $meta ) || ! \is_array( $meta ) || \is_wp_error( $meta ) ) {
 				Remote_Actors::add_error( $actor->ID, 'Failed to fetch or parse metadata' );
 			} else {
 				$id = Remote_Actors::upsert( $meta );


### PR DESCRIPTION
Fixes the scheduled refresh of cached remote actors so it actually re-fetches from the remote server. Right now it does not, which means stale avatar URLs and bios never recover via cron.

## Proposed changes

In `Scheduler::update_remote_actors()`, replace `get_remote_metadata_by_actor( $actor->guid, false )` with `Http::get_remote_object( $actor->guid, false )`.

`get_remote_metadata_by_actor()` calls `Remote_Actors::fetch_by_uri()`, which returns the locally cached `ap_actor` post when one exists and only falls back to a real HTTP request when it does not. So the scheduled loop just rewrites the same cached data on every tick.

The `Update` activity handler at `includes/handler/class-update.php` already documents this trap and uses `Http::get_remote_object()` for the same reason; this PR mirrors that.

### How this surfaces in production

Mastodon renames the avatar file on every profile edit. Once a commenter's avatar URL is captured locally, the old URL starts 404ing as soon as they update their picture. The scheduler is the only path that could recover stale URLs for users who do not send `Update` activities our way; today it cannot.

Verified on a site with ~440 cached remote actors: with the patched scheduler running, real remote refetches happen and `Avatar::clear_cached_avatar` (already wired to `save_post_` on the actor CPT) re-downloads avatars on next render.

## Testing instructions

1. Cache a remote actor locally (any Mastodon commenter is fine).
2. Change that user's avatar on their home server.
3. Wait for `activitypub_update_remote_actors` to fire, or trigger it: `wp cron event run activitypub_update_remote_actors`.
4. Without this patch: `wp post get <actor_id> --field=post_content | jq .icon.url` still shows the old URL.
5. With this patch: the URL updates to the current one, and the next page render fetches the new avatar locally.

### Other information

- [ ] No new tests yet. Happy to add a unit test that asserts `Http::get_remote_object()` is invoked rather than the local-cache path, if maintainers prefer.
