### PR TITLE
Content-negotiate by Accept quality, not JSON-only

### DIFF
--- a/.github/changelog/fix-accept-quality-negotiation
+++ b/.github/changelog/fix-accept-quality-negotiation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed posts and profiles not being found on Mastodon and other Fediverse software, which happened when a request asked for ActivityPub data but also accepted HTML as a low-priority fallback.

--- a/docs/how-to/caching.md
+++ b/docs/how-to/caching.md
@@ -55,13 +55,13 @@ Varnish does not pass through `Vary: Accept` by default. You need to configure i
 
 ```vcl
 sub vcl_hash {
-    if (req.http.Accept ~ "(?i)^[\s,]*[^\s,;]*(/json|\+json)\s*(;[^,]*)?([\s,]+[^\s,;]*(/json|\+json)\s*(;[^,]*)?)*[\s,]*$") {
+    if (req.http.Accept ~ "(?i)^[\s,]*(application/activity\+json|application/ld\+json[^,]*activitystreams)") {
         hash_data("activitypub");
     }
 }
 ```
 
-The pattern matches only requests whose `Accept` header is *entirely* JSON, so a browser (which also accepts HTML) shares the HTML cache, not the JSON one. It mirrors how the plugin itself decides.
+The pattern matches when the *first* media type is an ActivityPub type (`application/activity+json`, or `application/ld+json` with the ActivityStreams profile). A browser lists `text/html` first and shares the HTML cache; Mastodon lists ActivityPub first (even though it also accepts `text/html;q=0.1`) and gets the JSON cache. It can't compare `q` values like the plugin does, but for every real client the highest-`q` type is the one listed first, so it matches.
 
 Alternatively, add `Vary: Accept` in your Apache or Nginx config so Varnish sees it from the backend.
 
@@ -72,13 +72,13 @@ Use a map to distinguish JSON from HTML and add it to your cache key. Avoid usin
 ```nginx
 map $http_accept $activitypub_suffix {
     default   "html";
-    "~*^[\s,]*[^\s,;]*(/json|\+json)\s*(;[^,]*)?([\s,]+[^\s,;]*(/json|\+json)\s*(;[^,]*)?)*[\s,]*$"   "json";
+    "~*^[\s,]*(application/activity\+json|application/ld\+json[^,]*activitystreams)"   "json";
 }
 
 fastcgi_cache_key "$scheme$request_method$host$request_uri$activitypub_suffix";
 ```
 
-The regex only matches an `Accept` header that is entirely JSON, so a browser request (which also accepts HTML) maps to `html`, not `json`. A looser match like `~application/` would also catch a browser's `application/xhtml+xml` and mix HTML into the JSON bucket.
+The regex maps to `json` only when the first media type is an ActivityPub type, so a browser request (which lists `text/html` first) maps to `html`. A looser match like `~application/` would also catch a browser's `application/xhtml+xml` and mix HTML into the JSON bucket.
 
 ### Cloudflare
 
@@ -92,7 +92,7 @@ The plugin automatically adds `.htaccess` rules when it detects the LiteSpeed Ca
 # BEGIN ActivityPub LiteSpeed Cache
 <IfModule LiteSpeed>
 RewriteEngine On
