### PR TITLE
Add a companion module initialization gate

### DIFF
--- a/.github/changelog/add-module-initialization-gate
+++ b/.github/changelog/add-module-initialization-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a module initialization filter for companion plugins that replace selected domain surfaces.

--- a/activitypub.php
+++ b/activitypub.php
@@ -46,39 +46,99 @@ Autoloader::register_path( __NAMESPACE__, __DIR__ . '/includes' );
 \register_uninstall_hook( __FILE__, array( Activitypub::class, 'uninstall' ) );
 
 /**
+ * Check whether one independently initialized plugin module is enabled.
+ *
+ * Companion plugins may use this gate to replace a domain surface while retaining
+ * the official plugin's protocol implementation. Modules default to enabled so the
+ * filter is fully backwards compatible.
+ *
+ * @param string $module Stable module identifier.
+ * @return bool Whether the module may initialize.
+ */
+function is_module_enabled( $module ) {
+	/**
+	 * Filters whether an ActivityPub module may initialize.
+	 *
+	 * @param bool   $enabled Whether the module is enabled. Default true.
+	 * @param string $module  Module identifier such as `runtime.router` or `rest.inbox`.
+	 */
+	return (bool) \apply_filters( 'activitypub_module_enabled', true, (string) $module );
+}
+
+/**
  * Initialize REST routes.
  */
 function rest_init() {
-	Rest\Server::init();
-	( new Rest\Actors_Controller() )->register_routes();
-	( new Rest\Actors_Inbox_Controller() )->register_routes();
-	( new Rest\Admin\Actions_Controller() )->register_routes();
-	( new Rest\Admin\Statistics_Controller() )->register_routes();
-	( new Rest\Application_Controller() )->register_routes();
-	( new Rest\Stats_Image_Controller() )->register_routes();
-	( new Rest\Collections_Controller() )->register_routes();
-	( new Rest\Comments_Controller() )->register_routes();
-	( new Rest\Followers_Controller() )->register_routes();
-	( new Rest\Following_Controller() )->register_routes();
-	( new Rest\Liked_Controller() )->register_routes();
-	( new Rest\Inbox_Controller() )->register_routes();
-	( new Rest\Interaction_Controller() )->register_routes();
-	( new Rest\Moderators_Controller() )->register_routes();
-	if ( \get_option( 'activitypub_api', false ) ) {
+	if ( is_module_enabled( 'rest.server' ) ) {
+		Rest\Server::init();
+	}
+	if ( is_module_enabled( 'rest.actors' ) ) {
+		( new Rest\Actors_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.actors_inbox' ) ) {
+		( new Rest\Actors_Inbox_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.admin_actions' ) ) {
+		( new Rest\Admin\Actions_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.admin_statistics' ) ) {
+		( new Rest\Admin\Statistics_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.application' ) ) {
+		( new Rest\Application_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.stats_image' ) ) {
+		( new Rest\Stats_Image_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.collections' ) ) {
+		( new Rest\Collections_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.comments' ) ) {
+		( new Rest\Comments_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.followers' ) ) {
+		( new Rest\Followers_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.following' ) ) {
+		( new Rest\Following_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.liked' ) ) {
+		( new Rest\Liked_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.inbox' ) ) {
+		( new Rest\Inbox_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.interaction' ) ) {
+		( new Rest\Interaction_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.moderators' ) ) {
+		( new Rest\Moderators_Controller() )->register_routes();
+	}
+	if ( \get_option( 'activitypub_api', false ) && is_module_enabled( 'rest.oauth' ) ) {
 		( new Rest\OAuth\Authorization_Controller() )->register_routes();
 		( new Rest\OAuth\Clients_Controller() )->register_routes();
 		( new Rest\OAuth\Token_Controller() )->register_routes();
 	}
-	( new Rest\Outbox_Controller() )->register_routes();
-	( new Rest\Post_Controller() )->register_routes();
-	( new Rest\Replies_Controller() )->register_routes();
-	( new Rest\Webfinger_Controller() )->register_routes();
+	if ( is_module_enabled( 'rest.outbox' ) ) {
+		( new Rest\Outbox_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.post' ) ) {
+		( new Rest\Post_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.replies' ) ) {
+		( new Rest\Replies_Controller() )->register_routes();
+	}
+	if ( is_module_enabled( 'rest.webfinger' ) ) {
+		( new Rest\Webfinger_Controller() )->register_routes();
+	}
 
 	// Load NodeInfo endpoints only if blog is public.
-	if ( is_blog_public() ) {
+	if ( is_blog_public() && is_module_enabled( 'rest.nodeinfo' ) ) {
 		( new Rest\Nodeinfo_Controller() )->register_routes();
 	}
-	( new Rest\Proxy_Controller() )->register_routes();
+	if ( is_module_enabled( 'rest.proxy' ) ) {
+		( new Rest\Proxy_Controller() )->register_routes();
+	}
 }
 \add_action( 'rest_api_init', __NAMESPACE__ . '\rest_init' );
 
@@ -86,42 +146,55 @@ function rest_init() {
  * Initialize plugin.
  */
 function plugin_init() {
-	\add_action( 'init', array( __NAMESPACE__ . '\Activitypub', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Application', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Avatars', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Blurhash', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Cache', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Comment', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Dispatcher', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Embed', 'init' ) );
-	if ( \get_option( 'activitypub_api', false ) ) {
+	$modules = array(
+		'runtime.activitypub' => array( __NAMESPACE__ . '\Activitypub', 'init' ),
+		'runtime.application' => array( __NAMESPACE__ . '\Application', 'init' ),
+		'runtime.avatars'     => array( __NAMESPACE__ . '\Avatars', 'init' ),
+		'runtime.blurhash'    => array( __NAMESPACE__ . '\Blurhash', 'init' ),
+		'runtime.cache'       => array( __NAMESPACE__ . '\Cache', 'init' ),
+		'runtime.comment'     => array( __NAMESPACE__ . '\Comment', 'init' ),
+		'runtime.dispatcher'  => array( __NAMESPACE__ . '\Dispatcher', 'init' ),
+		'runtime.embed'       => array( __NAMESPACE__ . '\Embed', 'init' ),
+		'runtime.handler'     => array( __NAMESPACE__ . '\Handler', 'init' ),
+		'runtime.hashtag'     => array( __NAMESPACE__ . '\Hashtag', 'init' ),
+		'runtime.link'        => array( __NAMESPACE__ . '\Link', 'init' ),
+		'runtime.mailer'      => array( __NAMESPACE__ . '\Mailer', 'init' ),
+		'runtime.mention'     => array( __NAMESPACE__ . '\Mention', 'init' ),
+		'runtime.move'        => array( __NAMESPACE__ . '\Move', 'init' ),
+		'runtime.options'     => array( __NAMESPACE__ . '\Options', 'init' ),
+		'runtime.post_types'  => array( __NAMESPACE__ . '\Post_Types', 'init' ),
+		'runtime.router'      => array( __NAMESPACE__ . '\Router', 'init' ),
+		'runtime.search'      => array( __NAMESPACE__ . '\Search', 'init' ),
+		'runtime.signature'   => array( __NAMESPACE__ . '\Signature', 'init' ),
+	);
+
+	foreach ( $modules as $module => $callback ) {
+		if ( is_module_enabled( $module ) ) {
+			\add_action( 'init', $callback );
+		}
+	}
+
+	if ( \get_option( 'activitypub_api', false ) && is_module_enabled( 'runtime.event_stream' ) ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\Event_Stream', 'init' ) );
 	}
-	\add_action( 'init', array( __NAMESPACE__ . '\Handler', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Hashtag', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Link', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Mailer', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Mention', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Migration', 'init' ), 1 );
-	\add_action( 'init', array( __NAMESPACE__ . '\Move', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Options', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Post_Types', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Router', 'init' ) );
+	if ( is_module_enabled( 'runtime.migration' ) ) {
+		\add_action( 'init', array( __NAMESPACE__ . '\Migration', 'init' ), 1 );
+	}
 	// Priority 0 ensures Scheduler hooks are registered before Migration (priority 1) runs.
-	\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ), 0 );
-	\add_action( 'init', array( __NAMESPACE__ . '\Search', 'init' ) );
-	\add_action( 'init', array( __NAMESPACE__ . '\Signature', 'init' ) );
+	if ( is_module_enabled( 'runtime.scheduler' ) ) {
+		\add_action( 'init', array( __NAMESPACE__ . '\Scheduler', 'init' ), 0 );
+	}
 	// Only load OAuth Server if the ActivityPub API is enabled.
-	if ( \get_option( 'activitypub_api', false ) ) {
+	if ( \get_option( 'activitypub_api', false ) && is_module_enabled( 'runtime.oauth' ) ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\OAuth\Server', 'init' ) );
 	}
 
-	if ( site_supports_blocks() ) {
+	if ( site_supports_blocks() && is_module_enabled( 'runtime.blocks' ) ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\Blocks', 'init' ) );
 	}
 
 	// Only load relay if relay mode is enabled.
-	if ( \get_option( 'activitypub_relay_mode', false ) ) {
+	if ( \get_option( 'activitypub_relay_mode', false ) && is_module_enabled( 'runtime.relay' ) ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\Relay', 'init' ) );
 	}
 
@@ -139,6 +212,10 @@ function plugin_init() {
  * Initialize plugin admin.
  */
 function plugin_admin_init() {
+	if ( ! is_module_enabled( 'admin' ) ) {
+		return;
+	}
+
 	// Screen Options and Menus are set before `admin_init`.
 	\add_action( 'init', array( __NAMESPACE__ . '\WP_Admin\Heartbeat', 'init' ), 9 ); // Before script loader.
 	\add_filter( 'init', array( __NAMESPACE__ . '\WP_Admin\Screen_Options', 'init' ) );

--- a/tests/phpunit/tests/includes/class-test-activitypub.php
+++ b/tests/phpunit/tests/includes/class-test-activitypub.php
@@ -17,6 +17,33 @@ use Activitypub\Collection\Outbox;
  */
 class Test_Activitypub extends \WP_UnitTestCase {
 	/**
+	 * Test the default module gate.
+	 *
+	 * @covers \Activitypub\is_module_enabled
+	 */
+	public function test_modules_are_enabled_by_default() {
+		$this->assertTrue( \Activitypub\is_module_enabled( 'runtime.router' ) );
+		$this->assertTrue( \Activitypub\is_module_enabled( 'rest.inbox' ) );
+	}
+
+	/**
+	 * Test selective module replacement.
+	 *
+	 * @covers \Activitypub\is_module_enabled
+	 */
+	public function test_module_gate_is_selective() {
+		$filter = static function ( $enabled, $module ) {
+			return 'runtime.router' === $module ? false : $enabled;
+		};
+		\add_filter( 'activitypub_module_enabled', $filter, 10, 2 );
+
+		$this->assertFalse( \Activitypub\is_module_enabled( 'runtime.router' ) );
+		$this->assertTrue( \Activitypub\is_module_enabled( 'runtime.signature' ) );
+
+		\remove_filter( 'activitypub_module_enabled', $filter, 10 );
+	}
+
+	/**
 	 * Test environment.
 	 */
 	public function test_test_env() {


### PR DESCRIPTION
## Summary

This draft adds one backwards-compatible extension surface for companion plugins:

- `activitypub_module_enabled`, an early gate around independently initialized runtime, REST, and admin modules.

Every module remains enabled by default, so stock behavior is unchanged. A companion can retain the official protocol surfaces it needs while replacing selected presentation, lifecycle, or domain modules.

## Why

As [pfefferle pointed out](https://github.com/Automattic/wordpress-activitypub/pull/3541#issuecomment-4982845243), a new verified-Inbox handoff is not necessary. The existing REST controllers already fire `activitypub_inbox` and `activitypub_inbox_shared` after their permission callbacks, and `activitypub_skip_inbox_storage` can prevent duplicate CPT persistence.

The remaining purpose of this PR is narrower: provide a supported, stable way to stop module initializers before they register callbacks. Without a gate, companion plugins must reach into concrete class names, callbacks, and exact priorities with `remove_action()`. That is workable today, but silently becomes ineffective when an initializer or priority changes.

For example, a companion with its own URI-keyed Activity and relationship repositories can disable `runtime.handler` and `runtime.scheduler`, retain `runtime.signature`, `rest.server`, `rest.inbox`, and `rest.actors_inbox`, then consume the existing Inbox actions. The official plugin remains responsible for request validation and transport while the companion owns domain state.

This PR no longer adds or depends on a new Inbox handoff API. The previous handoff commit has been removed from the branch.

## Reference implementation

[Axismundi ActivityPub Bridge 0.0.12 Alpha](https://github.com/Jiwoon-Kim/axismundi/releases/tag/activitypub-bridge-v0.0.12) uses the module gate together with the existing Inbox actions:

- shared Inbox and per-Actor Inbox both record exactly one URI-keyed Activity;
- official type handlers remain dormant;
- `activitypub_skip_inbox_storage` skips `ap_inbox` only after Axismundi successfully claims the Activity; and
- unclaimed local deliveries retain the official Inbox snapshot fallback.

The surrounding alpha stack is available here:

- [Actors 0.0.26](https://github.com/Jiwoon-Kim/axismundi/releases/tag/actors-v0.0.26)
- [Object Projections 0.0.10](https://github.com/Jiwoon-Kim/axismundi/releases/tag/object-projections-v0.0.10)
- [Activities 0.0.8](https://github.com/Jiwoon-Kim/axismundi/releases/tag/activities-v0.0.8)
- [Media Library 0.0.26](https://github.com/Jiwoon-Kim/axismundi/releases/tag/media-library-v0.0.26)
- [Axismundi Theme 0.1.8](https://github.com/Jiwoon-Kim/axismundi/releases/tag/theme-v0.1.8)

The companion plugins and block theme provide local and remote Actor profile pages, Object and Activity views, social relationships, and federated-media presentation in the site's native frontend. Axismundi owns the URI-keyed domain and presentation layers; the official plugin remains the intended S2S transport and interoperability layer.

Staging references:

- [Site](https://designbusan.ai.kr/)
- [Actor profile](https://designbusan.ai.kr/@thaumiel999/)
- [WebFinger](https://designbusan.ai.kr/.well-known/webfinger?resource=acct%3Athaumiel999%40designbusan.ai.kr)
- [Media frontend](https://designbusan.ai.kr/media/)

## Validation

- Added upstream unit coverage for default-on and selective module behavior.
- Axismundi composition fixtures cover shared and per-Actor Inbox controllers, replay idempotency, successful claim storage suppression, and unclaimed snapshot fallback.
- Bridge composition: 8/8 Inbox checks and 20/20 module-scaffold checks.
- Activities state-machine regression: 68/68 checks.
- Bridge Plugin Check: 0 errors.
- Staging WebFinger returns the canonical Axismundi Actor document; signed cross-instance Follow/Accept E2E passed in both directions against mastodon.social. Like, Undo, shared-Inbox delivery, and Create delivery remain separate activity-level scenarios.

Refs #3533