### PR TITLE
Hide empty headings on the Followers and Following blocks

### DIFF
--- a/.github/changelog/fix-hide-empty-follow-block-heading
+++ b/.github/changelog/fix-hide-empty-follow-block-heading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide the heading on the Followers and Following blocks when its text is cleared, matching the Reactions block.

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -394,6 +394,10 @@ class Blocks {
 			unset( $attributes['title'], $attributes['className'] );
 		} else {
 			$content = \implode( PHP_EOL, \wp_list_pluck( $block->parsed_block['innerBlocks'], 'innerHTML' ) );
+			// Hide empty headings.
+			if ( empty( \wp_strip_all_tags( $content ) ) ) {
+				$content = '';
+			}
 		}
 
 		$user_id = self::get_user_id( $attributes['selectedUser'] );


### PR DESCRIPTION
Fixes #3573

## Proposed changes:

The **Followers** and **Following** blocks render a locked heading (`templateLock: 'all'`). The lock applies to the block *structure*, but the heading **text stays editable** — so a user who doesn't want a heading can simply clear its text. The **Reactions** block already drops the heading in that case; the Followers/Following blocks did not, leaving an empty `<h3>`.

This adds the same "hide empty heading" check to the shared `Blocks::render_actor_list_block()`, so all three blocks behave consistently: clear the heading text and it disappears on the frontend.

```php
$content = implode( PHP_EOL, wp_list_pluck( $block->parsed_block['innerBlocks'], 'innerHTML' ) );
// Hide empty headings.
if ( empty( wp_strip_all_tags( $content ) ) ) {
    $content = '';
}
```

This is the same pattern already present in `src/reactions/render.php`. No editor/JS changes and no new attribute — the heading remains removable by emptying it, which the reporter didn't realise was possible.

## Testing instructions:

* Add a **Followers** (or **Following**) block to a post; a heading appears.
* Select the heading and delete its text (the block stays, the text clears).
* View the post on the frontend: **before**, an empty heading rendered; **after**, no heading is output.
* Repeat with text present to confirm the heading still renders normally.
