### PR TITLE
Fix lookups for activities received from other WordPress sites

### DIFF
--- a/.github/changelog/fix-guid-storage-encoding
+++ b/.github/changelog/fix-guid-storage-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed duplicate entries and failed undo actions for activities received from other WordPress sites.

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -289,9 +289,15 @@ class Inbox {
 					);
 				}
 
-				// The comment stores the activity ID as it arrived, so decode the escaping
-				// WordPress applied to the GUID before comparing the two.
-				$result = Comment::object_id_to_comment( \esc_url_raw( \wp_specialchars_decode( $inbox_item->guid, ENT_QUOTES ) ) );
+				/*
+				 * The comment stores the activity ID as it arrived, so undo the escaping applied
+				 * to the GUID before comparing the two. Only the sequences that escaping can
+				 * produce are reversed, plus the `&amp;` that rows written before it carry:
+				 * decoding the full entity set would also rewrite a `&lt;` or `&quot;` that an ID
+				 * happens to contain as literal text, which escaping never put there.
+				 */
+				$decoded = \str_replace( array( '&#038;', '&amp;', '&#039;' ), array( '&', '&', "'" ), $inbox_item->guid );
+				$result  = Comment::object_id_to_comment( \esc_url_raw( $decoded ) );
 
 				if ( empty( $result ) ) {
 					return new \WP_Error(

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -127,8 +127,9 @@ class Inbox {
 			'post_content' => \wp_slash( $activity->to_json( true, true ) ),
 			'post_author'  => 0, // No specific author, recipients stored in meta.
 			'post_status'  => 'publish',
-			// Store the GUID the way get_by_guid() looks it up: WordPress escapes an explicitly
-			// passed GUID as `&amp;`, which no lookup form matches.
+			// Store the GUID the way get_by_guid() looks it up, which is with esc_url(): an
+			// ampersand becomes `&#038;`. Passing it unescaped instead lets `pre_post_guid`
+			// store it as `&amp;`, and the two spellings never match.
 			'guid'         => \esc_url( $activity->get_id() ),
 			'meta_input'   => array(
 				'_activitypub_object_id'             => $object_id,

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -288,7 +288,9 @@ class Inbox {
 					);
 				}
 
-				$result = Comment::object_id_to_comment( \esc_url_raw( $inbox_item->guid ) );
+				// The comment stores the activity ID as it arrived, so decode the escaping
+				// WordPress applied to the GUID before comparing the two.
+				$result = Comment::object_id_to_comment( \esc_url_raw( \wp_specialchars_decode( $inbox_item->guid, ENT_QUOTES ) ) );
 
 				if ( empty( $result ) ) {
 					return new \WP_Error(

--- a/includes/collection/class-inbox.php
+++ b/includes/collection/class-inbox.php
@@ -127,7 +127,9 @@ class Inbox {
 			'post_content' => \wp_slash( $activity->to_json( true, true ) ),
 			'post_author'  => 0, // No specific author, recipients stored in meta.
 			'post_status'  => 'publish',
-			'guid'         => $activity->get_id(),
+			// Store the GUID the way get_by_guid() looks it up: WordPress escapes an explicitly
+			// passed GUID as `&amp;`, which no lookup form matches.
+			'guid'         => \esc_url( $activity->get_id() ),
 			'meta_input'   => array(
 				'_activitypub_object_id'             => $object_id,
 				'_activitypub_activity_type'         => $activity->get_type(),

--- a/includes/collection/class-remote-posts.php
+++ b/includes/collection/class-remote-posts.php
@@ -348,7 +348,9 @@ class Remote_Posts {
 			'post_type'     => self::POST_TYPE,
 			'post_date_gmt' => $gm_date,
 			'post_date'     => \get_date_from_gmt( $gm_date ),
-			'guid'          => isset( $activity['id'] ) ? \esc_url_raw( $activity['id'] ) : '',
+			// Store the GUID the way get_by_guid() looks it up: WordPress escapes an explicitly
+			// passed GUID as `&amp;`, which no lookup form matches.
+			'guid'          => isset( $activity['id'] ) ? \esc_url( $activity['id'] ) : '',
 		);
 	}
 

--- a/includes/collection/class-remote-posts.php
+++ b/includes/collection/class-remote-posts.php
@@ -348,8 +348,9 @@ class Remote_Posts {
 			'post_type'     => self::POST_TYPE,
 			'post_date_gmt' => $gm_date,
 			'post_date'     => \get_date_from_gmt( $gm_date ),
-			// Store the GUID the way get_by_guid() looks it up: WordPress escapes an explicitly
-			// passed GUID as `&amp;`, which no lookup form matches.
+			// Store the GUID the way get_by_guid() looks it up, which is with esc_url(): an
+			// ampersand becomes `&#038;`. Passing it unescaped instead lets `pre_post_guid`
+			// store it as `&amp;`, and the two spellings never match.
 			'guid'          => isset( $activity['id'] ) ? \esc_url( $activity['id'] ) : '',
 		);
 	}

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -28,6 +28,34 @@ class Test_Inbox extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An activity whose ID contains an ampersand must be found again by that ID.
+	 *
+	 * Every WordPress peer federates activity IDs of the form `?post_type=ap_outbox&p=123`,
+	 * so the round trip has to survive the escaping WordPress applies to the GUID column.
+	 * Without it, redelivered activities are stored twice and an Undo cannot find its target.
+	 *
+	 * @covers ::add
+	 * @covers ::get_by_guid
+	 */
+	public function test_get_by_guid_with_ampersand() {
+		$activity_id = 'https://remote.example.com/?post_type=ap_outbox&p=123';
+
+		$activity = new Activity();
+		$activity->set_id( $activity_id );
+		$activity->set_type( 'Like' );
+		$activity->set_actor( 'https://remote.example.com/users/testuser' );
+		$activity->set_object( 'https://remote.example.com/objects/456' );
+
+		$inbox_id = Inbox::add( $activity, 1 );
+		$this->assertIsInt( $inbox_id );
+
+		$found = Inbox::get_by_guid( $activity_id );
+
+		$this->assertInstanceOf( 'WP_Post', $found, 'An activity ID containing an ampersand must be found again.' );
+		$this->assertSame( $inbox_id, $found->ID );
+	}
+
+	/**
 	 * Test adding an activity to the inbox and verify post meta is set correctly.
 	 *
 	 * @covers ::add

--- a/tests/phpunit/tests/includes/collection/class-test-inbox.php
+++ b/tests/phpunit/tests/includes/collection/class-test-inbox.php
@@ -56,6 +56,35 @@ class Test_Inbox extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Undoing an interaction whose activity ID contains an ampersand must find its comment.
+	 *
+	 * The comment records the activity ID as sent over the wire, while the inbox item records it
+	 * as WordPress escapes a GUID, so the two only match once the stored value is decoded again.
+	 *
+	 * @covers ::undo
+	 */
+	public function test_undo_with_ampersand_in_activity_id() {
+		$activity_id = 'https://remote.example.com/?post_type=ap_outbox&p=555';
+		$actor       = 'https://remote.example.com/users/testuser';
+
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::factory()->post->create() ) );
+		\add_comment_meta( $comment_id, 'source_id', \esc_url_raw( $activity_id ) );
+
+		$activity = new Activity();
+		$activity->set_id( $activity_id );
+		$activity->set_type( 'Like' );
+		$activity->set_actor( $actor );
+		$activity->set_object( 'https://remote.example.com/objects/456' );
+
+		$this->assertIsInt( Inbox::add( $activity, 1 ) );
+
+		$result = Inbox::undo( $activity_id, $actor );
+
+		$this->assertNotWPError( $result, 'Undo must find the comment behind an activity ID containing an ampersand.' );
+		$this->assertNull( \get_comment( $comment_id ), 'The comment should be deleted.' );
+	}
+
+	/**
 	 * Test adding an activity to the inbox and verify post meta is set correctly.
 	 *
 	 * @covers ::add

--- a/tests/phpunit/tests/includes/collection/class-test-remote-posts.php
+++ b/tests/phpunit/tests/includes/collection/class-test-remote-posts.php
@@ -396,6 +396,38 @@ class Test_Remote_Posts extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An object whose ID contains an ampersand must be found again by that ID.
+	 *
+	 * WordPress peers publish object IDs like `?p=123&foo=bar`, and WordPress escapes an
+	 * explicitly passed GUID, so the round trip has to survive that escaping.
+	 *
+	 * @covers ::add
+	 * @covers ::get_by_guid
+	 */
+	public function test_get_by_guid_with_ampersand() {
+		$object_id = 'https://example.com/?post_type=post&p=789';
+
+		$activity = array(
+			'actor'  => 'https://example.com/users/testuser',
+			'object' => array(
+				'id'           => $object_id,
+				'type'         => 'Note',
+				'name'         => 'Ampersand Object',
+				'content'      => '<p>Test content</p>',
+				'attributedTo' => 'https://example.com/users/testuser',
+			),
+		);
+
+		$post = Remote_Posts::add( $activity, 1 );
+		$this->assertInstanceOf( '\WP_Post', $post );
+
+		$retrieved_post = Remote_Posts::get_by_guid( $object_id );
+
+		$this->assertInstanceOf( '\WP_Post', $retrieved_post, 'An object ID containing an ampersand must be found again.' );
+		$this->assertEquals( $post->ID, $retrieved_post->ID );
+	}
+
+	/**
 	 * Test getting a non-existent object by GUID.
 	 *
 	 * @covers ::get_by_guid


### PR DESCRIPTION
## Proposed changes:

Activities received from another WordPress site could not be found again by their ID, so redelivered activities were stored twice and an Undo could not find its target.

The `ap_outbox` post type is not public, so every WordPress peer federates activity IDs of the form `?post_type=ap_outbox&p=123`. Passing a GUID to `wp_insert_post()` runs it through `pre_post_guid`, which stores the ampersand as `&amp;`, while `get_by_guid()` looks it up with `esc_url()`, which produces `&#038;`. Those never match, so every lookup missed.

The GUID is now stored the way it is looked up, in `Inbox::add()` and `Remote_Posts::add()`. The lookups are unchanged: `esc_url()` is what bridges the wire form (`&`) to the form WordPress stores, and it already worked for the outbox, whose GUID is generated by WordPress itself and skips that filter.

Rows written before this stay as they are. They are not findable today either, so nothing gets worse, but the duplicates that already exist do not clean themselves up.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Run `npm run env-test -- --filter=test_get_by_guid_with_ampersand`. Both new tests fail on trunk and pass here.
* From another WordPress site, like a post, then undo the like. The like should disappear.
* Deliver the same activity twice and confirm only one inbox entry is created.