-RewriteCond %{HTTP:Accept} ^[\s,]*[^\s,;]*(/json|\+json)\s*(;[^,]*)?([\s,]+[^\s,;]*(/json|\+json)\s*(;[^,]*)?)*[\s,]*$ [NC]
+RewriteCond %{HTTP:Accept} ^[\s,]*(application/activity\+json|application/ld\+json[^,]*activitystreams) [NC]
 RewriteRule ^ - [E=Cache-Control:vary=%{ENV:LSCACHE_VARY_VALUE}+isjson]
 </IfModule>
 # END ActivityPub LiteSpeed Cache

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -301,7 +301,7 @@ class Query {
 				// The other (more common) option to make an ActivityPub request  is to send an Accept header.
 			} elseif ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 				/*
-				 * The Accept-header decision is delegated to accept_prefers_json() so the plugin and the
+				 * The Accept-header decision is delegated to accept_prefers_activitypub() so the plugin and the
 				 * Surge cache drop-in classify byte-for-byte identically. Both must hand it the same raw
 				 * header, and they reach that raw form differently on purpose: this runs after
 				 * wp_magic_quotes() has addslashed $_SERVER, so it wp_unslash()es to recover the original
@@ -311,12 +311,12 @@ class Query {
 				 * bytes). It is only used to pick a content type, never stored or echoed.
 				 *
 				 * The request is ActivityPub when the highest-priority (by `q`, then order) media type is
-				 * JSON. A client that prefers HTML (a browser sending `text/html` at q=1) gets the normal
-				 * page; one that prefers JSON but also accepts HTML as a low-`q` fallback (Mastodon) gets
-				 * JSON.
+				 * an ActivityPub type (`application/activity+json`, or `application/ld+json` with the AS2
+				 * profile). A browser (`text/html` at q=1) gets the normal page; a client that prefers
+				 * ActivityPub but also accepts HTML as a low-`q` fallback (Mastodon) gets ActivityPub.
 				 */
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Classified only; wp_unslash() recovers the raw bytes the pre-plugin cache path sees, and it must not be sanitized.
-				if ( accept_prefers_json( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ) {
+				if ( accept_prefers_activitypub( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ) {
 					\defined( 'ACTIVITYPUB_REQUEST' ) || \define( 'ACTIVITYPUB_REQUEST', true );
 					$this->is_activitypub_request = true;
 				}

--- a/includes/class-query.php
+++ b/includes/class-query.php
@@ -301,7 +301,7 @@ class Query {
 				// The other (more common) option to make an ActivityPub request  is to send an Accept header.
 			} elseif ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 				/*
-				 * The Accept-header decision is delegated to is_json_only_accept() so the plugin and the
+				 * The Accept-header decision is delegated to accept_prefers_json() so the plugin and the
 				 * Surge cache drop-in classify byte-for-byte identically. Both must hand it the same raw
 				 * header, and they reach that raw form differently on purpose: this runs after
 				 * wp_magic_quotes() has addslashed $_SERVER, so it wp_unslash()es to recover the original
@@ -310,12 +310,13 @@ class Query {
 				 * the helper must not stripslashes() either (that would corrupt the drop-in's genuine
 				 * bytes). It is only used to pick a content type, never stored or echoed.
 				 *
-				 * The request is ActivityPub only when *every* media type is JSON; a client that also
-				 * accepts HTML (e.g. a browser sending `text/html, application/activity+json`) gets the
-				 * normal HTML page.
+				 * The request is ActivityPub when the highest-priority (by `q`, then order) media type is
+				 * JSON. A client that prefers HTML (a browser sending `text/html` at q=1) gets the normal
+				 * page; one that prefers JSON but also accepts HTML as a low-`q` fallback (Mastodon) gets
+				 * JSON.
 				 */
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Classified only; wp_unslash() recovers the raw bytes the pre-plugin cache path sees, and it must not be sanitized.
-				if ( is_json_only_accept( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ) {
+				if ( accept_prefers_json( \wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ) {
 					\defined( 'ACTIVITYPUB_REQUEST' ) || \define( 'ACTIVITYPUB_REQUEST', true );
 					$this->is_activitypub_request = true;
 				}

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -57,13 +57,13 @@ function use_authorized_fetch() {
  * Check whether the current request should be answered with ActivityPub (JSON).
  *
  * This is the full, plugin-facing check and the one normal plugin code should use. It honors the
- * `?activitypub` query var, a JSON-only Accept header (via is_json_only_accept()), and the
+ * `?activitypub` query var, an Accept header that prefers JSON (via accept_prefers_json()), and the
  * `activitypub_is_activitypub_request` filter.
  *
  * It depends on Activitypub\Query, the main `$wp_query`, and the plugin being fully loaded, so it
  * must NOT be called from code that runs earlier than that, e.g. a page-cache drop-in deciding a
  * cache key on the serve path. Such code has only the Accept header to go on and must call
- * is_json_only_accept() directly instead.
+ * accept_prefers_json() directly instead.
  *
  * @return bool False by default.
  */
@@ -81,21 +81,23 @@ function should_negotiate_content() {
 }
 
 /**
- * Whether every media type in an Accept header is a JSON type.
+ * Whether the client's most-preferred acceptable media type is a JSON type.
  *
  * This is only the Accept-header half of content negotiation. Normal plugin code wants
  * is_activitypub_request() instead, which also honors the `?activitypub` query var and the
  * `activitypub_is_activitypub_request` filter; this function ignores both. Its narrow job is to be
- * the single, dependency-free definition of a "JSON-only request" that is_activitypub_request() and
- * the Surge cache drop-in (integration/surge-cache-config.php) both use, so the representation the
- * plugin serves and the representation the cache keys on can never disagree. The drop-in runs before
- * the plugin loads and cannot call is_activitypub_request(), which is why this half lives on its own.
+ * the single, dependency-free definition of "does this request prefer JSON" that
+ * is_activitypub_request() and the Surge cache drop-in (integration/surge-cache-config.php) both
+ * use, so the representation the plugin serves and the one the cache keys on can never disagree. The
+ * drop-in runs before the plugin loads and cannot call is_activitypub_request(), which is why this
+ * half lives on its own.
  *
- * A request counts as JSON only when *every* listed media type is JSON (`application/json`,
- * `application/ld+json`, `application/activity+json`, or any other `*+json`). A client that also
- * accepts HTML, such as a browser sending `text/html, application/activity+json`, is not a JSON
- * request. Keep this free of side effects and WordPress/plugin dependencies so the drop-in can
- * include this file and call it on its pre-plugin serve path.
+ * It ranks the listed media types by quality (`;q=`), highest first, breaking ties by the order they
+ * appear, and reports whether the winner is a JSON type (a `/json` or `+json` suffix). This respects the
+ * client's preference rather than demanding a JSON-only header: Mastodon sends
+ * `application/ld+json;profile="…", application/activity+json, text/html;q=0.1`, prefers JSON 10:1,
+ * and must get JSON; a browser lists `text/html` at q=1 and gets HTML. A media type with no `q`
+ * defaults to 1.0.
  *
  * Pass the RAW, unslashed header; both callers must hand it identical bytes but reach that raw form
  * differently. The plugin runs after wp_magic_quotes() has addslashed $_SERVER, so it wp_unslash()es
@@ -103,38 +105,47 @@ function should_negotiate_content() {
  * is. This function deliberately does NOT unslash or sanitize: stripslashes() here would strip the
  * drop-in's genuine backslashes (which the plugin's wp_unslash() preserves), and sanitize_text_field()
  * (which the drop-in can't call anyway) would drop bytes such as a `%00`; either would let the two
- * paths disagree and cache a JSON response under the html variant. Only `\substr()` (never a PHP 8
- * polyfill like str_ends_with()) is used for the suffix test, since the drop-in runs before the
- * polyfills may be loaded.
+ * paths disagree. Keep it free of side effects and of any PHP 8 polyfill (str_ends_with()), since the
+ * drop-in runs before the polyfills may be loaded.
  *
  * @param string $accept The raw (unslashed) Accept header value.
  *
- * @return bool True when the header lists at least one media type and all of them are JSON.
+ * @return bool True when the highest-priority acceptable media type is JSON.
  */
-function is_json_only_accept( $accept ) {
-	$has_json = false;
+function accept_prefers_json( $accept ) {
+	$winner_quality = 0.0;
+	$winner_is_json = false;
 
-	foreach ( \explode( ',', (string) $accept ) as $mime_type ) {
-		// Drop any parameters such as `;q=0.9`.
-		$pos = \strpos( $mime_type, ';' );
-		if ( false !== $pos ) {
-			$mime_type = \substr( $mime_type, 0, $pos );
-		}
+	foreach ( \explode( ',', (string) $accept ) as $part ) {
+		$segments   = \explode( ';', $part );
+		$media_type = \strtolower( \trim( (string) \array_shift( $segments ) ) );
 
-		$mime_type = \strtolower( \trim( $mime_type ) );
-
-		if ( '' === $mime_type ) {
+		if ( '' === $media_type ) {
 			continue;
 		}
 
-		if ( '/json' !== \substr( $mime_type, -5 ) && '+json' !== \substr( $mime_type, -5 ) ) {
-			return false;
+		// Quality value: default 1.0, overridden by a `q=` parameter.
+		$quality = 1.0;
+		foreach ( $segments as $param ) {
+			$param = \trim( $param );
+			if ( 0 === \stripos( $param, 'q=' ) ) {
+				$quality = (float) \substr( $param, 2 );
+			}
 		}
 
-		$has_json = true;
+		// A `q=0` means the client refuses this type; ignore it entirely.
+		if ( $quality <= 0 ) {
+			continue;
+		}
+
+		// Highest quality wins; on a tie the earlier type in the header keeps the lead.
+		if ( $quality > $winner_quality ) {
+			$winner_quality = $quality;
+			$winner_is_json = '/json' === \substr( $media_type, -5 ) || '+json' === \substr( $media_type, -5 );
+		}
 	}
 
-	return $has_json;
+	return $winner_is_json;
 }
 
 /**

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -57,13 +57,13 @@ function use_authorized_fetch() {
  * Check whether the current request should be answered with ActivityPub (JSON).
  *
  * This is the full, plugin-facing check and the one normal plugin code should use. It honors the
- * `?activitypub` query var, an Accept header that prefers JSON (via accept_prefers_json()), and the
+ * `?activitypub` query var, an Accept header that prefers ActivityPub (via accept_prefers_activitypub()), and the
  * `activitypub_is_activitypub_request` filter.
  *
  * It depends on Activitypub\Query, the main `$wp_query`, and the plugin being fully loaded, so it
  * must NOT be called from code that runs earlier than that, e.g. a page-cache drop-in deciding a
  * cache key on the serve path. Such code has only the Accept header to go on and must call
- * accept_prefers_json() directly instead.
+ * accept_prefers_activitypub() directly instead.
  *
  * @return bool False by default.
  */
@@ -81,23 +81,26 @@ function should_negotiate_content() {
 }
 
 /**
- * Whether the client's most-preferred acceptable media type is a JSON type.
+ * Whether the client's most-preferred acceptable media type is ActivityPub.
  *
  * This is only the Accept-header half of content negotiation. Normal plugin code wants
  * is_activitypub_request() instead, which also honors the `?activitypub` query var and the
  * `activitypub_is_activitypub_request` filter; this function ignores both. Its narrow job is to be
- * the single, dependency-free definition of "does this request prefer JSON" that
+ * the single, dependency-free definition of "does this request prefer ActivityPub" that
  * is_activitypub_request() and the Surge cache drop-in (integration/surge-cache-config.php) both
  * use, so the representation the plugin serves and the one the cache keys on can never disagree. The
  * drop-in runs before the plugin loads and cannot call is_activitypub_request(), which is why this
  * half lives on its own.
  *
  * It ranks the listed media types by quality (`;q=`), highest first, breaking ties by the order they
- * appear, and reports whether the winner is a JSON type (a `/json` or `+json` suffix). This respects the
- * client's preference rather than demanding a JSON-only header: Mastodon sends
- * `application/ld+json;profile="…", application/activity+json, text/html;q=0.1`, prefers JSON 10:1,
- * and must get JSON; a browser lists `text/html` at q=1 and gets HTML. A media type with no `q`
- * defaults to 1.0.
+ * appear, and reports whether the winner is an ActivityPub type. That is `application/activity+json`,
+ * or `application/ld+json` carrying the ActivityStreams 2.0 profile
+ * (`profile="https://www.w3.org/ns/activitystreams"`); plain `application/json` and bare
+ * `application/ld+json` are not ActivityPub. This respects the client's preference rather than
+ * demanding an ActivityPub-only header: Mastodon sends
+ * `application/ld+json;profile="…activitystreams", application/activity+json, text/html;q=0.1`,
+ * prefers ActivityPub 10:1, and must get it; a browser lists `text/html` at q=1 and gets HTML. A
+ * media type with no `q` defaults to 1.0; a `q=0` refuses the type and is ignored.
  *
  * Pass the RAW, unslashed header; both callers must hand it identical bytes but reach that raw form
  * differently. The plugin runs after wp_magic_quotes() has addslashed $_SERVER, so it wp_unslash()es
@@ -110,11 +113,11 @@ function should_negotiate_content() {
  *
  * @param string $accept The raw (unslashed) Accept header value.
  *
- * @return bool True when the highest-priority acceptable media type is JSON.
+ * @return bool True when the highest-priority acceptable media type is ActivityPub.
  */
-function accept_prefers_json( $accept ) {
+function accept_prefers_activitypub( $accept ) {
 	$winner_quality = 0.0;
-	$winner_is_json = false;
+	$winner_is_ap   = false;
 
 	foreach ( \explode( ',', (string) $accept ) as $part ) {
 		$segments   = \explode( ';', $part );
@@ -124,12 +127,15 @@ function accept_prefers_json( $accept ) {
 			continue;
 		}
 
-		// Quality value: default 1.0, overridden by a `q=` parameter.
+		// Read the quality (default 1.0) and profile parameters, in any order.
 		$quality = 1.0;
+		$profile = '';
 		foreach ( $segments as $param ) {
 			$param = \trim( $param );
 			if ( 0 === \stripos( $param, 'q=' ) ) {
 				$quality = (float) \substr( $param, 2 );
+			} elseif ( 0 === \stripos( $param, 'profile=' ) ) {
+				$profile = \strtolower( \trim( \substr( $param, 8 ), '"' ) );
 			}
 		}
 
@@ -138,14 +144,19 @@ function accept_prefers_json( $accept ) {
 			continue;
 		}
 
+		// ActivityPub is `application/activity+json`, or `application/ld+json` with the AS2 profile
+		// (matched without the scheme so both the http and https profile URIs are accepted).
+		$is_activitypub = 'application/activity+json' === $media_type
+			|| ( 'application/ld+json' === $media_type && false !== \strpos( $profile, '://www.w3.org/ns/activitystreams' ) );
+
 		// Highest quality wins; on a tie the earlier type in the header keeps the lead.
 		if ( $quality > $winner_quality ) {
 			$winner_quality = $quality;
-			$winner_is_json = '/json' === \substr( $media_type, -5 ) || '+json' === \substr( $media_type, -5 );
+			$winner_is_ap   = $is_activitypub;
 		}
 	}
 
-	return $winner_is_json;
+	return $winner_is_ap;
 }
 
 /**

--- a/includes/functions-request.php
+++ b/includes/functions-request.php
@@ -133,7 +133,11 @@ function accept_prefers_activitypub( $accept ) {
 		foreach ( $segments as $param ) {
 			$param = \trim( $param );
 			if ( 0 === \stripos( $param, 'q=' ) ) {
-				$quality = (float) \substr( $param, 2 );
+				// Only a valid number sets the quality; a malformed `q=` keeps the 1.0 default.
+				$q_value = \trim( \substr( $param, 2 ) );
+				if ( \is_numeric( $q_value ) ) {
+					$quality = (float) $q_value;
+				}
 			} elseif ( 0 === \stripos( $param, 'profile=' ) ) {
 				$profile = \strtolower( \trim( \substr( $param, 8 ), '"' ) );
 			}
@@ -144,15 +148,14 @@ function accept_prefers_activitypub( $accept ) {
 			continue;
 		}
 
-		// ActivityPub is `application/activity+json`, or `application/ld+json` with the AS2 profile
-		// (matched without the scheme so both the http and https profile URIs are accepted).
-		$is_activitypub = 'application/activity+json' === $media_type
-			|| ( 'application/ld+json' === $media_type && false !== \strpos( $profile, '://www.w3.org/ns/activitystreams' ) );
-
 		// Highest quality wins; on a tie the earlier type in the header keeps the lead.
 		if ( $quality > $winner_quality ) {
 			$winner_quality = $quality;
-			$winner_is_ap   = $is_activitypub;
+
+			// ActivityPub is `application/activity+json`, or `application/ld+json` with the AS2 profile
+			// (matched without the scheme so both the http and https profile URIs are accepted).
+			$winner_is_ap = 'application/activity+json' === $media_type
+				|| ( 'application/ld+json' === $media_type && false !== \strpos( $profile, '://www.w3.org/ns/activitystreams' ) );
 		}
 	}
 

--- a/integration/class-litespeed-cache.php
+++ b/integration/class-litespeed-cache.php
@@ -23,7 +23,7 @@ class Litespeed_Cache {
 	 */
 	public static $rules = '<IfModule LiteSpeed>
 RewriteEngine On
-RewriteCond %{HTTP:Accept} ^[\s,]*[^\s,;]*(/json|\+json)\s*(;[^,]*)?([\s,]+[^\s,;]*(/json|\+json)\s*(;[^,]*)?)*[\s,]*$ [NC]
+RewriteCond %{HTTP:Accept} ^[\s,]*[^\s,;]*(/json|\+json) [NC]
 RewriteRule ^ - [E=Cache-Control:vary=%{ENV:LSCACHE_VARY_VALUE}+isjson]
 </IfModule>';
 

--- a/integration/class-litespeed-cache.php
+++ b/integration/class-litespeed-cache.php
@@ -23,7 +23,7 @@ class Litespeed_Cache {
 	 */
 	public static $rules = '<IfModule LiteSpeed>
 RewriteEngine On
-RewriteCond %{HTTP:Accept} ^[\s,]*[^\s,;]*(/json|\+json) [NC]
+RewriteCond %{HTTP:Accept} ^[\s,]*(application/activity\+json|application/ld\+json[^,]*activitystreams) [NC]
 RewriteRule ^ - [E=Cache-Control:vary=%{ENV:LSCACHE_VARY_VALUE}+isjson]
 </IfModule>';
 

--- a/integration/surge-cache-config.php
+++ b/integration/surge-cache-config.php
@@ -13,7 +13,10 @@ if ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 	/*
 	 * For a given URL, the html and JSON representations must land in different cache buckets, and
 	 * this boundary must match how the plugin negotiates that same URL, or one representation could be
-	 * replayed for the other. Reuse the plugin's single source of truth: Activitypub\is_json_only_accept().
+	 * replayed for the other. Reuse the plugin's single source of truth: Activitypub\accept_prefers_json(),
+	 * which buckets a request as JSON when its highest-priority (by `q`, then order) media type is JSON.
+	 * That keeps a JSON-preferring client such as Mastodon (which also accepts `text/html;q=0.1`) in the
+	 * JSON bucket instead of the html one.
 	 *
 	 * This mirrors only the Accept-header branch of Query::is_activitypub_request(), which is the sole
 	 * branch that varies a single URL. The `?activitypub` override also forces JSON, but it changes
@@ -23,14 +26,14 @@ if ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 	 * Do NOT call Activitypub\is_activitypub_request() here. Surge runs this config from its
 	 * advanced-cache.php drop-in, on the cache-serve path, before the plugin, the main $wp_query, and
 	 * the plugin's autoloader exist, so that function (which needs all three) would fatal. Only the
-	 * dependency-free is_json_only_accept() is safe on this path. functions-request.php is
+	 * dependency-free accept_prefers_json() is safe on this path. functions-request.php is
 	 * side-effect-free and the plugin loads it with require_once, so including it here neither runs
 	 * code nor risks a redeclare.
 	 */
 	require_once __DIR__ . '/../includes/functions-request.php';
 
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-	if ( \Activitypub\is_json_only_accept( $_SERVER['HTTP_ACCEPT'] ) ) {
+	if ( \Activitypub\accept_prefers_json( $_SERVER['HTTP_ACCEPT'] ) ) {
 		$representation = 'json';
 	}
 }

--- a/integration/surge-cache-config.php
+++ b/integration/surge-cache-config.php
@@ -11,12 +11,12 @@ $representation = 'html';
 
 if ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 	/*
-	 * For a given URL, the html and JSON representations must land in different cache buckets, and
-	 * this boundary must match how the plugin negotiates that same URL, or one representation could be
-	 * replayed for the other. Reuse the plugin's single source of truth: Activitypub\accept_prefers_json(),
-	 * which buckets a request as JSON when its highest-priority (by `q`, then order) media type is JSON.
-	 * That keeps a JSON-preferring client such as Mastodon (which also accepts `text/html;q=0.1`) in the
-	 * JSON bucket instead of the html one.
+	 * For a given URL, the html and ActivityPub representations must land in different cache buckets,
+	 * and this boundary must match how the plugin negotiates that same URL, or one representation could
+	 * be replayed for the other. Reuse the plugin's single source of truth:
+	 * Activitypub\accept_prefers_activitypub(), which buckets a request as JSON when its highest-priority
+	 * (by `q`, then order) media type is ActivityPub. That keeps an ActivityPub-preferring client such
+	 * as Mastodon (which also accepts `text/html;q=0.1`) in the JSON bucket instead of the html one.
 	 *
 	 * This mirrors only the Accept-header branch of Query::is_activitypub_request(), which is the sole
 	 * branch that varies a single URL. The `?activitypub` override also forces JSON, but it changes
@@ -26,14 +26,14 @@ if ( isset( $_SERVER['HTTP_ACCEPT'] ) ) {
 	 * Do NOT call Activitypub\is_activitypub_request() here. Surge runs this config from its
 	 * advanced-cache.php drop-in, on the cache-serve path, before the plugin, the main $wp_query, and
 	 * the plugin's autoloader exist, so that function (which needs all three) would fatal. Only the
-	 * dependency-free accept_prefers_json() is safe on this path. functions-request.php is
+	 * dependency-free accept_prefers_activitypub() is safe on this path. functions-request.php is
 	 * side-effect-free and the plugin loads it with require_once, so including it here neither runs
 	 * code nor risks a redeclare.
 	 */
 	require_once __DIR__ . '/../includes/functions-request.php';
 
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-	if ( \Activitypub\accept_prefers_json( $_SERVER['HTTP_ACCEPT'] ) ) {
+	if ( \Activitypub\accept_prefers_activitypub( $_SERVER['HTTP_ACCEPT'] ) ) {
 		$representation = 'json';
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -162,53 +162,55 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
-	 * Data provider for accept_prefers_json.
+	 * Data provider for accept_prefers_activitypub.
 	 *
 	 * @return array<string, array{0: string, 1: bool}>
 	 */
-	public function accept_prefers_json_provider() {
+	public function accept_prefers_activitypub_provider() {
 		return array(
-			// JSON is the highest-priority acceptable type -> true.
-			'activity_json'        => array( 'application/activity+json', true ),
-			'ld_json'              => array( 'application/ld+json', true ),
-			'plain_json'           => array( 'application/json', true ),
-			'ld_json_with_profile' => array( 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"', true ),
-			'multiple_json'        => array( 'application/activity+json, application/ld+json', true ),
-			'json_with_q'          => array( 'application/activity+json;q=0.9', true ),
-			'uppercase_json'       => array( 'Application/Activity+JSON', true ),
-			'trailing_comma'       => array( 'application/activity+json,', true ),
-			// Mastodon: JSON at q=1, text/html as a q=0.1 fallback -> prefers JSON.
-			'mastodon'             => array( 'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1', true ),
-			// Ties are broken by order: JSON listed first wins.
-			'json_first_on_tie'    => array( 'application/activity+json, text/html', true ),
-			'json_higher_q'        => array( 'text/html;q=0.5, application/activity+json;q=0.8', true ),
-			// HTML (or other) is the highest-priority type -> false.
-			'html_first_on_tie'    => array( 'text/html, application/activity+json', false ),
-			'html_higher_q'        => array( 'application/activity+json;q=0.5, text/html;q=0.8', false ),
-			// `q=0` refuses a type entirely, so it is ignored.
-			'json_refused_q0'      => array( 'application/activity+json;q=0, text/html', false ),
-			'html_refused_q0'      => array( 'application/activity+json;q=0.5, text/html;q=0', true ),
-			'browser'              => array( 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', false ),
-			'wildcard'             => array( '*/*', false ),
-			'plain_html'           => array( 'text/html', false ),
-			'empty'                => array( '', false ),
-			// Classifies the raw header (a `%00` keeps it out of JSON), matching the pre-plugin cache path.
-			'percent_octet'        => array( 'application/activity+json%00', false ),
+			// ActivityPub is the highest-priority acceptable type -> true.
+			'activity_json'         => array( 'application/activity+json', true ),
+			'ld_json_https_profile' => array( 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"', true ),
+			'ld_json_http_profile'  => array( 'application/ld+json; profile="http://www.w3.org/ns/activitystreams"', true ),
+			'activity_json_with_q'  => array( 'application/activity+json;q=0.9', true ),
+			'uppercase'             => array( 'Application/Activity+JSON', true ),
+			'trailing_comma'        => array( 'application/activity+json,', true ),
+			'activity_then_ld'      => array( 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"', true ),
+			// Mastodon: ActivityPub at q=1, text/html as a q=0.1 fallback.
+			'mastodon'              => array( 'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1', true ),
+			// Ties broken by order; higher q wins; a refused (q=0) type is ignored.
+			'ap_first_on_tie'       => array( 'application/activity+json, text/html', true ),
+			'ap_higher_q'           => array( 'text/html;q=0.5, application/activity+json;q=0.8', true ),
+			'html_refused_q0'       => array( 'application/activity+json;q=0.5, text/html;q=0', true ),
+			// Not ActivityPub: plain JSON, bare or wrongly-profiled ld+json, other +json -> false.
+			'plain_json'            => array( 'application/json', false ),
+			'ld_json_no_profile'    => array( 'application/ld+json', false ),
+			'ld_json_wrong_profile' => array( 'application/ld+json; profile="https://example.com/ns"', false ),
+			'other_plus_json'       => array( 'application/geo+json', false ),
+			'html_first_on_tie'     => array( 'text/html, application/activity+json', false ),
+			'html_higher_q'         => array( 'application/activity+json;q=0.5, text/html;q=0.8', false ),
+			'ap_refused_q0'         => array( 'application/activity+json;q=0, text/html', false ),
+			'browser'               => array( 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', false ),
+			'wildcard'              => array( '*/*', false ),
+			'plain_html'            => array( 'text/html', false ),
+			'empty'                 => array( '', false ),
+			// Classifies the raw header: a `%00` breaks the exact match, matching the pre-plugin cache path.
+			'percent_octet'         => array( 'application/activity+json%00', false ),
 		);
 	}
 
 	/**
-	 * Test the JSON-preference Accept-header check.
+	 * Test the ActivityPub-preference Accept-header check.
 	 *
-	 * @dataProvider accept_prefers_json_provider
+	 * @dataProvider accept_prefers_activitypub_provider
 	 *
-	 * @covers \Activitypub\accept_prefers_json
+	 * @covers \Activitypub\accept_prefers_activitypub
 	 *
 	 * @param string $accept   The Accept header value.
-	 * @param bool   $expected Whether the highest-priority acceptable media type is JSON.
+	 * @param bool   $expected Whether the highest-priority acceptable media type is ActivityPub.
 	 */
-	public function test_accept_prefers_json( $accept, $expected ) {
-		$this->assertSame( $expected, \Activitypub\accept_prefers_json( $accept ) );
+	public function test_accept_prefers_activitypub( $accept, $expected ) {
+		$this->assertSame( $expected, \Activitypub\accept_prefers_activitypub( $accept ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -182,6 +182,11 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'ap_first_on_tie'       => array( 'application/activity+json, text/html', true ),
 			'ap_higher_q'           => array( 'text/html;q=0.5, application/activity+json;q=0.8', true ),
 			'html_refused_q0'       => array( 'application/activity+json;q=0.5, text/html;q=0', true ),
+			// A malformed q (empty or non-numeric) keeps the 1.0 default rather than refusing the type.
+			'malformed_q_empty'     => array( 'application/activity+json;q=', true ),
+			'malformed_q_text'      => array( 'application/activity+json;q=high', true ),
+			// An out-of-range q>1.0 must not let an earlier q=1.0 non-AP type win the whole header.
+			'html_then_ap_q_over_1' => array( 'text/html, application/activity+json;q=1.5', true ),
 			// Not ActivityPub: plain JSON, bare or wrongly-profiled ld+json, other +json -> false.
 			'plain_json'            => array( 'application/json', false ),
 			'ld_json_no_profile'    => array( 'application/ld+json', false ),

--- a/tests/phpunit/tests/includes/class-test-functions-request.php
+++ b/tests/phpunit/tests/includes/class-test-functions-request.php
@@ -162,13 +162,13 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	/**
-	 * Data provider for is_json_only_accept.
+	 * Data provider for accept_prefers_json.
 	 *
 	 * @return array<string, array{0: string, 1: bool}>
 	 */
-	public function is_json_only_accept_provider() {
+	public function accept_prefers_json_provider() {
 		return array(
-			// Every media type is JSON -> true.
+			// JSON is the highest-priority acceptable type -> true.
 			'activity_json'        => array( 'application/activity+json', true ),
 			'ld_json'              => array( 'application/ld+json', true ),
 			'plain_json'           => array( 'application/json', true ),
@@ -177,31 +177,38 @@ class Test_Functions_Request extends ActivityPub_TestCase_Cache_HTTP {
 			'json_with_q'          => array( 'application/activity+json;q=0.9', true ),
 			'uppercase_json'       => array( 'Application/Activity+JSON', true ),
 			'trailing_comma'       => array( 'application/activity+json,', true ),
-			// At least one non-JSON media type -> false.
-			'html_then_json'       => array( 'text/html, application/activity+json', false ),
-			'json_then_html'       => array( 'application/activity+json, text/html', false ),
+			// Mastodon: JSON at q=1, text/html as a q=0.1 fallback -> prefers JSON.
+			'mastodon'             => array( 'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1', true ),
+			// Ties are broken by order: JSON listed first wins.
+			'json_first_on_tie'    => array( 'application/activity+json, text/html', true ),
+			'json_higher_q'        => array( 'text/html;q=0.5, application/activity+json;q=0.8', true ),
+			// HTML (or other) is the highest-priority type -> false.
+			'html_first_on_tie'    => array( 'text/html, application/activity+json', false ),
+			'html_higher_q'        => array( 'application/activity+json;q=0.5, text/html;q=0.8', false ),
+			// `q=0` refuses a type entirely, so it is ignored.
+			'json_refused_q0'      => array( 'application/activity+json;q=0, text/html', false ),
+			'html_refused_q0'      => array( 'application/activity+json;q=0.5, text/html;q=0', true ),
 			'browser'              => array( 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', false ),
 			'wildcard'             => array( '*/*', false ),
 			'plain_html'           => array( 'text/html', false ),
 			'empty'                => array( '', false ),
-			// Must classify the raw header, not a sanitized one, so it agrees with the pre-plugin cache
-			// path: `%00` keeps this out of JSON where sanitize_text_field() would have stripped it.
+			// Classifies the raw header (a `%00` keeps it out of JSON), matching the pre-plugin cache path.
 			'percent_octet'        => array( 'application/activity+json%00', false ),
 		);
 	}
 
 	/**
-	 * Test the JSON-only Accept-header check.
+	 * Test the JSON-preference Accept-header check.
 	 *
-	 * @dataProvider is_json_only_accept_provider
+	 * @dataProvider accept_prefers_json_provider
 	 *
-	 * @covers \Activitypub\is_json_only_accept
+	 * @covers \Activitypub\accept_prefers_json
 	 *
 	 * @param string $accept   The Accept header value.
-	 * @param bool   $expected Whether every listed media type is JSON.
+	 * @param bool   $expected Whether the highest-priority acceptable media type is JSON.
 	 */
-	public function test_is_json_only_accept( $accept, $expected ) {
-		$this->assertSame( $expected, \Activitypub\is_json_only_accept( $accept ) );
+	public function test_accept_prefers_json( $accept, $expected ) {
+		$this->assertSame( $expected, \Activitypub\accept_prefers_json( $accept ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-query.php
+++ b/tests/phpunit/tests/includes/class-test-query.php
@@ -223,10 +223,11 @@ class Test_Query extends \WP_UnitTestCase {
 		$this->go_to( get_permalink( self::$post_id ) );
 		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
 
+		// Bare `application/ld+json` (no ActivityStreams profile) is not an ActivityPub request.
 		Query::get_instance()->__destruct();
 		$_SERVER['HTTP_ACCEPT'] = 'application/ld+json';
 		$this->go_to( get_permalink( self::$post_id ) );
-		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
+		$this->assertFalse( Query::get_instance()->is_activitypub_request() );
 
 		Query::get_instance()->__destruct();
 		$_SERVER['HTTP_ACCEPT'] = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"';
@@ -243,10 +244,17 @@ class Test_Query extends \WP_UnitTestCase {
 		$this->go_to( get_permalink( self::$post_id ) );
 		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
 
+		// Mastodon's real header: ActivityPub at q=1 with a low-priority text/html fallback.
+		Query::get_instance()->__destruct();
+		$_SERVER['HTTP_ACCEPT'] = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1';
+		$this->go_to( get_permalink( self::$post_id ) );
+		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
+
+		// Plain `application/json` is not an ActivityPub request.
 		Query::get_instance()->__destruct();
 		$_SERVER['HTTP_ACCEPT'] = 'application/json';
 		$this->go_to( get_permalink( self::$post_id ) );
-		$this->assertTrue( Query::get_instance()->is_activitypub_request() );
+		$this->assertFalse( Query::get_instance()->is_activitypub_request() );
 
 		Query::get_instance()->__destruct();
 		$_SERVER['HTTP_ACCEPT'] = 'text/html';

--- a/tests/phpunit/tests/integration/class-test-litespeed-cache.php
+++ b/tests/phpunit/tests/integration/class-test-litespeed-cache.php
@@ -121,10 +121,14 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The htaccess Accept condition must classify a request exactly like the plugin's own
-	 * is_json_only_accept(), or a page served as one representation could be cached as the other.
+	 * The htaccess Accept condition must classify a request the same way the plugin's own
+	 * accept_prefers_json() does, or a page served as one representation could be cached as the other.
+	 *
+	 * Since mod_rewrite can't compare quality values, the rule approximates by matching when the
+	 * *first* media type is JSON. For every real client that equals the q-value result (the highest-`q`
+	 * type is the one listed first), so this covers only order-based cases, where the two agree exactly.
 	 */
-	public function test_rewrite_condition_matches_is_json_only_accept() {
+	public function test_rewrite_condition_matches_accept_prefers_json() {
 		\preg_match( '/RewriteCond %\{HTTP:Accept\} (\S+) \[NC\]/', Litespeed_Cache::$rules, $matches );
 		$this->assertNotEmpty( $matches[1] ?? '', 'Could not find the Accept RewriteCond pattern in the rules.' );
 		$pattern = '#' . $matches[1] . '#i';
@@ -137,9 +141,10 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 			'application/activity+json, application/ld+json' => true,
 			'application/activity+json;q=0.9'      => true,
 			'application/activity+json,'           => true,
+			'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1' => true,
+			'application/activity+json, text/html' => true,
 			'text/html'                            => false,
 			'text/html, application/activity+json' => false,
-			'application/activity+json, text/html' => false,
 			'*/*'                                  => false,
 			'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' => false,
 			''                                     => false,
@@ -147,7 +152,7 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 
 		foreach ( $cases as $accept => $expected ) {
 			$this->assertSame( $expected, (bool) \preg_match( $pattern, $accept ), "htaccess regex disagrees for: $accept" );
-			$this->assertSame( $expected, \Activitypub\is_json_only_accept( $accept ), "is_json_only_accept disagrees for: $accept" );
+			$this->assertSame( $expected, \Activitypub\accept_prefers_json( $accept ), "accept_prefers_json disagrees for: $accept" );
 		}
 	}
 

--- a/tests/phpunit/tests/integration/class-test-litespeed-cache.php
+++ b/tests/phpunit/tests/integration/class-test-litespeed-cache.php
@@ -122,27 +122,29 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 
 	/**
 	 * The htaccess Accept condition must classify a request the same way the plugin's own
-	 * accept_prefers_json() does, or a page served as one representation could be cached as the other.
+	 * accept_prefers_activitypub() does, or a page served as one representation could be cached as the other.
 	 *
 	 * Since mod_rewrite can't compare quality values, the rule approximates by matching when the
-	 * *first* media type is JSON. For every real client that equals the q-value result (the highest-`q`
-	 * type is the one listed first), so this covers only order-based cases, where the two agree exactly.
+	 * *first* media type is ActivityPub. For every real client that equals the q-value result (the
+	 * highest-`q` type is the one listed first), so this covers only order-based cases, where the two
+	 * agree exactly.
 	 */
-	public function test_rewrite_condition_matches_accept_prefers_json() {
+	public function test_rewrite_condition_matches_accept_prefers_activitypub() {
 		\preg_match( '/RewriteCond %\{HTTP:Accept\} (\S+) \[NC\]/', Litespeed_Cache::$rules, $matches );
 		$this->assertNotEmpty( $matches[1] ?? '', 'Could not find the Accept RewriteCond pattern in the rules.' );
 		$pattern = '#' . $matches[1] . '#i';
 
 		$cases = array(
 			'application/activity+json'            => true,
-			'application/ld+json'                  => true,
-			'application/json'                     => true,
 			'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' => true,
-			'application/activity+json, application/ld+json' => true,
+			'application/ld+json; profile="http://www.w3.org/ns/activitystreams"' => true,
 			'application/activity+json;q=0.9'      => true,
 			'application/activity+json,'           => true,
 			'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1' => true,
 			'application/activity+json, text/html' => true,
+			'application/json'                     => false,
+			'application/ld+json'                  => false,
+			'application/ld+json; profile="https://example.com/ns"' => false,
 			'text/html'                            => false,
 			'text/html, application/activity+json' => false,
 			'*/*'                                  => false,
@@ -152,7 +154,7 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 
 		foreach ( $cases as $accept => $expected ) {
 			$this->assertSame( $expected, (bool) \preg_match( $pattern, $accept ), "htaccess regex disagrees for: $accept" );
-			$this->assertSame( $expected, \Activitypub\accept_prefers_json( $accept ), "accept_prefers_json disagrees for: $accept" );
+			$this->assertSame( $expected, \Activitypub\accept_prefers_activitypub( $accept ), "accept_prefers_activitypub disagrees for: $accept" );
 		}
 	}
 

--- a/tests/phpunit/tests/integration/class-test-litespeed-cache.php
+++ b/tests/phpunit/tests/integration/class-test-litespeed-cache.php
@@ -127,7 +127,9 @@ class Test_Litespeed_Cache extends \WP_UnitTestCase {
 	 * Since mod_rewrite can't compare quality values, the rule approximates by matching when the
 	 * *first* media type is ActivityPub. For every real client that equals the q-value result (the
 	 * highest-`q` type is the one listed first), so this covers only order-based cases, where the two
-	 * agree exactly.
+	 * agree exactly. It also can't see a `q=0` that refuses that first type (e.g.
+	 * `application/activity+json;q=0, text/html`), which accept_prefers_activitypub() would treat as
+	 * HTML; no real client sends that, so those cases are left out of the shared assertion below.
 	 */
 	public function test_rewrite_condition_matches_accept_prefers_activitypub() {
 		\preg_match( '/RewriteCond %\{HTTP:Accept\} (\S+) \[NC\]/', Litespeed_Cache::$rules, $matches );


### PR DESCRIPTION
## Proposed changes:

9.2.0 tightened content negotiation to treat a request as ActivityPub only when the `Accept` header was JSON and nothing else. Mastodon (and other software) send `text/html;q=0.1` as a low-priority fallback alongside the ActivityPub types, so that check stopped recognizing them and served the HTML page instead, which broke lookups and federation.

This replaces it with a quality-aware, ActivityPub-specific check, `accept_prefers_activitypub()`:

- It ranks the `Accept` media types by `q` (ties broken by the order they appear) and looks at the winner.
- The winner counts as ActivityPub only if it is `application/activity+json`, or `application/ld+json` carrying the ActivityStreams 2.0 profile (matched without the scheme, so `http://` and `https://` both work). Plain `application/json`, bare `application/ld+json`, and other `*+json` types are **not** ActivityPub.
- A `q=0` refuses a type and is ignored.

So Mastodon (ActivityPub at `q=1`, `text/html` at `q=0.1`) gets ActivityPub again; a browser (`text/html` at `q=1`) gets HTML.

The Surge cache drop-in calls the same helper. The LiteSpeed `.htaccess` rule and the Varnish/Nginx doc examples can't compare quality values, so they approximate by matching when the *first* media type is ActivityPub, which equals the q-value result for every real client.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Publish a post and confirm it resolves when you paste its URL into Mastodon search.
* `curl -H 'Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1' <post-url>` returns `application/activity+json` (Mastodon's exact header).
* A normal browser request still returns the HTML page.
