### PR TITLE
Tighten agent and skill guidance after review

### DIFF
--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -36,6 +36,26 @@ Always use `'activitypub'` for translations:
 ### WordPress Global Functions
 When in a namespace, always escape WordPress functions with backslash: `\get_option()`, `\add_action()`, etc.
 
+### Imports and Class References
+Two symmetric rules, both enforced in review:
+
+```php
+// Plugin classes: import with `use`, never reference inline.
+use Activitypub\Collection\Outbox;
+
+Outbox::add( $activity );          // ✅
+\Activitypub\Collection\Outbox::add( $activity ); // ❌ no inline namespaces
+
+// Global (WordPress/PHP) classes: reference inline with a backslash, never import.
+$query = new \WP_Query( $args );   // ✅
+class Command extends \WP_CLI_Command {} // ✅
+use WP_Query;                      // ❌ no `use` for global classes
+```
+
+### Comments
+- `/* */` for multi-line comments, `//` for single-line — not stacked `//` lines.
+- Place each comment at the line it documents, not as one block above a block of code. Detail is fine; split it per statement.
+
 ## Comprehensive Standards
 
 See `docs/php-coding-standards.md` for complete WordPress coding standards.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -63,10 +63,10 @@ git cherry-pick -m 1 <commit-hash>
 # 3. Update changelog and versions.
 composer changelog:write
 
-# Manually update versions in:
-# - activitypub.php
+# Manually update versions in (see Version File Locations above):
+# - activitypub.php (Version header AND ACTIVITYPUB_PLUGIN_VERSION constant)
 # - readme.txt
-# - package.json
+# - includes/class-migration.php
 
 # 4. Push branch and create GitHub release.
 git push -u origin tags/5.3.1

--- a/.claude/agents/bug-bounty.md
+++ b/.claude/agents/bug-bounty.md
@@ -98,6 +98,8 @@ Poll every 30 seconds for a maximum of 30 minutes (60 attempts). If the run has 
 2. Apply the **code-style** and **test** skills to diagnose the issue.
 3. Fix the failing test(s), push, and repeat until CI is green.
 
+**Green local tests do NOT imply green CI.** Local wp-env runs PHP 8.x, but CI also tests PHP 7.4 — named arguments, union types, `match`, nullsafe `?->`, and constructor property promotion pass locally and fail there. CI also hits environment differences like empty `post_date_gmt` (`0000-00-00`). Check the PHP 7.4 job specifically.
+
 **Do NOT consider the task done until CI passes.** A draft PR with red CI is not a valid deliverable.
 
 ## Guidelines

--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -43,6 +43,7 @@ Apply the **code-style** skill standards when reviewing. In addition, check for:
 - Capability checks before privileged operations
 - No direct database queries without `$wpdb->prepare()`
 - No `eval()`, `extract()`, or unserialize of untrusted data
+- Any surface that exposes a post's content, metadata, or existence to unauthenticated callers gates on `is_post_publicly_queryable()` — NOT `is_post_disabled()`, whose lifecycle escape hatch intentionally passes previously-federated-now-private posts through (known leak vector, see the security-audit agent's vulnerability history)
 
 ### Code Quality
 - No unused variables, imports, or dead code
@@ -52,7 +53,7 @@ Apply the **code-style** skill standards when reviewing. In addition, check for:
 - Functions/methods have a single responsibility
 
 ### Compatibility
-- PHP 7.4+ compatible syntax
+- PHP 7.4+ compatible syntax — flag any PHP 8.0+ construct: named arguments, union types, `match`, nullsafe `?->`, constructor property promotion. Local wp-env runs PHP 8.x, so these pass local tests but fail the PHP 7.4 CI job. (`str_contains()` etc. are fine — WordPress core polyfills them.)
 - No breaking changes to public APIs without deprecation path
 - Integration points with third-party plugins preserved
 

--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -18,7 +18,7 @@ You check for weaknesses informed by the plugin's CVE history, its federation su
 
 ## Known Vulnerability History
 
