### PR TITLE
Add get_visible_actor_types() actor-visibility accessor

### DIFF
--- a/includes/functions-user.php
+++ b/includes/functions-user.php
@@ -223,19 +223,42 @@ function is_user_type_disabled( $type ) {
 }
 
 /**
+ * Get the actor types that are visible (enabled) on this site.
+ *
+ * This is the single seam for "which actor types does this site expose":
+ * it folds the actor-mode option and the legacy override constants into a
+ * plain list, so callers do not need to re-derive mode semantics.
+ *
+ * @since unreleased
+ *
+ * @return string[] Subset of array( 'user', 'blog' ).
+ */
+function get_visible_actor_types() {
+	$types = array();
+
+	foreach ( array( 'user', 'blog' ) as $type ) {
+		if ( ! is_user_type_disabled( $type ) ) {
+			$types[] = $type;
+		}
+	}
+
+	/**
+	 * Filters the actor types that are visible on this site.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string[] $types Visible actor types, subset of array( 'user', 'blog' ).
+	 */
+	return \apply_filters( 'activitypub_visible_actor_types', $types );
+}
+
+/**
  * Check if the blog is in single-user mode.
  *
  * @return boolean True if the blog is in single-user mode, false otherwise.
  */
 function is_single_user() {
-	if (
-		false === is_user_type_disabled( 'blog' ) &&
-		true === is_user_type_disabled( 'user' )
-	) {
-		return true;
-	}
-
-	return false;
+	return array( 'blog' ) === get_visible_actor_types();
 }
 
 /**

--- a/tests/phpunit/tests/includes/class-test-functions-user.php
+++ b/tests/phpunit/tests/includes/class-test-functions-user.php
@@ -181,4 +181,119 @@ class Test_Functions_User extends \WP_UnitTestCase {
 			$cleanup();
 		}
 	}
+
+	/**
+	 * The visible actor types follow the actor mode.
+	 *
+	 * @covers \Activitypub\get_visible_actor_types
+	 *
+	 * @dataProvider actor_mode_provider
+	 *
+	 * @param string   $mode     The actor mode option value.
+	 * @param string[] $expected The expected visible actor types.
+	 */
+	public function test_get_visible_actor_types( $mode, $expected ) {
+		\update_option( 'activitypub_actor_mode', $mode );
+
+		$this->assertSame( $expected, \Activitypub\get_visible_actor_types() );
+
+		\delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * Data provider mapping actor modes to visible types.
+	 *
+	 * @return array[]
+	 */
+	public function actor_mode_provider() {
+		return array(
+			'actor and blog mode' => array( ACTIVITYPUB_ACTOR_AND_BLOG_MODE, array( 'user', 'blog' ) ),
+			'actor mode'          => array( ACTIVITYPUB_ACTOR_MODE, array( 'user' ) ),
+			'blog mode'           => array( ACTIVITYPUB_BLOG_MODE, array( 'blog' ) ),
+		);
+	}
+
+	/**
+	 * The accessor agrees with is_user_type_disabled() in every mode, including
+	 * when the legacy per-type filter changes the answer.
+	 *
+	 * @covers \Activitypub\get_visible_actor_types
+	 *
+	 * @dataProvider actor_mode_provider
+	 *
+	 * @param string $mode The actor mode option value.
+	 */
+	public function test_get_visible_actor_types_parity( $mode ) {
+		\update_option( 'activitypub_actor_mode', $mode );
+
+		foreach ( array( 'user', 'blog' ) as $type ) {
+			$this->assertSame(
+				! \Activitypub\is_user_type_disabled( $type ),
+				\in_array( $type, \Activitypub\get_visible_actor_types(), true ),
+				"Accessor and is_user_type_disabled() must agree on '{$type}' in mode '{$mode}'."
+			);
+		}
+
+		// The legacy per-type filter is reflected by the accessor.
+		$disable_blog = function ( $disabled, $type ) {
+			return 'blog' === $type ? true : $disabled;
+		};
+		\add_filter( 'activitypub_is_user_type_disabled', $disable_blog, 10, 2 );
+
+		$this->assertNotContains( 'blog', \Activitypub\get_visible_actor_types(), 'A type disabled via the legacy filter must not be visible.' );
+
+		\remove_filter( 'activitypub_is_user_type_disabled', $disable_blog );
+		\delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * The single-user check is true only in blog mode.
+	 *
+	 * @covers \Activitypub\is_single_user
+	 *
+	 * @dataProvider single_user_provider
+	 *
+	 * @param string $mode     The actor mode option value.
+	 * @param bool   $expected Whether the site is in single-user (blog-only) mode.
+	 */
+	public function test_is_single_user( $mode, $expected ) {
+		\update_option( 'activitypub_actor_mode', $mode );
+
+		$this->assertSame( $expected, \Activitypub\is_single_user() );
+
+		\delete_option( 'activitypub_actor_mode' );
+	}
+
+	/**
+	 * Data provider mapping actor modes to single-user expectation.
+	 *
+	 * @return array[]
+	 */
+	public function single_user_provider() {
+		return array(
+			'actor and blog mode' => array( ACTIVITYPUB_ACTOR_AND_BLOG_MODE, false ),
+			'actor mode'          => array( ACTIVITYPUB_ACTOR_MODE, false ),
+			'blog mode'           => array( ACTIVITYPUB_BLOG_MODE, true ),
+		);
+	}
+
+	/**
+	 * The visible types can be filtered.
+	 *
+	 * @covers \Activitypub\get_visible_actor_types
+	 */
+	public function test_get_visible_actor_types_filter() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_ACTOR_MODE );
+
+		$add_blog = function ( $types ) {
+			$types[] = 'blog';
+			return $types;
+		};
+		\add_filter( 'activitypub_visible_actor_types', $add_blog );
+
+		$this->assertSame( array( 'user', 'blog' ), \Activitypub\get_visible_actor_types() );
+
+		\remove_filter( 'activitypub_visible_actor_types', $add_blog );
+		\delete_option( 'activitypub_actor_mode' );
+	}
 }


