### PR TITLE
Use `esc_url_raw()` for URLs emitted into ActivityPub JSON

### DIFF
--- a/.github/changelog/fix-actor-json-url-encoding
+++ b/.github/changelog/fix-actor-json-url-encoding
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix URLs with multiple query parameters (such as avatars, images, and profile links) being corrupted in content sent to the Fediverse.
+Fix URLs with multiple query parameters (such as avatars, images, profile links, and podcast media) being corrupted in content sent to the Fediverse.

--- a/.github/changelog/fix-actor-json-url-encoding
+++ b/.github/changelog/fix-actor-json-url-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix URLs with multiple query parameters (such as avatars, images, and profile links) being corrupted in content sent to the Fediverse.

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -132,7 +132,7 @@ class Extra_Fields {
 					$attachment = array(
 						'type' => 'Link',
 						'name' => $title,
-						'href' => \esc_url( $tags->get_attribute( 'href' ) ),
+						'href' => \esc_url_raw( $tags->get_attribute( 'href' ) ),
 					);
 
 					$rel = $tags->get_attribute( 'rel' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -137,7 +137,7 @@ function site_icon() {
 
 	return array(
 		'type' => 'Image',
-		'url'  => \esc_url( $icon_url ),
+		'url'  => \esc_url_raw( $icon_url ),
 	);
 }
 

--- a/includes/model/class-application.php
+++ b/includes/model/class-application.php
@@ -156,7 +156,7 @@ class Application extends Actor {
 		if ( \has_header_image() ) {
 			return array(
 				'type' => 'Image',
-				'url'  => \esc_url( \get_header_image() ),
+				'url'  => \esc_url_raw( \get_header_image() ),
 			);
 		}
 

--- a/includes/model/class-blog.php
+++ b/includes/model/class-blog.php
@@ -94,7 +94,7 @@ class Blog extends Actor {
 		$permalink = \get_option( 'activitypub_use_permalink_as_id_for_blog', false );
 
 		if ( $permalink ) {
-			return \esc_url( \home_url( '/@' . $this->get_preferred_username() ) );
+			return \esc_url_raw( \home_url( '/@' . $this->get_preferred_username() ) );
 		}
 
 		return \add_query_arg( 'author', $this->_id, \home_url( '/' ) );
@@ -170,7 +170,7 @@ class Blog extends Actor {
 	 * @return string The User-Url.
 	 */
 	public function get_alternate_url() {
-		return \esc_url( \trailingslashit( \get_home_url() ) );
+		return \esc_url_raw( \trailingslashit( \get_home_url() ) );
 	}
 
 	/**
@@ -239,7 +239,7 @@ class Blog extends Actor {
 		if ( $image_url ) {
 			return array(
 				'type' => 'Image',
-				'url'  => \esc_url( $image_url ),
+				'url'  => \esc_url_raw( $image_url ),
 			);
 		}
 

--- a/includes/model/class-user.php
+++ b/includes/model/class-user.php
@@ -153,7 +153,7 @@ class User extends Actor {
 	 * @return string The User url.
 	 */
 	public function get_url() {
-		return \esc_url( \get_author_posts_url( $this->_id ) );
+		return \esc_url_raw( \get_author_posts_url( $this->_id ) );
 	}
 
 	/**
@@ -162,7 +162,7 @@ class User extends Actor {
 	 * @return string The User URL with @-Prefix for the username.
 	 */
 	public function get_alternate_url() {
-		return \esc_url( \trailingslashit( \get_home_url() ) . '@' . $this->get_preferred_username() );
+		return \esc_url_raw( \trailingslashit( \get_home_url() ) . '@' . $this->get_preferred_username() );
 	}
 
 	/**
@@ -191,11 +191,11 @@ class User extends Actor {
 		if ( false !== $icon && \wp_attachment_is_image( $icon ) ) {
 			return array(
 				'type' => 'Image',
-				'url'  => \esc_url( \wp_get_attachment_url( $icon ) ),
+				'url'  => \esc_url_raw( \wp_get_attachment_url( $icon ) ),
 			);
 		}
 
-		$icon = \esc_url(
+		$icon = \esc_url_raw(
 			\get_avatar_url(
 				$this->_id,
 				array( 'size' => 120 )
@@ -228,7 +228,7 @@ class User extends Actor {
 		if ( $image_url ) {
 			return array(
 				'type' => 'Image',
-				'url'  => \esc_url( $image_url ),
+				'url'  => \esc_url_raw( $image_url ),
 			);
 		}
 

--- a/includes/rest/class-collections-controller.php
+++ b/includes/rest/class-collections-controller.php
@@ -139,7 +139,7 @@ class Collections_Controller extends Actors_Controller {
 		foreach ( $tags as $tag ) {
 			$response['items'][] = array(
 				'type' => 'Hashtag',
-				'href' => \esc_url( \get_tag_link( $tag ) ),
+				'href' => \esc_url_raw( \get_tag_link( $tag ) ),
 				'name' => esc_hashtag( $tag->name ),
 			);
 		}

--- a/includes/rest/class-interaction-controller.php
+++ b/includes/rest/class-interaction-controller.php
@@ -110,7 +110,7 @@ class Interaction_Controller extends \WP_REST_Controller {
 		}
 
 		if ( ! empty( $object['id'] ) ) {
-			$uri = \esc_url( $object['id'] );
+			$uri = \esc_url_raw( $object['id'] );
 		}
 
 		// Prepare URL parameter.

--- a/includes/rest/class-post-controller.php
+++ b/includes/rest/class-post-controller.php
@@ -165,13 +165,14 @@ class Post_Controller extends \WP_REST_Controller {
 						 * Decode entities first so a stored pseudo-tag like
 						 * `&lt;img&gt;` becomes a real `<img>` for the next
 						 * step to remove, then strip any tags so the JSON
-						 * response contains only plain text. `esc_url()`
-						 * rejects `javascript:` and other unsafe schemes.
+						 * response contains only plain text. `esc_url_raw()`
+						 * rejects `javascript:` and other unsafe schemes without
+						 * HTML-encoding ampersands (this is JSON, not markup).
 						 */
 						return array(
 							'name'   => \wp_strip_all_tags( \html_entity_decode( $comment->comment_author, ENT_QUOTES ) ),
-							'url'    => \esc_url( $comment->comment_author_url ),
-							'avatar' => \esc_url( \get_avatar_url( $comment ) ),
+							'url'    => \esc_url_raw( $comment->comment_author_url ),
+							'avatar' => \esc_url_raw( \get_avatar_url( $comment ) ),
 						);
 					},
 					$comments

--- a/includes/transformer/class-activity-object.php
+++ b/includes/transformer/class-activity-object.php
@@ -145,7 +145,7 @@ class Activity_Object extends Base {
 			foreach ( $mentions as $mention => $url ) {
 				$tag    = array(
 					'type' => 'Mention',
-					'href' => \esc_url( $url ),
+					'href' => \esc_url_raw( $url ),
 					'name' => \esc_html( $mention ),
 				);
 				$tags[] = $tag;

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -347,7 +347,7 @@ abstract class Base {
 		foreach ( $mentions as $mention => $url ) {
 			$tags[] = array(
 				'type' => 'Mention',
-				'href' => \esc_url( $url ),
+				'href' => \esc_url_raw( $url ),
 				'name' => \esc_html( $mention ),
 			);
 		}
@@ -528,7 +528,7 @@ abstract class Base {
 				if ( $thumbnail ) {
 					$image = array(
 						'type'      => 'Image',
-						'url'       => \esc_url( $thumbnail[0] ),
+						'url'       => \esc_url_raw( $thumbnail[0] ),
 						'mediaType' => \esc_attr( $mime_type ),
 					);
 
@@ -557,7 +557,7 @@ abstract class Base {
 				$attachment = array(
 					'type'      => \ucfirst( $media_type ),
 					'mediaType' => \esc_attr( $mime_type ),
-					'url'       => \esc_url( \wp_get_attachment_url( $id ) ),
+					'url'       => \esc_url_raw( \wp_get_attachment_url( $id ) ),
 					'name'      => \esc_attr( \get_the_title( $id ) ),
 				);
 

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -264,7 +264,7 @@ class Post extends Base {
 				break;
 		}
 
-		return \esc_url( $permalink );
+		return \esc_url_raw( $permalink );
 	}
 
 	/**
@@ -319,7 +319,7 @@ class Post extends Base {
 
 		$image = array(
 			'type'      => 'Image',
-			'url'       => \esc_url( $thumbnail[0] ),
+			'url'       => \esc_url_raw( $thumbnail[0] ),
 			'mediaType' => \esc_attr( $mime_type ),
 		);
 
@@ -375,7 +375,7 @@ class Post extends Base {
 
 		$image = array(
 			'type'      => 'Image',
-			'url'       => \esc_url( $thumbnail[0] ),
+			'url'       => \esc_url_raw( $thumbnail[0] ),
 			'mediaType' => \esc_attr( $mime_type ),
 		);
 
@@ -552,7 +552,7 @@ class Post extends Base {
 
 				$tags[] = array(
 					'type' => 'Hashtag',
-					'href' => \esc_url( \get_tag_link( $post_tag->term_id ) ),
+					'href' => \esc_url_raw( \get_tag_link( $post_tag->term_id ) ),
 					'name' => esc_hashtag( $post_tag->name ),
 				);
 			}

--- a/includes/transformer/class-term.php
+++ b/includes/transformer/class-term.php
@@ -63,6 +63,6 @@ class Term extends Base {
 			return '';
 		}
 
-		return \esc_url( $term_link );
+		return \esc_url_raw( $term_link );
 	}
 }

--- a/integration/class-podlove-podcast-publisher.php
+++ b/integration/class-podlove-podcast-publisher.php
@@ -114,7 +114,7 @@ class Podlove_Podcast_Publisher extends Post {
 
 			$attachment = array(
 				'type'      => \esc_attr( \ucfirst( $file_type->type ) ),
-				'url'       => \esc_url( $file_url ),
+				'url'       => \esc_url_raw( $file_url ),
 				'mediaType' => \esc_attr( $file_type->mime_type ),
 				'name'      => \esc_attr( $episode->title() ?? '' ),
 			);
@@ -134,7 +134,7 @@ class Podlove_Podcast_Publisher extends Post {
 
 			if ( $icon ) {
 				foreach ( $attachments as $key => $attachment ) {
-					$attachments[ $key ]['icon'] = \esc_url( $icon );
+					$attachments[ $key ]['icon'] = \esc_url_raw( $icon );
 				}
 			}
 		}

--- a/integration/class-seriously-simple-podcasting.php
+++ b/integration/class-seriously-simple-podcasting.php
@@ -31,7 +31,7 @@ class Seriously_Simple_Podcasting extends Post {
 		$post       = $this->item;
 		$attachment = array(
 			'type' => \esc_attr( \ucfirst( \get_post_meta( $post->ID, 'episode_type', true ) ?? 'Audio' ) ),
-			'url'  => \esc_url( \get_post_meta( $post->ID, 'audio_file', true ) ),
+			'url'  => \esc_url_raw( \get_post_meta( $post->ID, 'audio_file', true ) ),
 			'name' => \esc_attr( \get_the_title( $post->ID ) ?? '' ),
 		);
 
@@ -41,7 +41,7 @@ class Seriously_Simple_Podcasting extends Post {
 		}
 
 		if ( $icon ) {
-			$attachment['icon'] = \esc_url( object_to_uri( $icon ) );
+			$attachment['icon'] = \esc_url_raw( object_to_uri( $icon ) );
 		}
 
 		return array( $attachment );

--- a/tests/phpunit/tests/includes/model/class-test-user.php
+++ b/tests/phpunit/tests/includes/model/class-test-user.php
@@ -110,6 +110,35 @@ class Test_User extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Ampersands in avatar URLs must survive actor-JSON serialization intact.
+	 *
+	 * The esc_url() function HTML-encodes `&` to `&#038;`, which corrupts
+	 * multi-parameter URLs (e.g. Photon/Gravatar) in the machine-readable actor
+	 * document. The non-display esc_url_raw() variant keeps the ampersand as-is.
+	 *
+	 * @ticket https://github.com/Automattic/wordpress-activitypub/issues/3566
+	 * @covers ::get_icon
+	 */
+	public function test_get_icon_preserves_ampersands() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$user    = User::from_wp_user( $user_id );
+
+		$avatar_url = 'https://i0.wp.com/example.com/avatar.jpg?resize=215&ssl=1';
+		$filter     = static function ( $args ) use ( $avatar_url ) {
+			$args['url'] = $avatar_url;
+			return $args;
+		};
+		\add_filter( 'get_avatar_data', $filter );
+
+		$icon = $user->get_icon();
+
+		\remove_filter( 'get_avatar_data', $filter );
+
+		$this->assertStringContainsString( 'resize=215&ssl=1', $icon['url'], 'The ampersand must survive as a real separator.' );
+		$this->assertStringNotContainsString( '&#0', $icon['url'], 'The ampersand must not be HTML-entity-encoded in JSON output.' );
+	}
+
+	/**
 	 * Tests the get_moved_to method.
 	 *
 	 * @covers ::get_moved_to


### PR DESCRIPTION
Fixes #3566

## Proposed changes:

URLs destined for **ActivityPub JSON** were escaped with `esc_url()`, whose *display* context HTML-encodes ampersands (`&` → `&#038;`). That is right for an HTML attribute but wrong for a machine-readable document: a multi-parameter URL like a Photon/Gravatar avatar (`…?fit=215,215&ssl=1`) ships with the ampersand entity-encoded, and a strict receiving server can treat `&#038;` as a fragment and silently drop the trailing parameter.

This switches every URL that is **serialized into JSON** to `esc_url_raw()` — the non-display variant that keeps the ampersand intact while still rejecting unsafe schemes (`javascript:`, etc.):

- **Actor models:** site icon, user/blog/application icon, avatar, header image, and profile URLs.
- **Transformers:** post permalinks, image and attachment URLs, and `Mention`/`Hashtag` hrefs.
- **Collections & REST:** extra-field `Link` hrefs, the Hashtag collection, the interaction redirect id (which is `rawurlencode`d), and the reactions REST response.

Deliberately **unchanged** (where `esc_url()` is correct): mention/hashtag anchor tags and media `<img>` tags embedded in the AP `content` HTML, all `wp-admin/` UI, and the `esc_url( $guid )` SQL `WHERE guid = %s` lookups (which normalize against stored guids rather than emitting output).

The reporter noted the transformers "already use `esc_url_raw()`"; in fact they had the same bug, which is why this sweep is broader than the five spots in the issue.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Set a site icon or user avatar to a URL with more than one query parameter (a Jetpack/Photon or Gravatar avatar is a natural example, e.g. `…?resize=215&ssl=1`).
* Fetch the actor document, e.g. `curl -H "Accept: application/activity+json" https://example.com/author/<user>/`.
* **Before:** the `icon` / `image` URL contains `&#038;` and the trailing parameter is broken.
* **After:** the URL contains a plain `&` and is intact.
* The same applies to `url`, image attachments, and `Mention`/`Hashtag` hrefs in a transformed post, and to the reactions REST response.

### Changelog entry

A changelog entry is included in the branch (`.github/changelog/fix-actor-json-url-encoding`).
