### PR TITLE
Only serve ActivityPub to JSON-only requests

### DIFF
--- a/.github/changelog/tighten-content-negotiation-json-only
+++ b/.github/changelog/tighten-content-negotiation-json-only
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+ActivityPub responses are now served only to clients that ask for ActivityPub data and nothing else, which keeps that data out of page caches meant for regular web pages.

--- a/docs/how-to/caching.md
+++ b/docs/how-to/caching.md
@@ -55,11 +55,13 @@ Varnish does not pass through `Vary: Accept` by default. You need to configure i
 
 ```vcl
 sub vcl_hash {
-    if (req.http.Accept ~ "application/(ld\+json|activity\+json|json)") {
+    if (req.http.Accept ~ "(?i)^[\s,]*[^\s,;]*(/json|\+json)\s*(;[^,]*)?([\s,]+[^\s,;]*(/json|\+json)\s*(;[^,]*)?)*[\s,]*$") {
         hash_data("activitypub");
     }
 }
 ```
+
+The pattern matches only requests whose `Accept` header is *entirely* JSON, so a browser (which also accepts HTML) shares the HTML cache, not the JSON one. It mirrors how the plugin itself decides.
 
 Alternatively, add `Vary: Accept` in your Apache or Nginx config so Varnish sees it from the backend.
 
@@ -69,12 +71,14 @@ Use a map to distinguish JSON from HTML and add it to your cache key. Avoid usin
 
 ```nginx
 map $http_accept $activitypub_suffix {
-    default        "html";
-    ~application/  "json";
+    default   "html";
+    "~*^[\s,]*[^\s,;]*(/json|\+json)\s*(;[^,]*)?([\s,]+[^\s,;]*(/json|\+json)\s*(;[^,]*)?)*[\s,]*$"   "json";
 }
 
 fastcgi_cache_key "$scheme$request_method$host$request_uri$activitypub_suffix";
 ```
+
+The regex only matches an `Accept` header that is entirely JSON, so a browser request (which also accepts HTML) maps to `html`, not `json`. A looser match like `~application/` would also catch a browser's `application/xhtml+xml` and mix HTML into the JSON bucket.
 
 ### Cloudflare
 
@@ -88,7 +92,7 @@ The plugin automatically adds `.htaccess` rules when it detects the LiteSpeed Ca
 # BEGIN ActivityPub LiteSpeed Cache
 <IfModule LiteSpeed>
 RewriteEngine On
-RewriteCond %{HTTP:Accept} application
+RewriteCond %{HTTP:Accept} ^[\s,]*[^\s,;]*(/json|\+json)\s*(;[^,]*)?([\s,]+[^\s,;]*(/json|\+json)\s*(;[^,]*)?)*[\s,]*$ [NC]
 RewriteRule ^ - [E=Cache-Control:vary=%{ENV:LSCACHE_VARY_VALUE}+isjson]
 </IfModule>
 # END ActivityPub LiteSpeed Cache

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -301,19 +301,21 @@ class Query {
 				// The other (more common) option to make an ActivityPub request  is to send an Accept header.
 			} elseif ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 				/*
-				 * The Accept-header decision is delegated to is_json_only_accept() on purpose: the Surge
-				 * cache drop-in calls the exact same function on the exact same raw superglobal, so what
-				 * the plugin serves and what the cache keys on can never drift apart. The function does
-				 * its own unslashing; do not sanitize the value here (the drop-in can't reproduce that,
-				 * its sanitizers aren't loaded yet, and a mismatch could cache JSON under the html
-				 * variant). It is only used to pick a content type, never stored or echoed.
+				 * The Accept-header decision is delegated to is_json_only_accept() so the plugin and the
+				 * Surge cache drop-in classify byte-for-byte identically. Both must hand it the same raw
+				 * header, and they reach that raw form differently on purpose: this runs after
+				 * wp_magic_quotes() has addslashed $_SERVER, so it wp_unslash()es to recover the original
+				 * bytes; the drop-in runs before wp_magic_quotes() and passes its already-raw value
+				 * untouched. Do NOT sanitize it (the drop-in can't, its sanitizers aren't loaded yet) and
+				 * the helper must not stripslashes() either (that would corrupt the drop-in's genuine
+				 * bytes). It is only used to pick a content type, never stored or echoed.
 				 *
 				 * The request is ActivityPub only when *every* media type is JSON; a client that also
 				 * accepts HTML (e.g. a browser sending `text/html, application/activity+json`) gets the
 				 * normal HTML page.
 				 */