### PR DESCRIPTION
Part of the **Actors v2** refactor ([CMF-556](https://linear.app/a8c/issue/CMF-556)), step 1.

## Proposed changes:
* Introduce `Activitypub\get_visible_actor_types()` — a single accessor that answers "which actor types does this site expose?", returning the subset of `user`/`blog` that is not disabled. It folds the `activitypub_actor_mode` option and the legacy override constants (`ACTIVITYPUB_SINGLE_USER_MODE`, `ACTIVITYPUB_DISABLE_BLOG_USER`, `ACTIVITYPUB_DISABLE_USER`) into a plain list, computed via the existing `is_user_type_disabled()` so all current filters keep firing.
* Add an `activitypub_visible_actor_types` filter over the result.
* Refactor `is_single_user()` to read through the accessor (`array( 'blog' ) === get_visible_actor_types()`), giving the new seam a first caller and revealing intent.

This is a pure, behavior-preserving refactor. The mode option is read directly in ~two dozen places today; this establishes the one seam that later steps of the project (blog actor always-on, replacing the mode option with visible-actor-types) build on, instead of touching every call site at once.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Tests cover the mode→types mapping across all three actor modes, parity with `is_user_type_disabled()` (including the legacy `activitypub_is_user_type_disabled` filter), the new `activitypub_visible_actor_types` filter, and `is_single_user()` directly across all modes.

## Testing instructions:

* `npm run env-test -- --filter=Test_Functions_User` — all green.
* No user-facing change: an existing site behaves identically. The accessor is internal plumbing for the Actors v2 work.

### Changelog entry

No changelog needed — internal refactor with no user-facing change (Skip Changelog).
