### PR TITLE
Only cancel a follow when the account you followed declines it

### DIFF
--- a/.github/changelog/fix-reject-handler-confused-deputy
+++ b/.github/changelog/fix-reject-handler-confused-deputy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure a follow can only be declined by the account you followed.

--- a/includes/handler/class-reject.php
+++ b/includes/handler/class-reject.php
@@ -56,8 +56,18 @@ class Reject {
 	 * @param int|int[] $user_ids The user ID(s).
 	 */
 	private static function reject_follow( $reject, $user_ids ) {
-		$actor_uri  = $reject['object']['actor'] ?? '';
-		$actor_post = Remote_Actors::get_by_uri( object_to_uri( $actor_uri ) );
+		/*
+		 * For a Follow Reject, the sender must be the actor that was followed.
+		 * Without this, a signed Reject from one actor could cancel a Follow that
+		 * targeted another actor by referencing that pending Follow's outbox GUID.
+		 */
+		$reject_actor   = object_to_uri( $reject['actor'] ?? '' );
+		$followed_actor = object_to_uri( $reject['object']['object'] ?? '' );
+		if ( ! $reject_actor || ! $followed_actor || $reject_actor !== $followed_actor ) {
+			return;
+		}
+
+		$actor_post = Remote_Actors::get_by_uri( $followed_actor );
 
 		if ( \is_wp_error( $actor_post ) ) {
 			return;
@@ -99,6 +109,14 @@ class Reject {
 		}
 
 		if ( ! isset( $activity['actor'], $activity['object'] ) ) {
+			return false;
+		}
+
+		if ( ! \is_array( $activity['object'] ) ) {
+			return false;
+		}
+
+		if ( ! isset( $activity['object']['id'], $activity['object']['type'], $activity['object']['actor'], $activity['object']['object'] ) ) {
 			return false;
 		}
 

--- a/tests/phpunit/tests/includes/handler/class-test-reject.php
+++ b/tests/phpunit/tests/includes/handler/class-test-reject.php
@@ -150,12 +150,13 @@ class Test_Reject extends \WP_UnitTestCase {
 		$this->assertContains( (string) $user_id, $pending );
 
 		// Prepare reject array as expected by handle_reject, using the real outbox guid.
+		// The sender (top-level actor) must be the actor that was followed.
 		$reject = array(
 			'type'   => 'Reject',
-			'actor'  => 'https://example.net/actor/123',
+			'actor'  => $object_guid,
 			'object' => array(
 				'id'     => $outbox_guid,
-				'actor'  => 'https://example.com/actor/123',
+				'actor'  => 'https://example.com/follower/123',
 				'type'   => 'Follow',
 				'object' => $object_guid,
 			),
@@ -173,5 +174,59 @@ class Test_Reject extends \WP_UnitTestCase {
 		// Assert: user_id is STILL in _activitypub_followed_by_pending.
 		$pending = \get_post_meta( $post_id, Following::PENDING_META_KEY, false );
 		$this->assertNotContains( (string) $user_id, $pending );
+	}
+
+	/**
+	 * A Reject whose sender is not the followed actor must be ignored.
+	 *
+	 * Guards against any peer cancelling a user's Follow of an unrelated actor
+	 * by referencing that pending Follow's outbox GUID.
+	 */
+	public function test_handle_reject_rejects_actor_object_mismatch() {
+		$user_id     = self::$user_id;
+		$object_guid = 'https://example.com/actor/123';
+		$outbox_guid = 'https://example.com/outbox/123';
+
+		$outbox_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Outbox::POST_TYPE,
+				'post_status' => 'publish',
+				'guid'        => $outbox_guid,
+			)
+		);
+
+		\add_post_meta( $outbox_post_id, '_activitypub_activity_type', 'Follow' );
+
+		// Create remote actor post the local user is following.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Remote_Actors::POST_TYPE,
+				'post_status' => 'publish',
+				'guid'        => $object_guid,
+			)
+		);
+
+		\add_post_meta( $post_id, Following::FOLLOWING_META_KEY, (string) $user_id );
+
+		// Reject signed by an unrelated actor, pointing at the victim's Follow GUID
+		// and naming the followed actor so it would be unfollowed if unguarded.
+		$reject = array(
+			'type'   => 'Reject',
+			'actor'  => 'https://evil.example/actor/999',
+			'object' => array(
+				'id'     => $outbox_guid,
+				'actor'  => $object_guid,
+				'type'   => 'Follow',
+				'object' => $object_guid,
+			),
+		);
+
+		Reject::handle_reject( $reject, $user_id );
+
+		\clean_post_cache( $post_id );
+
+		// Assert: the follow relationship is untouched.
+		$following = \get_post_meta( $post_id, Following::FOLLOWING_META_KEY, false );
+		$this->assertContains( (string) $user_id, $following );
 	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -399,8 +399,8 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 				'to'     => array( $user_actor->get_id() ),
 			);
 
-			// `Accept` needs an `object` with `actor` and `object`.
-			if ( 'Accept' === $type ) {
+			// `Accept` and `Reject` need an `object` with `actor` and `object`.
+			if ( 'Accept' === $type || 'Reject' === $type ) {
 				$json['object']['actor']  = 'https://remote.example/@test';
 				$json['object']['object'] = 'https://remote.example/post/test';
 			}


### PR DESCRIPTION
Fixes CM-851

## Proposed changes:

When your site follows a remote account, that account's server can reply with a "Reject" to decline the follow. The plugin used to match a Reject to your pending follow using only the follow's outbox ID, and then removed the follow named in the message — without confirming the Reject actually came from the account you followed.

This updates the Reject handler to require that the sender is the account that was followed, and to work out which follow to cancel from that confirmed value rather than from a field the sender can set freely. It's the same rule the Accept handler already applies to the other half of the follow handshake, so both sides now behave consistently. Object validation is also tightened to match Accept.

Normal Rejects from the account you followed keep working exactly as before; only mismatched ones are now ignored.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run the handler tests: `npm run env-test -- --filter=Test_Reject` and `npm run env-test -- --filter=Test_Accept`. All pass.
* The new `test_handle_reject_rejects_actor_object_mismatch` covers a Reject whose sender is not the followed account: the follow is left untouched. The existing `test_handle_reject_keeps_user_in_pending` continues to cover the normal decline flow.
* Functionally: from a WordPress site, follow a remote account (e.g. on Mastodon). When that account declines the follow, confirm your site drops the pending follow as expected. A Reject that names your follow but comes from a different account should have no effect on it.

### Changelog entry

A changelog entry is included in the branch (Fixed / patch): "Ensure a follow can only be declined by the account you followed."