-				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Classified only; is_json_only_accept() unslashes it and must see the same raw header as the pre-plugin cache path.
-				if ( is_json_only_accept( $_SERVER['HTTP_ACCEPT'] ) ) {
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Classified only; wp_unslash() recovers the raw bytes the pre-plugin cache path sees, and it must not be sanitized.
+				if ( is_json_only_accept( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ) {
 					\defined( 'ACTIVITYPUB_REQUEST' ) || \define( 'ACTIVITYPUB_REQUEST', true );
 					$this->is_activitypub_request = true;
 				}

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -302,19 +302,18 @@ class Query {
 			} elseif ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 				/*
 				 * The Accept-header decision is delegated to is_json_only_accept() on purpose: the Surge
-				 * cache drop-in shares that exact function, so what the plugin serves and what the cache
-				 * keys on can never drift apart. That only holds if both classify the same bytes, so the
-				 * header is unslashed here but never sanitized. The drop-in runs before WordPress' own
-				 * sanitizers are loaded and cannot match sanitize_text_field(), which would, for example,
-				 * strip a `%00` and flip the result, so a response served as JSON could be cached under
-				 * the html variant. The value is only used to pick a content type, never stored or echoed.
+				 * cache drop-in calls the exact same function on the exact same raw superglobal, so what
+				 * the plugin serves and what the cache keys on can never drift apart. The function does
+				 * its own unslashing; do not sanitize the value here (the drop-in can't reproduce that,
+				 * its sanitizers aren't loaded yet, and a mismatch could cache JSON under the html
+				 * variant). It is only used to pick a content type, never stored or echoed.
 				 *
 				 * The request is ActivityPub only when *every* media type is JSON; a client that also
 				 * accepts HTML (e.g. a browser sending `text/html, application/activity+json`) gets the
 				 * normal HTML page.
 				 */
-				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Classified only; must match the raw header the pre-plugin Surge cache path sees.
-				if ( is_json_only_accept( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ) {
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Classified only; is_json_only_accept() unslashes it and must see the same raw header as the pre-plugin cache path.
+				if ( is_json_only_accept( $_SERVER['HTTP_ACCEPT'] ) ) {
 					\defined( 'ACTIVITYPUB_REQUEST' ) || \define( 'ACTIVITYPUB_REQUEST', true );
 					$this->is_activitypub_request = true;
 				}

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -300,16 +300,21 @@ class Query {
 
 				// The other (more common) option to make an ActivityPub request  is to send an Accept header.
 			} elseif ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
-				$accept = \sanitize_text_field( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) );
-
 				/*
 				 * The Accept-header decision is delegated to is_json_only_accept() on purpose: the Surge
 				 * cache drop-in shares that exact function, so what the plugin serves and what the cache
-				 * keys on can never drift apart. The request is ActivityPub only when *every* media type
-				 * is JSON; a client that also accepts HTML (e.g. a browser sending
-				 * `text/html, application/activity+json`) gets the normal HTML page.
+				 * keys on can never drift apart. That only holds if both classify the same bytes, so the
+				 * header is unslashed here but never sanitized. The drop-in runs before WordPress' own
+				 * sanitizers are loaded and cannot match sanitize_text_field(), which would, for example,
+				 * strip a `%00` and flip the result, so a response served as JSON could be cached under
+				 * the html variant. The value is only used to pick a content type, never stored or echoed.
+				 *
+				 * The request is ActivityPub only when *every* media type is JSON; a client that also
+				 * accepts HTML (e.g. a browser sending `text/html, application/activity+json`) gets the
+				 * normal HTML page.
 				 */
-				if ( is_json_only_accept( $accept ) ) {
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Classified only; must match the raw header the pre-plugin Surge cache path sees.
+				if ( is_json_only_accept( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ) {
 					\defined( 'ACTIVITYPUB_REQUEST' ) || \define( 'ACTIVITYPUB_REQUEST', true );
 					$this->is_activitypub_request = true;
 				}

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -303,14 +303,13 @@ class Query {
 				$accept = \sanitize_text_field( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) );
 
 				/*
-				 * $accept can be a single value, or a comma separated list of values.
-				 * We want to support both scenarios,
-				 * and return true when the header includes at least one of the following:
-				 * - application/activity+json
-				 * - application/ld+json
-				 * - application/json
+				 * The Accept-header decision is delegated to is_json_only_accept() on purpose: the Surge
+				 * cache drop-in shares that exact function, so what the plugin serves and what the cache
+				 * keys on can never drift apart. The request is ActivityPub only when *every* media type
+				 * is JSON; a client that also accepts HTML (e.g. a browser sending
+				 * `text/html, application/activity+json`) gets the normal HTML page.
 				 */
-				if ( \preg_match( '/(application\/(ld\+json|activity\+json|json))/i', $accept ) ) {
+				if ( is_json_only_accept( $accept ) ) {
 					\defined( 'ACTIVITYPUB_REQUEST' ) || \define( 'ACTIVITYPUB_REQUEST', true );
 					$this->is_activitypub_request = true;
 				}

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -97,16 +97,20 @@ function should_negotiate_content() {
  * request. Keep this free of side effects and WordPress/plugin dependencies so the drop-in can
  * include this file and call it on its pre-plugin serve path.
  *
- * Pass the raw (only unslashed) header. Callers must NOT run it through sanitize_text_field() or
- * similar first: the drop-in cannot, because WordPress' sanitizers are not loaded when it runs, and
- * both paths have to classify identical bytes or a JSON response could be cached under the html
- * variant (e.g. `application/activity+json%00` is not JSON, but sanitizing would turn it into JSON).
+ * Pass the raw superglobal from either caller. The function unslashes it itself with stripslashes()
+ * (the scalar equivalent of wp_unslash()), so the plugin's magic-quoted `$_SERVER` and the drop-in's
+ * raw one classify identical bytes; the drop-in cannot call wp_unslash(), since WordPress' functions
+ * are not loaded when it runs. Callers must NOT run it through sanitize_text_field() or similar
+ * first: the drop-in cannot reproduce that, and any mismatch could cache a JSON response under the
+ * html variant (e.g. `application/activity+json%00` is not JSON, but sanitizing would turn it into JSON).
  *
- * @param string $accept The raw (unslashed) Accept header value.
+ * @param string $accept The raw Accept header value (slashed or not; unslashed internally).
  *
  * @return bool True when the header lists at least one media type and all of them are JSON.
  */
 function is_json_only_accept( $accept ) {
+	// Unslash so a magic-quoted superglobal (plugin) and a raw one (drop-in) classify identically.
+	$accept   = \stripslashes( (string) $accept );
 	$has_json = false;
 
 	foreach ( \explode( ',', $accept ) as $mime_type ) {

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -54,7 +54,16 @@ function use_authorized_fetch() {
 }
 
 /**
- * Check if a request is for an ActivityPub request.
+ * Check whether the current request should be answered with ActivityPub (JSON).
+ *
+ * This is the full, plugin-facing check and the one normal plugin code should use. It honors the
+ * `?activitypub` query var, a JSON-only Accept header (via is_json_only_accept()), and the
+ * `activitypub_is_activitypub_request` filter.
+ *
+ * It depends on Activitypub\Query, the main `$wp_query`, and the plugin being fully loaded, so it
+ * must NOT be called from code that runs earlier than that, e.g. a page-cache drop-in deciding a
+ * cache key on the serve path. Such code has only the Accept header to go on and must call
+ * is_json_only_accept() directly instead.
  *
  * @return bool False by default.
  */
@@ -69,6 +78,53 @@ function is_activitypub_request() {
  */
 function should_negotiate_content() {
 	return Query::get_instance()->should_negotiate_content();
+}
+
+/**
+ * Whether every media type in an Accept header is a JSON type.
+ *
+ * This is only the Accept-header half of content negotiation. Normal plugin code wants
+ * is_activitypub_request() instead, which also honors the `?activitypub` query var and the
+ * `activitypub_is_activitypub_request` filter; this function ignores both. Its narrow job is to be
+ * the single, dependency-free definition of a "JSON-only request" that is_activitypub_request() and
+ * the Surge cache drop-in (integration/surge-cache-config.php) both use, so the representation the
+ * plugin serves and the representation the cache keys on can never disagree. The drop-in runs before
+ * the plugin loads and cannot call is_activitypub_request(), which is why this half lives on its own.
+ *
+ * A request counts as JSON only when *every* listed media type is JSON (`application/json`,
+ * `application/ld+json`, `application/activity+json`, or any other `*+json`). A client that also
+ * accepts HTML, such as a browser sending `text/html, application/activity+json`, is not a JSON
+ * request. Keep this free of side effects and WordPress/plugin dependencies so the drop-in can
+ * include this file and call it on its pre-plugin serve path.
+ *
+ * @param string $accept The Accept header value.
+ *
+ * @return bool True when the header lists at least one media type and all of them are JSON.
+ */
+function is_json_only_accept( $accept ) {
+	$has_json = false;
+
+	foreach ( \explode( ',', $accept ) as $mime_type ) {
+		// Drop any parameters such as `;q=0.9`.
+		$pos = \strpos( $mime_type, ';' );
+		if ( false !== $pos ) {
+			$mime_type = \substr( $mime_type, 0, $pos );
+		}
+
+		$mime_type = \strtolower( \trim( $mime_type ) );
+
+		if ( '' === $mime_type ) {
+			continue;
+		}
+
+		if ( '/json' !== \substr( $mime_type, -5 ) && '+json' !== \substr( $mime_type, -5 ) ) {
+			return false;
+		}
+
+		$has_json = true;
+	}
+
+	return $has_json;
 }
 
 /**

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -97,7 +97,12 @@ function should_negotiate_content() {
  * request. Keep this free of side effects and WordPress/plugin dependencies so the drop-in can
  * include this file and call it on its pre-plugin serve path.
  *
- * @param string $accept The Accept header value.
+ * Pass the raw (only unslashed) header. Callers must NOT run it through sanitize_text_field() or
+ * similar first: the drop-in cannot, because WordPress' sanitizers are not loaded when it runs, and
+ * both paths have to classify identical bytes or a JSON response could be cached under the html
+ * variant (e.g. `application/activity+json%00` is not JSON, but sanitizing would turn it into JSON).
+ *
+ * @param string $accept The raw (unslashed) Accept header value.
  *
  * @return bool True when the header lists at least one media type and all of them are JSON.
  */

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -97,23 +97,24 @@ function should_negotiate_content() {
  * request. Keep this free of side effects and WordPress/plugin dependencies so the drop-in can
  * include this file and call it on its pre-plugin serve path.
  *
- * Pass the raw superglobal from either caller. The function unslashes it itself with stripslashes()
- * (the scalar equivalent of wp_unslash()), so the plugin's magic-quoted `$_SERVER` and the drop-in's
- * raw one classify identical bytes; the drop-in cannot call wp_unslash(), since WordPress' functions
- * are not loaded when it runs. Callers must NOT run it through sanitize_text_field() or similar
- * first: the drop-in cannot reproduce that, and any mismatch could cache a JSON response under the
- * html variant (e.g. `application/activity+json%00` is not JSON, but sanitizing would turn it into JSON).
+ * Pass the RAW, unslashed header; both callers must hand it identical bytes but reach that raw form
+ * differently. The plugin runs after wp_magic_quotes() has addslashed $_SERVER, so it wp_unslash()es
+ * before calling; the Surge drop-in runs before wp_magic_quotes() and passes its already-raw value as
+ * is. This function deliberately does NOT unslash or sanitize: stripslashes() here would strip the
+ * drop-in's genuine backslashes (which the plugin's wp_unslash() preserves), and sanitize_text_field()
+ * (which the drop-in can't call anyway) would drop bytes such as a `%00`; either would let the two
+ * paths disagree and cache a JSON response under the html variant. Only `\substr()` (never a PHP 8
+ * polyfill like str_ends_with()) is used for the suffix test, since the drop-in runs before the
+ * polyfills may be loaded.
  *
- * @param string $accept The raw Accept header value (slashed or not; unslashed internally).
+ * @param string $accept The raw (unslashed) Accept header value.
  *
  * @return bool True when the header lists at least one media type and all of them are JSON.
  */
 function is_json_only_accept( $accept ) {
-	// Unslash so a magic-quoted superglobal (plugin) and a raw one (drop-in) classify identically.
-	$accept   = \stripslashes( (string) $accept );
 	$has_json = false;
 
-	foreach ( \explode( ',', $accept ) as $mime_type ) {
+	foreach ( \explode( ',', (string) $accept ) as $mime_type ) {
 		// Drop any parameters such as `;q=0.9`.
 		$pos = \strpos( $mime_type, ';' );
 		if ( false !== $pos ) {

--- a/integration/class-litespeed-cache.php
+++ b/integration/class-litespeed-cache.php
@@ -23,7 +23,7 @@ class Litespeed_Cache {
 	 */
 	public static $rules = '<IfModule LiteSpeed>
 RewriteEngine On
-RewriteCond %{HTTP:Accept} application
+RewriteCond %{HTTP:Accept} ^[\s,]*[^\s,;]*(/json|\+json)\s*(;[^,]*)?([\s,]+[^\s,;]*(/json|\+json)\s*(;[^,]*)?)*[\s,]*$ [NC]
 RewriteRule ^ - [E=Cache-Control:vary=%{ENV:LSCACHE_VARY_VALUE}+isjson]
 </IfModule>';
 
@@ -54,7 +54,9 @@ RewriteRule ^ - [E=Cache-Control:vary=%{ENV:LSCACHE_VARY_VALUE}+isjson]
 	public static function init() {
 		// Add rules if LiteSpeed Cache is active and rules aren't set.
 		if ( is_plugin_active( self::$plugin_slug ) ) {
-			if ( ! \get_option( self::$option_name ) ) {
+			// (Re)write when the installed rules differ from the current ones: first setup, or a rules
+			// update that must replace a previously written (looser) block on existing installs.
+			if ( \get_option( self::$option_name ) !== \md5( self::$rules ) ) {
 				self::add_htaccess_rules();
 			}
 
@@ -86,8 +88,9 @@ RewriteRule ^ - [E=Cache-Control:vary=%{ENV:LSCACHE_VARY_VALUE}+isjson]
 	public static function add_htaccess_rules() {
 		$added_rules = self::append_with_markers( self::$marker, self::$rules );
 
+		// Store a fingerprint of the written rules so a later change re-applies them (see init()).
 		if ( $added_rules ) {
-			\update_option( self::$option_name, '1' );
+			\update_option( self::$option_name, \md5( self::$rules ) );
 		} else {
 			\update_option( self::$option_name, '0' );
 		}

--- a/integration/surge-cache-config.php
+++ b/integration/surge-cache-config.php
@@ -10,21 +10,31 @@
 $representation = 'html';
 
 if ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
-	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-	$accept = strtolower( $_SERVER['HTTP_ACCEPT'] );
+	/*
+	 * The html and JSON representations of a URL must land in different cache buckets, and this
+	 * bucket boundary must match exactly what the plugin decides to serve, or a page that was served
+	 * as one representation could be replayed as the other.
+	 *
+	 * Reuse the plugin's single source of truth for that boundary: Activitypub\is_json_only_accept().
+	 * Do NOT call Activitypub\is_activitypub_request() here. Surge runs this config from its
+	 * advanced-cache.php drop-in, on the cache-serve path, before the plugin, the main $wp_query, and
+	 * the plugin's autoloader exist, so that function (which needs all three) would fatal. Only the
+	 * dependency-free is_json_only_accept() is safe on this path.
+	 *
+	 * functions-request.php is side-effect-free and the plugin loads it with require_once, so
+	 * including it here neither runs code nor risks a redeclare.
+	 */
+	require_once __DIR__ . '/../includes/functions-request.php';
 
-	if (
-		str_contains( $accept, 'application/json' ) ||
-		str_contains( $accept, 'application/activity+json' ) ||
-		str_contains( $accept, 'application/ld+json' )
-	) {
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+	if ( \Activitypub\is_json_only_accept( $_SERVER['HTTP_ACCEPT'] ) ) {
 		$representation = 'json';
 	}
 }
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 $config['variants']['representation'] = $representation;
-unset( $accept, $representation );
+unset( $representation );
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 return $config;

--- a/integration/surge-cache-config.php
+++ b/integration/surge-cache-config.php
@@ -11,18 +11,21 @@ $representation = 'html';
 
 if ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 	/*
-	 * The html and JSON representations of a URL must land in different cache buckets, and this
-	 * bucket boundary must match exactly what the plugin decides to serve, or a page that was served
-	 * as one representation could be replayed as the other.
+	 * For a given URL, the html and JSON representations must land in different cache buckets, and
+	 * this boundary must match how the plugin negotiates that same URL, or one representation could be
+	 * replayed for the other. Reuse the plugin's single source of truth: Activitypub\is_json_only_accept().
 	 *
-	 * Reuse the plugin's single source of truth for that boundary: Activitypub\is_json_only_accept().
+	 * This mirrors only the Accept-header branch of Query::is_activitypub_request(), which is the sole
+	 * branch that varies a single URL. The `?activitypub` override also forces JSON, but it changes
+	 * the URL and Surge already keys on the full URL, so those requests are segregated on their own and
+	 * never share a bucket with the negotiated ones.
+	 *
 	 * Do NOT call Activitypub\is_activitypub_request() here. Surge runs this config from its
 	 * advanced-cache.php drop-in, on the cache-serve path, before the plugin, the main $wp_query, and
 	 * the plugin's autoloader exist, so that function (which needs all three) would fatal. Only the
-	 * dependency-free is_json_only_accept() is safe on this path.
-	 *
-	 * functions-request.php is side-effect-free and the plugin loads it with require_once, so
-	 * including it here neither runs code nor risks a redeclare.
+	 * dependency-free is_json_only_accept() is safe on this path. functions-request.php is
+	 * side-effect-free and the plugin loads it with require_once, so including it here neither runs
+	 * code nor risks a redeclare.
 	 */
 	require_once __DIR__ . '/../includes/functions-request.php';
 

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -184,6 +184,9 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'wildcard'             => array( '*/*', false ),
 			'plain_html'           => array( 'text/html', false ),
 			'empty'                => array( '', false ),
+			// Must classify the raw header, not a sanitized one, so it agrees with the pre-plugin cache
+			// path: `%00` keeps this out of JSON where sanitize_text_field() would have stripped it.
+			'percent_octet'        => array( 'application/activity+json%00', false ),
 		);
 	}
 

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -177,8 +177,6 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'json_with_q'          => array( 'application/activity+json;q=0.9', true ),
 			'uppercase_json'       => array( 'Application/Activity+JSON', true ),
 			'trailing_comma'       => array( 'application/activity+json,', true ),
-			// Slashed like a magic-quoted superglobal; the function unslashes internally.
-			'slashed_profile'      => array( 'application/ld+json; profile=\\"https://www.w3.org/ns/activitystreams\\"', true ),
 			// At least one non-JSON media type -> false.
 			'html_then_json'       => array( 'text/html, application/activity+json', false ),
 			'json_then_html'       => array( 'application/activity+json, text/html', false ),

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -162,6 +162,46 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
+	 * Data provider for is_json_only_accept.
+	 *
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public function is_json_only_accept_provider() {
+		return array(
+			// Every media type is JSON -> true.
+			'activity_json'        => array( 'application/activity+json', true ),
+			'ld_json'              => array( 'application/ld+json', true ),
+			'plain_json'           => array( 'application/json', true ),
+			'ld_json_with_profile' => array( 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"', true ),
+			'multiple_json'        => array( 'application/activity+json, application/ld+json', true ),
+			'json_with_q'          => array( 'application/activity+json;q=0.9', true ),
+			'uppercase_json'       => array( 'Application/Activity+JSON', true ),
+			'trailing_comma'       => array( 'application/activity+json,', true ),
+			// At least one non-JSON media type -> false.
+			'html_then_json'       => array( 'text/html, application/activity+json', false ),
+			'json_then_html'       => array( 'application/activity+json, text/html', false ),
+			'browser'              => array( 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', false ),
+			'wildcard'             => array( '*/*', false ),
+			'plain_html'           => array( 'text/html', false ),
+			'empty'                => array( '', false ),
+		);
+	}
+
+	/**
+	 * Test the JSON-only Accept-header check.
+	 *
+	 * @dataProvider is_json_only_accept_provider
+	 *
+	 * @covers \Activitypub\is_json_only_accept
+	 *
+	 * @param string $accept   The Accept header value.
+	 * @param bool   $expected Whether every listed media type is JSON.
+	 */
+	public function test_is_json_only_accept( $accept, $expected ) {
+		$this->assertSame( $expected, \Activitypub\is_json_only_accept( $accept ) );
+	}
+
+	/**
 	 * Data provider for is_unsafe_ipv6_literal.
 	 *
 	 * @return array<string, array{0: string, 1: bool}>

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -177,6 +177,8 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'json_with_q'          => array( 'application/activity+json;q=0.9', true ),
 			'uppercase_json'       => array( 'Application/Activity+JSON', true ),
 			'trailing_comma'       => array( 'application/activity+json,', true ),
+			// Slashed like a magic-quoted superglobal; the function unslashes internally.
+			'slashed_profile'      => array( 'application/ld+json; profile=\\"https://www.w3.org/ns/activitystreams\\"', true ),
 			// At least one non-JSON media type -> false.
 			'html_then_json'       => array( 'text/html, application/activity+json', false ),
 			'json_then_html'       => array( 'application/activity+json, text/html', false ),

--- a/tests/phpunit/tests/includes/class-test-query.php
+++ b/tests/phpunit/tests/includes/class-test-query.php
@@ -229,12 +229,32 @@ class Test_Query extends \WP_UnitTestCase {
 		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
 
 		Query::get_instance()->__destruct();
+		$_SERVER['HTTP_ACCEPT'] = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"';
+		$this->go_to( get_permalink( self::$post_id ) );
+		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
+
+		Query::get_instance()->__destruct();
+		$_SERVER['HTTP_ACCEPT'] = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json';
+		$this->go_to( get_permalink( self::$post_id ) );
+		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
+
+		Query::get_instance()->__destruct();
+		$_SERVER['HTTP_ACCEPT'] = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json; q=0.9';
+		$this->go_to( get_permalink( self::$post_id ) );
+		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
+
+		Query::get_instance()->__destruct();
 		$_SERVER['HTTP_ACCEPT'] = 'application/json';
 		$this->go_to( get_permalink( self::$post_id ) );
 		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
 
 		Query::get_instance()->__destruct();
 		$_SERVER['HTTP_ACCEPT'] = 'text/html';
+		$this->go_to( get_permalink( self::$post_id ) );
+		$this->assertFalse( Query::get_instance()->is_activitypub_request() );
+
+		Query::get_instance()->__destruct();
+		$_SERVER['HTTP_ACCEPT'] = 'application/json, text/html';
 		$this->go_to( get_permalink( self::$post_id ) );
 		$this->assertFalse( Query::get_instance()->is_activitypub_request() );
 

--- a/tests/phpunit/tests/integration/class-test-litespeed-cache.php
+++ b/tests/phpunit/tests/integration/class-test-litespeed-cache.php
@@ -117,7 +117,38 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 	public function test_option_updated_on_add() {
 		Litespeed_Cache::add_htaccess_rules();
 		$option = \get_option( Litespeed_Cache::$option_name );
-		$this->assertEquals( '1', $option, 'Option should be set to 1 after adding rules' );
+		$this->assertEquals( \md5( Litespeed_Cache::$rules ), $option, 'Option should store the current rules fingerprint after adding rules' );
+	}
+
+	/**
+	 * The htaccess Accept condition must classify a request exactly like the plugin's own
+	 * is_json_only_accept(), or a page served as one representation could be cached as the other.
+	 */
+	public function test_rewrite_condition_matches_is_json_only_accept() {
+		\preg_match( '/RewriteCond %\{HTTP:Accept\} (\S+) \[NC\]/', Litespeed_Cache::$rules, $matches );
+		$this->assertNotEmpty( $matches[1] ?? '', 'Could not find the Accept RewriteCond pattern in the rules.' );
+		$pattern = '#' . $matches[1] . '#i';
+
+		$cases = array(
+			'application/activity+json'            => true,
+			'application/ld+json'                  => true,
+			'application/json'                     => true,
+			'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' => true,
+			'application/activity+json, application/ld+json' => true,
+			'application/activity+json;q=0.9'      => true,
+			'application/activity+json,'           => true,
+			'text/html'                            => false,
+			'text/html, application/activity+json' => false,
+			'application/activity+json, text/html' => false,
+			'*/*'                                  => false,
+			'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' => false,
+			''                                     => false,
+		);
+
+		foreach ( $cases as $accept => $expected ) {
+			$this->assertSame( $expected, (bool) \preg_match( $pattern, $accept ), "htaccess regex disagrees for: $accept" );
+			$this->assertSame( $expected, \Activitypub\is_json_only_accept( $accept ), "is_json_only_accept disagrees for: $accept" );
+		}
 	}
 
 	/**
@@ -205,7 +236,7 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 	public function test_cleanup_when_litespeed_deactivated() {
 		// Simulate rules being previously added.
 		Litespeed_Cache::add_htaccess_rules();
-		$this->assertEquals( '1', \get_option( Litespeed_Cache::$option_name ) );
+		$this->assertEquals( \md5( Litespeed_Cache::$rules ), \get_option( Litespeed_Cache::$option_name ) );
 
 		// Mock that LiteSpeed is NOT active.
 		$plugin_active_filter = function ( $is_active, $plugin ) {
@@ -237,7 +268,7 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 	public function test_cleanup_on_activitypub_deactivation() {
 		// Add rules first.
 		Litespeed_Cache::add_htaccess_rules();
-		$this->assertEquals( '1', \get_option( Litespeed_Cache::$option_name ) );
+		$this->assertEquals( \md5( Litespeed_Cache::$rules ), \get_option( Litespeed_Cache::$option_name ) );
 
 		// phpcs:ignore
 		$contents_before = \file_get_contents( $this->htaccess_file );
@@ -263,7 +294,7 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 	public function test_cleanup_when_litespeed_deleted() {
 		// Add rules first.
 		Litespeed_Cache::add_htaccess_rules();
-		$this->assertEquals( '1', \get_option( Litespeed_Cache::$option_name ) );
+		$this->assertEquals( \md5( Litespeed_Cache::$rules ), \get_option( Litespeed_Cache::$option_name ) );
 
 		// phpcs:ignore
 		$contents_before = \file_get_contents( $this->htaccess_file );
@@ -288,13 +319,13 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 	public function test_no_cleanup_when_other_plugin_deleted() {
 		// Add rules first.
 		Litespeed_Cache::add_htaccess_rules();
-		$this->assertEquals( '1', \get_option( Litespeed_Cache::$option_name ) );
+		$this->assertEquals( \md5( Litespeed_Cache::$rules ), \get_option( Litespeed_Cache::$option_name ) );
 
 		// Simulate a different plugin deletion.
 		\do_action( 'deleted_plugin', 'some-other-plugin/plugin.php', false );
 
 		// Verify rules still exist.
-		$this->assertEquals( '1', \get_option( Litespeed_Cache::$option_name ), 'Option should remain when other plugin is deleted' );
+		$this->assertEquals( \md5( Litespeed_Cache::$rules ), \get_option( Litespeed_Cache::$option_name ), 'Option should remain when other plugin is deleted' );
 
 		// phpcs:ignore
 		$contents = \file_get_contents( $this->htaccess_file );


### PR DESCRIPTION
## Proposed changes:

Content negotiation now treats a request as ActivityPub only when *every* media type in the `Accept` header is JSON (`application/json`, `application/ld+json`, `application/activity+json`, or any other `*+json`). Before, we matched "contains JSON anywhere", so a request that also accepted HTML (e.g. `text/html, application/activity+json`) still got JSON.

The loose rule made our JSON responses fragile against any shared page cache that varies only on "JSON-only" requests. Tightening it keeps content-negotiated JSON out of those caches in general, not just one patched cache. I ran the JSON-only rule against Mastodon, Misskey, GoToSocial, Akkoma, Lemmy and Friendica `Accept` headers, and they all still resolve to JSON, because every one is JSON-only.

The decision lives in one dependency-free helper, `is_json_only_accept()`. `is_activitypub_request()` delegates to it, and the Surge cache drop-in (`integration/surge-cache-config.php`) reuses the same helper to pick its `representation` cache variant, so the bucket the cache keys on can never disagree with what the plugin serves. The drop-in runs from Surge's `advanced-cache.php` before the plugin loads, so it can only call the dependency-free helper, not `is_activitypub_request()` (which needs `Query`, `$wp_query` and the plugin loaded). Both sides also classify the header in the same raw form: the drop-in runs before WordPress' sanitizers are even loaded, so the plugin no longer sanitizes it either, or the two could classify the same request differently. The docblocks spell all of this out so no one reaches for the wrong one.

One behavior change worth calling out: a client sending a mixed `text/html, application/activity+json` now gets HTML instead of JSON. No major platform does that, and the `activitypub_is_activitypub_request` filter is still there as an escape hatch.

Not in this PR: the LiteSpeed `.htaccess` rule has the same coarse boundary and is harder to express as JSON-only in mod_rewrite, so I left it for a follow-up.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Publish a post.
* `curl -H "Accept: application/activity+json" <post-url>` returns `Content-Type: application/activity+json`.
* `curl -H "Accept: application/ld+json" <post-url>` still returns JSON.
* `curl -H "Accept: text/html, application/activity+json" <post-url>` now returns `text/html` (this is the change).
* A normal browser request still returns `text/html`.
* With Surge active, confirm the JSON and HTML variants land in separate cache buckets (a mixed or browser request never replays a pure-JSON response, and the other way round).
