### PR TITLE
Process deletes delivered to the shared inbox

### DIFF
--- a/.github/changelog/fix-shared-inbox-delete
+++ b/.github/changelog/fix-shared-inbox-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed deletions from Mastodon and other servers not removing the corresponding comment on your site.

--- a/includes/handler/class-delete.php
+++ b/includes/handler/class-delete.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Handler;
 
+use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Interactions;
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Collection\Remote_Posts;
@@ -22,7 +23,8 @@ class Delete {
 	 * Initialize the class, registering WordPress hooks.
 	 */
 	public static function init() {
-		\add_action( 'activitypub_inbox_delete', array( self::class, 'handle_delete' ), 10, 2 );
+		\add_action( 'activitypub_inbox_delete', array( self::class, 'handle_delete' ), 10, 4 );
+		\add_action( 'activitypub_inbox_shared_delete', array( self::class, 'handle_delete' ), 10, 4 );
 		\add_filter( 'activitypub_skip_inbox_storage', array( self::class, 'skip_inbox_storage' ), 10, 2 );
 		\add_filter( 'activitypub_defer_signature_verification', array( self::class, 'defer_signature_verification' ), 10, 3 );
 		\add_action( 'activitypub_delete_remote_actor_interactions', array( self::class, 'delete_interactions' ) );
@@ -35,10 +37,18 @@ class Delete {
 	/**
 	 * Handles "Delete" requests.
 	 *
-	 * @param array     $activity The delete activity.
-	 * @param int|int[] $user_ids The local user ID(s).
+	 * @param array                               $activity        The delete activity.
+	 * @param int|int[]                           $user_ids        The local user ID(s).
+	 * @param \Activitypub\Activity\Activity|null $activity_object Optional. The activity object. Default null.
+	 * @param string|null                         $context         Optional. The inbox context. Default null.
 	 */
-	public static function handle_delete( $activity, $user_ids ) {
+	public static function handle_delete( $activity, $user_ids, $activity_object = null, $context = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// The shared inbox invokes this once per resolved recipient and once on the shared hook;
+		// handle that path only on the shared hook, so it runs once with the full recipient list.
+		if ( Inbox::CONTEXT_SHARED_INBOX === $context && 'activitypub_inbox_shared_delete' !== \current_filter() ) {
+			return;
+		}
+
 		$object_type = $activity['object']['type'] ?? '';
 
 		switch ( $object_type ) {

--- a/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-inbox-controller.php
@@ -118,6 +118,99 @@ class Test_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controller_Test
 	}
 
 	/**
+	 * A Public-only Delete on the shared inbox reaches the Delete handler even when no local
+	 * recipient can be resolved from its addressing.
+	 *
+	 * This is the shape of a real Mastodon reply-delete: addressed only to Public, from an actor
+	 * the site does not follow. Nothing in `to`/`cc`/followers names a local user, so the shared
+	 * inbox's per-recipient loop never runs — the handler has to fire on the shared hook instead.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_shared_inbox_handles_public_only_delete() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		// Keep the Tombstone existence re-fetch off the network.
+		$no_http = static function () {
+			return new \WP_Error( 'no_http', 'blocked in test' );
+		};
+		\add_filter( 'pre_http_request', $no_http );
+
+		$handled = new \MockAction();
+		\add_action( 'activitypub_handled_delete', array( $handled, 'action' ) );
+
+		$json = array(
+			'id'     => 'https://remote.example/users/alice/statuses/9#delete',
+			'type'   => 'Delete',
+			'actor'  => 'https://remote.example/users/alice',
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'object' => array(
+				'id'   => 'https://remote.example/users/alice/statuses/9',
+				'type' => 'Tombstone',
+			),
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+
+		\remove_action( 'activitypub_handled_delete', array( $handled, 'action' ) );
+		\remove_filter( 'pre_http_request', $no_http );
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		$this->assertSame( 202, $response->get_status() );
+		$this->assertSame( 1, $handled->get_call_count(), 'The Delete handler must run for a Public-only delete on the shared inbox.' );
+	}
+
+	/**
+	 * The Delete handler runs exactly once when a local recipient resolves.
+	 *
+	 * With a resolvable recipient the shared inbox fires both the per-recipient hook and the
+	 * shared hook, so without a guard the handler would run twice.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_shared_inbox_handles_delete_once_when_recipient_resolves() {
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		$no_http = static function () {
+			return new \WP_Error( 'no_http', 'blocked in test' );
+		};
+		\add_filter( 'pre_http_request', $no_http );
+
+		$user_id = self::factory()->user->create();
+		\get_user_by( 'id', $user_id )->add_cap( 'activitypub' );
+		$actor_uri = Actors::get_by_id( $user_id )->get_id();
+
+		$handled = new \MockAction();
+		\add_action( 'activitypub_handled_delete', array( $handled, 'action' ) );
+
+		$json = array(
+			'id'     => 'https://remote.example/users/bob/statuses/7#delete',
+			'type'   => 'Delete',
+			'actor'  => 'https://remote.example/users/bob',
+			'to'     => array( $actor_uri ),
+			'object' => array(
+				'id'   => 'https://remote.example/users/bob/statuses/7',
+				'type' => 'Tombstone',
+			),
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $json ) );
+
+		$response = \rest_do_request( $request );
+
+		\remove_action( 'activitypub_handled_delete', array( $handled, 'action' ) );
+		\remove_filter( 'pre_http_request', $no_http );
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+
+		$this->assertSame( 202, $response->get_status() );
+		$this->assertSame( 1, $handled->get_call_count(), 'The Delete handler must run exactly once even when a recipient resolves.' );
+	}
+
+	/**
 	 * Test disallow list block.
 	 *
 	 * @covers ::create_item


### PR DESCRIPTION
Fixes #3408

## Proposed changes:

A `Delete` delivered to the shared inbox is not processed when it resolves to no local recipient, which is the shape of a normal Mastodon reply-delete: it is addressed only to `Public`, from an actor the site does not follow, so nothing in `to`/`cc`/followers names a local user. On the shared inbox the per-recipient hooks only fire inside the recipient loop, so with no recipient the loop never runs and the Delete handler is never called. The activity reaches WordPress and returns 202, but nothing acts on it, so the comment stays.

The Delete handler now also runs on `activitypub_inbox_shared_delete`, which fires once per activity regardless of recipients. A Delete targets its object, not a recipient, so this is the right hook for it. A small per-request guard keeps the handler running once even when both the per-recipient and the shared hook fire.

This only fixes the delivery of the Delete to the handler. Whether the comment is then removed still depends on the existing tombstone check, which re-fetches the object to confirm it is gone.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* From a Mastodon account, reply to one of your posts, then delete the reply, and confirm the comment is removed.
* `npm run env-test -- --filter=test_shared_inbox_handles`. One test delivers a Public-only delete to the shared inbox and asserts the handler runs (fails on trunk); the other asserts it runs exactly once when a recipient does resolve.
