### PR TITLE
Update: Gate the pre-PR review by change type and reserve Opus for the security audit

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -18,7 +18,10 @@ description: INVOKE THIS SKILL before creating any PR to ensure compliance with 
 
 ## Pre-PR Review
 
-Before creating a PR, delegate to the **code-review** agent to review all changes on the branch. Address any critical issues before proceeding.
+Scope the review to what changed — don't review every PR:
+
+- **Skip** for docs-only (`*.md`, `docs/`, `README`), tooling/config-only (`.claude/`, `.agents/`, workflow files), and trivial edits (typo, comment, whitespace). Push these straight to PR.
+- **Run** the **code-review** agent only when the branch changes plugin code (PHP/JS/CSS logic). Address any critical issues before proceeding.
 
 ## PR Creation
 

--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -2,7 +2,7 @@
 name: security-audit
 description: Defensive first-party security review of the plugin's own code to detect and help fix weaknesses (SSRF, content disclosure, auth bypass, XSS, content negotiation) before release. Use when asked to check security, harden the plugin, or review the code for vulnerabilities to fix.
 tools: Bash, Read, Glob, Grep, WebFetch
-model: sonnet
+model: opus
 skills: federation, code-style
 ---
 


### PR DESCRIPTION
## Proposed changes:

Make the pre-PR review step efficient so trivial PRs don't pay for a review they don't need, and reserve the expensive model tier for the rare, deliberate audits.

* **`pr` skill** — Gate the pre-PR review by change type. Skip the code-review agent for docs-only (`*.md`, `docs/`, `README`), tooling/config-only (`.claude/`, `.agents/`, workflow files), and trivial edits (typo, comment, whitespace). Only run it when the branch changes plugin code (PHP/JS/CSS logic). Previously every PR triggered a full agent review.
* **`security-audit` agent** — Run on the Opus tier. It is the most reasoning-dense, highest-stakes agent (vulnerability audit) and runs only on demand, so the stronger model is worth it. The `code-review` agent stays on Sonnet because it runs on every code PR and should stay affordable.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Tooling/config only, no plugin code changes, so no tests apply.

## Testing instructions:

* Open `.agents/skills/pr/SKILL.md` and confirm the "Pre-PR Review" section gates the review by change type.
* Open `.claude/agents/security-audit.md` and confirm `model: opus`; confirm `.claude/agents/code-review.md` remains `model: sonnet`.
