### PR TITLE
Add: Inspect Internal Storage snippet

### DIFF
--- a/snippets/README.md
+++ b/snippets/README.md
@@ -16,6 +16,7 @@ Think of snippets as a testing ground, similar to WordPress' [feature plugin](ht
 | [ATproto DID for Bridgy Fed](atproto-did-for-bridgy-fed/) | Allows you to serve an ATproto DID from your blog's `.well-known` directory to allow Bridgy Fed to use your blog's hostname as its Bluesky handle. |
 | [Quotes as Comments](quotes-as-comments/) | Displays ActivityPub quotes as regular comments instead of facepile reactions. |
 | [Auto-Approve Reactions](auto-approve-reactions/) | Automatically approves all incoming ActivityPub reactions (likes, reposts, and quotes) without manual moderation. |
+| [Inspect Internal Storage](inspect-internal-storage/) | Makes the plugin's internal Inbox, Outbox, and remote post (`ap_post`) storage visible in the WordPress admin for inspection and debugging. |
 
 ## How to Use
 

--- a/snippets/inspect-internal-storage/README.md
+++ b/snippets/inspect-internal-storage/README.md
@@ -1,0 +1,35 @@
+# Inspect Internal Storage
+
+Makes the ActivityPub plugin's internal Inbox, Outbox, and remote post (`ap_post`) storage visible in the WordPress admin, so you can inspect the raw activities the plugin sends and receives.
+
+## How It Works
+
+The ActivityPub plugin stores the activities it exchanges with the Fediverse as hidden custom post types:
+
+- **Inbox** (`ap_inbox`) — activities received from remote servers.
+- **Outbox** (`ap_outbox`) — activities your site has sent.
+- **Posts** (`ap_post`) — cached remote objects (the content shown in the reader).
+
+These are registered with `show_ui` disabled, so they never appear in the admin. This snippet hooks into `register_post_type_args` and `register_taxonomy_args` to flip those screens on, adds menu icons, and exposes the `ap_post` taxonomies (`ap_object_type`, `ap_tag`) for filtering. It also adds a **Meta** column to the Inbox and Outbox list tables so you can read each activity's stored metadata at a glance.
+
+Nothing about how the plugin behaves changes — the snippet only reveals existing data for inspection.
+
+## When to Use
+
+This is useful if you want to:
+
+- Debug federation problems by confirming whether an activity (a Follow, Like, or Delete) actually reached your Inbox.
+- See exactly what your site sent in its Outbox, and to whom.
+- Inspect cached remote objects and their object types.
+
+> **Note:** This exposes raw, internal data intended for debugging. Use it on a staging or development site, and deactivate it when you are done.
+
+## Installation
+
+Copy this folder to `wp-content/plugins/` and activate **Inspect Internal Storage** from the WordPress admin, or copy `inspect-internal-storage.php` to `wp-content/mu-plugins/` for automatic activation.
+
+## Requirements
+
+- WordPress 5.9+
+- PHP 7.4+
+- [ActivityPub](https://wordpress.org/plugins/activitypub/) plugin

--- a/snippets/inspect-internal-storage/inspect-internal-storage.php
+++ b/snippets/inspect-internal-storage/inspect-internal-storage.php
@@ -28,7 +28,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * These collections are normally hidden (`show_ui` is false). The slugs are the
  * plugin's Inbox (received activities), Outbox (sent activities), and remote
- * post / `ap_post` (cached remote objects) storage.
+ * post / `ap_post` (cached remote objects) storage. The `ap_tombstone` type is
+ * intentionally left out; add it here if you also need to inspect tombstones.
  *
  * @return array<string, string> Post type slug => dashicon class.
  */

--- a/snippets/inspect-internal-storage/inspect-internal-storage.php
+++ b/snippets/inspect-internal-storage/inspect-internal-storage.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Plugin Name:       Inspect Internal Storage
+ * Plugin URI:        https://github.com/Automattic/wordpress-activitypub
+ * Description:       Makes the ActivityPub plugin's internal Inbox, Outbox, and remote post (ap_post) storage visible in the WordPress admin, so you can inspect the raw activities the plugin sends and receives.
+ * Version:           1.0.0
+ * Requires at least: 5.9
+ * Requires PHP:      7.4
+ * Author:            Automattic
+ * Author URI:        https://automattic.com/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       activitypub-inspect-internal-storage
+ * Requires Plugins:  activitypub
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Snippets;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The ActivityPub internal post types to expose, mapped to a dashicon.
+ *
+ * These collections are normally hidden (`show_ui` is false). The slugs are the
+ * plugin's Inbox (received activities), Outbox (sent activities), and remote
+ * post / `ap_post` (cached remote objects) storage.
+ *
+ * @return array<string, string> Post type slug => dashicon class.
+ */
+function inspect_internal_storage_post_types() {
+	return array(
+		'ap_inbox'  => 'dashicons-download',
+		'ap_outbox' => 'dashicons-upload',
+		'ap_post'   => 'dashicons-media-document',
+	);
+}
+
+/**
+ * Make the internal post types visible in the admin UI.
+ *
+ * @param array  $args      The post type arguments.
+ * @param string $post_type The post type slug.
+ *
+ * @return array The filtered post type arguments.
+ */
+function inspect_internal_storage_post_type( $args, $post_type ) {
+	$post_types = inspect_internal_storage_post_types();
+
+	if ( ! isset( $post_types[ $post_type ] ) ) {
+		return $args;
+	}
+
+	$args['show_ui']      = true;
+	$args['show_in_menu'] = true;
+	$args['menu_icon']    = $post_types[ $post_type ];
+
+	return $args;
+}
+\add_filter( 'register_post_type_args', __NAMESPACE__ . '\inspect_internal_storage_post_type', 10, 2 );
+
+/**
+ * Make the ap_post taxonomies (object type and tags) visible in the admin UI.
+ *
+ * @param array  $args     The taxonomy arguments.
+ * @param string $taxonomy The taxonomy slug.
+ *
+ * @return array The filtered taxonomy arguments.
+ */
+function inspect_internal_storage_taxonomy( $args, $taxonomy ) {
+	if ( ! \in_array( $taxonomy, array( 'ap_object_type', 'ap_tag' ), true ) ) {
+		return $args;
+	}
+
+	$args['show_ui']      = true;
+	$args['show_in_menu'] = true;
+
+	return $args;
+}
+\add_filter( 'register_taxonomy_args', __NAMESPACE__ . '\inspect_internal_storage_taxonomy', 10, 2 );
+
+/**
+ * Add a "Meta" column to the Inbox and Outbox list tables.
+ *
+ * @param array  $columns   The list table columns.
+ * @param string $post_type The post type slug.
+ *
+ * @return array The filtered columns.
+ */
+function inspect_internal_storage_columns( $columns, $post_type ) {
+	if ( ! \in_array( $post_type, array( 'ap_inbox', 'ap_outbox' ), true ) ) {
+		return $columns;
+	}
+
+	$columns['ap_meta'] = 'Meta';
+
+	return $columns;
+}
+\add_filter( 'manage_posts_columns', __NAMESPACE__ . '\inspect_internal_storage_columns', 10, 2 );
+
+/**
+ * Render the "Meta" column by listing each stored meta key and value.
+ *
+ * @param string $column_name The current column name.
+ * @param int    $post_id     The current post ID.
+ */
+function inspect_internal_storage_column_content( $column_name, $post_id ) {
+	if ( 'ap_meta' !== $column_name ) {
+		return;
+	}
+
+	foreach ( \get_post_meta( $post_id ) as $key => $value ) {
+		echo \esc_html( $key ) . ': ' . \esc_html( $value[0] ) . '<br>';
+	}
+}
+\add_action( 'manage_posts_custom_column', __NAMESPACE__ . '\inspect_internal_storage_column_content', 10, 2 );


### PR DESCRIPTION
## Proposed changes:

Adds a contributor snippet that makes the ActivityPub plugin's internal storage visible in the WordPress admin, so site owners can inspect the raw activities the plugin sends and receives when debugging federation.

* New snippet `snippets/inspect-internal-storage/` exposes the normally-hidden internal post types in wp-admin: **Inbox** (`ap_inbox`), **Outbox** (`ap_outbox`), and **Posts** (`ap_post`), via `register_post_type_args`.
* Also exposes the `ap_post` taxonomies (`ap_object_type`, `ap_tag`) and adds a **Meta** column to the Inbox/Outbox list tables so each activity's stored metadata is readable at a glance.
* It is a focused port of the admin-visibility behavior of `local/class-debug.php`, with the logging left out. It changes no plugin behavior and is a no-op when deactivated.
* Decoupled from the plugin's classes (matches on slug strings, not class constants), so it cannot fatal when the plugin is inactive.
* Updates the snippets index table.

This also gives users a no-code way to confirm whether an activity (a Follow, Like, or Delete) actually reached their Inbox, which helps triage reports like #3408.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Snippets are standalone example plugins without a test suite, consistent with the existing snippets.

## Testing instructions:

* Copy `snippets/inspect-internal-storage/` to `wp-content/plugins/` and activate **Inspect Internal Storage** (or drop the PHP file into `wp-content/mu-plugins/`).
* Confirm new admin menus appear for the ActivityPub Inbox, Outbox, and Posts post types.
* Open the Inbox or Outbox list and confirm the **Meta** column lists each activity's stored metadata.
* Deactivate the snippet and confirm the menus disappear and nothing else changes.

### Changelog entry

This only touches the `snippets/` folder, which is not shipped to users, so no changelog entry is needed ("Skip Changelog").