-Past CVEs and security fixes inform what patterns to watch for. The full list is tracked on [WPScan](https://wpscan.com/plugin/activitypub/). Check this list periodically to stay current on newly disclosed vulnerabilities and update the entries below accordingly.
+Past CVEs and security fixes inform what patterns to watch for. The full list is tracked on [WPScan](https://wpscan.com/plugin/activitypub/). Check this list at the start of an audit; if it contains disclosures missing below, include them in your report so a maintainer can update this file (you cannot edit it yourself).
 
 1. **Unauthenticated REST API access** (WPScan `5fb58642-61ba-447c-80ac-68d3777486d7`, CVE-2023-52199, fixed 1.0.6, 2024) — endpoints accessible without auth.
 2. **Post title/content disclosure** (WPScan `daa4d93a-…` / `541bbe4c-…`, fixed 1.0.0, 2023) — low-privilege users accessing unpublished content.
@@ -214,6 +214,34 @@ curl -s -X POST "$URL/wp-json/activitypub/1.0/oauth/clients" -H "Content-Type: a
 curl -s -o /dev/null -w "%{http_code}" "$URL/?activitypub"
 ```
 
+## Verification Protocol — a Pattern Match Is a Lead, Not a Finding
+
+In a past full audit run, exactly ONE flagged finding was a real vulnerability; the rest were pattern-matched noise, and one proposed "fix" would have broken federation with Mastodon. The failure modes are known and recur. Every candidate finding MUST pass all four checks below before it may appear in the report.
+
+**1. Read every caller before flagging a missing guard.**
+"Function X lacks a password/visibility/capability check" is only a finding if some *reachable* call path actually hits X with unvetted input. Grep for all call sites and walk each one upstream until you hit either a guard (not a finding — record it under Passed Checks with the guard's `file:line`) or an unguarded entry point (a finding — name that exact path). A helper that is guarded by all of its current callers is at most a Low defense-in-depth note, never Critical or High.
+
+**2. Verify against the current branch, not against the vulnerability history.**
+The Known Vulnerability History tells you *where to look*, not *what is true*. Before flagging "this matches vuln #N", confirm the vulnerable pattern still exists in the code you are auditing — read the current implementation and check `git log`/`git blame` for the fix. Reporting an already-fixed issue as current is a false positive.
+
+**3. Write a concrete exploitation sketch, or downgrade the finding.**
+Each Critical or High finding must include: entry point (URL / route / hook), authentication required (unauthenticated? which capability?), the exact request or activity shape that triggers it, and the observable impact. If you cannot write that sketch, the finding is at most Medium and must carry the `NEEDS-VERIFICATION` verdict.
+
+**4. Check what legitimate traffic relies on the current behavior before proposing a fix.**
+A fix that tightens verification or acceptance (signature algorithms, required headers, content types, actor validation) can break interop with legitimate fediverse software. Before recommending it, identify what Mastodon / Pleroma / Pixelfed etc. actually send on that path (FEDERATION.md, the specs, code comments, tests). Canonical failure: recommending that the draft-signature `algorithm` default return `WP_Error` would have rejected `rsa-sha256` — exactly what Mastodon sends; the permissive default was also harmless because verification still requires the right key. If your fix changes accepted inputs, the report must name the implementations affected and say why they keep working.
+
+**Verdicts — label every finding:**
+- `CONFIRMED` — full path traced from entry point to impact; all callers and guards read; evidence cited.
+- `NEEDS-VERIFICATION` — a suspicious pattern you could not fully trace. It goes in its own report section, phrased as a question to investigate, never as a vulnerability.
+
+| Rationalization | Reality |
+|---|---|
+| "The function has no guard — that's a finding" | Guards live in callers too. Read every call site first. |
+| "This matches known vuln #N" | The history is a search heuristic. Check whether the fix already landed. |
+| "Better to over-report than to miss something" | False positives burn maintainer time and cause regression "fixes". Use `NEEDS-VERIFICATION` instead. |
+| "Stricter validation is always safer" | Stricter acceptance breaks federation with real servers. Name what relies on current behavior. |
+| "I traced enough of the path" | If you can't write the exploitation sketch, you haven't. Downgrade it. |
+
 ## Output Format
 
 ```markdown
@@ -221,27 +249,33 @@ curl -s -o /dev/null -w "%{http_code}" "$URL/?activitypub"
 
 ### Critical
 Issues that could lead to data disclosure, auth bypass, or remote code execution.
-- **[VULN-ID]** — severity / file:line — description and proof
+- **[VULN-ID]** — CONFIRMED / file:line — description, exploitation sketch (entry point, auth, request shape, impact), callers/guards checked, proposed fix + interop impact
 
 ### High
 Issues that could be exploited with some preconditions.
-- **[VULN-ID]** — severity / file:line — description
+- **[VULN-ID]** — CONFIRMED / file:line — description, exploitation sketch, callers/guards checked, proposed fix + interop impact
 
 ### Medium
 Defense-in-depth concerns and hardening opportunities.
-- **[VULN-ID]** — severity / file:line — description
+- **[VULN-ID]** — verdict / file:line — description
 
 ### Low / Informational
 Minor issues and observations.
-- **[VULN-ID]** — severity / file:line — description
+- **[VULN-ID]** — verdict / file:line — description
+
+### Needs Verification
+Suspicious patterns that could not be fully traced — questions for a maintainer, not vulnerabilities.
+- **[ID]** — file:line — what looks off, what was checked, what remains to verify
 
 ### Passed Checks
-Areas that were audited and found secure.
-- [area] — what was checked and why it's OK
+Areas that were audited and found secure — including candidate findings dismissed after tracing (cite the guard that dismissed them).
+- [area] — what was checked and why it's OK (guard at file:line)
 
 ### Recommendations
-Prioritized list of fixes, from most to least urgent.
+Prioritized list of fixes, from most to least urgent. For any fix that changes accepted inputs, name the fediverse implementations affected.
 ```
+
+Only `CONFIRMED` findings may appear under Critical and High.
 
 ## Guidelines
 


### PR DESCRIPTION
## Proposed changes:
* **security-audit agent:** add a mandatory verification protocol built from documented failure modes of past runs (a full audit produced one real finding, the rest pattern-matched noise, and one proposed fix would have rejected rsa-sha256, i.e. broken Mastodon federation). Every finding must now: trace all callers before flagging a missing guard, be verified against the current branch rather than the vulnerability history, include a concrete exploitation sketch to qualify as Critical/High, and assess fediverse interop impact before proposing stricter validation. Findings carry CONFIRMED / NEEDS-VERIFICATION verdicts, and only CONFIRMED ones may appear under Critical/High. Also reworded the vuln-history upkeep note, since the agent has no Write/Edit tools and cannot update its own definition.
* **code-review agent:** security checklist now includes the content-exposure rule (gate on is_post_publicly_queryable(), never is_post_disabled(), whose lifecycle escape hatch is a known leak vector), and the PHP 7.4 compatibility check lists the concrete PHP 8.0+ constructs to flag.
* **bug-bounty agent:** the CI verification step warns that green local tests (wp-env on PHP 8.x) do not imply a green PHP 7.4 CI job.
* **release skill:** the patch-release workflow no longer tells you to bump package.json (it has no version field, as the Version File Locations section already stated); it now matches bin/release.js: plugin header + constant, readme.txt, class-migration.php.
* **code-style skill:** documents import conventions (use imports for plugin classes, inline backslash references for global classes) and comment style/placement.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

The security-audit protocol change was validated with three independent agent runs against the exact scenario a past audit got wrong (generate_post_summary() and its caller guards): all three traced the callers and reported a Low defense-in-depth note instead of a false Critical.

## Testing instructions:

* Read the diff; these are agent/skill guidance files only, no plugin code changes.
* Optionally run the security-audit agent on a narrow scope (e.g. "does generate_post_summary() leak password-protected content?") and confirm the report labels findings with verdicts and cites caller guards under Passed Checks.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
