### PR TITLE
Add external Activity delivery transport for companion stores

### DIFF
--- a/.github/changelog/add-external-activity-delivery
+++ b/.github/changelog/add-external-activity-delivery
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add an opt-in external Activity delivery spool for companion plugins with URI-keyed domain stores.

--- a/activitypub.php
+++ b/activitypub.php
@@ -94,6 +94,7 @@ function plugin_init() {
 	\add_action( 'init', array( __NAMESPACE__ . '\Comment', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Dispatcher', 'init' ) );
 	\add_action( 'init', array( __NAMESPACE__ . '\Embed', 'init' ) );
+	\add_action( 'init', array( __NAMESPACE__ . '\External_Delivery', 'init' ) );
 	if ( \get_option( 'activitypub_api', false ) ) {
 		\add_action( 'init', array( __NAMESPACE__ . '\Event_Stream', 'init' ) );
 	}

--- a/includes/class-external-delivery.php
+++ b/includes/class-external-delivery.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * External Activity delivery spool.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub;
+
+use Activitypub\Collection\Outbox;
+
+/** Transport complete Activity payloads owned by companion plugins. */
+class External_Delivery {
+	const PROCESS_HOOK = 'activitypub_process_external_delivery';
+
+	/** Register only the transport spool and its worker. */
+	public static function init() {
+		Post_Types::register_outbox_post_type();
+		\add_action( self::PROCESS_HOOK, array( self::class, 'process' ), 10, 2 );
+	}
+
+	/**
+	 * Queue one immutable Activity payload for explicit Inbox URLs.
+	 *
+	 * @param array $payload Activity payload.
+	 * @param array $sender  External signing descriptor.
+	 * @param array $inboxes Explicit recipient Inboxes.
+	 * @param array $options Optional transport settings.
+	 * @return int|\WP_Error
+	 */
+	public static function enqueue( $payload, $sender, $inboxes, $options = array() ) {
+		unset( $options );
+		if ( ! \is_array( $payload ) || ! \is_array( $sender ) || ! \is_array( $inboxes ) ) {
+			return new \WP_Error( 'activitypub_external_delivery_invalid', \__( 'External delivery requires array arguments.', 'activitypub' ) );
+		}
+		if ( isset( $sender['private_key'] ) ) {
+			return new \WP_Error( 'activitypub_external_delivery_private_key', \__( 'Private key material must not be passed to the delivery spool.', 'activitypub' ) );
+		}
+
+		$activity_uri = self::http_uri( $payload['id'] ?? '' );
+		$actor_uri    = self::http_uri( $sender['actor_uri'] ?? '' );
+		$key_id       = self::http_uri( $sender['key_id'] ?? '' );
+		$key_ref      = \is_scalar( $sender['private_key_ref'] ?? null ) ? \sanitize_text_field( (string) $sender['private_key_ref'] ) : '';
+		if ( '' === $activity_uri || '' === $actor_uri || '' === $key_id || '' === $key_ref || self::member_uri( $payload['actor'] ?? '' ) !== $actor_uri ) {
+			return new \WP_Error( 'activitypub_external_delivery_sender', \__( 'The Activity or external signing descriptor is invalid.', 'activitypub' ) );
+		}
+
+		$recipients = array();
+		foreach ( $inboxes as $inbox ) {
+			$inbox = self::http_uri( $inbox, true );
+			if ( '' === $inbox || ! \wp_http_validate_url( $inbox ) ) {
+				return new \WP_Error( 'activitypub_external_delivery_inbox', \__( 'Every recipient Inbox must be a public HTTPS URL.', 'activitypub' ) );
+			}
+			$recipients[] = $inbox;
+		}
+		$recipients = \array_values( \array_unique( $recipients ) );
+		if ( empty( $recipients ) ) {
+			return new \WP_Error( 'activitypub_external_delivery_recipients', \__( 'At least one recipient Inbox is required.', 'activitypub' ) );
+		}
+
+		$json = \wp_json_encode( $payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		if ( ! \is_string( $json ) || \strlen( $json ) > MB_IN_BYTES ) {
+			return new \WP_Error( 'activitypub_external_delivery_payload', \__( 'The Activity payload is invalid or exceeds one MiB.', 'activitypub' ) );
+		}
+
+		$existing = self::find( $activity_uri );
+		if ( 0 < $existing ) {
+			return $existing;
+		}
+
+		$has_kses = false !== \has_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		if ( $has_kses ) {
+			\kses_remove_filters();
+		}
+		$post_id = \wp_insert_post(
+			array(
+				'post_type'    => Outbox::POST_TYPE,
+				'post_status'  => 'pending',
+				'post_author'  => 0,
+				'post_title'   => \sprintf( '[External %s] %s', \sanitize_text_field( (string) ( $payload['type'] ?? 'Activity' ) ), $activity_uri ),
+				'post_content' => \wp_slash( $json ),
+				// phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned,WordPress.Arrays.MultipleStatementAlignment.LongIndexSpaceBeforeDoubleArrow
+				'meta_input'   => array(
+					'_activitypub_external_delivery'     => 1,
+					'_activitypub_external_activity_uri' => $activity_uri,
+					'_activitypub_external_activity_uri_hash' => \hash( 'sha256', $activity_uri ),
+					'_activitypub_external_actor_uri'    => $actor_uri,
+					'_activitypub_external_key_id'       => $key_id,
+					'_activitypub_external_private_key_ref' => $key_ref,
+					'_activitypub_external_inboxes'      => \wp_json_encode( $recipients ),
+					'_activitypub_external_pending_inboxes' => \wp_json_encode( $recipients ),
+					'_activitypub_external_attempt'      => 0,
+					'_activitypub_external_status'       => 'queued',
+				),
+				// phpcs:enable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned,WordPress.Arrays.MultipleStatementAlignment.LongIndexSpaceBeforeDoubleArrow
+			),
+			true
+		);
+		if ( $has_kses ) {
+			\kses_init_filters();
+		}
+		if ( \is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+		\wp_schedule_single_event( \time(), self::PROCESS_HOOK, array( (int) $post_id, 1 ) );
+		return (int) $post_id;
+	}
+
+	/**
+	 * Process one transport spool row.
+	 *
+	 * @param int $post_id Transport spool post ID.
+	 * @param int $attempt Current delivery attempt.
+	 */
+	public static function process( $post_id, $attempt = 1 ) {
+		$post = \get_post( (int) $post_id );
+		if ( ! $post || Outbox::POST_TYPE !== $post->post_type || ! \get_post_meta( $post->ID, '_activitypub_external_delivery', true ) ) {
+			return;
+		}
+		$descriptor = array(
+			'actor_uri'       => (string) \get_post_meta( $post->ID, '_activitypub_external_actor_uri', true ),
+			'key_id'          => (string) \get_post_meta( $post->ID, '_activitypub_external_key_id', true ),
+			'private_key_ref' => (string) \get_post_meta( $post->ID, '_activitypub_external_private_key_ref', true ),
+		);
+		/**
+		 * Resolve transient signing material for one external sender.
+		 *
+		 * @param null|array $identity   actor_uri, key_id, private_key.
+		 * @param array      $descriptor Persisted non-secret descriptor.
+		 * @param int        $post_id    Transport spool post ID.
+		 */
+		$identity = \apply_filters( 'activitypub_resolve_external_signing_identity', null, $descriptor, $post->ID );
+		if ( ! \is_array( $identity )
+			|| ! \hash_equals( $descriptor['actor_uri'], (string) ( $identity['actor_uri'] ?? '' ) )
+			|| ! \hash_equals( $descriptor['key_id'], (string) ( $identity['key_id'] ?? '' ) )
+			|| empty( $identity['private_key'] )
+		) {
+			self::finish( $post->ID, 'failed', \__( 'The external signing identity could not be resolved.', 'activitypub' ) );
+			return;
+		}
+
+		$pending = \json_decode( (string) \get_post_meta( $post->ID, '_activitypub_external_pending_inboxes', true ), true );
+		$pending = \is_array( $pending ) ? $pending : array();
+		$retry   = array();
+		$errors  = array();
+		foreach ( $pending as $inbox ) {
+			$response = \wp_safe_remote_post(
+				$inbox,
+				array(
+					'body'                => $post->post_content,
+					'headers'             => array(
+						'Accept'       => 'application/activity+json',
+						'Content-Type' => 'application/activity+json',
+						'Date'         => \gmdate( 'D, d M Y H:i:s T' ),
+					),
+					'timeout'             => 10,
+					'limit_response_size' => MB_IN_BYTES,
+					'redirection'         => 0,
+					'data_format'         => 'body',
+					'key_id'              => $identity['key_id'],
+					'private_key'         => $identity['private_key'],
+				)
+			);
+			$code     = \is_wp_error( $response ) ? 0 : (int) \wp_remote_retrieve_response_code( $response );
+			if ( \is_wp_error( $response ) || \in_array( $code, Dispatcher::get_retry_error_codes(), true ) ) {
+				$retry[]  = $inbox;
+				$errors[] = \is_wp_error( $response ) ? $response->get_error_message() : 'HTTP ' . $code;
+			} elseif ( 200 > $code || 300 <= $code ) {
+				$errors[] = 'HTTP ' . $code;
+			}
+		}
+
+		\update_post_meta( $post->ID, '_activitypub_external_attempt', (int) $attempt );
+		\update_post_meta( $post->ID, '_activitypub_external_pending_inboxes', \wp_json_encode( $retry ) );
+		if ( ! empty( $retry ) && (int) $attempt < Dispatcher::get_retry_max_attempts() ) {
+			\update_post_meta( $post->ID, '_activitypub_external_status', 'retrying' );
+			\update_post_meta( $post->ID, '_activitypub_external_last_error', \implode( '; ', $errors ) );
+			$next = (int) $attempt + 1;
+			\wp_schedule_single_event( \time() + ( $next * $next * Dispatcher::get_retry_delay() ), self::PROCESS_HOOK, array( $post->ID, $next ) );
+			return;
+		}
+
+		self::finish( $post->ID, empty( $errors ) ? 'delivered' : 'failed', \implode( '; ', $errors ) );
+	}
+
+	/**
+	 * Find a transport spool row by exact Activity URI.
+	 *
+	 * @param string $activity_uri Canonical Activity URI.
+	 * @return int
+	 */
+	private static function find( $activity_uri ) {
+		$ids = \get_posts(
+			array(
+				'post_type'      => Outbox::POST_TYPE,
+				'post_status'    => array( 'pending', 'publish' ),
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'meta_key'       => '_activitypub_external_activity_uri', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $activity_uri, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+		return isset( $ids[0] ) ? (int) $ids[0] : 0;
+	}
+
+	/**
+	 * Publish a completed spool row and retain its transport result.
+	 *
+	 * @param int    $post_id Transport spool post ID.
+	 * @param string $status  delivered|failed.
+	 * @param string $error   Last transport error.
+	 */
+	private static function finish( $post_id, $status, $error = '' ) {
+		\update_post_meta( $post_id, '_activitypub_external_status', $status );
+		\update_post_meta( $post_id, '_activitypub_external_last_error', $error );
+		\wp_publish_post( $post_id );
+	}
+
+	/**
+	 * Validate one absolute HTTP URI, optionally requiring HTTPS.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @param bool  $https Require HTTPS.
+	 * @return string
+	 */
+	private static function http_uri( $value, $https = false ) {
+		$uri   = \is_scalar( $value ) ? \trim( (string) $value ) : '';
+		$parts = \wp_parse_url( $uri );
+		if ( ! \is_array( $parts ) || empty( $parts['host'] ) || isset( $parts['user'] ) || isset( $parts['pass'] ) ) {
+			return '';
+		}
+		$scheme = \strtolower( (string) ( $parts['scheme'] ?? '' ) );
+		return ( $https ? 'https' === $scheme : \in_array( $scheme, array( 'http', 'https' ), true ) ) ? $uri : '';
+	}
+
+	/**
+	 * Resolve an ActivityStreams URI member.
+	 *
+	 * @param mixed $value ActivityStreams member.
+	 * @return string
+	 */
+	private static function member_uri( $value ) {
+		if ( \is_scalar( $value ) ) {
+			return self::http_uri( $value );
+		}
+		if ( \is_array( $value ) && ! \array_is_list( $value ) ) {
+			return self::member_uri( $value['id'] ?? '' );
+		}
+		return '';
+	}
+}

--- a/includes/functions-federation.php
+++ b/includes/functions-federation.php
@@ -17,6 +17,25 @@ use Activitypub\Collection\Remote_Actors;
 use Activitypub\Transformer\Factory as Transformer_Factory;
 
 /**
+ * Queue a complete Activity payload for delivery by an external domain owner.
+ *
+ * The caller remains authoritative for Activity and relationship state. The
+ * official plugin owns only the transport spool, signatures, retries, and HTTP
+ * delivery. Private key material is never accepted or persisted.
+ *
+ * @since unreleased
+ *
+ * @param array $activity_payload  Complete ActivityStreams Activity.
+ * @param array $sender            actor_uri, key_id, and private_key_ref.
+ * @param array $recipient_inboxes Explicit recipient Inbox URLs.
+ * @param array $options           Optional transport settings.
+ * @return int|\WP_Error Transport spool post ID or an error.
+ */
+function deliver_activity( $activity_payload, $sender, $recipient_inboxes, $options = array() ) {
+	return External_Delivery::enqueue( $activity_payload, $sender, $recipient_inboxes, $options );
+}
+
+/**
  * Set the federation state of a WordPress object.
  *
  * @param \WP_Comment|\WP_Post $wp_object The WordPress object.

--- a/tests/phpunit/tests/includes/class-test-external-delivery.php
+++ b/tests/phpunit/tests/includes/class-test-external-delivery.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * External delivery tests.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests;
+
+use Activitypub\External_Delivery;
+
+/**
+ * External delivery test case.
+ *
+ * @coversDefaultClass \Activitypub\External_Delivery
+ */
+class Test_External_Delivery extends \WP_UnitTestCase {
+	/**
+	 * Exact fixture spool rows.
+	 *
+	 * @var int[]
+	 */
+	private $spool_ids = array();
+
+	/** Register the isolated transport surface. */
+	public function set_up() {
+		parent::set_up();
+		External_Delivery::init();
+	}
+
+	/** Clean exact fixture rows and events. */
+	public function tear_down() {
+		foreach ( $this->spool_ids as $post_id ) {
+			\wp_clear_scheduled_hook( External_Delivery::PROCESS_HOOK, array( $post_id, 1 ) );
+			\wp_delete_post( $post_id, true );
+		}
+		parent::tear_down();
+	}
+
+	/** Reject secret material at the persistence boundary. */
+	public function test_rejects_private_key_input() {
+		$result = \Activitypub\deliver_activity(
+			$this->payload(),
+			\array_merge( $this->sender(), array( 'private_key' => 'secret' ) ),
+			array( 'https://example.com/inbox' )
+		);
+		$this->assertWPError( $result );
+		$this->assertSame( 'activitypub_external_delivery_private_key', $result->get_error_code() );
+	}
+
+	/** Persist one idempotent, transport-only row without key material. */
+	public function test_enqueue_is_idempotent_and_non_secret() {
+		$payload = $this->payload();
+		$sender  = $this->sender();
+		$first   = \Activitypub\deliver_activity( $payload, $sender, array( 'https://example.com/inbox' ) );
+		$this->assertIsInt( $first );
+		$this->spool_ids[] = $first;
+		$this->assertSame( $first, \Activitypub\deliver_activity( $payload, $sender, array( 'https://example.com/inbox' ) ) );
+		$this->assertStringContainsString( $payload['id'], \get_post( $first )->post_content );
+		$this->assertStringNotContainsString( 'PRIVATE KEY', \wp_json_encode( \get_post_meta( $first ) ) );
+		$this->assertSame( $sender['private_key_ref'], \get_post_meta( $first, '_activitypub_external_private_key_ref', true ) );
+	}
+
+	/** Complete Activity fixture. */
+	private function payload() {
+		return array(
+			'id'     => 'https://local.example/activities/' . \wp_generate_uuid4(),
+			'type'   => 'Follow',
+			'actor'  => 'https://local.example/actors/alice',
+			'object' => 'https://example.com/users/bob',
+		);
+	}
+
+	/** Non-secret external sender descriptor. */
+	private function sender() {
+		return array(
+			'actor_uri'       => 'https://local.example/actors/alice',
+			'key_id'          => 'https://local.example/actors/alice#main-key',
+			'private_key_ref' => 'fixture:alice',
+		);
+	}
+}


### PR DESCRIPTION
## Summary

This draft explores a supported outbound transport surface for companion plugins that own their own Actor, Object, Activity, and relationship stores.

It adds an opt-in `deliver_activity()` API that accepts:

- a complete ActivityStreams Activity payload;
- an external URI-backed signing descriptor (`actor_uri`, `key_id`, and a non-secret `private_key_ref`); and
- explicit recipient Inbox URLs.

The official plugin remains responsible for the transport spool, transient key resolution, HTTP signatures, retries, and delivery. The caller remains authoritative for Activity and relationship state.

## API shape question

Before treating this particular API as final, I would appreciate maintainer guidance on the smallest preferred extension shape.

The companion needs only two capabilities that the current Outbox API cannot express:

1. a URI-backed signing identity that is not necessarily an integer `WP_User` ID; and
2. explicit recipient Inbox URLs supplied by the companion's authoritative relationship store.

Would you prefer extending the existing `add_to_outbox()` / `Outbox::add()` path to accept those two inputs instead of adding a separate `deliver_activity()` entry point? Reusing the existing path would be welcome if it can preserve the external Actor identity and avoid deriving recipients from the official follower store.

This draft uses a separate transport-only spool because the current path:

- gates delivery through `user_can_activitypub( $user_id )`;
- derives the signing Actor and key identity from an integer user ID; and
- derives recipients from the official plugin's follower model rather than accepting explicit Inboxes.

That makes a virtual Actor discoverable through the existing Actor filters, but it cannot send as the same URI-backed identity without creating duplicate domain state or a split signing identity.

## Implementation

- Stores the complete bounded payload in an `ap_outbox` transport row identified idempotently by Activity URI.
- Stores only a non-secret key reference; private key material is rejected at enqueue time and resolved in memory by `activitypub_resolve_external_signing_identity` during the worker run.
- Requires public HTTPS Inbox URLs, sends no cookies, follows no redirects, and uses the existing retry policy.
- Exposes transport status without making the spool authoritative Activity or relationship state.
- Leaves all stock publishing and delivery behavior unchanged unless a companion explicitly calls the new API.

## Reference composition and E2E

The reference implementation is the [Axismundi ActivityPub Bridge 0.0.14 Alpha](https://github.com/Jiwoon-Kim/axismundi/releases/tag/activitypub-bridge-v0.0.14), together with:

- [Activities 0.0.11 Alpha](https://github.com/Jiwoon-Kim/axismundi/releases/tag/activities-v0.0.11)
- [Object Projections 0.0.11 Alpha](https://github.com/Jiwoon-Kim/axismundi/releases/tag/object-projections-v0.0.11)
- [Actors 0.0.27 Alpha](https://github.com/Jiwoon-Kim/axismundi/releases/tag/actors-v0.0.27)

A signed bidirectional Follow/Accept E2E passed against mastodon.social:

- Mastodon Follow -> official signature/request validation -> existing Inbox action -> Axismundi URI-keyed ledger -> outbound Accept through this transport -> accepted by Mastodon.
- Axismundi Follow -> this transport's queue/sign/retry path -> Mastodon Accept -> official validation/Inbox action -> Axismundi relationship reached `accepted`.

The staging Actor is [@thaumiel999@designbusan.ai.kr](https://designbusan.ai.kr/@thaumiel999/).

Scope of the current E2E evidence is Follow/Accept. Like, Undo, shared-Inbox delivery, and Create delivery remain separate activity-level scenarios.

## Validation

- Added focused PHPUnit coverage for validation, idempotent queueing, transient signing resolution, and worker delivery state.
- Changed-file PHPCS: 4/4 clean.
- Axismundi Bridge transport composition: 15/15.
- Real signed Follow/Accept E2E: passed in both directions against mastodon.social.

## Relationship to #3541

#3541 addresses selective module initialization and the inbound composition side. This draft is independent of that branch and contains only the outbound transport surface.

Refs #3533
