### PR TITLE
Fix remote profile lookups and tighten checks on boosted content

### DIFF
--- a/.github/changelog/fix-announce-origin-binding
+++ b/.github/changelog/fix-announce-origin-binding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved checks on boosted content so it is only accepted from the server that published it.

--- a/.github/changelog/fix-audit-hardening
+++ b/.github/changelog/fix-audit-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve lookups for remote profiles and tighten checks on boosted content from other servers.

--- a/.github/changelog/fix-audit-hardening
+++ b/.github/changelog/fix-audit-hardening
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improve lookups for remote profiles and tighten checks on boosted content from other servers.

--- a/.github/changelog/fix-remote-lookup-escaping
+++ b/.github/changelog/fix-remote-lookup-escaping
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed remote profiles and followers not being found when their address contains a quote.
+Fixed remote profiles and followers not being found when their address contains unusual characters.

--- a/.github/changelog/fix-remote-lookup-escaping
+++ b/.github/changelog/fix-remote-lookup-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed remote profiles and followers not being found when their address contains a quote.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -452,8 +452,7 @@ class Comment {
 		if ( \in_array( $comment_type, $comment_types, true ) ) {
 			$where .= $wpdb->prepare( ' AND comment_type = %s', $comment_type );
 		} else {
-			$comment_types = \array_map( 'esc_sql', $comment_types );
-			$placeholders  = \implode( ', ', \array_fill( 0, \count( $comment_types ), '%s' ) );
+			$placeholders = \implode( ', ', \array_fill( 0, \count( $comment_types ), '%s' ) );
 			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.NotPrepared
 			$where .= $wpdb->prepare( \sprintf( ' AND comment_type NOT IN (%s)', $placeholders ), ...$comment_types );
 		}

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -145,10 +145,10 @@ class Followers {
 			$wpdb->prepare(
 				"SELECT DISTINCT p.ID FROM $wpdb->posts p INNER JOIN $wpdb->postmeta pm ON p.ID = pm.post_id WHERE p.post_type = %s AND pm.meta_key = %s AND pm.meta_value = %d AND p.guid = %s",
 				array(
-					\esc_sql( Remote_Actors::POST_TYPE ),
-					\esc_sql( self::FOLLOWER_META_KEY ),
-					\esc_sql( $user_id ),
-					\esc_sql( $actor ),
+					Remote_Actors::POST_TYPE,
+					self::FOLLOWER_META_KEY,
+					$user_id,
+					$actor,
 				)
 			)
 		);

--- a/includes/collection/class-followers.php
+++ b/includes/collection/class-followers.php
@@ -148,7 +148,8 @@ class Followers {
 					Remote_Actors::POST_TYPE,
 					self::FOLLOWER_META_KEY,
 					$user_id,
-					$actor,
+					// Normalize the way the actor's GUID was stored; prepare() handles the escaping.
+					\esc_url_raw( $actor ),
 				)
 			)
 		);

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -209,7 +209,8 @@ class Remote_Actors {
 		$post_id = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT ID FROM $wpdb->posts WHERE guid=%s AND post_type=%s",
-				$actor_uri,
+				// Normalize the way upsert() stores the GUID; prepare() handles the SQL escaping.
+				\esc_url_raw( $actor_uri ),
 				self::POST_TYPE
 			)
 		);

