### PR TITLE
Show the Fediverse Preview for scheduled posts

### DIFF
--- a/.github/changelog/fix-fediverse-preview-scheduled-posts
+++ b/.github/changelog/fix-fediverse-preview-scheduled-posts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show the Fediverse Preview for scheduled posts instead of the regular post preview.

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -142,8 +142,8 @@ function is_post_publicly_queryable( $post ) {
 		'attachment' === $post->post_type &&
 		( ! $post->post_parent || is_post_publicly_queryable( $post->post_parent ) );
 
-	// Drafts and pending posts are allowed during preview requests so the Fediverse Preview works.
-	$is_preview = \in_array( $post->post_status, array( 'draft', 'pending' ), true ) &&
+	// Draft, pending, and scheduled posts are allowed during preview requests so the Fediverse Preview works.
+	$is_preview = \in_array( $post->post_status, array( 'draft', 'pending', 'future' ), true ) &&
 		\get_query_var( 'preview' ) &&
 		\current_user_can( 'edit_post', $post->ID );
 

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -178,8 +178,8 @@ function is_post_publicly_queryable( $post ) {
  * switched to local visibility, or its post type loses ActivityPub support.
  *
  * The federation-state check also keeps `is_post_publicly_queryable()`'s
- * preview allowance inert here: a draft/pending post is never in the federated
- * state, so the preview branch can never make this return true.
+ * preview allowance inert here: a draft/pending/scheduled post is never in the
+ * federated state, so the preview branch can never make this return true.
  *
  * @since 9.0.0
  *

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -833,8 +833,9 @@ class Post extends Base {
 	 * covers non-public status, password protection, the `local`/`private`
 	 * content-visibility meta, and a post type that no longer supports
 	 * ActivityPub. The Fediverse Preview keeps working because
-	 * `is_post_publicly_queryable()` itself treats a draft/pending post as
-	 * queryable during a `?preview=true` request from a user who can edit it.
+	 * `is_post_publicly_queryable()` itself treats a draft/pending/scheduled
+	 * post as queryable during a `?preview=true` request from a user who can
+	 * edit it.
 	 *
 	 * Note: we deliberately rely on `is_post_publicly_queryable()` rather than
 	 * `post_password_required()`. Federation output is per-instance, never

--- a/tests/phpunit/tests/includes/class-test-functions-post.php
+++ b/tests/phpunit/tests/includes/class-test-functions-post.php
@@ -346,6 +346,39 @@ class Test_Functions_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A scheduled post is queryable during a preview request for a user who
+	 * can edit it, so the Fediverse Preview works — and stays hidden otherwise.
+	 *
+	 * @covers \Activitypub\is_post_publicly_queryable
+	 */
+	public function test_is_post_publicly_queryable_scheduled_preview() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'future',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_author' => $user_id,
+			)
+		);
+
+		// Without the preview query var, a scheduled post is not queryable.
+		\wp_set_current_user( $user_id );
+		$this->assertFalse( \Activitypub\is_post_publicly_queryable( $post_id ), 'Scheduled posts should not be queryable without preview.' );
+
+		// With preview, the author gets the Fediverse Preview.
+		\set_query_var( 'preview', true );
+		$this->assertTrue( \Activitypub\is_post_publicly_queryable( $post_id ), 'Scheduled posts should be queryable during preview for authorized user.' );
+
+		// Users without edit capability stay locked out even during preview.
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		\wp_set_current_user( $subscriber_id );
+		$this->assertFalse( \Activitypub\is_post_publicly_queryable( $post_id ), 'Scheduled posts should not be queryable during preview for unauthorized user.' );
+
+		// Clean up.
+		\set_query_var( 'preview', false );
+	}
+
+	/**
 	 * Non-public statuses, password-protected posts, and local/private visibility
 	 * must not be queryable. Unlike is_post_disabled(), there is no lifecycle
 	 * override — a previously federated post that is now non-public is still


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/fediverse-preview-for-scheduled-drafts/

## Proposed changes:

* Add the `future` status to the preview exception in `is_post_publicly_queryable()`, so the Fediverse Preview renders for scheduled posts instead of falling back to the regular post preview.
* The exception stays gated behind the `preview` query var and the `edit_post` capability, so scheduled content remains hidden from unauthenticated and unauthorized requests.
* Update the two adjacent code comments that described the preview allowance as draft/pending-only.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Create a post and schedule it for a future date.
* In the editor, open the Preview dropdown and click "Fediverse preview ⁂".
* Before this change, the regular post preview is shown; after, the Fediverse preview renders.
* Verify a draft post's Fediverse preview still works, and that opening the preview URL of the scheduled post as a logged-out user does not expose the post.

### Changelog entry

Changelog entry is already included in the PR (`.github/changelog/fix-fediverse-preview-scheduled-posts`).

-   [ ] Automatically create a changelog entry from the details below.