### PR TITLE
Add an actor autocomplete endpoint (SWICG Actor Autocomplete)

### DIFF
--- a/.github/changelog/add-actor-autocomplete
+++ b/.github/changelog/add-actor-autocomplete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add an actor autocomplete endpoint so Fediverse apps can offer typeahead search when mentioning people.

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -7,6 +7,7 @@ The WordPress plugin largely follows ActivityPub's server-to-server specificatio
 - [ActivityPub](https://www.w3.org/TR/activitypub/) (Server-to-Server)
 - [ActivityPub API: Basic Profile](https://swicg.github.io/activitypub-api/basicprofile) (Client-to-Server, partial; see [OAuth 2.0 for Client-to-Server](#oauth-20-for-client-to-server))
 - [ActivityPub API: Server-Sent Events](https://swicg.github.io/activitypub-api/sse) (partial, see below)
+- [ActivityPub API: Actor Autocomplete](https://swicg.github.io/activitypub-api/autocomplete) (typeahead search over local and cached remote actors; requires the ActivityPub API to be enabled)
 - [WebFinger](https://www.w3.org/community/reports/socialcg/CG-FINAL-apwf-20240608/)
 - [HTTP Signatures](https://swicg.github.io/activitypub-http-signature/)
 - [NodeInfo](https://nodeinfo.diaspora.software/)

--- a/activitypub.php
+++ b/activitypub.php
@@ -65,10 +65,10 @@ function rest_init() {
 	( new Rest\Interaction_Controller() )->register_routes();
 	( new Rest\Moderators_Controller() )->register_routes();
 	if ( \get_option( 'activitypub_api', false ) ) {
+		( new Rest\Actor_Autocomplete_Controller() )->register_routes();
 		( new Rest\OAuth\Authorization_Controller() )->register_routes();
 		( new Rest\OAuth\Clients_Controller() )->register_routes();
 		( new Rest\OAuth\Token_Controller() )->register_routes();
-		( new Rest\Actor_Autocomplete_Controller() )->register_routes();
 	}
 	( new Rest\Outbox_Controller() )->register_routes();
 	( new Rest\Post_Controller() )->register_routes();

--- a/activitypub.php
+++ b/activitypub.php
@@ -68,6 +68,7 @@ function rest_init() {
 		( new Rest\OAuth\Authorization_Controller() )->register_routes();
 		( new Rest\OAuth\Clients_Controller() )->register_routes();
 		( new Rest\OAuth\Token_Controller() )->register_routes();
+		( new Rest\Actor_Autocomplete_Controller() )->register_routes();
 	}
 	( new Rest\Outbox_Controller() )->register_routes();
 	( new Rest\Post_Controller() )->register_routes();

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -419,13 +419,16 @@ class Actors {
 			}
 		}
 
-		if ( ! is_user_type_disabled( 'user' ) ) {
+		// Only query as many users as the Blog actor left room for, so a match is never fetched then trimmed.
+		$remaining = $number - \count( $actors );
+
+		if ( $remaining > 0 && ! is_user_type_disabled( 'user' ) ) {
 			$users = \get_users(
 				array(
 					'capability__in' => array( 'activitypub' ),
 					'search'         => '*' . $query . '*',
 					'search_columns' => array( 'user_login', 'user_nicename', 'display_name' ),
-					'number'         => $number,
+					'number'         => $remaining,
 				)
 			);
 
@@ -437,7 +440,7 @@ class Actors {
 			}
 		}
 
-		return \array_slice( $actors, 0, $number );
+		return $actors;
 	}
 
 	/**

--- a/includes/collection/class-actors.php
+++ b/includes/collection/class-actors.php
@@ -396,6 +396,51 @@ class Actors {
 	}
 
 	/**
+	 * Search local actors by name or username.
+	 *
+	 * Backs the actor autocomplete endpoint. Matches the search term against the WordPress user's
+	 * login, nicename, and display name; the Blog actor is included when its name or identifier
+	 * matches. Disabled actor types are excluded, mirroring get_collection()/get_all().
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $query  The search term.
+	 * @param int    $number Optional. Maximum number of actors to return. Default 10.
+	 *
+	 * @return Actor[] The matching local actor objects.
+	 */
+	public static function search( $query, $number = 10 ) {
+		$actors = array();
+
+		if ( ! is_user_type_disabled( 'blog' ) ) {
+			$blog = new Blog();
+			if ( false !== \stripos( $blog->get_name(), $query ) || false !== \stripos( (string) $blog->get_preferred_username(), $query ) ) {
+				$actors[] = $blog;
+			}
+		}
+
+		if ( ! is_user_type_disabled( 'user' ) ) {
+			$users = \get_users(
+				array(
+					'capability__in' => array( 'activitypub' ),
+					'search'         => '*' . $query . '*',
+					'search_columns' => array( 'user_login', 'user_nicename', 'display_name' ),
+					'number'         => $number,
+				)
+			);
+
+			foreach ( $users as $user ) {
+				$actor = User::from_wp_user( $user->ID );
+				if ( ! \is_wp_error( $actor ) ) {
+					$actors[] = $actor;
+				}
+			}
+		}
+
+		return \array_slice( $actors, 0, $number );
+	}
+
+	/**
 	 * Get all active actors, including the Blog actor if enabled.
 	 *
 	 * @return int[] Array of User and Blog actor IDs.

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -229,12 +229,13 @@ class Remote_Actors {
 	}
 
 	/**
-	 * Search cached remote actors by name or handle.
+	 * Search cached remote actors by name, handle, or actor URI.
 	 *
 	 * Backs the actor autocomplete endpoint. Matches the search term against the stored post title
 	 * (the actor's name or preferred username) and the webfinger handle (user@host), newest first.
-	 * The actor URI is intentionally not matched: as every URI shares the https scheme and host
-	 * shape, a short query would match nearly every cached actor.
+	 * The actor URI (guid) is matched only when the query itself looks like a URL: every URI shares
+	 * the same scheme and host shape, so matching it for a short term would return nearly every
+	 * cached actor.
 	 *
 	 * @since unreleased
 	 *
@@ -246,22 +247,32 @@ class Remote_Actors {
 	public static function search( $query, $number = 10 ) {
 		global $wpdb;
 
-		$like = '%' . $wpdb->esc_like( $query ) . '%';
+		$like       = '%' . $wpdb->esc_like( $query ) . '%';
+		$conditions = 'p.post_title LIKE %s OR acct.meta_value LIKE %s';
+		$params     = array( self::POST_TYPE, $like, $like );
 
-		// Select full rows so get_post() hydrates each in place instead of re-querying per ID.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// Match the actor URI only for URL-like queries, so short terms don't match every https:// guid.
+		if ( \str_contains( $query, '://' ) ) {
+			$conditions .= ' OR p.guid LIKE %s';
+			$params[]    = $like;
+		}
+
+		$params[] = $number;
+
+		// Select full rows so get_post() hydrates each in place instead of re-querying per ID. The
+		// interpolated $conditions is built from the literal fragments above, not from user input,
+		// and the placeholder count is dynamic because the guid clause is optional.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$posts = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT DISTINCT p.* FROM $wpdb->posts p
 				LEFT JOIN $wpdb->postmeta acct ON acct.post_id = p.ID AND acct.meta_key = '_activitypub_acct'
-				WHERE p.post_type = %s AND p.post_status = 'publish' AND ( p.post_title LIKE %s OR acct.meta_value LIKE %s )
+				WHERE p.post_type = %s AND p.post_status = 'publish' AND ( $conditions )
 				ORDER BY p.ID DESC LIMIT %d",
-				self::POST_TYPE,
-				$like,
-				$like,
-				$number
+				$params
 			)
 		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		return \array_map( '\get_post', $posts );
 	}

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -259,9 +259,11 @@ class Remote_Actors {
 
 		$params[] = $number;
 
-		// Select full rows so get_post() hydrates each in place instead of re-querying per ID. The
-		// interpolated $conditions is built from the literal fragments above, not from user input,
-		// and the placeholder count is dynamic because the guid clause is optional.
+		/*
+		 * Select full rows so get_post() hydrates each in place instead of re-querying per ID. The
+		 * interpolated $conditions is built from the literal fragments above, not from user input,
+		 * and the placeholder count is dynamic because the guid clause is optional.
+		 */
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$posts = $wpdb->get_results(
 			$wpdb->prepare(

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -229,10 +229,12 @@ class Remote_Actors {
 	}
 
 	/**
-	 * Search cached remote actors by name, username, or actor URI.
+	 * Search cached remote actors by name or handle.
 	 *
 	 * Backs the actor autocomplete endpoint. Matches the search term against the stored post title
-	 * (the actor's name or preferred username) and the guid (the actor URI), newest first.
+	 * (the actor's name or preferred username) and the webfinger handle (user@host), newest first.
+	 * The actor URI is intentionally not matched: as every URI shares the https scheme and host
+	 * shape, a short query would match nearly every cached actor.
 	 *
 	 * @since unreleased
 	 *
@@ -249,9 +251,10 @@ class Remote_Actors {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$post_ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT ID FROM $wpdb->posts
-				WHERE post_type = %s AND post_status = 'publish' AND ( post_title LIKE %s OR guid LIKE %s )
-				ORDER BY ID DESC LIMIT %d",
+				"SELECT DISTINCT p.ID FROM $wpdb->posts p
+				LEFT JOIN $wpdb->postmeta acct ON acct.post_id = p.ID AND acct.meta_key = '_activitypub_acct'
+				WHERE p.post_type = %s AND p.post_status = 'publish' AND ( p.post_title LIKE %s OR acct.meta_value LIKE %s )
+				ORDER BY p.ID DESC LIMIT %d",
 				self::POST_TYPE,
 				$like,
 				$like,

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -248,10 +248,11 @@ class Remote_Actors {
 
 		$like = '%' . $wpdb->esc_like( $query ) . '%';
 
+		// Select full rows so get_post() hydrates each in place instead of re-querying per ID.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$post_ids = $wpdb->get_col(
+		$posts = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT DISTINCT p.ID FROM $wpdb->posts p
+				"SELECT DISTINCT p.* FROM $wpdb->posts p
 				LEFT JOIN $wpdb->postmeta acct ON acct.post_id = p.ID AND acct.meta_key = '_activitypub_acct'
 				WHERE p.post_type = %s AND p.post_status = 'publish' AND ( p.post_title LIKE %s OR acct.meta_value LIKE %s )
 				ORDER BY p.ID DESC LIMIT %d",
@@ -262,7 +263,7 @@ class Remote_Actors {
 			)
 		);
 
-		return \array_filter( \array_map( '\get_post', $post_ids ) );
+		return \array_map( '\get_post', $posts );
 	}
 
 	/**

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -229,6 +229,40 @@ class Remote_Actors {
 	}
 
 	/**
+	 * Search cached remote actors by name, username, or actor URI.
+	 *
+	 * Backs the actor autocomplete endpoint. Matches the search term against the stored post title
+	 * (the actor's name or preferred username) and the guid (the actor URI), newest first.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $query  The search term.
+	 * @param int    $number Optional. Maximum number of actors to return. Default 10.
+	 *
+	 * @return \WP_Post[] The matching remote actor posts.
+	 */
+	public static function search( $query, $number = 10 ) {
+		global $wpdb;
+
+		$like = '%' . $wpdb->esc_like( $query ) . '%';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$post_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM $wpdb->posts
+				WHERE post_type = %s AND post_status = 'publish' AND ( post_title LIKE %s OR guid LIKE %s )
+				ORDER BY ID DESC LIMIT %d",
+				self::POST_TYPE,
+				$like,
+				$like,
+				$number
+			)
+		);
+
+		return \array_filter( \array_map( '\get_post', $post_ids ) );
+	}
+
+	/**
 	 * Look up which of the given URIs already exist as cached remote actors.
 	 *
 	 * Single batched query (chunked at 200 placeholders to stay well within

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -405,11 +405,9 @@ class Blog extends Actor {
 		);
 
 		if ( \get_option( 'activitypub_api', false ) ) {
-			// RFC 6570 template; the {q} placeholder must stay unencoded. Pick the separator by hand
-			// because plain-permalink sites already return a URL with a query string (?rest_route=…).
-			$autocomplete                   = get_rest_url_by_path( 'actors/autocomplete' );
-			$autocomplete                  .= ( \str_contains( $autocomplete, '?' ) ? '&' : '?' ) . 'q={q}';
-			$endpoints['actorAutocomplete'] = $autocomplete;
+			// RFC 6570 template. add_query_arg() picks the ?/& separator (plain permalinks already carry
+			// a query string) and does not encode values, so the {q} placeholder stays intact.
+			$endpoints['actorAutocomplete'] = \add_query_arg( 'q', '{q}', get_rest_url_by_path( 'actors/autocomplete' ) );
 		}
 
 		return $endpoints;

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -405,8 +405,10 @@ class Blog extends Actor {
 		);
 
 		if ( \get_option( 'activitypub_api', false ) ) {
-			// RFC 6570 template. add_query_arg() picks the ?/& separator (plain permalinks already carry
-			// a query string) and does not encode values, so the {q} placeholder stays intact.
+			/*
+			 * RFC 6570 template. add_query_arg() picks the ?/& separator (plain permalinks already
+			 * carry a query string) and does not encode values, so the {q} placeholder stays intact.
+			 */
 			$endpoints['actorAutocomplete'] = \add_query_arg( 'q', '{q}', get_rest_url_by_path( 'actors/autocomplete' ) );
 		}
 

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -405,8 +405,11 @@ class Blog extends Actor {
 		);
 
 		if ( \get_option( 'activitypub_api', false ) ) {
-			// RFC 6570 template; the {q} placeholder must stay unencoded.
-			$endpoints['actorAutocomplete'] = get_rest_url_by_path( 'actors/autocomplete' ) . '?q={q}';
+			// RFC 6570 template; the {q} placeholder must stay unencoded. Pick the separator by hand
+			// because plain-permalink sites already return a URL with a query string (?rest_route=…).
+			$autocomplete                   = get_rest_url_by_path( 'actors/autocomplete' );
+			$autocomplete                  .= ( \str_contains( $autocomplete, '?' ) ? '&' : '?' ) . 'q={q}';
+			$endpoints['actorAutocomplete'] = $autocomplete;
 		}
 
 		return $endpoints;

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -395,7 +395,7 @@ class Blog extends Actor {
 	 * @return string[]|null The endpoints.
 	 */
 	public function get_endpoints() {
-		return array(
+		$endpoints = array(
 			'sharedInbox'                => get_rest_url_by_path( 'inbox' ),
 			'oauthAuthorizationEndpoint' => get_rest_url_by_path( 'oauth/authorize' ),
 			'oauthTokenEndpoint'         => get_rest_url_by_path( 'oauth/token' ),
@@ -403,6 +403,13 @@ class Blog extends Actor {
 			'proxyUrl'                   => get_rest_url_by_path( 'proxy' ),
 			'proxyEventStream'           => get_rest_url_by_path( 'proxy/stream' ),
 		);
+
+		if ( \get_option( 'activitypub_api', false ) ) {
+			// RFC 6570 template; the {q} placeholder must stay unencoded.
+			$endpoints['actorAutocomplete'] = get_rest_url_by_path( 'actors/autocomplete' ) . '?q={q}';
+		}
+
+		return $endpoints;
 	}
 
 	/**

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -328,7 +328,7 @@ class User extends Actor {
 	 * @return string[]|null The endpoints.
 	 */
 	public function get_endpoints() {
-		return array(
+		$endpoints = array(
 			'sharedInbox'                => get_rest_url_by_path( 'inbox' ),
 			'oauthAuthorizationEndpoint' => get_rest_url_by_path( 'oauth/authorize' ),
 			'oauthTokenEndpoint'         => get_rest_url_by_path( 'oauth/token' ),
@@ -336,6 +336,13 @@ class User extends Actor {
 			'proxyUrl'                   => get_rest_url_by_path( 'proxy' ),
 			'proxyEventStream'           => get_rest_url_by_path( 'proxy/stream' ),
 		);
+
+		if ( \get_option( 'activitypub_api', false ) ) {
+			// RFC 6570 template; the {q} placeholder must stay unencoded.
+			$endpoints['actorAutocomplete'] = get_rest_url_by_path( 'actors/autocomplete' ) . '?q={q}';
+		}
+
+		return $endpoints;
 	}
 
 	/**

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -338,11 +338,9 @@ class User extends Actor {
 		);
 
 		if ( \get_option( 'activitypub_api', false ) ) {
-			// RFC 6570 template; the {q} placeholder must stay unencoded. Pick the separator by hand
-			// because plain-permalink sites already return a URL with a query string (?rest_route=…).
-			$autocomplete                   = get_rest_url_by_path( 'actors/autocomplete' );
-			$autocomplete                  .= ( \str_contains( $autocomplete, '?' ) ? '&' : '?' ) . 'q={q}';
-			$endpoints['actorAutocomplete'] = $autocomplete;
+			// RFC 6570 template. add_query_arg() picks the ?/& separator (plain permalinks already carry
+			// a query string) and does not encode values, so the {q} placeholder stays intact.
+			$endpoints['actorAutocomplete'] = \add_query_arg( 'q', '{q}', get_rest_url_by_path( 'actors/autocomplete' ) );
 		}
 
 		return $endpoints;

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -338,8 +338,11 @@ class User extends Actor {
 		);
 
 		if ( \get_option( 'activitypub_api', false ) ) {
-			// RFC 6570 template; the {q} placeholder must stay unencoded.
-			$endpoints['actorAutocomplete'] = get_rest_url_by_path( 'actors/autocomplete' ) . '?q={q}';
+			// RFC 6570 template; the {q} placeholder must stay unencoded. Pick the separator by hand
+			// because plain-permalink sites already return a URL with a query string (?rest_route=…).
+			$autocomplete                   = get_rest_url_by_path( 'actors/autocomplete' );
+			$autocomplete                  .= ( \str_contains( $autocomplete, '?' ) ? '&' : '?' ) . 'q={q}';
+			$endpoints['actorAutocomplete'] = $autocomplete;
 		}
 
 		return $endpoints;

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -338,8 +338,10 @@ class User extends Actor {
 		);
 
 		if ( \get_option( 'activitypub_api', false ) ) {
-			// RFC 6570 template. add_query_arg() picks the ?/& separator (plain permalinks already carry
-			// a query string) and does not encode values, so the {q} placeholder stays intact.
+			/*
+			 * RFC 6570 template. add_query_arg() picks the ?/& separator (plain permalinks already
+			 * carry a query string) and does not encode values, so the {q} placeholder stays intact.
+			 */
 			$endpoints['actorAutocomplete'] = \add_query_arg( 'q', '{q}', get_rest_url_by_path( 'actors/autocomplete' ) );
 		}
 

--- a/includes/rest/class-actor-autocomplete-controller.php
+++ b/includes/rest/class-actor-autocomplete-controller.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Actor_Autocomplete_Controller file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Rest;
+
+use Activitypub\Activity\Base_Object;
+use Activitypub\Collection\Actors;
+use Activitypub\Collection\Remote_Actors;
+
+use function Activitypub\get_masked_wp_version;
+use function Activitypub\get_rest_url_by_path;
+
+/**
+ * ActivityPub Actor Autocomplete Controller.
+ *
+ * Implements the SWICG ActivityPub API actor autocomplete extension: a typeahead search over the
+ * actors this server knows (its own local actors and the remote actors it has cached), returning an
+ * ActivityStreams Collection of actor objects.
+ *
+ * @see https://swicg.github.io/activitypub-api/autocomplete
+ */
+class Actor_Autocomplete_Controller extends \WP_REST_Controller {
+	use Verification;
+
+	/**
+	 * The JSON-LD context for the actor autocomplete extension.
+	 *
+	 * @var string
+	 */
+	const CONTEXT = 'https://swicg.github.io/activitypub-api/autocomplete';
+
+	/**
+	 * The namespace of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $namespace = ACTIVITYPUB_REST_NAMESPACE;
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'actors/autocomplete';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		\register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'verify_authentication' ),
+					'args'                => array(
+						'q' => array(
+							'description' => 'The text typed so far.',
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Search actors matching the query.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response|\WP_Error Collection of actor objects, or WP_Error on failure.
+	 */
+	public function get_items( $request ) {
+		$query = \trim( (string) $request->get_param( 'q' ) );
+
+		/**
+		 * Filters the minimum number of characters required before actors are searched.
+		 *
+		 * @param int $min_length The minimum query length. Default 2.
+		 */
+		$min_length = (int) \apply_filters( 'activitypub_actor_autocomplete_min_length', 2 );
+
+		if ( \mb_strlen( $query ) < $min_length ) {
+			return new \WP_Error(
+				'activitypub_query_too_short',
+				\sprintf(
+					/* translators: %d: minimum number of characters */
+					\__( 'The search query must be at least %d characters long.', 'activitypub' ),
+					$min_length
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		/**
+		 * Filters the maximum number of actors returned by the autocomplete endpoint.
+		 *
+		 * @param int              $number  The maximum number of actors. Default 10.
+		 * @param \WP_REST_Request $request The request object.
+		 */
+		$number = (int) \apply_filters( 'activitypub_actor_autocomplete_number', 10, $request );
+
+		$items = array();
+		$seen  = array();
+
+		foreach ( Actors::search( $query, $number ) as $actor ) {
+			$item                     = $actor->to_array( false );
+			$items[]                  = $item;
+			$seen[ $actor->get_id() ] = true;
+		}
+
+		foreach ( Remote_Actors::search( $query, $number ) as $post ) {
+			$actor = Remote_Actors::get_actor( $post );
+			if ( \is_wp_error( $actor ) || isset( $seen[ $actor->get_id() ] ) ) {
+				continue;
+			}
+			$items[]                  = $actor->to_array( false );
+			$seen[ $actor->get_id() ] = true;
+		}
+
+		$items = \array_slice( $items, 0, $number );
+
+		$response = array(
+			'@context'   => array( Base_Object::JSON_LD_CONTEXT, self::CONTEXT ),
+			'id'         => \add_query_arg( 'q', \rawurlencode( $query ), get_rest_url_by_path( $this->rest_base ) ),
+			'generator'  => 'https://wordpress.org/?v=' . get_masked_wp_version(),
+			'type'       => 'Collection',
+			'totalItems' => \count( $items ),
+			'items'      => $items,
+		);
+
+		$response = \rest_ensure_response( $response );
+		$response->header( 'Content-Type', 'application/activity+json; charset=' . \get_option( 'blog_charset' ) );
+
+		return $response;
+	}
+}

--- a/includes/rest/class-actor-autocomplete-controller.php
+++ b/includes/rest/class-actor-autocomplete-controller.php
@@ -129,7 +129,8 @@ class Actor_Autocomplete_Controller extends \WP_REST_Controller {
 		}
 
 		$response = array(
-			'@context'   => array( Base_Object::JSON_LD_CONTEXT, self::CONTEXT ),
+			// JSON_LD_CONTEXT is already a context array, so merge the extension IRI in rather than nesting it.
+			'@context'   => \array_merge( (array) Base_Object::JSON_LD_CONTEXT, array( self::CONTEXT ) ),
 			'id'         => \add_query_arg( 'q', $query, get_rest_url_by_path( $this->rest_base ) ),
 			'generator'  => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'type'       => 'Collection',

--- a/includes/rest/class-actor-autocomplete-controller.php
+++ b/includes/rest/class-actor-autocomplete-controller.php
@@ -119,13 +119,15 @@ class Actor_Autocomplete_Controller extends \WP_REST_Controller {
 		// Only look up as many remote actors as are still needed to fill the result set.
 		$remaining = $number - \count( $items );
 
-		foreach ( $remaining > 0 ? Remote_Actors::search( $query, $remaining ) : array() as $post ) {
-			$actor = Remote_Actors::get_actor( $post );
-			if ( \is_wp_error( $actor ) || isset( $seen[ $actor->get_id() ] ) ) {
-				continue;
+		if ( $remaining > 0 ) {
+			foreach ( Remote_Actors::search( $query, $remaining ) as $post ) {
+				$actor = Remote_Actors::get_actor( $post );
+				if ( \is_wp_error( $actor ) || isset( $seen[ $actor->get_id() ] ) ) {
+					continue;
+				}
+				$items[]                  = $actor->to_array( false );
+				$seen[ $actor->get_id() ] = true;
 			}
-			$items[]                  = $actor->to_array( false );
-			$seen[ $actor->get_id() ] = true;
 		}
 
 		$response = array(

--- a/includes/rest/class-actor-autocomplete-controller.php
+++ b/includes/rest/class-actor-autocomplete-controller.php
@@ -61,9 +61,10 @@ class Actor_Autocomplete_Controller extends \WP_REST_Controller {
 					'permission_callback' => array( $this, 'verify_authentication' ),
 					'args'                => array(
 						'q' => array(
-							'description' => 'The text typed so far.',
-							'type'        => 'string',
-							'required'    => true,
+							'description'       => 'The text typed so far.',
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 				),
@@ -111,12 +112,14 @@ class Actor_Autocomplete_Controller extends \WP_REST_Controller {
 		$seen  = array();
 
 		foreach ( Actors::search( $query, $number ) as $actor ) {
-			$item                     = $actor->to_array( false );
-			$items[]                  = $item;
+			$items[]                  = $actor->to_array( false );
 			$seen[ $actor->get_id() ] = true;
 		}
 
-		foreach ( Remote_Actors::search( $query, $number ) as $post ) {
+		// Only look up as many remote actors as are still needed to fill the result set.
+		$remaining = $number - \count( $items );
+
+		foreach ( $remaining > 0 ? Remote_Actors::search( $query, $remaining ) : array() as $post ) {
 			$actor = Remote_Actors::get_actor( $post );
 			if ( \is_wp_error( $actor ) || isset( $seen[ $actor->get_id() ] ) ) {
 				continue;
@@ -124,8 +127,6 @@ class Actor_Autocomplete_Controller extends \WP_REST_Controller {
 			$items[]                  = $actor->to_array( false );
 			$seen[ $actor->get_id() ] = true;
 		}
-
-		$items = \array_slice( $items, 0, $number );
 
 		$response = array(
 			'@context'   => array( Base_Object::JSON_LD_CONTEXT, self::CONTEXT ),

--- a/includes/rest/class-actor-autocomplete-controller.php
+++ b/includes/rest/class-actor-autocomplete-controller.php
@@ -106,7 +106,7 @@ class Actor_Autocomplete_Controller extends \WP_REST_Controller {
 		 * @param int              $number  The maximum number of actors. Default 10.
 		 * @param \WP_REST_Request $request The request object.
 		 */
-		$number = (int) \apply_filters( 'activitypub_actor_autocomplete_number', 10, $request );
+		$number = \max( 1, (int) \apply_filters( 'activitypub_actor_autocomplete_number', 10, $request ) );
 
 		$items = array();
 		$seen  = array();
@@ -130,7 +130,7 @@ class Actor_Autocomplete_Controller extends \WP_REST_Controller {
 
 		$response = array(
 			'@context'   => array( Base_Object::JSON_LD_CONTEXT, self::CONTEXT ),
-			'id'         => \add_query_arg( 'q', \rawurlencode( $query ), get_rest_url_by_path( $this->rest_base ) ),
+			'id'         => \add_query_arg( 'q', $query, get_rest_url_by_path( $this->rest_base ) ),
 			'generator'  => 'https://wordpress.org/?v=' . get_masked_wp_version(),
 			'type'       => 'Collection',
 			'totalItems' => \count( $items ),

--- a/tests/phpunit/tests/includes/rest/class-test-actor-autocomplete-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-actor-autocomplete-controller.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Actor Autocomplete REST endpoint test file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Rest;
+
+use Activitypub\Collection\Actors;
+use Activitypub\Collection\Remote_Actors;
+use Activitypub\Model\Blog;
+use Activitypub\Model\User;
+use Activitypub\Rest\Actor_Autocomplete_Controller;
+
+/**
+ * Tests for the Actor Autocomplete REST endpoint.
+ *
+ * @group rest
+ * @coversDefaultClass \Activitypub\Rest\Actor_Autocomplete_Controller
+ */
+class Test_Actor_Autocomplete_Controller extends \WP_UnitTestCase {
+
+	/**
+	 * Set up before each test: register the route and cache a remote actor.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		\update_option( 'activitypub_api', '1' );
+
+		global $wp_rest_server;
+		$wp_rest_server = new \Spy_REST_Server();
+		\do_action( 'rest_api_init', $wp_rest_server );
+
+		Remote_Actors::create(
+			array(
+				'id'                => 'https://remote.example.com/actor/alice',
+				'type'              => 'Person',
+				'inbox'             => 'https://remote.example.com/actor/alice/inbox',
+				'name'              => 'Alice Remote',
+				'preferredUsername' => 'alice',
+			)
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		\delete_option( 'activitypub_api' );
+		\remove_filter( 'activitypub_oauth_check_permission', '__return_true' );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Grant OAuth permission for the request under test.
+	 */
+	private function authenticate() {
+		\add_filter( 'activitypub_oauth_check_permission', '__return_true' );
+	}
+
+	/**
+	 * The route is registered under the ActivityPub namespace.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete', $routes );
+	}
+
+	/**
+	 * The endpoint requires authentication.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_requires_authentication() {
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'alice' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * A query shorter than the minimum length returns a 400.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_query_too_short() {
+		$this->authenticate();
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'a' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * A query matching nothing returns a 200 with an empty Collection.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_empty_results_return_empty_collection() {
+		$this->authenticate();
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'nobodymatchesthis' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 'Collection', $data['type'] );
+		$this->assertSame( 0, $data['totalItems'] );
+		$this->assertSame( array(), $data['items'] );
+	}
+
+	/**
+	 * A cached remote actor is returned as an actor object.
+	 *
+	 * @covers ::get_items
+	 * @covers \Activitypub\Collection\Remote_Actors::search
+	 */
+	public function test_matches_remote_actor() {
+		$this->authenticate();
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'alice' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 1, $data['totalItems'] );
+		$this->assertSame( 'https://remote.example.com/actor/alice', $data['items'][0]['id'] );
+		$this->assertSame( 'Person', $data['items'][0]['type'] );
+		$this->assertArrayNotHasKey( '@context', $data['items'][0] );
+	}
+
+	/**
+	 * A local user is returned as an actor object.
+	 *
+	 * @covers ::get_items
+	 * @covers \Activitypub\Collection\Actors::search
+	 */
+	public function test_matches_local_user() {
+		$this->authenticate();
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role'         => 'author',
+				'display_name' => 'Aloysius Author',
+				'user_login'   => 'aloysius',
+			)
+		);
+		\get_user_by( 'id', $user_id )->add_cap( 'activitypub' );
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'aloysius' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$ids = \wp_list_pluck( $data['items'], 'id' );
+		$this->assertContains( Actors::get_by_id( $user_id )->get_id(), $ids );
+	}
+
+	/**
+	 * The response advertises both the ActivityStreams and autocomplete contexts.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_response_context() {
+		$this->authenticate();
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'alice' );
+
+		$data = rest_get_server()->dispatch( $request )->get_data();
+
+		$this->assertContains( 'https://swicg.github.io/activitypub-api/autocomplete', $data['@context'] );
+	}
+
+	/**
+	 * The Blog and User actors advertise actorAutocomplete when the API is enabled.
+	 *
+	 * @covers \Activitypub\Model\Blog::get_endpoints
+	 * @covers \Activitypub\Model\User::get_endpoints
+	 */
+	public function test_actors_advertise_autocomplete_endpoint() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'id', $user_id )->add_cap( 'activitypub' );
+
+		$blog_endpoints = ( new Blog() )->get_endpoints();
+		$user_endpoints = User::from_wp_user( $user_id )->get_endpoints();
+
+		$this->assertArrayHasKey( 'actorAutocomplete', $blog_endpoints );
+		$this->assertStringEndsWith( '?q={q}', $blog_endpoints['actorAutocomplete'] );
+		$this->assertArrayHasKey( 'actorAutocomplete', $user_endpoints );
+		$this->assertStringEndsWith( '?q={q}', $user_endpoints['actorAutocomplete'] );
+	}
+
+	/**
+	 * The actorAutocomplete endpoint is not advertised when the API is disabled.
+	 *
+	 * @covers \Activitypub\Model\Blog::get_endpoints
+	 */
+	public function test_autocomplete_endpoint_hidden_when_api_disabled() {
+		\delete_option( 'activitypub_api' );
+
+		$this->assertArrayNotHasKey( 'actorAutocomplete', ( new Blog() )->get_endpoints() );
+	}
+}

--- a/tests/phpunit/tests/includes/rest/class-test-actor-autocomplete-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-actor-autocomplete-controller.php
@@ -175,6 +175,23 @@ class Test_Actor_Autocomplete_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A URL-like query matches a cached actor by its actor URI (guid).
+	 *
+	 * @covers \Activitypub\Collection\Remote_Actors::search
+	 */
+	public function test_matches_remote_actor_by_uri() {
+		$this->authenticate();
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'https://remote.example.com/actor/alice' );
+
+		$data = rest_get_server()->dispatch( $request )->get_data();
+
+		$ids = \wp_list_pluck( $data['items'], 'id' );
+		$this->assertContains( 'https://remote.example.com/actor/alice', $ids );
+	}
+
+	/**
 	 * A short query does not flood results by matching the actor URI scheme.
 	 *
 	 * @covers \Activitypub\Collection\Remote_Actors::search

--- a/tests/phpunit/tests/includes/rest/class-test-actor-autocomplete-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-actor-autocomplete-controller.php
@@ -147,6 +147,52 @@ class Test_Actor_Autocomplete_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A cached remote actor is findable by its handle even when it differs from the display name.
+	 *
+	 * @covers ::get_items
+	 * @covers \Activitypub\Collection\Remote_Actors::search
+	 */
+	public function test_matches_remote_actor_by_handle() {
+		$this->authenticate();
+
+		Remote_Actors::create(
+			array(
+				'id'                => 'https://remote.example.com/users/42',
+				'type'              => 'Person',
+				'inbox'             => 'https://remote.example.com/users/42/inbox',
+				'name'              => 'Bob Smith',
+				'preferredUsername' => 'bob123',
+			)
+		);
+
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'bob123' );
+
+		$data = rest_get_server()->dispatch( $request )->get_data();
+
+		$ids = \wp_list_pluck( $data['items'], 'id' );
+		$this->assertContains( 'https://remote.example.com/users/42', $ids );
+	}
+
+	/**
+	 * A short query does not flood results by matching the actor URI scheme.
+	 *
+	 * @covers \Activitypub\Collection\Remote_Actors::search
+	 */
+	public function test_short_query_does_not_match_uri_scheme() {
+		$this->authenticate();
+
+		// 'ht' appears in every actor's https:// URI but not in the Alice fixture's name/handle.
+		$request = new \WP_REST_Request( 'GET', '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/autocomplete' );
+		$request->set_param( 'q', 'ht' );
+
+		$data = rest_get_server()->dispatch( $request )->get_data();
+
+		$ids = \wp_list_pluck( $data['items'], 'id' );
+		$this->assertNotContains( 'https://remote.example.com/actor/alice', $ids );
+	}
+
+	/**
 	 * A local user is returned as an actor object.
 	 *
 	 * @covers ::get_items
@@ -189,6 +235,8 @@ class Test_Actor_Autocomplete_Controller extends \WP_UnitTestCase {
 		$data = rest_get_server()->dispatch( $request )->get_data();
 
 		$this->assertContains( 'https://swicg.github.io/activitypub-api/autocomplete', $data['@context'] );
+		// The ActivityStreams context must be merged in, not nested as an array element.
+		$this->assertSame( 'https://www.w3.org/ns/activitystreams', $data['@context'][0] );
 	}
 
 	/**
@@ -204,10 +252,12 @@ class Test_Actor_Autocomplete_Controller extends \WP_UnitTestCase {
 		$blog_endpoints = ( new Blog() )->get_endpoints();
 		$user_endpoints = User::from_wp_user( $user_id )->get_endpoints();
 
-		$this->assertArrayHasKey( 'actorAutocomplete', $blog_endpoints );
-		$this->assertStringEndsWith( '?q={q}', $blog_endpoints['actorAutocomplete'] );
-		$this->assertArrayHasKey( 'actorAutocomplete', $user_endpoints );
-		$this->assertStringEndsWith( '?q={q}', $user_endpoints['actorAutocomplete'] );
+		foreach ( array( $blog_endpoints, $user_endpoints ) as $endpoints ) {
+			$this->assertArrayHasKey( 'actorAutocomplete', $endpoints );
+			$this->assertStringEndsWith( 'q={q}', $endpoints['actorAutocomplete'] );
+			// The template must be a well-formed URL with a single query string, even on plain permalinks.
+			$this->assertSame( 1, \substr_count( $endpoints['actorAutocomplete'], '?' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

Implements the SWICG [ActivityPub API: Actor Autocomplete](https://swicg.github.io/activitypub-api/autocomplete) extension, which lets a Fediverse client offer typeahead search over the actors this server knows when a user is mentioning someone.

* **New `/actors/autocomplete` endpoint** (`Actor_Autocomplete_Controller`): `GET /wp-json/activitypub/1.0/actors/autocomplete?q=<text>`. It searches the site's own local actors and the remote actors it has cached, and returns an ActivityStreams `Collection` of actor objects. An empty match still returns `200` with an empty collection, per the spec; a query shorter than the minimum length returns a `400` problem response.
* **Actor search** on both collections: `Actors::search()` matches local users (by login, nicename, and display name) and the Blog actor; `Remote_Actors::search()` matches cached remote actors by name, handle (webfinger), or, for URL-like queries, actor URI. Results are combined and de-duplicated by actor id.
* **`actorAutocomplete` advertisement**: the RFC 6570 template (`…/actors/autocomplete?q={q}`) is added to each actor's `endpoints`, so clients can discover the endpoint from the actor document.

The endpoint requires authentication (OAuth bearer token, the spec's recommendation), so it is registered and advertised only when the ActivityPub API is enabled, alongside the other API endpoints. The minimum query length (default 2) and the maximum number of results (default 10) are both filterable.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

9 tests cover route registration, authentication required (401), the minimum-length 400, a query matching nothing returning a 200 empty collection, matching a local user and a cached remote actor, the response advertising the autocomplete JSON-LD context, and the `actorAutocomplete` endpoint being advertised only when the API is enabled.

## Testing instructions:

* Enable the ActivityPub API (Settings → ActivityPub → the ActivityPub API / OAuth option).
* Fetch an actor document (e.g. `GET /wp-json/activitypub/1.0/actors/0`) and confirm its `endpoints.actorAutocomplete` is present and ends with `?q={q}`.
* With a valid OAuth bearer token: `GET /wp-json/activitypub/1.0/actors/autocomplete?q=<name>` and confirm the response is an ActivityStreams `Collection` whose `items` are actor objects matching the query.
* Confirm a one-character query returns a 400, and a query matching nothing returns a 200 with an empty `items` array.

### Changelog entry

Changelog entry is committed in `.github/changelog/add-actor-autocomplete`.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>


