### PR TITLE
Fix phpcs alignment warning in the scheduler test

### DIFF
--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -953,7 +953,7 @@ class Test_Scheduler extends \WP_UnitTestCase {
 
 		global $wpdb;
 		$modified = \gmdate( 'Y-m-d H:i:s', \time() - 9 * DAY_IN_SECONDS );
-		$updated = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$updated  = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$wpdb->prepare(
 				"UPDATE $wpdb->posts SET post_modified = %s, post_modified_gmt = %s WHERE ID = %d",
 				array( $modified, $modified, $id )


### PR DESCRIPTION
Aligns the consecutive `$modified` / `$updated` assignment operators in `tests/phpunit/tests/includes/class-test-scheduler.php` (`Generic.Formatting.MultipleStatementAlignment`), which was failing the PHP_CodeSniffer CI check on trunk. Test-only formatting; no behavior change.

- [x] No changelog entry needed (test-only formatting).