### PR TITLE
Improve validation of incoming federated activities

### DIFF
--- a/.github/changelog/fix-inbox-key-actor-binding
+++ b/.github/changelog/fix-inbox-key-actor-binding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve validation of incoming federated activities so the signing key and referenced objects are bound to the sender.

--- a/includes/handler/class-feature-request.php
+++ b/includes/handler/class-feature-request.php
@@ -13,6 +13,7 @@ use Activitypub\Collection\Followers;
 use Activitypub\Collection\Remote_Actors;
 
 use function Activitypub\add_to_outbox;
+use function Activitypub\is_same_host;
 use function Activitypub\object_to_uri;
 use function Activitypub\user_can_activitypub;
 
@@ -342,6 +343,12 @@ class Feature_Request {
 		}
 
 		if ( ! isset( $activity['actor'], $activity['object'], $activity['instrument'] ) ) {
+			return false;
+		}
+
+		// The instrument is the requester's own object, so it must live on the actor's host.
+		// Otherwise a remote server could stamp a local actor with a third-party reference.
+		if ( ! is_same_host( $activity['actor'], $activity['instrument'] ) ) {
 			return false;
 		}
 

--- a/includes/handler/class-quote-request.php
+++ b/includes/handler/class-quote-request.php
@@ -14,6 +14,7 @@ use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Remote_Actors;
 
 use function Activitypub\add_to_outbox;
+use function Activitypub\is_same_host;
 use function Activitypub\object_to_uri;
 use function Activitypub\user_can_activitypub;
 
@@ -328,6 +329,12 @@ class Quote_Request {
 		}
 
 		if ( ! isset( $activity['actor'], $activity['object'], $activity['instrument'] ) ) {
+			return false;
+		}
+
+		// The instrument is the quoting object, authored by the actor, so it must live on the
+		// actor's host. Otherwise a remote server could bind a third-party reference to a local post.
+		if ( ! is_same_host( $activity['actor'], $activity['instrument'] ) ) {
 			return false;
 		}
 

--- a/includes/rest/trait-verification.php
+++ b/includes/rest/trait-verification.php
@@ -12,6 +12,7 @@ use Activitypub\OAuth\Scope;
 use Activitypub\OAuth\Server as OAuth_Server;
 use Activitypub\Signature;
 
+use function Activitypub\is_same_host;
 use function Activitypub\object_to_uri;
 use function Activitypub\use_authorized_fetch;
 use function Activitypub\user_can_act_as_blog;
