### PR TITLE
Fix check for *JSON accept header if it also contains text/html

### DIFF
--- a/.github/changelog/3558-from-description
+++ b/.github/changelog/3558-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed using the correct cache representation in Surge config

--- a/integration/surge-cache-config.php
+++ b/integration/surge-cache-config.php
@@ -13,9 +13,7 @@ if ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 	$accept = strtolower( $_SERVER['HTTP_ACCEPT'] );
 
-	if ( str_contains( $accept, 'text/html' ) ) {
-		$representation = 'html';
-	} elseif (
+	if (
 		str_contains( $accept, 'application/json' ) ||
 		str_contains( $accept, 'application/activity+json' ) ||
 		str_contains( $accept, 'application/ld+json' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #3557 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removing the `if` check for `text/html`, since the representation `html` is already the default and it may result false positives for requests with these accept headers:

```
application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enabling Surge on the website
* Request a post from the Mona client (e.g. by searching for it)
* Accessing the post again in the browser

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -→

Fixed using the correct cache representation in Surge config

</details>
