### PR TITLE
Improve permission checks for admin actions

### DIFF
--- a/.github/changelog/fix-admin-actions-permission
+++ b/.github/changelog/fix-admin-actions-permission
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve permission checks for admin-only actions.

--- a/includes/rest/admin/class-actions-controller.php
+++ b/includes/rest/admin/class-actions-controller.php
@@ -125,7 +125,12 @@ class Actions_Controller extends \WP_REST_Controller {
 			return $denied;
 		}
 
-		if ( ! user_can_activitypub( \get_current_user_id() ) ) {
+		/*
+		 * A logged-out request has user ID 0, which is also the blog actor's ID
+		 * (Actors::BLOG_USER_ID). Without the login check, user_can_activitypub( 0 ) reports the
+		 * enabled blog actor, so an anonymous caller would pass and act with the blog's rights.
+		 */
+		if ( ! \is_user_logged_in() || ! user_can_activitypub( \get_current_user_id() ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				\__( 'Sorry, you are not allowed to perform this action.', 'activitypub' ),

--- a/tests/phpunit/tests/includes/rest/admin/class-test-actions-controller.php
+++ b/tests/phpunit/tests/includes/rest/admin/class-test-actions-controller.php
@@ -117,4 +117,21 @@ class Test_Actions_Controller extends \WP_UnitTestCase {
 		$this->assertEquals( 'activitypub_oauth_not_allowed', $result->get_error_code() );
 		$this->assertEquals( 403, $result->get_error_data()['status'] );
 	}
+
+	/**
+	 * A logged-out request must be denied even when the blog actor is enabled, whose ID (0)
+	 * collides with the anonymous user ID.
+	 *
+	 * @covers ::check_permission
+	 */
+	public function test_anonymous_request_is_denied_with_blog_actor_enabled() {
+		\update_option( 'activitypub_actor_mode', 'actor_blog' );
+		\wp_set_current_user( 0 );
+
+		$result = $this->controller->check_permission();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+		$this->assertEquals( 403, $result->get_error_data()['status'] );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/admin/class-test-actions-controller.php
+++ b/tests/phpunit/tests/includes/rest/admin/class-test-actions-controller.php
@@ -50,6 +50,7 @@ class Test_Actions_Controller extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		\wp_set_current_user( 0 );
+		\delete_option( 'activitypub_actor_mode' );
 
 		// Clear any OAuth session established during the test.
 		unset( $_SERVER['HTTP_AUTHORIZATION'] );


### PR DESCRIPTION
## Proposed changes:

Tightens the permission check on the admin action endpoints so they require a logged-in user before the capability check runs.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Call an admin action endpoint while logged out and confirm it returns a 403.
* As a user with the right capability, confirm the action still works.
