### PR TITLE
oauth: improve restrictions on rest routes

### DIFF
--- a/.github/changelog/fix-oauth-token-scope-core-routes
+++ b/.github/changelog/fix-oauth-token-scope-core-routes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Ensure apps you connect can only act within the access you granted them, and not make wider changes to your site.

--- a/includes/oauth/class-server.php
+++ b/includes/oauth/class-server.php
@@ -116,6 +116,32 @@ class Server {
 	}
 
 	/**
+	 * Reject requests that authenticated with an OAuth bearer token.
+	 *
+	 * OAuth bearer tokens are scoped ActivityPub C2S grants and must not reach
+	 * the plugin's admin and management endpoints, which authorize by WordPress
+	 * capability rather than by OAuth scope. Without this guard a token consented
+	 * to for a narrow scope (e.g. read) could drive privileged, capability-gated
+	 * actions such as moderation. Cookie-authenticated admin-UI requests do not
+	 * establish an OAuth session and are unaffected.
+	 *
+	 * @since unreleased
+	 *
+	 * @return \WP_Error|null WP_Error when the request is OAuth-authenticated, null otherwise.
+	 */
+	public static function deny_if_oauth() {
+		if ( ! self::is_oauth_request() ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			'activitypub_oauth_not_allowed',
+			\__( 'OAuth authentication is not allowed for this endpoint.', 'activitypub' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	/**
 	 * Get the current OAuth token from the request.
 	 *
 	 * @return Token|null The validated token or null.

--- a/includes/oauth/class-server.php
+++ b/includes/oauth/class-server.php
@@ -56,6 +56,22 @@ class Server {
 			return $result;
 		}
 
+		/*
+		 * Only honor OAuth bearer tokens on the plugin's own REST API.
+		 *
+		 * These are scoped ActivityPub C2S grants. Honoring them on core routes
+		 * (e.g. POST /wp/v2/posts) would establish a full-capability session that
+		 * ignores the token's granted scope, since scope is only enforced where
+		 * the plugin opts in via check_oauth_permission() (CWE-863). Every C2S
+		 * endpoint lives under ACTIVITYPUB_REST_NAMESPACE, so restricting here
+		 * does not affect legitimate clients. Direct callers (outbox permalinks,
+		 * SSE query-param auth) invoke this method outside REST dispatch and are
+		 * trusted to have scoped the context themselves.
+		 */
+		if ( ! self::is_authenticatable_request() ) {
+			return $result;
+		}
+
 		$validated = Token::validate( $token );
 
 		if ( \is_wp_error( $validated ) ) {
@@ -66,6 +82,37 @@ class Server {
 		\wp_set_current_user( $validated->get_user_id() );
 
 		return true;
+	}
+
+	/**
+	 * Whether the current request may be authenticated with an OAuth bearer token.
+	 *
+	 * Bearer tokens are scoped ActivityPub C2S grants and must only authenticate
+	 * the plugin's own REST API. During REST dispatch we therefore require the
+	 * requested route to live under {@see ACTIVITYPUB_REST_NAMESPACE}; a token
+	 * presented to a core route such as `/wp/v2/posts` is ignored so its granted
+	 * scope cannot be bypassed. Outside REST dispatch (e.g. outbox permalinks
+	 * that authenticate explicitly) there is no route to scope against, so the
+	 * request is allowed through to the caller's own checks.
+	 *
+	 * @since unreleased
+	 *
+	 * @return bool True if the request may be OAuth-authenticated.
+	 */
+	private static function is_authenticatable_request() {
+		global $wp;
+
+		$route = isset( $wp->query_vars['rest_route'] ) ? (string) $wp->query_vars['rest_route'] : '';
+
+		if ( '' === $route ) {
+			// No REST route in context: only trust non-REST (direct/permalink) callers.
+			return ! \wp_is_serving_rest_request();
+		}
+
+		$route     = '/' . \ltrim( $route, '/' );
+		$namespace = '/' . \trim( ACTIVITYPUB_REST_NAMESPACE, '/' );
+
+		return $route === $namespace || 0 === \strpos( $route, $namespace . '/' );
 	}
 
 	/**

--- a/includes/rest/admin/class-actions-controller.php
+++ b/includes/rest/admin/class-actions-controller.php
@@ -13,6 +13,7 @@ use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Moderation;
+use Activitypub\OAuth\Server as OAuth_Server;
 
 use function Activitypub\user_can_activitypub;
 
@@ -118,6 +119,12 @@ class Actions_Controller extends \WP_REST_Controller {
 	 * @return bool|\WP_Error True if the request has permission, WP_Error object otherwise.
 	 */
 	public function check_permission() {
+		// This is an admin endpoint; scoped OAuth C2S tokens must not drive it.
+		$denied = OAuth_Server::deny_if_oauth();
+		if ( null !== $denied ) {
+			return $denied;
+		}
+
 		if ( ! user_can_activitypub( \get_current_user_id() ) ) {
 			return new \WP_Error(
 				'rest_forbidden',

--- a/includes/rest/admin/class-statistics-controller.php
+++ b/includes/rest/admin/class-statistics-controller.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Rest\Admin;
 
 use Activitypub\Collection\Actors;
+use Activitypub\OAuth\Server as OAuth_Server;
 use Activitypub\Statistics;
 
 use function Activitypub\user_can_act_as_blog;
@@ -65,6 +66,12 @@ class Statistics_Controller extends \WP_REST_Controller {
 	 * @return true|\WP_Error True if the request has access, WP_Error otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
+		// This is an admin endpoint; scoped OAuth C2S tokens must not drive it.
+		$denied = OAuth_Server::deny_if_oauth();
+		if ( null !== $denied ) {
+			return $denied;
+		}
+
 		$user_id = (int) $request->get_param( 'user_id' );
 
 		// Check if user can access stats for this actor.

--- a/tests/phpunit/tests/includes/oauth/class-test-server.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-server.php
@@ -89,6 +89,9 @@ class Test_Server extends \WP_UnitTestCase {
 			$wp->query_vars['rest_route'] = $this->original_rest_route;
 		}
 
+		// Reset the static OAuth session so it does not leak into later tests.
+		Server::authenticate_oauth( null );
+
 		\wp_set_current_user( 0 );
 
 		if ( $this->client_id ) {
@@ -200,5 +203,33 @@ class Test_Server extends \WP_UnitTestCase {
 		$this->assertTrue( $result, 'Direct (non-REST) callers must still authenticate.' );
 		$this->assertTrue( Server::is_oauth_request() );
 		$this->assertSame( $this->user_id, \get_current_user_id() );
+	}
+
+	/**
+	 * The guard lets non-OAuth requests through.
+	 *
+	 * @covers ::deny_if_oauth
+	 */
+	public function test_deny_if_oauth_allows_non_oauth_request() {
+		$this->assertNull( Server::deny_if_oauth() );
+	}
+
+	/**
+	 * The guard blocks requests authenticated with a bearer token.
+	 *
+	 * Protects the plugin's capability-gated admin endpoints from scoped C2S tokens.
+	 *
+	 * @covers ::deny_if_oauth
+	 */
+	public function test_deny_if_oauth_blocks_oauth_request() {
+		$this->set_bearer_header();
+		$this->set_rest_route( '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $this->user_id . '/outbox' );
+		Server::authenticate_oauth( null );
+
+		$result = Server::deny_if_oauth();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'activitypub_oauth_not_allowed', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
 	}
 }

--- a/tests/phpunit/tests/includes/oauth/class-test-server.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-server.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Test file for OAuth Server class.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\OAuth;
+
+use Activitypub\OAuth\Client;
+use Activitypub\OAuth\Scope;
+use Activitypub\OAuth\Server;
+use Activitypub\OAuth\Token;
+use Activitypub\Post_Types;
+
+/**
+ * Test class for OAuth Server.
+ *
+ * @coversDefaultClass \Activitypub\OAuth\Server
+ *
+ * @group activitypub
+ * @group oauth
+ */
+class Test_Server extends \WP_UnitTestCase {
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	protected $user_id;
+
+	/**
+	 * Test client ID.
+	 *
+	 * @var string
+	 */
+	protected $client_id;
+
+	/**
+	 * A valid access token string for the test user.
+	 *
+	 * @var string
+	 */
+	protected $access_token;
+
+	/**
+	 * Original `rest_route` query var, restored on tear down.
+	 *
+	 * @var mixed
+	 */
+	protected $original_rest_route;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Post_Types::register_oauth_post_types();
+
+		$this->user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$client          = Client::register(
+			array(
+				'name'          => 'Test Client',
+				'redirect_uris' => array( 'https://example.com/callback' ),
+			)
+		);
+		$this->client_id = $client['client_id'];
+
+		$token              = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+		$this->access_token = $token['access_token'];
+
+		global $wp;
+		$this->original_rest_route = $wp->query_vars['rest_route'] ?? null;
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tear_down() {
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+
+		global $wp;
+		if ( null === $this->original_rest_route ) {
+			unset( $wp->query_vars['rest_route'] );
+		} else {
+			$wp->query_vars['rest_route'] = $this->original_rest_route;
+		}
+
+		\wp_set_current_user( 0 );
+
+		if ( $this->client_id ) {
+			Client::delete( $this->client_id );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Present the test user's bearer token on the request.
+	 */
+	private function set_bearer_header() {
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $this->access_token;
+	}
+
+	/**
+	 * Set the REST route the request is dispatching to.
+	 *
+	 * @param string|null $route The route, or null to clear it (non-REST context).
+	 */
+	private function set_rest_route( $route ) {
+		global $wp;
+		if ( null === $route ) {
+			unset( $wp->query_vars['rest_route'] );
+		} else {
+			$wp->query_vars['rest_route'] = $route;
+		}
+	}
+
+	/**
+	 * A valid bearer token must not authenticate core REST routes.
+	 *
+	 * Regression test: honoring the token on `/wp/v2/*` would grant a full,
+	 * unscoped session, letting a `read`-only client write content (CWE-863).
+	 *
+	 * @covers ::authenticate_oauth
+	 */
+	public function test_bearer_token_ignored_on_core_rest_route() {
+		$this->set_bearer_header();
+		$this->set_rest_route( '/wp/v2/posts' );
+
+		$result = Server::authenticate_oauth( null );
+
+		$this->assertNull( $result, 'OAuth must not authenticate core REST routes.' );
+		$this->assertFalse( Server::is_oauth_request(), 'No OAuth session should be established.' );
+		$this->assertSame( 0, \get_current_user_id(), 'The current user must not be set from the token.' );
+	}
+
+	/**
+	 * A prior authentication error on a core route must be preserved untouched.
+	 *
+	 * @covers ::authenticate_oauth
+	 */
+	public function test_bearer_token_preserves_prior_result_on_core_rest_route() {
+		$this->set_bearer_header();
+		$this->set_rest_route( '/wp/v2/users/me' );
+
+		$prior  = new \WP_Error( 'some_prior_error', 'Prior error.' );
+		$result = Server::authenticate_oauth( $prior );
+
+		$this->assertSame( $prior, $result, 'The incoming result must be returned unchanged.' );
+		$this->assertFalse( Server::is_oauth_request() );
+	}
+
+	/**
+	 * A valid bearer token authenticates the plugin's own REST namespace.
+	 *
+	 * @covers ::authenticate_oauth
+	 */
+	public function test_bearer_token_authenticates_activitypub_route() {
+		$this->set_bearer_header();
+		$this->set_rest_route( '/' . ACTIVITYPUB_REST_NAMESPACE . '/actors/' . $this->user_id . '/outbox' );
+
+		$result = Server::authenticate_oauth( null );
+
+		$this->assertTrue( $result, 'OAuth must authenticate ActivityPub routes.' );
+		$this->assertTrue( Server::is_oauth_request() );
+		$this->assertSame( $this->user_id, \get_current_user_id() );
+	}
+
+	/**
+	 * A look-alike namespace prefix must not be treated as an ActivityPub route.
+	 *
+	 * @covers ::authenticate_oauth
+	 */
+	public function test_bearer_token_ignored_on_lookalike_namespace() {
+		$this->set_bearer_header();
+		$this->set_rest_route( '/' . ACTIVITYPUB_REST_NAMESPACE . 'evil/steal' );
+
+		$result = Server::authenticate_oauth( null );
+
+		$this->assertNull( $result );
+		$this->assertFalse( Server::is_oauth_request() );
+		$this->assertSame( 0, \get_current_user_id() );
+	}
+
+	/**
+	 * Outside REST dispatch (e.g. outbox permalinks) the token still authenticates.
+	 *
+	 * @covers ::authenticate_oauth
+	 */
+	public function test_bearer_token_authenticates_non_rest_request() {
+		$this->set_bearer_header();
+		$this->set_rest_route( null );
+
+		$result = Server::authenticate_oauth( null );
+
+		$this->assertTrue( $result, 'Direct (non-REST) callers must still authenticate.' );
+		$this->assertTrue( Server::is_oauth_request() );
+		$this->assertSame( $this->user_id, \get_current_user_id() );
+	}
+}

--- a/tests/phpunit/tests/includes/rest/admin/class-test-actions-controller.php
+++ b/tests/phpunit/tests/includes/rest/admin/class-test-actions-controller.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Test file for Actions_Controller permissions.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Rest\Admin;
+
+use Activitypub\OAuth\Client;
+use Activitypub\OAuth\Scope;
+use Activitypub\OAuth\Server;
+use Activitypub\OAuth\Token;
+use Activitypub\Post_Types;
+use Activitypub\Rest\Admin\Actions_Controller;
+
+/**
+ * Test class for Actions_Controller permissions.
+ *
+ * @group rest
+ * @coversDefaultClass \Activitypub\Rest\Admin\Actions_Controller
+ */
+class Test_Actions_Controller extends \WP_UnitTestCase {
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var Actions_Controller
+	 */
+	protected $controller;
+
+	/**
+	 * OAuth client ID created for the denial test, if any.
+	 *
+	 * @var string
+	 */
+	protected $client_id = '';
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->controller = new Actions_Controller();
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tear_down() {
+		\wp_set_current_user( 0 );
+
+		// Clear any OAuth session established during the test.
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		Server::authenticate_oauth( null );
+
+		if ( $this->client_id ) {
+			Client::delete( $this->client_id );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Authenticate the current request as the given user via an OAuth bearer token.
+	 *
+	 * @param int $user_id The user to mint a token for.
+	 */
+	private function authenticate_via_oauth( $user_id ) {
+		Post_Types::register_oauth_post_types();
+
+		$client          = Client::register(
+			array(
+				'name'          => 'Test Client',
+				'redirect_uris' => array( 'https://example.com/callback' ),
+			)
+		);
+		$this->client_id = $client['client_id'];
+
+		$token                         = Token::create( $user_id, $this->client_id, array( Scope::READ ) );
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token['access_token'];
+
+		Server::authenticate_oauth( null );
+	}
+
+	/**
+	 * Test an ActivityPub-enabled user is allowed when authenticated by cookie.
+	 *
+	 * @covers ::check_permission
+	 */
+	public function test_activitypub_user_is_allowed() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'id', $user_id )->add_cap( 'activitypub' );
+		\wp_set_current_user( $user_id );
+
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	/**
+	 * Test OAuth-authenticated requests are denied.
+	 *
+	 * Moderation actions are an admin surface, not part of the ActivityPub C2S
+	 * API, so a scoped OAuth token must not reach them even when its user would
+	 * otherwise be capable.
+	 *
+	 * @covers ::check_permission
+	 */
+	public function test_oauth_authenticated_request_is_denied() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		\get_user_by( 'id', $user_id )->add_cap( 'activitypub' );
+		$this->authenticate_via_oauth( $user_id );
+
+		$result = $this->controller->check_permission();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_oauth_not_allowed', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
+}

--- a/tests/phpunit/tests/includes/rest/admin/class-test-statistics-controller.php
+++ b/tests/phpunit/tests/includes/rest/admin/class-test-statistics-controller.php
@@ -7,6 +7,11 @@
 
 namespace Activitypub\Tests\Rest\Admin;
 
+use Activitypub\OAuth\Client;
+use Activitypub\OAuth\Scope;
+use Activitypub\OAuth\Server;
+use Activitypub\OAuth\Token;
+use Activitypub\Post_Types;
 use Activitypub\Rest\Admin\Statistics_Controller;
 
 /**
@@ -25,6 +30,13 @@ class Test_Statistics_Controller extends \WP_UnitTestCase {
 	protected $controller;
 
 	/**
+	 * OAuth client ID created for the denial test, if any.
+	 *
+	 * @var string
+	 */
+	protected $client_id = '';
+
+	/**
 	 * Set up the test.
 	 */
 	public function set_up() {
@@ -40,7 +52,37 @@ class Test_Statistics_Controller extends \WP_UnitTestCase {
 		\wp_set_current_user( 0 );
 		\remove_all_filters( 'activitypub_user_can_act_as_blog' );
 
+		// Clear any OAuth session established during the test.
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		Server::authenticate_oauth( null );
+
+		if ( $this->client_id ) {
+			Client::delete( $this->client_id );
+		}
+
 		parent::tear_down();
+	}
+
+	/**
+	 * Authenticate the current request as the given user via an OAuth bearer token.
+	 *
+	 * @param int $user_id The user to mint a token for.
+	 */
+	private function authenticate_via_oauth( $user_id ) {
+		Post_Types::register_oauth_post_types();
+
+		$client          = Client::register(
+			array(
+				'name'          => 'Test Client',
+				'redirect_uris' => array( 'https://example.com/callback' ),
+			)
+		);
+		$this->client_id = $client['client_id'];
+
+		$token                         = Token::create( $user_id, $this->client_id, array( Scope::READ ) );
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token['access_token'];
+
+		Server::authenticate_oauth( null );
 	}
 
 	/**
@@ -123,5 +165,24 @@ class Test_Statistics_Controller extends \WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Test OAuth-authenticated requests are denied, even for the user's own stats.
+	 *
+	 * Statistics is an admin surface, not part of the ActivityPub C2S API, so a
+	 * scoped OAuth token must not reach it.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_oauth_authenticated_request_is_denied() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$this->authenticate_via_oauth( $user_id );
+
+		$result = $this->controller->get_item_permissions_check( $this->build_request( $user_id ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'activitypub_oauth_not_allowed', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
 	}
 }


### PR DESCRIPTION
Fixes CM-852

## Proposed changes:

The plugin's OAuth server (`Activitypub\OAuth\Server::authenticate_oauth()`) is hooked globally on `rest_authentication_errors`. For any valid bearer token it called `wp_set_current_user()` and returned `true`, establishing a full-capability WordPress session for the **entire** REST API. The token's granted OAuth scope is only enforced where the plugin opts in via `check_oauth_permission()` (two call sites), so the scope was ignored everywhere else.

This fixes that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

Check CI

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs crated from a fork under GitHub organizations. -->
<!-- In this case, you can create entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
