### PR TITLE
Release 9.0.2

### DIFF
--- a/.github/changelog/fix-verify-announced-activity-origin
+++ b/.github/changelog/fix-verify-announced-activity-origin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improve handling of content received from other servers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.2] - 2026-06-29
+### Fixed
+- Improve handling of content received from other servers. [#3475]
+
 ## [9.0.1] - 2026-06-15
 ### Added
 - Add FAQ guides that help solve follow requests stuck on "pending" and comments from the Fediverse not showing up. [#3404]

--- a/activitypub.php
+++ b/activitypub.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActivityPub
  * Plugin URI: https://github.com/Automattic/wordpress-activitypub
  * Description: The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
- * Version: 9.0.1
+ * Version: 9.0.2
  * Author: Matthias Pfefferle & Automattic
  * Author URI: https://automattic.com/
  * License: MIT
@@ -17,7 +17,7 @@
 
 namespace Activitypub;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '9.0.1' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '9.0.2' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaf
 Tags: fediverse, activitypub, indieweb, activitystream, social web
 Requires at least: 6.5
 Tested up to: 7.0
-Stable tag: 9.0.1
+Stable tag: 9.0.2
 Requires PHP: 7.4
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -110,6 +110,10 @@ For reasons of data protection, it is not possible to see the followers of other
 5. A Blog-Profile on Mastodon
 
 == Changelog ==
+
+### 9.0.2 - 2026-06-29
+#### Fixed
+- Improve handling of content received from other servers.
 
 ### 9.0.1 - 2026-06-15
 #### Added


### PR DESCRIPTION
## Proposed changes:

Records the **9.0.2** patch release on trunk.

* Bumps the version to `9.0.2` in `activitypub.php` (plugin header + `ACTIVITYPUB_PLUGIN_VERSION`) and `readme.txt` (`Stable tag`).
* Adds the `9.0.2` section to `CHANGELOG.md` and `readme.txt`.
* Removes the `fix-verify-announced-activity-origin` pending changelog entry, which already shipped in 9.0.2 (#3475, already on trunk), so the next release won't list it twice.

9.0.2 itself was cut from a separate `release/9.0.2` branch off the `9.0.1` tag; this PR brings trunk in line, matching the previous "Release 9.0.1 (#3409)" / "Release 9.0.0 (#3392)" commits.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Version/changelog only; no code changes.

## Testing instructions:

* Confirm the version is `9.0.2` in `activitypub.php` (header + constant) and `readme.txt` (`Stable tag`).
* Confirm `CHANGELOG.md` and `readme.txt` list a `9.0.2` section above `9.0.1`.
* Confirm `.github/changelog/fix-verify-announced-activity-origin` is gone and the other pending entries remain.
