### PR TITLE
Require the ActivityPub capability for OAuth access tokens

### DIFF
--- a/.github/changelog/oauth-token-capability-check
+++ b/.github/changelog/oauth-token-capability-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Only users enabled for ActivityPub can obtain and use OAuth access tokens.

--- a/includes/oauth/class-token.php
+++ b/includes/oauth/class-token.php
@@ -97,6 +97,11 @@ class Token {
 	 * @return array|\WP_Error Token data or error.
 	 */
 	public static function create( $user_id, $client_id, $scopes, $expires = self::DEFAULT_EXPIRATION ) {
+		$user_access = self::validate_user_access( $user_id );
+		if ( \is_wp_error( $user_access ) ) {
+			return $user_access;
+		}
+
 		// Generate tokens.
 		$access_token  = self::generate_token();
 		$refresh_token = self::generate_token();
@@ -219,6 +224,11 @@ class Token {
 			);
 		}
 
+		$user_access = self::validate_user_access( $user_id );
+		if ( \is_wp_error( $user_access ) ) {
+			return $user_access;
+		}
+
 		// Throttle last_used_at writes to avoid a DB write on every request.
 		$last_used = $token_data['last_used_at'] ?? 0;
 		if ( empty( $last_used ) || ( \time() - $last_used ) > 5 * MINUTE_IN_SECONDS ) {
@@ -315,12 +325,42 @@ class Token {
 			);
 		}
 
+		// Reject before tearing down the existing token, so a failed refresh does not destroy the grant.
+		$user_access = self::validate_user_access( $user_id );
+		if ( \is_wp_error( $user_access ) ) {
+			return $user_access;
+		}
+
 		// Delete the old token and index.
 		\delete_user_meta( $user_id, $meta_key );
 		\delete_user_meta( $user_id, $refresh_index_key );
 
 		// Create a new token.
 		return self::create( $user_id, $client_id, $token_data['scopes'] );
+	}
+
+	/**
+	 * Validate that a token's user holds the ActivityPub capability.
+	 *
+	 * Checks the `activitypub` capability directly rather than user_can_activitypub(), which also
+	 * short-circuits on the site actor mode: a capable user must keep their token even when the site
+	 * runs in blog-only or single-user mode, where per-user actors are not exposed.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return true|\WP_Error True when the user has the capability, WP_Error otherwise.
+	 */
+	private static function validate_user_access( $user_id ) {
+		if ( \user_can( $user_id, 'activitypub' ) ) {
+			return true;
+		}
+
+		return new \WP_Error(
+			'activitypub_user_not_enabled',
+			\__( 'This user is not enabled for ActivityPub.', 'activitypub' ),
+			array( 'status' => 403 )
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/oauth/class-test-server.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-server.php
@@ -60,6 +60,7 @@ class Test_Server extends \WP_UnitTestCase {
 		Post_Types::register_oauth_post_types();
 
 		$this->user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		\get_user_by( 'id', $this->user_id )->add_cap( 'activitypub' );
 
 		$client          = Client::register(
 			array(
@@ -171,6 +172,25 @@ class Test_Server extends \WP_UnitTestCase {
 		$this->assertTrue( $result, 'OAuth must authenticate ActivityPub routes.' );
 		$this->assertTrue( Server::is_oauth_request() );
 		$this->assertSame( $this->user_id, \get_current_user_id() );
+	}
+
+	/**
+	 * A bearer token must not authenticate a user who is not enabled for ActivityPub.
+	 *
+	 * @covers ::authenticate_oauth
+	 */
+	public function test_bearer_token_rejected_for_user_without_activitypub_capability() {
+		\get_user_by( 'id', $this->user_id )->remove_cap( 'activitypub' );
+		$this->set_bearer_header();
+		$this->set_rest_route( '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
+
+		$result = Server::authenticate_oauth( null );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'activitypub_user_not_enabled', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+		$this->assertFalse( Server::is_oauth_request() );
+		$this->assertSame( 0, \get_current_user_id() );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/oauth/class-test-token.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-token.php
@@ -51,6 +51,7 @@ class Test_Token extends \WP_UnitTestCase {
 				'role' => 'editor',
 			)
 		);
+		\get_user_by( 'id', $this->user_id )->add_cap( 'activitypub' );
 
 		// Create a test client.
 		$client_result   = Client::register(
@@ -133,6 +134,38 @@ class Test_Token extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test create rejects users who are not enabled for ActivityPub.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_rejects_user_without_activitypub_capability() {
+		\get_user_by( 'id', $this->user_id )->remove_cap( 'activitypub' );
+
+		$result = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'activitypub_user_not_enabled', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A user who holds the activitypub capability keeps token access in blog-only mode, where
+	 * user_can_activitypub() would short-circuit to false but the capability is unchanged.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_allows_capable_user_in_blog_only_mode() {
+		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
+
+		$result = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+
+		\delete_option( 'activitypub_actor_mode' );
+
+		$this->assertNotWPError( $result );
+		$this->assertArrayHasKey( 'access_token', $result );
+	}
+
+	/**
 	 * Test validate method with valid token.
 	 *
 	 * @covers ::validate
@@ -144,6 +177,36 @@ class Test_Token extends \WP_UnitTestCase {
 		$this->assertInstanceOf( Token::class, $token );
 		$this->assertEquals( $this->user_id, $token->get_user_id() );
 		$this->assertEquals( $this->client_id, $token->get_client_id() );
+	}
+
+	/**
+	 * Test validate rejects tokens after their user is disabled for ActivityPub.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_rejects_user_without_activitypub_capability() {
+		$result = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+		\get_user_by( 'id', $this->user_id )->remove_cap( 'activitypub' );
+
+		$validation = Token::validate( $result['access_token'] );
+
+		$this->assertWPError( $validation );
+		$this->assertSame( 'activitypub_user_not_enabled', $validation->get_error_code() );
+		$this->assertSame( 403, $validation->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test introspection marks a disabled user's token as inactive.
+	 *
+	 * @covers ::introspect
+	 */
+	public function test_introspect_marks_disabled_user_token_inactive() {
+		$result = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+		\get_user_by( 'id', $this->user_id )->remove_cap( 'activitypub' );
+
+		$introspection = Token::introspect( $result['access_token'] );
+
+		$this->assertFalse( $introspection['active'] );
 	}
 
 	/**
@@ -249,6 +312,22 @@ class Test_Token extends \WP_UnitTestCase {
 		// Old token should be revoked.
 		$old_validation = Token::validate( $original['access_token'] );
 		$this->assertInstanceOf( \WP_Error::class, $old_validation );
+	}
+
+	/**
+	 * Test refresh rejects tokens after their user is disabled for ActivityPub.
+	 *
+	 * @covers ::refresh
+	 */
+	public function test_refresh_rejects_user_without_activitypub_capability() {
+		$original = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
+		\get_user_by( 'id', $this->user_id )->remove_cap( 'activitypub' );
+
+		$result = Token::refresh( $original['refresh_token'], $this->client_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'activitypub_user_not_enabled', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/oauth/class-test-token.php
+++ b/tests/phpunit/tests/includes/oauth/class-test-token.php
@@ -155,11 +155,12 @@ class Test_Token extends \WP_UnitTestCase {
 	 * @covers ::create
 	 */
 	public function test_create_allows_capable_user_in_blog_only_mode() {
+		$actor_mode = \get_option( 'activitypub_actor_mode' );
 		\update_option( 'activitypub_actor_mode', ACTIVITYPUB_BLOG_MODE );
 
 		$result = Token::create( $this->user_id, $this->client_id, array( Scope::READ ) );
 
-		\delete_option( 'activitypub_actor_mode' );
+		\update_option( 'activitypub_actor_mode', $actor_mode );
 
 		$this->assertNotWPError( $result );
 		$this->assertArrayHasKey( 'access_token', $result );
@@ -328,6 +329,11 @@ class Test_Token extends \WP_UnitTestCase {
 		$this->assertWPError( $result );
 		$this->assertSame( 'activitypub_user_not_enabled', $result->get_error_code() );
 		$this->assertSame( 403, $result->get_error_data()['status'] );
+
+		// The rejected refresh must not tear down the existing grant: once the user is enabled again,
+		// the original access token still validates.
+		\get_user_by( 'id', $this->user_id )->add_cap( 'activitypub' );
+		$this->assertNotWPError( Token::validate( $original['access_token'] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

OAuth access tokens are now tied to the `activitypub` capability. `create()`, `validate()`, and `refresh()` refuse a user who doesn't have it, so a user who was never enabled for ActivityPub, or had it removed, can't get or keep a connected-app token.

I check the capability directly instead of `user_can_activitypub()` on purpose: that helper also short-circuits on the site's actor mode, so it would have rejected real, capable users on blog-only and single-user sites, where per-user actors aren't exposed but the capability is still the right signal. `refresh()` runs the check before it deletes the old token, so a failed refresh never destroys a still-valid grant.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* On a site in "both" or user mode, remove the `activitypub` capability from a user, then run the OAuth flow for them from a client: token issuance returns `403`, and an existing token stops validating.
* Give the capability back: the same client can obtain and use a token again.
* Switch the site to blog-only mode with a capable user connected: their token keeps working. This is the case the direct capability check preserves.

### Changelog entry

A changelog entry is already committed to the branch (`.github/changelog/oauth-token-capability-check`), so the "Skip Changelog" label isn't needed.
