### PR TITLE
Improve escaping of embedded link URLs

### DIFF
--- a/.github/changelog/fix-embed-link-escaping
+++ b/.github/changelog/fix-embed-link-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve escaping of embedded link URLs in federated content.

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1168,7 +1168,11 @@ class Blocks {
 		if ( ! isset( $block['attrs']['url'] ) ) {
 			return $block_content;
 		}
-		return '<p><a href="' . \esc_url( $block['attrs']['url'] ) . '">' . $block['attrs']['url'] . '</a></p>';
+
+		// Escape once and reuse: the URL is also the visible link text, so it must be safe there too.
+		$url = \esc_url( $block['attrs']['url'] );
+
+		return '<p><a href="' . $url . '">' . $url . '</a></p>';
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-blocks.php
+++ b/tests/phpunit/tests/includes/class-test-blocks.php
@@ -1422,4 +1422,16 @@ class Test_Blocks extends \WP_UnitTestCase {
 		$this->assertContains( $plain_post, $ids, 'Plain posts must stay visible under ?filter=posts.' );
 		$this->assertNotContains( $reply_post, $ids, 'Reply-block posts must be hidden under ?filter=posts.' );
 	}
+
+	/**
+	 * The embed URL is escaped so it can't inject markup as the link text.
+	 *
+	 * @covers ::revert_embed_links
+	 */
+	public function test_revert_embed_links_escapes_url() {
+		$block  = array( 'attrs' => array( 'url' => 'https://example.com/<script>alert(1)</script>' ) );
+		$output = Blocks::revert_embed_links( '', $block );
+
+		$this->assertStringNotContainsString( '<script>', $output );
+	}
 }


### PR DESCRIPTION
## Proposed changes:

* When an embed block is turned into a plain link for federation, the URL is now escaped for the visible link text as well as the `href`, so block attributes set outside the editor (e.g. via `wp_insert_post()` or the REST API) can't put raw markup into the output.

## Testing instructions:

* Create a post with a `core/embed` block whose `url` attribute contains markup (e.g. `https://example.com/<script>...`), for example via `wp_insert_post()`.
* Fetch the post's ActivityPub representation and confirm the embed link's text is escaped, not raw.