--- a/includes/collection/class-remote-actors.php
+++ b/includes/collection/class-remote-actors.php
@@ -209,8 +209,8 @@ class Remote_Actors {
 		$post_id = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT ID FROM $wpdb->posts WHERE guid=%s AND post_type=%s",
-				\esc_sql( $actor_uri ),
-				\esc_sql( self::POST_TYPE )
+				$actor_uri,
+				self::POST_TYPE
 			)
 		);
 

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -102,11 +102,15 @@ class Announce {
 		 * document from the id it declares when the two disagree, and returns the re-fetched copy.
 		 * Bind the actor to that id as well, which an authentic activity shares a host with.
 		 *
-		 * Only when the document declares one: get_remote_object() returns an id-less document as
-		 * served, so it was never re-fetched and the origin check above is already authoritative.
-		 * Requiring an id here would drop relayed activities that legitimately omit it.
+		 * Only when the document declares one. The id is derived exactly as get_remote_object()
+		 * derives it, so the two cannot disagree about what counts as declared: whatever it treats
+		 * as id-less it returns as served, without re-fetching, and the origin check above is
+		 * already authoritative for those. Binding them here would drop relayed activities that
+		 * legitimately omit an id.
 		 */
-		if ( isset( $object['id'] ) && \is_string( $object['id'] ) && ! is_same_host( $object['id'], $object['actor'] ?? '' ) ) {
+		$declared_id = isset( $object['id'] ) && \is_string( $object['id'] ) ? $object['id'] : '';
+
+		if ( '' !== $declared_id && ! is_same_host( $declared_id, $object['actor'] ?? '' ) ) {
 			return;
 		}
 

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -99,10 +99,14 @@ class Announce {
 
 		/*
 		 * The requested URL is not always the host that answered: get_remote_object() re-fetches a
-		 * document from the id it declares when the two disagree. Bind the actor to that id as
-		 * well, which an authentic activity always shares a host with.
+		 * document from the id it declares when the two disagree, and returns the re-fetched copy.
+		 * Bind the actor to that id as well, which an authentic activity shares a host with.
+		 *
+		 * Only when the document declares one: get_remote_object() returns an id-less document as
+		 * served, so it was never re-fetched and the origin check above is already authoritative.
+		 * Requiring an id here would drop relayed activities that legitimately omit it.
 		 */
-		if ( ! is_same_host( $object['id'] ?? '', $object['actor'] ?? '' ) ) {
+		if ( isset( $object['id'] ) && \is_string( $object['id'] ) && ! is_same_host( $object['id'], $object['actor'] ?? '' ) ) {
 			return;
 		}
 

--- a/includes/handler/class-announce.php
+++ b/includes/handler/class-announce.php
@@ -14,6 +14,7 @@ use Activitypub\Http;
 
 use function Activitypub\is_activity;
 use function Activitypub\is_activity_public;
+use function Activitypub\is_same_host;
 use function Activitypub\object_to_uri;
 
 /**
@@ -93,6 +94,15 @@ class Announce {
 		 * to every relayed activity type.
 		 */
 		if ( '' === $origin_host || '' === $actor_host || $origin_host !== $actor_host ) {
+			return;
+		}
+
+		/*
+		 * The requested URL is not always the host that answered: get_remote_object() re-fetches a
+		 * document from the id it declares when the two disagree. Bind the actor to that id as
+		 * well, which an authentic activity always shares a host with.
+		 */
+		if ( ! is_same_host( $object['id'] ?? '', $object['actor'] ?? '' ) ) {
 			return;
 		}
 

--- a/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
+++ b/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
@@ -794,21 +794,28 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 	 * @covers ::get_by_uri
 	 */
 	public function test_get_by_uri_with_quote() {
-		$actor_uri = "https://remote.example.com/actor/o'brien";
-
-		$post_id = \wp_insert_post(
-			array(
-				'post_type'   => \Activitypub\Collection\Remote_Actors::POST_TYPE,
-				'post_status' => 'publish',
-				'post_title'  => "O'Brien",
-				'guid'        => $actor_uri,
-			)
+		$uris = array(
+			"https://remote.example.com/actor/o'brien",
+			'https://remote.example.com/actor/say"hi',
+			'https://remote.example.com/actor/a b',
 		);
 
-		$found = \Activitypub\Collection\Remote_Actors::get_by_uri( $actor_uri );
+		foreach ( $uris as $actor_uri ) {
+			$actor = array(
+				'id'                => $actor_uri,
+				'type'              => 'Person',
+				'inbox'             => 'https://remote.example.com/inbox',
+				'preferredUsername' => 'quoted',
+			);
 
-		$this->assertInstanceOf( 'WP_Post', $found, 'An actor URI containing a quote must be found.' );
-		$this->assertSame( $post_id, $found->ID );
+			$post_id = \Activitypub\Collection\Remote_Actors::upsert( $actor );
+			$this->assertIsInt( $post_id );
+
+			$found = \Activitypub\Collection\Remote_Actors::get_by_uri( $actor_uri );
+
+			$this->assertInstanceOf( 'WP_Post', $found, "An actor URI must be found: $actor_uri" );
+			$this->assertSame( $post_id, $found->ID );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
+++ b/tests/phpunit/tests/includes/collection/class-test-remote-actors.php
@@ -786,6 +786,32 @@ tjUBdXrPxz998Ns/cu9jjg06d+XV3TcSU+AOldmGLJuB/AWV/+F9c9DlczqmnXqd
 	}
 
 	/**
+	 * An actor URI containing a quote must still be found.
+	 *
+	 * `$wpdb->prepare()` escapes the values it is given, so escaping them beforehand as well
+	 * leaves the lookup key no longer matching what was stored.
+	 *
+	 * @covers ::get_by_uri
+	 */
+	public function test_get_by_uri_with_quote() {
+		$actor_uri = "https://remote.example.com/actor/o'brien";
+
+		$post_id = \wp_insert_post(
+			array(
+				'post_type'   => \Activitypub\Collection\Remote_Actors::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => "O'Brien",
+				'guid'        => $actor_uri,
+			)
+		);
+
+		$found = \Activitypub\Collection\Remote_Actors::get_by_uri( $actor_uri );
+
+		$this->assertInstanceOf( 'WP_Post', $found, 'An actor URI containing a quote must be found.' );
+		$this->assertSame( $post_id, $found->ID );
+	}
+
+	/**
 	 * Test get_by_uri.
 	 *
 	 * @covers ::get_by_uri

--- a/tests/phpunit/tests/includes/handler/class-test-announce.php
+++ b/tests/phpunit/tests/includes/handler/class-test-announce.php
@@ -192,6 +192,49 @@ class Test_Announce extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An announced activity whose own id is on a different host than the actor is not relayed.
+	 *
+	 * `Http::get_remote_object()` may return a document re-fetched from the id it declares, so the
+	 * URL that was requested is not always the host that served the answer. The document's own id
+	 * is, and an authentic activity always shares a host with its actor.
+	 *
+	 * @covers ::handle_announce
+	 */
+	public function test_handle_announce_rejects_activity_whose_id_host_differs_from_actor() {
+		$activity_url = 'https://example.com/activities/like-2';
+		$fetch        = function ( $pre, $url_or_object ) use ( $activity_url ) {
+			if ( $activity_url !== $url_or_object ) {
+				return $pre;
+			}
+
+			// Requested from example.com, but the document belongs to attacker.test.
+			return array(
+				'id'     => 'https://attacker.test/activities/like-2',
+				'type'   => 'Like',
+				'actor'  => 'https://example.com/user',
+				'object' => $this->post_permalink,
+			);
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $fetch, 10, 2 );
+
+		$inbox = new \MockAction();
+		\add_action( 'activitypub_inbox', array( $inbox, 'action' ) );
+
+		$announce = array(
+			'actor'  => 'https://booster.example/user',
+			'type'   => 'Announce',
+			'id'     => 'https://booster.example/a/2',
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'object' => $activity_url,
+		);
+		Announce::handle_announce( $announce, $this->user_id, Activity::init_from_array( $announce ) );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $fetch, 10 );
+
+		$this->assertSame( 0, $inbox->get_call_count(), 'An activity whose id host differs from its actor must not be relayed.' );
+	}
+
+	/**
 	 * An announced activity whose actor is on a different host than the origin it
 	 * was fetched from is a forgery and must not be relayed, regardless of type.
 	 * This is the core fix for the nested Announce -> Undo/Delete authority bypass.

--- a/tests/phpunit/tests/includes/handler/class-test-announce.php
+++ b/tests/phpunit/tests/includes/handler/class-test-announce.php
@@ -192,6 +192,46 @@ class Test_Announce extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An announced activity that declares no id is still relayed.
+	 *
+	 * `Http::get_remote_object()` returns an id-less document as served, so it was never re-fetched
+	 * and the origin check already covers it. Requiring an id would drop legitimate relayed traffic.
+	 *
+	 * @covers ::handle_announce
+	 */
+	public function test_handle_announce_relays_activity_without_id() {
+		$activity_url = 'https://example.com/activities/idless-1';
+		$fetch        = function ( $pre, $url_or_object ) use ( $activity_url ) {
+			if ( $activity_url !== $url_or_object ) {
+				return $pre;
+			}
+
+			return array(
+				'type'   => 'Like',
+				'actor'  => 'https://example.com/user',
+				'object' => $this->post_permalink,
+			);
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $fetch, 10, 2 );
+
+		$inbox = new \MockAction();
+		\add_action( 'activitypub_inbox', array( $inbox, 'action' ) );
+
+		$announce = array(
+			'actor'  => 'https://booster.example/user',
+			'type'   => 'Announce',
+			'id'     => 'https://booster.example/a/idless',
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'object' => $activity_url,
+		);
+		Announce::handle_announce( $announce, $this->user_id, Activity::init_from_array( $announce ) );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $fetch, 10 );
+
+		$this->assertSame( 1, $inbox->get_call_count(), 'An announced activity without an id must still be relayed.' );
+	}
+
+	/**
 	 * An announced activity whose own id is on a different host than the actor is not relayed.
 	 *
 	 * `Http::get_remote_object()` may return a document re-fetched from the id it declares, so the

--- a/tests/phpunit/tests/includes/handler/class-test-announce.php
+++ b/tests/phpunit/tests/includes/handler/class-test-announce.php
@@ -212,6 +212,41 @@ class Test_Announce extends \WP_UnitTestCase {
 				'object' => $this->post_permalink,
 			);
 		};
+		$this->assert_announced_activity_is_relayed( $activity_url, $fetch );
+	}
+
+	/**
+	 * An announced activity whose id is an empty string is still relayed.
+	 *
+	 * `Http::get_remote_object()` treats an empty id exactly like a missing one, so it is returned
+	 * as served and was never re-fetched.
+	 *
+	 * @covers ::handle_announce
+	 */
+	public function test_handle_announce_relays_activity_with_empty_id() {
+		$activity_url = 'https://example.com/activities/emptyid-1';
+		$fetch        = function ( $pre, $url_or_object ) use ( $activity_url ) {
+			if ( $activity_url !== $url_or_object ) {
+				return $pre;
+			}
+
+			return array(
+				'id'     => '',
+				'type'   => 'Like',
+				'actor'  => 'https://example.com/user',
+				'object' => $this->post_permalink,
+			);
+		};
+		$this->assert_announced_activity_is_relayed( $activity_url, $fetch );
+	}
+
+	/**
+	 * Announce the activity at the given URL and assert it reached the inbox handlers.
+	 *
+	 * @param string   $activity_url The URL the announced activity is served from.
+	 * @param callable $fetch        Filter callback returning the fetched document.
+	 */
+	private function assert_announced_activity_is_relayed( $activity_url, $fetch ) {
 		\add_filter( 'activitypub_pre_http_get_remote_object', $fetch, 10, 2 );
 
 		$inbox = new \MockAction();


### PR DESCRIPTION
## Proposed changes:

Two unrelated fixes that came out of a security audit. Each one has a test that was written first and confirmed to fail without the change.

**Remote profile and follower lookups.** `Remote_Actors::get_by_uri()`, `Followers::get_by_uri()` and the comment-type filter passed their values through `esc_sql()` before handing them to `$wpdb->prepare()`. Both call `wpdb::_real_escape()`, so the value was escaped twice and the lookup key no longer matched what was stored. An actor URI containing a quote was never found, which means an incoming Undo could not find the follower record and every Follow inserted another copy of the same actor. The lookups now normalize the same way `upsert()` writes the GUID, and leave the SQL escaping to `prepare()`.

**Boosted content.** `Announce` bound the actor to the host the object was requested from. `Http::get_remote_object()` re-fetches a document from the id it declares when the two disagree and returns that copy, so the host that answered is not always the one that was asked. The actor is now also bound to the document's own id, which an authentic activity shares a host with. Only when the document declares one: an id-less document is returned as served and was never re-fetched, so requiring an id there would drop relayed activities that legitimately omit it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Follow a remote actor and then unfollow it, and confirm the follower disappears.
* Boost a post from another server and confirm it still shows up.
* `npm run env-test -- --filter='test_get_by_uri_with_quote|Test_Announce'`. Both new tests fail on trunk and pass here.