@@ -98,29 +99,31 @@ trait Verification {
 	 * request can present several signature labels (or a draft and an RFC 9421 header) with
 	 * different keyIds, and only the verifier knows which one validated.
 	 *
+	 * Fails closed when either side has no parsable host. A non-URL keyId such as
+	 * `acct:mallory@attacker.example` resolves to a real key through WebFinger yet yields no host,
+	 * so treating "no host" as "nothing to check" would drop the only tie between the signing key
+	 * and the claimed actor. Both hosts must be present and equal.
+	 *
 	 * @since 8.1.0
 	 * @since 9.0.0 Added the `$key_id` parameter; binds against the verified keyId.
+	 * @since unreleased Reject a keyId or actor with no parsable host instead of allowing it.
 	 *
 	 * @param \WP_REST_Request $request The request object.
 	 * @param string|null      $key_id  The keyId that verified the signature.
 	 * @return true|\WP_Error True if valid, WP_Error on mismatch.
 	 */
 	private function verify_key_id( $request, $key_id ) {
-		if ( ! $key_id ) {
+		$json  = $request->get_json_params();
+		$actor = isset( $json['actor'] ) ? object_to_uri( $json['actor'] ) : null;
+
+		// A signed request without a body actor (e.g. an authorized-fetch GET) has nothing to bind.
+		if ( ! $actor ) {
 			return true;
 		}
 
-		$key_host = \strtolower( (string) \wp_parse_url( $key_id, \PHP_URL_HOST ) );
-		$json     = $request->get_json_params();
-		$actor    = isset( $json['actor'] ) ? object_to_uri( $json['actor'] ) : null;
-
-		if ( ! $actor || ! $key_host ) {
-			return true;
-		}
-
-		$actor_host = \strtolower( (string) \wp_parse_url( $actor, \PHP_URL_HOST ) );
-
-		if ( ! $actor_host || $key_host !== $actor_host ) {
+		// The keyId and the actor must resolve to the same host; an identifier with no parsable
+		// host (e.g. an `acct:` keyId) is unbindable and therefore not an authorized one.
+		if ( ! is_same_host( $key_id, $actor ) ) {
 			return new \WP_Error(
 				'activitypub_key_actor_mismatch',
 				\__( 'Signing key and activity actor must be on the same host.', 'activitypub' ),

--- a/tests/phpunit/tests/includes/handler/class-test-feature-request.php
+++ b/tests/phpunit/tests/includes/handler/class-test-feature-request.php
@@ -80,6 +80,23 @@ class Test_Feature_Request extends ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test that validate_object rejects an instrument hosted off the actor's domain.
+	 *
+	 * @covers ::validate_object
+	 */
+	public function test_validate_object_fails_for_cross_host_instrument() {
+		$activity               = $this->create_feature_request_activity();
+		$activity['instrument'] = 'https://victim.example/users/alice/featured/1';
+
+		$request = new \WP_REST_Request( 'POST', '/inbox' );
+		$request->set_body( wp_json_encode( $activity ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$valid = Feature_Request::validate_object( true, 'object', $request );
+		$this->assertFalse( $valid );
+	}
+
+	/**
 	 * Test that validate_object passes through unrelated activity types unchanged.
 	 *
 	 * @covers ::validate_object

--- a/tests/phpunit/tests/includes/handler/class-test-quote-request.php
+++ b/tests/phpunit/tests/includes/handler/class-test-quote-request.php
@@ -390,6 +390,28 @@ class Test_Quote_Request extends ActivityPub_Outbox_TestCase {
 	}
 
 	/**
+	 * Test validate_object rejects an instrument hosted off the actor's domain.
+	 *
+	 * @covers ::validate_object
+	 */
+	public function test_validate_object_fails_for_cross_host_instrument() {
+		$request_data = array(
+			'type'       => 'QuoteRequest',
+			'actor'      => 'https://remote.example.com/users/remote_user',
+			'object'     => get_permalink( self::$post_id ),
+			'instrument' => 'https://victim.example/posts/456',
+		);
+
+		$request = new \WP_REST_Request();
+		$request->set_body( \wp_json_encode( $request_data ) );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$result = Quote_Request::validate_object( true, 'object', $request );
+
+		$this->assertFalse( $result, 'QuoteRequest with a cross-host instrument should fail validation' );
+	}
+
+	/**
 	 * Test validate_object with missing required attributes.
 	 *
 	 * @covers ::validate_object

--- a/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
+++ b/tests/phpunit/tests/includes/rest/class-test-trait-verification.php
@@ -486,10 +486,36 @@ class Test_Trait_Verification extends \WP_UnitTestCase {
 				null,
 				true,
 			),
+			// A missing keyId cannot be bound to the actor, so it must fail closed.
 			'no verified key id'      => array(
 				null,
 				'https://remote.example/users/alice',
-				true,
+				false,
+			),
+			// A non-URL `acct:` keyId resolves to a real key but yields no host: the bypass this guards.
+			'acct key id cannot bind' => array(
+				'acct:mallory@attacker.example',
+				'https://victim.example/users/alice',
+				false,
+			),
+			// An `acct:` actor likewise has no host and cannot be bound.
+			'acct actor cannot bind'  => array(
+				'https://remote.example/users/alice#main-key',
+				'acct:alice@remote.example',
+				false,
+			),
+			// The FeatureRequest fill sets actor = strip_fragment( keyId ); a hostless `acct:`
+			// keyId makes both sides hostless, which must still fail closed rather than self-match.
+			'acct key id and actor'   => array(
+				'acct:mallory@attacker.example',
+				'acct:mallory@attacker.example',
+				false,
+			),
+			// An empty keyId string has no host and cannot be bound.
+			'empty key id'            => array(
+				'',
+				'https://remote.example/users/alice',
+				false,
 			),
 			'actor as object with id' => array(
 				'https://remote.example/users/alice#main-key',


### PR DESCRIPTION
## Proposed changes:

Tightens how the inbox validates incoming federated activities. It confirms the signing key resolves to the same host as the activity actor, and that a request's referenced objects belong to the sending actor, rejecting anything that cannot be bound to the sender. Reuses the existing `is_same_host()` helper so all the inbox binding checks go through one implementation.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Federation with Mastodon and other servers keeps working: follow, reply, boost, and quote a post.
* A signed request whose key and actor are on different hosts is rejected with a 403.
