### PR TITLE
Clean up stale cached avatars automatically

### DIFF
--- a/.github/changelog/fix-3583-avatar-cache-cleanup
+++ b/.github/changelog/fix-3583-avatar-cache-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevented unused copies of remote profile pictures from accumulating on your server and added automatic cleanup for leftover cached avatars.

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -122,21 +122,33 @@ class Avatar extends File {
 			return $url;
 		}
 
-		// A pure cache hit leaves no new files behind, so skip the stale-file
-		// sweep to keep the hot render path cheap. Only a fresh download can
-		// orphan an older avatar version.
-		if ( static::get( $url, $entity_id ) ) {
-			return self::get_or_cache( $url, $entity_id, array( 'max_dimension' => self::MAX_DIMENSION ) );
-		}
-
 		$cached_url = self::get_or_cache( $url, $entity_id, array( 'max_dimension' => self::MAX_DIMENSION ) );
 
+		return $cached_url ?: $url;
+	}
+
+	/**
+	 * Cache a remote avatar locally, then drop older versions of it.
+	 *
+	 * Overrides the shared write path so that any avatar hash it leaves behind
+	 * for the same actor is removed in the same call. Remote actors change
+	 * their icon URL frequently, and each change would otherwise pile up an
+	 * orphaned copy of the previous image.
+	 *
+	 * @param string     $url       The remote URL.
+	 * @param string|int $entity_id The entity identifier (actor post ID).
+	 * @param array      $options   Optional. Additional options.
+	 *
+	 * @return string|false The local URL on success, false on failure.
+	 */
+	public static function cache( $url, $entity_id, $options = array() ) {
+		$cached_url = parent::cache( $url, $entity_id, $options );
+
 		if ( $cached_url ) {
-			// Remove older avatar versions that no longer match the current icon.
 			self::prune_stale_files( $entity_id, self::generate_hash( $url ) );
 		}
 
-		return $cached_url ?: $url;
+		return $cached_url;
 	}
 
 	/**

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -128,30 +128,6 @@ class Avatar extends File {
 	}
 
 	/**
-	 * Cache a remote avatar locally, then drop older versions of it.
-	 *
-	 * Overrides the shared write path so that any avatar hash it leaves behind
-	 * for the same actor is removed in the same call. Remote actors change
-	 * their icon URL frequently, and each change would otherwise pile up an
-	 * orphaned copy of the previous image.
-	 *
-	 * @param string     $url       The remote URL.
-	 * @param string|int $entity_id The entity identifier (actor post ID).
-	 * @param array      $options   Optional. Additional options.
-	 *
-	 * @return string|false The local URL on success, false on failure.
-	 */
-	public static function cache( $url, $entity_id, $options = array() ) {
-		$cached_url = parent::cache( $url, $entity_id, $options );
-
-		if ( $cached_url ) {
-			self::prune_stale_files( $entity_id, self::generate_hash( $url ) );
-		}
-
-		return $cached_url;
-	}
-
-	/**
 	 * Maybe clean up cached avatar when actor is deleted.
 	 *
 	 * @param int $post_id The post ID being deleted.
@@ -197,6 +173,26 @@ class Avatar extends File {
 	}
 
 	/**
+	 * Drop older cached avatar versions once a new one is written.
+	 *
+	 * Hooked into the shared write path via File::cache(), so every avatar
+	 * write removes the files it replaced. Runs after the final filename is
+	 * known, so the file just written is always kept, even when a collision
+	 * renamed it to hash-1.webp.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string     $url       The remote URL that was cached.
+	 * @param string|int $entity_id The entity identifier (actor post ID).
+	 * @param string     $file_path The path of the file that was written.
+	 * @param string     $file_name The basename of the file that was written.
+	 * @param array      $options   Cache options.
+	 */
+	protected static function after_cache( $url, $entity_id, $file_path, $file_name, $options ) {
+		self::prune_stale_files( $entity_id, self::generate_hash( $url ), $file_name );
+	}
+
+	/**
 	 * Get the hash of the avatar currently referenced by an actor.
 	 *
 	 * Reads the actor's icon directly from post content without running the
@@ -206,22 +202,37 @@ class Avatar extends File {
 	 *
 	 * @param int $post_id The actor post ID.
 	 *
-	 * @return string|false The md5 hash of the current avatar URL, or false if none.
+	 * @return string|false The md5 hash of the current avatar URL, false if the
+	 *                      post is missing or not an actor, empty string when
+	 *                      the actor has no usable icon.
 	 */
 	public static function get_actor_avatar_hash( $post_id ) {
 		$post = \get_post( $post_id );
-		if ( ! $post || empty( $post->post_content ) ) {
+		if ( ! $post || Remote_Actors::POST_TYPE !== $post->post_type ) {
 			return false;
 		}
 
+		return self::get_actor_avatar_hash_from_post( $post );
+	}
+
+	/**
+	 * Get avatar hash from an actor post.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Post $post Actor post.
+	 *
+	 * @return string The avatar hash, empty string when the actor has no usable icon.
+	 */
+	protected static function get_actor_avatar_hash_from_post( $post ) {
 		$actor_data = \json_decode( $post->post_content, true );
 		if ( empty( $actor_data['icon'] ) ) {
-			return false;
+			return '';
 		}
 
 		$avatar_url = object_to_uri( $actor_data['icon'] );
 		if ( empty( $avatar_url ) || ! \filter_var( $avatar_url, FILTER_VALIDATE_URL ) ) {
-			return false;
+			return '';
 		}
 
 		return self::generate_hash( $avatar_url );
@@ -236,10 +247,11 @@ class Avatar extends File {
 	 *
 	 * @since unreleased
 	 *
-	 * @param int    $entity_id    The actor post ID.
-	 * @param string $current_hash The hash of the current avatar URL.
+	 * @param int         $entity_id      The actor post ID.
+	 * @param string      $current_hash   The hash of the current avatar URL.
+	 * @param string|null $current_file   The basename of the cached file to keep.
 	 */
-	public static function prune_stale_files( $entity_id, $current_hash ) {
+	public static function prune_stale_files( $entity_id, $current_hash, $current_file = null ) {
 		$paths = static::get_storage_paths( $entity_id );
 		if ( ! \is_dir( $paths['basedir'] ) ) {
 			return;
@@ -253,7 +265,8 @@ class Avatar extends File {
 		$prefix = $current_hash . '.';
 
 		foreach ( $files as $file ) {
-			if ( 0 === \strpos( \basename( $file ), $prefix ) ) {
+			$filename = \basename( $file );
+			if ( $filename === $current_file || 0 === \strpos( $filename, $prefix ) ) {
 				continue;
 			}
 
@@ -262,6 +275,12 @@ class Avatar extends File {
 			} else {
 				static::get_filesystem()->delete( $file );
 			}
+		}
+
+		// Drop the entity directory itself when pruning left it empty.
+		$remaining = \glob( $paths['basedir'] . '/*' );
+		if ( empty( $remaining ) ) {
+			static::delete_directory( $paths['basedir'] );
 		}
 	}
 
@@ -277,29 +296,22 @@ class Avatar extends File {
 	public static function cleanup_actors() {
 		// Lock the cleanup with an autoload-disabled option so overlapping
 		// cron workers never run it twice at once.
-		if ( ! \add_option( 'activitypub_avatar_cache_cleanup_lock', time(), '', false ) ) {
+		$now = \time();
+		if ( ! \add_option( 'activitypub_avatar_cache_cleanup_lock', $now, '', false ) ) {
 			$lock_time = (int) \get_option( 'activitypub_avatar_cache_cleanup_lock' );
-			if ( $lock_time && ( time() - $lock_time ) < 30 * MINUTE_IN_SECONDS ) {
+			if ( $lock_time && ( $now - $lock_time ) < 30 * MINUTE_IN_SECONDS ) {
 				return;
 			}
-			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
-			if ( ! \add_option( 'activitypub_avatar_cache_cleanup_lock', time(), '', false ) ) {
-				return;
-			}
+			\update_option( 'activitypub_avatar_cache_cleanup_lock', $now, false );
 		}
 
 		$upload_dir = \wp_upload_dir();
 		$root       = $upload_dir['basedir'] . static::get_base_dir();
-		$dirs       = \glob( $root . '/*', GLOB_ONLYDIR );
-
-		if ( empty( $dirs ) ) {
+		if ( ! \is_dir( $root ) ) {
 			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
 			\delete_option( 'activitypub_avatar_cache_cursor' );
 			return;
 		}
-
-		// Sort so the resume position stays stable between runs.
-		\sort( $dirs );
 
 		/**
 		 * Filters how many actor directories are scanned per cleanup run.
@@ -308,38 +320,78 @@ class Avatar extends File {
 		 *
 		 * @param int $limit The maximum number of directories to scan.
 		 */
-		$limit = \apply_filters( 'activitypub_cleanup_actor_cache_limit', 100 );
+		$limit  = \max( 1, (int) \apply_filters( 'activitypub_cleanup_actor_cache_limit', 100 ) );
+		$cursor = (string) \get_option( 'activitypub_avatar_cache_cursor', '' );
+		$dirs   = array();
+		$found  = empty( $cursor );
 
-		// Resume where the previous run stopped so a large backlog drains
-		// over several runs instead of always revisiting the first batch.
-		$total = \count( $dirs );
-		$start = (int) \get_option( 'activitypub_avatar_cache_cursor', 0 ) % $total;
-		$batch = \array_slice( $dirs, $start, \max( 1, (int) $limit ) );
-
-		foreach ( $batch as $dir ) {
-			$dirname = \basename( $dir );
-
-			// Only touch directories with a numeric name, to stay clear of junk.
-			if ( ! \preg_match( '/^\d+$/', $dirname ) ) {
+		$iterator = new \DirectoryIterator( $root );
+		foreach ( $iterator as $directory ) {
+			if ( $directory->isDot() || ! $directory->isDir() ) {
 				continue;
 			}
 
-			$post_id = (int) $dirname;
-			$post    = \get_post( $post_id );
+			$dirname = $directory->getFilename();
+			if ( ! $found ) {
+				if ( $dirname === $cursor ) {
+					$found = true;
+				}
+				continue;
+			}
+			if ( ! \preg_match( '/^\\d+$/', $dirname ) ) {
+				continue;
+			}
 
-			// Remove directories that no longer belong to an actor post.
-			if ( ! $post || Remote_Actors::POST_TYPE !== $post->post_type ) {
+			$dirs[ (int) $dirname ] = $directory->getPathname();
+			if ( \count( $dirs ) >= $limit ) {
+				break;
+			}
+		}
+
+		// Restart from the beginning after reaching the end of the directory tree.
+		if ( empty( $dirs ) && ! empty( $cursor ) ) {
+			\delete_option( 'activitypub_avatar_cache_cursor' );
+			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+			return;
+		}
+		if ( empty( $dirs ) ) {
+			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+			return;
+		}
+
+		$post_ids = \array_keys( $dirs );
+		$posts    = \get_posts(
+			array(
+				'post__in'       => $post_ids,
+				'post_type'      => Remote_Actors::POST_TYPE,
+				'post_status'    => 'any',
+				'posts_per_page' => \count( $post_ids ),
+				'orderby'        => 'post__in',
+			)
+		);
+		$post_map = array();
+		foreach ( $posts as $post ) {
+			$post_map[ $post->ID ] = $post;
+		}
+
+		$last_dir = null;
+		foreach ( $dirs as $post_id => $dir ) {
+			if ( empty( $post_map[ $post_id ] ) ) {
 				static::delete_directory( $dir );
 				continue;
 			}
 
-			$hash = self::get_actor_avatar_hash( $post_id );
-			if ( $hash ) {
-				self::prune_stale_files( $post_id, $hash );
-			}
+			$hash     = self::get_actor_avatar_hash_from_post( $post_map[ $post_id ] );
+			self::prune_stale_files( $post_id, $hash );
+			$last_dir = (string) $post_id;
 		}
 
-		\update_option( 'activitypub_avatar_cache_cursor', ( $start + \count( $batch ) ) % $total, false );
+		// Resume after the last surviving directory. A directory pruned as an
+		// orphan is gone from disk, so it can never be matched next run; only
+		// anchor the cursor on a directory that still exists.
+		if ( null !== $last_dir ) {
+			\update_option( 'activitypub_avatar_cache_cursor', $last_dir, false );
+		}
 		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
 	}
 }

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -186,9 +186,8 @@ class Avatar extends File {
 	 * @param string|int $entity_id The entity identifier (actor post ID).
 	 * @param string     $file_path The path of the file that was written.
 	 * @param string     $file_name The basename of the file that was written.
-	 * @param array      $options   Cache options.
 	 */
-	protected static function after_cache( $url, $entity_id, $file_path, $file_name, $options ) {
+	protected static function after_cache( $url, $entity_id, $file_path, $file_name ) {
 		self::prune_stale_files( $entity_id, self::generate_hash( $url ), $file_name );
 	}
 

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -9,6 +9,8 @@ namespace Activitypub\Cache;
 
 use Activitypub\Collection\Remote_Actors;
 
+use function Activitypub\object_to_uri;
+
 /**
  * Avatar cache class.
  *
@@ -120,7 +122,19 @@ class Avatar extends File {
 			return $url;
 		}
 
+		// A pure cache hit leaves no new files behind, so skip the stale-file
+		// sweep to keep the hot render path cheap. Only a fresh download can
+		// orphan an older avatar version.
+		if ( static::get( $url, $entity_id ) ) {
+			return self::get_or_cache( $url, $entity_id, array( 'max_dimension' => self::MAX_DIMENSION ) );
+		}
+
 		$cached_url = self::get_or_cache( $url, $entity_id, array( 'max_dimension' => self::MAX_DIMENSION ) );
+
+		if ( $cached_url ) {
+			// Remove older avatar versions that no longer match the current icon.
+			self::prune_stale_files( $entity_id, self::generate_hash( $url ) );
+		}
 
 		return $cached_url ?: $url;
 	}
@@ -168,5 +182,152 @@ class Avatar extends File {
 			$actor_id,
 			array( 'max_dimension' => self::MAX_DIMENSION )
 		);
+	}
+
+	/**
+	 * Get the hash of the avatar currently referenced by an actor.
+	 *
+	 * Reads the actor's icon directly from post content without running the
+	 * remote media filter, so this never triggers a lazy download.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int $post_id The actor post ID.
+	 *
+	 * @return string|false The md5 hash of the current avatar URL, or false if none.
+	 */
+	public static function get_actor_avatar_hash( $post_id ) {
+		$post = \get_post( $post_id );
+		if ( ! $post || empty( $post->post_content ) ) {
+			return false;
+		}
+
+		$actor_data = \json_decode( $post->post_content, true );
+		if ( empty( $actor_data['icon'] ) ) {
+			return false;
+		}
+
+		$avatar_url = object_to_uri( $actor_data['icon'] );
+		if ( empty( $avatar_url ) || ! \filter_var( $avatar_url, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
+
+		return self::generate_hash( $avatar_url );
+	}
+
+	/**
+	 * Remove cached avatar files that no longer match the current icon.
+	 *
+	 * Keeps any file whose basename starts with the current hash and deletes
+	 * the rest. Runs after the current avatar is written, so the active file
+	 * is never removed.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int    $entity_id    The actor post ID.
+	 * @param string $current_hash The hash of the current avatar URL.
+	 */
+	public static function prune_stale_files( $entity_id, $current_hash ) {
+		$paths = static::get_storage_paths( $entity_id );
+		if ( ! \is_dir( $paths['basedir'] ) ) {
+			return;
+		}
+
+		$files = \glob( $paths['basedir'] . '/*' );
+		if ( empty( $files ) ) {
+			return;
+		}
+
+		$prefix = $current_hash . '.';
+
+		foreach ( $files as $file ) {
+			if ( 0 === \strpos( \basename( $file ), $prefix ) ) {
+				continue;
+			}
+
+			if ( \is_dir( $file ) ) {
+				static::delete_directory( $file );
+			} else {
+				static::get_filesystem()->delete( $file );
+			}
+		}
+	}
+
+	/**
+	 * Clean up stale cached avatars.
+	 *
+	 * Run daily by cron. Deletes orphaned actor directories that no longer
+	 * match an actor post and removes older avatar versions for surviving
+	 * actors. Processed in batches so a large backlog drains over several runs.
+	 *
+	 * @since unreleased
+	 */
+	public static function cleanup_actors() {
+		// Lock the cleanup with an autoload-disabled option so overlapping
+		// cron workers never run it twice at once.
+		if ( ! \add_option( 'activitypub_avatar_cache_cleanup_lock', time(), '', false ) ) {
+			$lock_time = (int) \get_option( 'activitypub_avatar_cache_cleanup_lock' );
+			if ( $lock_time && ( time() - $lock_time ) < 30 * MINUTE_IN_SECONDS ) {
+				return;
+			}
+			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+			if ( ! \add_option( 'activitypub_avatar_cache_cleanup_lock', time(), '', false ) ) {
+				return;
+			}
+		}
+
+		$upload_dir = \wp_upload_dir();
+		$root       = $upload_dir['basedir'] . static::get_base_dir();
+		$dirs       = \glob( $root . '/*', GLOB_ONLYDIR );
+
+		if ( empty( $dirs ) ) {
+			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+			\delete_option( 'activitypub_avatar_cache_cursor' );
+			return;
+		}
+
+		// Sort so the resume position stays stable between runs.
+		\sort( $dirs );
+
+		/**
+		 * Filters how many actor directories are scanned per cleanup run.
+		 *
+		 * @since unreleased
+		 *
+		 * @param int $limit The maximum number of directories to scan.
+		 */
+		$limit = \apply_filters( 'activitypub_cleanup_actor_cache_limit', 100 );
+
+		// Resume where the previous run stopped so a large backlog drains
+		// over several runs instead of always revisiting the first batch.
+		$total = \count( $dirs );
+		$start = (int) \get_option( 'activitypub_avatar_cache_cursor', 0 ) % $total;
+		$batch = \array_slice( $dirs, $start, \max( 1, (int) $limit ) );
+
+		foreach ( $batch as $dir ) {
+			$dirname = \basename( $dir );
+
+			// Only touch directories with a numeric name, to stay clear of junk.
+			if ( ! \preg_match( '/^\d+$/', $dirname ) ) {
+				continue;
+			}
+
+			$post_id = (int) $dirname;
+			$post    = \get_post( $post_id );
+
+			// Remove directories that no longer belong to an actor post.
+			if ( ! $post || Remote_Actors::POST_TYPE !== $post->post_type ) {
+				static::delete_directory( $dir );
+				continue;
+			}
+
+			$hash = self::get_actor_avatar_hash( $post_id );
+			if ( $hash ) {
+				self::prune_stale_files( $post_id, $hash );
+			}
+		}
+
+		\update_option( 'activitypub_avatar_cache_cursor', ( $start + \count( $batch ) ) % $total, false );
+		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
 	}
 }

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -203,7 +203,7 @@ class Avatar extends File {
 	 */
 	protected static function get_actor_avatar_hash_from_post( $post ) {
 		$actor_data = \json_decode( $post->post_content, true );
-		if ( empty( $actor_data['icon'] ) ) {
+		if ( ! \is_array( $actor_data ) || empty( $actor_data['icon'] ) ) {
 			return '';
 		}
 
@@ -243,7 +243,10 @@ class Avatar extends File {
 
 		foreach ( $files as $file ) {
 			$filename = \basename( $file );
-			if ( $filename === $current_file || 0 === \strpos( $filename, $prefix ) ) {
+			// The hash-prefix keep applies only when no exact filename is
+			// known (the cron sweep). During a write, the loser of a
+			// collision is pruned so File::get() cannot keep serving it.
+			if ( $filename === $current_file || ( null === $current_file && 0 === \strpos( $filename, $prefix ) ) ) {
 				continue;
 			}
 
@@ -279,7 +282,9 @@ class Avatar extends File {
 			if ( $lock_time && ( $now - $lock_time ) < 30 * MINUTE_IN_SECONDS ) {
 				return;
 			}
-			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+			if ( ! self::release_stale_lock( $lock_time ) ) {
+				return;
+			}
 			if ( ! \add_option( 'activitypub_avatar_cache_cleanup_lock', $now, '', false ) ) {
 				return;
 			}
@@ -362,5 +367,34 @@ class Avatar extends File {
 			\update_option( 'activitypub_avatar_cache_cursor', $last_dir, false );
 		}
 		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+	}
+
+	/**
+	 * Delete a stale cleanup lock only if its value still matches.
+	 *
+	 * Two workers can both see the same expired lock; deleting it
+	 * unconditionally would let the second worker remove the first
+	 * worker's fresh lock and start a second sweep. Comparing the
+	 * stored value makes the takeover fail for whichever worker lost
+	 * the race.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int $lock_time The stale lock timestamp being taken over.
+	 *
+	 * @return bool True when the stale lock was removed by this worker.
+	 */
+	protected static function release_stale_lock( $lock_time ) {
+		global $wpdb;
+
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM $wpdb->options WHERE option_name = %s AND option_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				'activitypub_avatar_cache_cleanup_lock',
+				(string) $lock_time
+			)
+		);
+
+		return 1 === (int) $deleted;
 	}
 }

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -193,29 +193,6 @@ class Avatar extends File {
 	}
 
 	/**
-	 * Get the hash of the avatar currently referenced by an actor.
-	 *
-	 * Reads the actor's icon directly from post content without running the
-	 * remote media filter, so this never triggers a lazy download.
-	 *
-	 * @since unreleased
-	 *
-	 * @param int $post_id The actor post ID.
-	 *
-	 * @return string|false The md5 hash of the current avatar URL, false if the
-	 *                      post is missing or not an actor, empty string when
-	 *                      the actor has no usable icon.
-	 */
-	public static function get_actor_avatar_hash( $post_id ) {
-		$post = \get_post( $post_id );
-		if ( ! $post || Remote_Actors::POST_TYPE !== $post->post_type ) {
-			return false;
-		}
-
-		return self::get_actor_avatar_hash_from_post( $post );
-	}
-
-	/**
 	 * Get avatar hash from an actor post.
 	 *
 	 * @since unreleased
@@ -293,7 +270,7 @@ class Avatar extends File {
 	 *
 	 * @since unreleased
 	 */
-	public static function cleanup_actors() {
+	public static function cleanup() {
 		// Lock the cleanup with an autoload-disabled option so overlapping
 		// cron workers never run it twice at once.
 		$now = \time();
@@ -302,7 +279,10 @@ class Avatar extends File {
 			if ( $lock_time && ( $now - $lock_time ) < 30 * MINUTE_IN_SECONDS ) {
 				return;
 			}
-			\update_option( 'activitypub_avatar_cache_cleanup_lock', $now, false );
+			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+			if ( ! \add_option( 'activitypub_avatar_cache_cleanup_lock', $now, '', false ) ) {
+				return;
+			}
 		}
 
 		$upload_dir = \wp_upload_dir();
@@ -320,46 +300,37 @@ class Avatar extends File {
 		 *
 		 * @param int $limit The maximum number of directories to scan.
 		 */
-		$limit  = \max( 1, (int) \apply_filters( 'activitypub_cleanup_actor_cache_limit', 100 ) );
-		$cursor = (string) \get_option( 'activitypub_avatar_cache_cursor', '' );
-		$dirs   = array();
-		$found  = empty( $cursor );
+		$limit = \max( 1, (int) \apply_filters( 'activitypub_cleanup_avatar_cache_limit', 100 ) );
+		// Cursor is the highest actor post ID already swept; skip IDs at or
+		// below it so resuming stays deterministic across runs.
+		$cursor = (int) \get_option( 'activitypub_avatar_cache_cursor', 0 );
 
-		$iterator = new \DirectoryIterator( $root );
-		foreach ( $iterator as $directory ) {
+		$dirs = array();
+		$it   = new \DirectoryIterator( $root );
+		foreach ( $it as $directory ) {
 			if ( $directory->isDot() || ! $directory->isDir() ) {
 				continue;
 			}
 
 			$dirname = $directory->getFilename();
-			if ( ! $found ) {
-				if ( $dirname === $cursor ) {
-					$found = true;
-				}
-				continue;
-			}
-			if ( ! \preg_match( '/^\\d+$/', $dirname ) ) {
+			if ( ! \ctype_digit( $dirname ) || (int) $dirname <= $cursor ) {
 				continue;
 			}
 
-			$dirs[ (int) $dirname ] = $directory->getPathname();
-			if ( \count( $dirs ) >= $limit ) {
-				break;
-			}
+			$dirs[] = (int) $dirname;
 		}
+		\sort( $dirs, SORT_NUMERIC );
+		$dirs = \array_slice( $dirs, 0, $limit );
 
-		// Restart from the beginning after reaching the end of the directory tree.
-		if ( empty( $dirs ) && ! empty( $cursor ) ) {
+		if ( empty( $dirs ) ) {
 			\delete_option( 'activitypub_avatar_cache_cursor' );
 			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
 			return;
 		}
-		if ( empty( $dirs ) ) {
-			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
-			return;
-		}
 
-		$post_ids = \array_keys( $dirs );
+		// 'any' excludes trashed posts, so a trashed actor's cache directory
+		// counts as orphaned here and is deleted below.
+		$post_ids = $dirs;
 		$posts    = \get_posts(
 			array(
 				'post__in'       => $post_ids,
@@ -375,20 +346,18 @@ class Avatar extends File {
 		}
 
 		$last_dir = null;
-		foreach ( $dirs as $post_id => $dir ) {
+		foreach ( $dirs as $post_id ) {
+			$last_dir = (int) $post_id;
 			if ( empty( $post_map[ $post_id ] ) ) {
-				static::delete_directory( $dir );
+				static::delete_directory( $root . '/' . $post_id );
 				continue;
 			}
 
-			$hash     = self::get_actor_avatar_hash_from_post( $post_map[ $post_id ] );
+			$hash = self::get_actor_avatar_hash_from_post( $post_map[ $post_id ] );
 			self::prune_stale_files( $post_id, $hash );
-			$last_dir = (string) $post_id;
 		}
 
-		// Resume after the last surviving directory. A directory pruned as an
-		// orphan is gone from disk, so it can never be matched next run; only
-		// anchor the cursor on a directory that still exists.
+		// Resume after the last processed directory, including orphaned ones.
 		if ( null !== $last_dir ) {
 			\update_option( 'activitypub_avatar_cache_cursor', $last_dir, false );
 		}

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -186,8 +186,9 @@ class Avatar extends File {
 	 * @param string|int $entity_id The entity identifier (actor post ID).
 	 * @param string     $file_path The path of the file that was written.
 	 * @param string     $file_name The basename of the file that was written.
+	 * @param array      $options   Cache options inherited from File::cache().
 	 */
-	protected static function after_cache( $url, $entity_id, $file_path, $file_name ) {
+	protected static function after_cache( $url, $entity_id, $file_path, $file_name, $options ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required to match File::after_cache() signature.
 		self::prune_stale_files( $entity_id, self::generate_hash( $url ), $file_name );
 	}
 

--- a/includes/cache/class-avatar.php
+++ b/includes/cache/class-avatar.php
@@ -387,9 +387,9 @@ class Avatar extends File {
 	protected static function release_stale_lock( $lock_time ) {
 		global $wpdb;
 
-		$deleted = $wpdb->query(
+		$deleted = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				"DELETE FROM $wpdb->options WHERE option_name = %s AND option_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				"DELETE FROM $wpdb->options WHERE option_name = %s AND option_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				'activitypub_avatar_cache_cleanup_lock',
 				(string) $lock_time
 			)

--- a/includes/cache/class-file.php
+++ b/includes/cache/class-file.php
@@ -255,6 +255,9 @@ abstract class File {
 		$file_path     = static::optimize_image( $file_path, $max_dimension );
 		$file_name     = \basename( $file_path );
 
+		// Allow cache types to remove stale files without deleting this write.
+		static::after_cache( $url, $entity_id, $file_path, $file_name, $options );
+
 		$local_url = $paths['baseurl'] . '/' . $file_name;
 
 		/**
@@ -273,6 +276,21 @@ abstract class File {
 		\do_action( 'activitypub_media_cached', $local_url, $url, $entity_id, static::get_type(), $file_path );
 
 		return $local_url;
+	}
+
+	/**
+	 * Run cache-type-specific cleanup after writing a file.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string     $url       The remote URL.
+	 * @param string|int $entity_id The entity identifier.
+	 * @param string     $file_path The written file path.
+	 * @param string     $file_name The written file basename.
+	 * @param array      $options   Cache options.
+	 */
+	protected static function after_cache( $url, $entity_id, $file_path, $file_name, $options ) {
+		// Cache types with multiple files need no cleanup.
 	}
 
 	/**

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -9,6 +9,7 @@ namespace Activitypub;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
+use Activitypub\Cache\Avatar;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
@@ -35,6 +36,7 @@ class Scheduler {
 	const SCHEDULES = array(
 		'activitypub_update_remote_actors'         => 'hourly',
 		'activitypub_cleanup_remote_actors'        => 'daily',
+		'activitypub_cleanup_actor_cache'          => 'daily',
 		'activitypub_reprocess_outbox'             => 'hourly',
 		'activitypub_outbox_purge'                 => 'daily',
 		'activitypub_inbox_purge'                  => 'daily',
@@ -83,6 +85,9 @@ class Scheduler {
 		// Follower Cleanups.
 		\add_action( 'activitypub_update_remote_actors', array( self::class, 'update_remote_actors' ) );
 		\add_action( 'activitypub_cleanup_remote_actors', array( self::class, 'cleanup_remote_actors' ) );
+
+		// Cached avatar cleanup.
+		\add_action( 'activitypub_cleanup_actor_cache', array( Avatar::class, 'cleanup_actors' ) );
 
 		// Event callbacks.
 		\add_action( 'activitypub_async_batch', array( self::class, 'async_batch' ), 10, 99 );

--- a/includes/class-scheduler.php
+++ b/includes/class-scheduler.php
@@ -36,7 +36,7 @@ class Scheduler {
 	const SCHEDULES = array(
 		'activitypub_update_remote_actors'         => 'hourly',
 		'activitypub_cleanup_remote_actors'        => 'daily',
-		'activitypub_cleanup_actor_cache'          => 'daily',
+		'activitypub_cleanup_avatar_cache'         => 'daily',
 		'activitypub_reprocess_outbox'             => 'hourly',
 		'activitypub_outbox_purge'                 => 'daily',
 		'activitypub_inbox_purge'                  => 'daily',
@@ -87,7 +87,7 @@ class Scheduler {
 		\add_action( 'activitypub_cleanup_remote_actors', array( self::class, 'cleanup_remote_actors' ) );
 
 		// Cached avatar cleanup.
-		\add_action( 'activitypub_cleanup_actor_cache', array( Avatar::class, 'cleanup_actors' ) );
+		\add_action( 'activitypub_cleanup_avatar_cache', array( Avatar::class, 'cleanup' ) );
 
 		// Event callbacks.
 		\add_action( 'activitypub_async_batch', array( self::class, 'async_batch' ), 10, 99 );

--- a/tests/phpunit/tests/includes/cache/class-test-avatar.php
+++ b/tests/phpunit/tests/includes/cache/class-test-avatar.php
@@ -134,6 +134,60 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that caching a new avatar URL drops the previous version.
+	 *
+	 * This is the root cause of #3583: when an actor changes their icon URL,
+	 * the old hash file must not linger next to the new one.
+	 */
+	public function test_new_avatar_url_prunes_previous_version() {
+		$post_id     = self::factory()->post->create();
+		$old_url     = 'https://example.com/old-avatar.jpg';
+		$new_url     = 'https://example.com/new-avatar.jpg';
+		$old_hash    = md5( $old_url );
+		$new_hash    = md5( $new_url );
+		$paths       = Avatar::get_storage_paths( $post_id );
+		$mock_prefix = '/test-avatar-';
+
+		$mock_download = function ( $result, $download_url ) use ( $old_url, $new_url, $mock_prefix ) {
+			if ( $download_url === $old_url || $download_url === $new_url ) {
+				$tmp_file = \wp_tempnam( $mock_prefix . md5( $download_url ) . '.jpg' );
+				copy( AP_TESTS_DIR . '/data/assets/test.jpg', $tmp_file );
+
+				return array(
+					'file'      => $tmp_file,
+					'mime_type' => 'image/jpeg',
+				);
+			}
+
+			return $result;
+		};
+
+		\add_filter( 'activitypub_pre_download_url', $mock_download, 10, 2 );
+
+		// Cache the first avatar.
+		Avatar::maybe_cache( $old_url, 'avatar', $post_id );
+		$this->assertTrue(
+			\file_exists( $paths['basedir'] . '/' . $old_hash . '.webp' ) || (bool) \glob( $paths['basedir'] . '/' . $old_hash . '.*' ),
+			'Old avatar should be cached after the first download'
+		);
+
+		// Cache a new avatar; the old one should be gone in the same call.
+		Avatar::maybe_cache( $new_url, 'avatar', $post_id );
+		$this->assertEmpty(
+			\glob( $paths['basedir'] . '/' . $old_hash . '.*' ),
+			'The previous avatar hash should be pruned when the new one is cached'
+		);
+		$this->assertNotEmpty(
+			\glob( $paths['basedir'] . '/' . $new_hash . '.*' ),
+			'The new avatar hash should be cached'
+		);
+
+		// Clean up.
+		\remove_filter( 'activitypub_pre_download_url', $mock_download );
+		Avatar::invalidate_entity( $post_id );
+	}
+
+	/**
 	 * Test maybe_cache returns original URL when download fails.
 	 */
 	public function test_maybe_cache_returns_original_url_on_failure() {

--- a/tests/phpunit/tests/includes/cache/class-test-avatar.php
+++ b/tests/phpunit/tests/includes/cache/class-test-avatar.php
@@ -8,6 +8,7 @@
 namespace Activitypub\Tests\Cache;
 
 use Activitypub\Cache\Avatar;
+use Activitypub\Collection\Remote_Actors;
 use WP_UnitTestCase;
 
 /**
@@ -227,5 +228,222 @@ class Test_Avatar extends WP_UnitTestCase {
 		$this->assertNotFalse(
 			has_action( 'before_delete_post', array( Avatar::class, 'maybe_cleanup' ) )
 		);
+	}
+
+	/**
+	 * Test that get_actor_avatar_hash resolves the current icon without caching.
+	 */
+	public function test_get_actor_avatar_hash() {
+		$icon_url = 'https://example.com/avatar.jpg';
+		$post_id  = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Actors::POST_TYPE,
+				'post_content' => wp_json_encode( array( 'icon' => array( 'url' => $icon_url ) ) ),
+			)
+		);
+
+		$fired   = false;
+		$capture = function ( $value ) use ( &$fired ) {
+			$fired = true;
+			return $value;
+		};
+		\add_filter( 'activitypub_remote_media_url', $capture );
+
+		$this->assertEquals( md5( $icon_url ), Avatar::get_actor_avatar_hash( $post_id ) );
+		$this->assertFalse( $fired, 'The cache filter should not fire when resolving the hash' );
+
+		\remove_filter( 'activitypub_remote_media_url', $capture );
+	}
+
+	/**
+	 * Test that get_actor_avatar_hash returns false when the actor has no icon.
+	 */
+	public function test_get_actor_avatar_hash_no_icon() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Actors::POST_TYPE,
+				'post_content' => wp_json_encode( array( 'name' => 'Test' ) ),
+			)
+		);
+
+		$this->assertFalse( Avatar::get_actor_avatar_hash( $post_id ) );
+	}
+
+	/**
+	 * Test that get_actor_avatar_hash returns false for a missing post.
+	 */
+	public function test_get_actor_avatar_hash_missing_post() {
+		$this->assertFalse( Avatar::get_actor_avatar_hash( 999999 ) );
+	}
+
+	/**
+	 * Test that prune_stale_files keeps the current hash and deletes others.
+	 */
+	public function test_prune_stale_files_keeps_current() {
+		$post_id     = self::factory()->post->create();
+		$current     = md5( 'https://example.com/current.jpg' );
+		$stale       = md5( 'https://example.com/stale.jpg' );
+		$paths       = Avatar::get_storage_paths( $post_id );
+		$current_ext = 'webp';
+		$stale_ext   = 'jpg';
+		wp_mkdir_p( $paths['basedir'] );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . "/{$current}.{$current_ext}", 'current' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . "/{$stale}.{$stale_ext}", 'stale' );
+
+		Avatar::prune_stale_files( $post_id, $current );
+
+		$this->assertTrue( file_exists( $paths['basedir'] . "/{$current}.{$current_ext}" ) );
+		$this->assertFalse( file_exists( $paths['basedir'] . "/{$stale}.{$stale_ext}" ) );
+
+		Avatar::invalidate_entity( $post_id );
+	}
+
+	/**
+	 * Test that prune_stale_files deletes everything when nothing matches.
+	 */
+	public function test_prune_stale_files_no_match() {
+		$post_id = self::factory()->post->create();
+		$hash    = md5( 'https://example.com/some.jpg' );
+		$paths   = Avatar::get_storage_paths( $post_id );
+		wp_mkdir_p( $paths['basedir'] );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . "/{$hash}.jpg", 'x' );
+
+		Avatar::prune_stale_files( $post_id, md5( 'https://example.com/other.jpg' ) );
+
+		$this->assertFalse( file_exists( $paths['basedir'] . "/{$hash}.jpg" ) );
+
+		Avatar::invalidate_entity( $post_id );
+	}
+
+	/**
+	 * Test that cleanup_actors removes orphaned actor directories.
+	 */
+	public function test_cleanup_actors_removes_orphan_dir() {
+		$post_id = self::factory()->post->create();
+		$paths   = Avatar::get_storage_paths( $post_id );
+		wp_mkdir_p( $paths['basedir'] );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . '/abc.jpg', 'x' );
+
+		Avatar::cleanup_actors();
+
+		$this->assertFalse( file_exists( $paths['basedir'] ) );
+		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+		\delete_option( 'activitypub_avatar_cache_cursor' );
+	}
+
+	/**
+	 * Test that cleanup_actors leaves non-numeric directories alone.
+	 */
+	public function test_cleanup_actors_leaves_non_numeric_dir() {
+		$root  = wp_upload_dir()['basedir'] . Avatar::get_base_dir();
+		$junk  = $root . '/not-a-number';
+		wp_mkdir_p( $junk );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $junk . '/a.jpg', 'x' );
+
+		Avatar::cleanup_actors();
+
+		$this->assertTrue( file_exists( $junk . '/a.jpg' ) );
+
+		wp_delete_file( $junk . '/a.jpg' );
+		rmdir( $junk ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+		\delete_option( 'activitypub_avatar_cache_cursor' );
+	}
+
+	/**
+	 * Test that cleanup_actors prunes stale files for a surviving actor.
+	 */
+	public function test_cleanup_actors_prunes_surviving_actor() {
+		$icon_url = 'https://example.com/current.png';
+		$post_id  = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Actors::POST_TYPE,
+				'post_content' => wp_json_encode( array( 'icon' => array( 'url' => $icon_url ) ) ),
+			)
+		);
+
+		$current = md5( $icon_url );
+		$stale   = md5( 'https://example.com/stale.png' );
+		$paths   = Avatar::get_storage_paths( $post_id );
+		wp_mkdir_p( $paths['basedir'] );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . "/{$current}.png", 'current' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . "/{$stale}.png", 'stale' );
+
+		Avatar::cleanup_actors();
+
+		$this->assertTrue( file_exists( $paths['basedir'] . "/{$current}.png" ) );
+		$this->assertFalse( file_exists( $paths['basedir'] . "/{$stale}.png" ) );
+
+		Avatar::invalidate_entity( $post_id );
+		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+		\delete_option( 'activitypub_avatar_cache_cursor' );
+	}
+
+	/**
+	 * Test that a second cleanup run while locked returns early.
+	 */
+	public function test_cleanup_actors_reentrant_lock() {
+		$post_id = self::factory()->post->create();
+		$paths   = Avatar::get_storage_paths( $post_id );
+		wp_mkdir_p( $paths['basedir'] );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . '/abc.jpg', 'x' );
+
+		\add_option( 'activitypub_avatar_cache_cleanup_lock', time(), '', false );
+
+		Avatar::cleanup_actors();
+
+		$this->assertTrue( file_exists( $paths['basedir'] . '/abc.jpg' ), 'Orphan dir should not be removed while locked' );
+
+		Avatar::invalidate_entity( $post_id );
+		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+		\delete_option( 'activitypub_avatar_cache_cursor' );
+	}
+
+	/**
+	 * Test that a cleanup run advances past the batch so the backlog drains.
+	 *
+	 * With more actor directories than the per-run limit, the second run
+	 * should pick up where the first left off rather than revisiting the
+	 * same directories.
+	 */
+	public function test_cleanup_actors_advances_batch_cursor() {
+		// Limit the batch to one directory per run.
+		$limit_one = static function () {
+			return 1;
+		};
+		\add_filter( 'activitypub_cleanup_actor_cache_limit', $limit_one );
+
+		$root = wp_upload_dir()['basedir'] . Avatar::get_base_dir();
+
+		// Two orphan actor directories, sorted so 1 comes before 2.
+		$first  = $root . '/1';
+		$second = $root . '/2';
+		wp_mkdir_p( $first );
+		wp_mkdir_p( $second );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $first . '/a.jpg', 'x' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $second . '/b.jpg', 'x' );
+
+		// First run should process only the first directory.
+		Avatar::cleanup_actors();
+		$this->assertFalse( file_exists( $first . '/a.jpg' ), 'First run should clean the first batch' );
+		$this->assertTrue( file_exists( $second . '/b.jpg' ), 'First run should stop after the batch limit' );
+
+		// Second run should advance and clean the next directory.
+		Avatar::cleanup_actors();
+		$this->assertFalse( file_exists( $second . '/b.jpg' ), 'Second run should clean the next batch' );
+
+		\remove_filter( 'activitypub_cleanup_actor_cache_limit', $limit_one );
+		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+		\delete_option( 'activitypub_avatar_cache_cursor' );
 	}
 }

--- a/tests/phpunit/tests/includes/cache/class-test-avatar.php
+++ b/tests/phpunit/tests/includes/cache/class-test-avatar.php
@@ -188,6 +188,42 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a filename collision keeps the file that was written.
+	 */
+	public function test_cache_collision_keeps_written_file() {
+		$post_id = self::factory()->post->create();
+		$url     = 'https://example.com/collision-avatar.jpg';
+		$hash    = md5( $url );
+		$paths   = Avatar::get_storage_paths( $post_id );
+		wp_mkdir_p( $paths['basedir'] );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . '/' . $hash . '.webp', 'existing' );
+
+		$mock_download = function ( $result, $download_url ) use ( $url ) {
+			if ( $download_url === $url ) {
+				$tmp_file = \wp_tempnam( 'collision-avatar.jpg' );
+				copy( AP_TESTS_DIR . '/data/assets/test.jpg', $tmp_file );
+
+				return array(
+					'file'      => $tmp_file,
+					'mime_type' => 'image/jpeg',
+				);
+			}
+
+			return $result;
+		};
+		\add_filter( 'activitypub_pre_download_url', $mock_download, 10, 2 );
+
+		$result = Avatar::cache( $url, $post_id, array( 'max_dimension' => Avatar::MAX_DIMENSION ) );
+
+		$this->assertStringEndsWith( '/' . $hash . '-1.webp', $result );
+		$this->assertTrue( file_exists( $paths['basedir'] . '/' . $hash . '-1.webp' ) );
+
+		\remove_filter( 'activitypub_pre_download_url', $mock_download );
+		Avatar::invalidate_entity( $post_id );
+	}
+
+	/**
 	 * Test maybe_cache returns original URL when download fails.
 	 */
 	public function test_maybe_cache_returns_original_url_on_failure() {
@@ -310,7 +346,7 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_actor_avatar_hash returns false when the actor has no icon.
+	 * Test that get_actor_avatar_hash returns an empty hash when the actor has no icon.
 	 */
 	public function test_get_actor_avatar_hash_no_icon() {
 		$post_id = self::factory()->post->create(
@@ -320,7 +356,7 @@ class Test_Avatar extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( Avatar::get_actor_avatar_hash( $post_id ) );
+		$this->assertSame( '', Avatar::get_actor_avatar_hash( $post_id ) );
 	}
 
 	/**
@@ -368,6 +404,7 @@ class Test_Avatar extends WP_UnitTestCase {
 		Avatar::prune_stale_files( $post_id, md5( 'https://example.com/other.jpg' ) );
 
 		$this->assertFalse( file_exists( $paths['basedir'] . "/{$hash}.jpg" ) );
+		$this->assertFalse( file_exists( $paths['basedir'] ), 'Empty actor directory should be removed' );
 
 		Avatar::invalidate_entity( $post_id );
 	}
@@ -476,25 +513,36 @@ class Test_Avatar extends WP_UnitTestCase {
 		\add_filter( 'activitypub_cleanup_actor_cache_limit', $limit_one );
 
 		$root = wp_upload_dir()['basedir'] . Avatar::get_base_dir();
+		$dirs = array();
 
-		// Two orphan actor directories, sorted so 1 comes before 2.
-		$first  = $root . '/1';
-		$second = $root . '/2';
-		wp_mkdir_p( $first );
-		wp_mkdir_p( $second );
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		file_put_contents( $first . '/a.jpg', 'x' );
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		file_put_contents( $second . '/b.jpg', 'x' );
+		// Create unique numeric directories, then use DirectoryIterator order directly.
+		// get_base_dir() ends with a slash, so concatenate names without another one.
+		foreach ( range( 1, 3 ) as $index ) {
+			$directory = $root . ( 900000 + getmypid() + $index );
+			\wp_mkdir_p( $directory );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			file_put_contents( $directory . '/avatar.jpg', 'x' );
+			$dirs[] = $directory;
+		}
 
-		// First run should process only the first directory.
+		$iterator = new \DirectoryIterator( $root );
+		$ordered = array();
+		foreach ( $iterator as $directory ) {
+			if ( ! $directory->isDot() && $directory->isDir() && in_array( $directory->getPathname(), $dirs, true ) ) {
+				$ordered[] = $directory->getPathname();
+			}
+		}
+		$this->assertCount( 3, $ordered );
+		\update_option( 'activitypub_avatar_cache_cursor', basename( $ordered[0] ), false );
+
+		// First run processes directory after cursor, regardless of filesystem order.
 		Avatar::cleanup_actors();
-		$this->assertFalse( file_exists( $first . '/a.jpg' ), 'First run should clean the first batch' );
-		$this->assertTrue( file_exists( $second . '/b.jpg' ), 'First run should stop after the batch limit' );
+		$this->assertFalse( file_exists( $ordered[1] . '/avatar.jpg' ), 'First run should clean the first batch' );
+		$this->assertTrue( file_exists( $ordered[2] . '/avatar.jpg' ), 'First run should stop after the batch limit' );
 
 		// Second run should advance and clean the next directory.
 		Avatar::cleanup_actors();
-		$this->assertFalse( file_exists( $second . '/b.jpg' ), 'Second run should clean the next batch' );
+		$this->assertFalse( file_exists( $ordered[2] . '/avatar.jpg' ), 'Second run should clean the next batch' );
 
 		\remove_filter( 'activitypub_cleanup_actor_cache_limit', $limit_one );
 		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );

--- a/tests/phpunit/tests/includes/cache/class-test-avatar.php
+++ b/tests/phpunit/tests/includes/cache/class-test-avatar.php
@@ -321,52 +321,6 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_actor_avatar_hash resolves the current icon without caching.
-	 */
-	public function test_get_actor_avatar_hash() {
-		$icon_url = 'https://example.com/avatar.jpg';
-		$post_id  = self::factory()->post->create(
-			array(
-				'post_type'    => Remote_Actors::POST_TYPE,
-				'post_content' => wp_json_encode( array( 'icon' => array( 'url' => $icon_url ) ) ),
-			)
-		);
-
-		$fired   = false;
-		$capture = function ( $value ) use ( &$fired ) {
-			$fired = true;
-			return $value;
-		};
-		\add_filter( 'activitypub_remote_media_url', $capture );
-
-		$this->assertEquals( md5( $icon_url ), Avatar::get_actor_avatar_hash( $post_id ) );
-		$this->assertFalse( $fired, 'The cache filter should not fire when resolving the hash' );
-
-		\remove_filter( 'activitypub_remote_media_url', $capture );
-	}
-
-	/**
-	 * Test that get_actor_avatar_hash returns an empty hash when the actor has no icon.
-	 */
-	public function test_get_actor_avatar_hash_no_icon() {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_type'    => Remote_Actors::POST_TYPE,
-				'post_content' => wp_json_encode( array( 'name' => 'Test' ) ),
-			)
-		);
-
-		$this->assertSame( '', Avatar::get_actor_avatar_hash( $post_id ) );
-	}
-
-	/**
-	 * Test that get_actor_avatar_hash returns false for a missing post.
-	 */
-	public function test_get_actor_avatar_hash_missing_post() {
-		$this->assertFalse( Avatar::get_actor_avatar_hash( 999999 ) );
-	}
-
-	/**
 	 * Test that prune_stale_files keeps the current hash and deletes others.
 	 */
 	public function test_prune_stale_files_keeps_current() {
@@ -410,16 +364,16 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that cleanup_actors removes orphaned actor directories.
+	 * Test that cleanup removes orphaned actor directories.
 	 */
-	public function test_cleanup_actors_removes_orphan_dir() {
+	public function test_cleanup_removes_orphan_dir() {
 		$post_id = self::factory()->post->create();
 		$paths   = Avatar::get_storage_paths( $post_id );
 		wp_mkdir_p( $paths['basedir'] );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		file_put_contents( $paths['basedir'] . '/abc.jpg', 'x' );
 
-		Avatar::cleanup_actors();
+		Avatar::cleanup();
 
 		$this->assertFalse( file_exists( $paths['basedir'] ) );
 		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
@@ -427,16 +381,16 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that cleanup_actors leaves non-numeric directories alone.
+	 * Test that cleanup leaves non-numeric directories alone.
 	 */
-	public function test_cleanup_actors_leaves_non_numeric_dir() {
-		$root  = wp_upload_dir()['basedir'] . Avatar::get_base_dir();
-		$junk  = $root . '/not-a-number';
+	public function test_cleanup_leaves_non_numeric_dir() {
+		$root = wp_upload_dir()['basedir'] . Avatar::get_base_dir();
+		$junk = $root . '/not-a-number';
 		wp_mkdir_p( $junk );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		file_put_contents( $junk . '/a.jpg', 'x' );
 
-		Avatar::cleanup_actors();
+		Avatar::cleanup();
 
 		$this->assertTrue( file_exists( $junk . '/a.jpg' ) );
 
@@ -447,9 +401,9 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that cleanup_actors prunes stale files for a surviving actor.
+	 * Test that cleanup prunes stale files for a surviving actor.
 	 */
-	public function test_cleanup_actors_prunes_surviving_actor() {
+	public function test_cleanup_prunes_surviving_actor() {
 		$icon_url = 'https://example.com/current.png';
 		$post_id  = self::factory()->post->create(
 			array(
@@ -467,7 +421,7 @@ class Test_Avatar extends WP_UnitTestCase {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		file_put_contents( $paths['basedir'] . "/{$stale}.png", 'stale' );
 
-		Avatar::cleanup_actors();
+		Avatar::cleanup();
 
 		$this->assertTrue( file_exists( $paths['basedir'] . "/{$current}.png" ) );
 		$this->assertFalse( file_exists( $paths['basedir'] . "/{$stale}.png" ) );
@@ -478,9 +432,32 @@ class Test_Avatar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that cleanup removes files for an actor whose icon is gone.
+	 */
+	public function test_cleanup_removes_files_for_actor_without_icon() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Actors::POST_TYPE,
+				'post_content' => wp_json_encode( array( 'name' => 'Test' ) ),
+			)
+		);
+
+		$paths = Avatar::get_storage_paths( $post_id );
+		wp_mkdir_p( $paths['basedir'] );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $paths['basedir'] . '/abc.jpg', 'x' );
+
+		Avatar::cleanup();
+
+		$this->assertFalse( file_exists( $paths['basedir'] ) );
+		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+		\delete_option( 'activitypub_avatar_cache_cursor' );
+	}
+
+	/**
 	 * Test that a second cleanup run while locked returns early.
 	 */
-	public function test_cleanup_actors_reentrant_lock() {
+	public function test_cleanup_reentrant_lock() {
 		$post_id = self::factory()->post->create();
 		$paths   = Avatar::get_storage_paths( $post_id );
 		wp_mkdir_p( $paths['basedir'] );
@@ -489,7 +466,7 @@ class Test_Avatar extends WP_UnitTestCase {
 
 		\add_option( 'activitypub_avatar_cache_cleanup_lock', time(), '', false );
 
-		Avatar::cleanup_actors();
+		Avatar::cleanup();
 
 		$this->assertTrue( file_exists( $paths['basedir'] . '/abc.jpg' ), 'Orphan dir should not be removed while locked' );
 
@@ -505,18 +482,14 @@ class Test_Avatar extends WP_UnitTestCase {
 	 * should pick up where the first left off rather than revisiting the
 	 * same directories.
 	 */
-	public function test_cleanup_actors_advances_batch_cursor() {
-		// Limit the batch to one directory per run.
+	public function test_cleanup_advances_batch_cursor() {
 		$limit_one = static function () {
 			return 1;
 		};
-		\add_filter( 'activitypub_cleanup_actor_cache_limit', $limit_one );
+		\add_filter( 'activitypub_cleanup_avatar_cache_limit', $limit_one );
 
 		$root = wp_upload_dir()['basedir'] . Avatar::get_base_dir();
 		$dirs = array();
-
-		// Create unique numeric directories, then use DirectoryIterator order directly.
-		// get_base_dir() ends with a slash, so concatenate names without another one.
 		foreach ( range( 1, 3 ) as $index ) {
 			$directory = $root . ( 900000 + getmypid() + $index );
 			\wp_mkdir_p( $directory );
@@ -525,27 +498,30 @@ class Test_Avatar extends WP_UnitTestCase {
 			$dirs[] = $directory;
 		}
 
-		$iterator = new \DirectoryIterator( $root );
-		$ordered = array();
-		foreach ( $iterator as $directory ) {
-			if ( ! $directory->isDot() && $directory->isDir() && in_array( $directory->getPathname(), $dirs, true ) ) {
-				$ordered[] = $directory->getPathname();
+		try {
+			$ids = array_map( 'basename', $dirs );
+			sort( $ids, SORT_NUMERIC );
+			\update_option( 'activitypub_avatar_cache_cursor', (int) $ids[0], false );
+
+			Avatar::cleanup();
+			$remaining = array_filter( $dirs, 'is_dir' );
+			$this->assertCount( 2, $remaining, 'First run should clean one directory' );
+
+			$first_cursor = (int) \get_option( 'activitypub_avatar_cache_cursor' );
+			$this->assertGreaterThan( (int) $ids[0], $first_cursor );
+
+			Avatar::cleanup();
+			$this->assertCount( 1, array_filter( $dirs, 'is_dir' ), 'Second run should clean one more directory' );
+		} finally {
+			foreach ( $dirs as $directory ) {
+				if ( is_dir( $directory ) ) {
+					Avatar::delete_directory( $directory );
+				}
 			}
+			\remove_filter( 'activitypub_cleanup_avatar_cache_limit', $limit_one );
+			\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
+			\delete_option( 'activitypub_avatar_cache_cursor' );
 		}
-		$this->assertCount( 3, $ordered );
-		\update_option( 'activitypub_avatar_cache_cursor', basename( $ordered[0] ), false );
-
-		// First run processes directory after cursor, regardless of filesystem order.
-		Avatar::cleanup_actors();
-		$this->assertFalse( file_exists( $ordered[1] . '/avatar.jpg' ), 'First run should clean the first batch' );
-		$this->assertTrue( file_exists( $ordered[2] . '/avatar.jpg' ), 'First run should stop after the batch limit' );
-
-		// Second run should advance and clean the next directory.
-		Avatar::cleanup_actors();
-		$this->assertFalse( file_exists( $ordered[2] . '/avatar.jpg' ), 'Second run should clean the next batch' );
-
-		\remove_filter( 'activitypub_cleanup_actor_cache_limit', $limit_one );
-		\delete_option( 'activitypub_avatar_cache_cleanup_lock' );
-		\delete_option( 'activitypub_avatar_cache_cursor' );
 	}
+
 }

--- a/tests/phpunit/tests/includes/cache/class-test-avatar.php
+++ b/tests/phpunit/tests/includes/cache/class-test-avatar.php
@@ -218,6 +218,10 @@ class Test_Avatar extends WP_UnitTestCase {
 
 		$this->assertStringEndsWith( '/' . $hash . '-1.webp', $result );
 		$this->assertTrue( file_exists( $paths['basedir'] . '/' . $hash . '-1.webp' ) );
+		$this->assertFileDoesNotExist(
+			$paths['basedir'] . '/' . $hash . '.webp',
+			'The collision loser must be pruned so later reads resolve to the written file'
+		);
 
 		\remove_filter( 'activitypub_pre_download_url', $mock_download );
 		Avatar::invalidate_entity( $post_id );

--- a/tests/phpunit/tests/includes/cache/class-test-avatar.php
+++ b/tests/phpunit/tests/includes/cache/class-test-avatar.php
@@ -527,5 +527,4 @@ class Test_Avatar extends WP_UnitTestCase {
 			\delete_option( 'activitypub_avatar_cache_cursor' );
 		}
 	}
-
 }

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -9,6 +9,7 @@ namespace Activitypub\Tests;
 
 use Activitypub\Activity\Activity;
 use Activitypub\Activity\Base_Object;
+use Activitypub\Cache\Avatar;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Inbox;
 use Activitypub\Collection\Outbox;
@@ -1053,5 +1054,24 @@ class Test_Scheduler extends \WP_UnitTestCase {
 		$this->assertSame( $uri, \get_post( $id )->guid, 'The cached actor guid must be left unchanged.' );
 		$this->assertSame( 'Old Name', \get_post( $id )->post_title, 'A changed remote identity must not be applied to the cached actor.' );
 		$this->assertEmpty( Remote_Actors::get_outdated(), 'A skipped actor must be touched so it is not re-fetched on the next run.' );
+	}
+
+	/**
+	 * Test that the avatar cache cleanup schedule is registered.
+	 */
+	public function test_cleanup_actor_cache_schedule_registered() {
+		$this->assertArrayHasKey( 'activitypub_cleanup_actor_cache', Scheduler::SCHEDULES );
+		$this->assertEquals( 'daily', Scheduler::SCHEDULES['activitypub_cleanup_actor_cache'] );
+	}
+
+	/**
+	 * Test that the avatar cache cleanup action is registered on init.
+	 */
+	public function test_cleanup_actor_cache_action_registered() {
+		Scheduler::init();
+
+		$this->assertNotFalse(
+			\has_action( 'activitypub_cleanup_actor_cache', array( Avatar::class, 'cleanup_actors' ) )
+		);
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-scheduler.php
+++ b/tests/phpunit/tests/includes/class-test-scheduler.php
@@ -1059,19 +1059,19 @@ class Test_Scheduler extends \WP_UnitTestCase {
 	/**
 	 * Test that the avatar cache cleanup schedule is registered.
 	 */
-	public function test_cleanup_actor_cache_schedule_registered() {
-		$this->assertArrayHasKey( 'activitypub_cleanup_actor_cache', Scheduler::SCHEDULES );
-		$this->assertEquals( 'daily', Scheduler::SCHEDULES['activitypub_cleanup_actor_cache'] );
+	public function test_cleanup_avatar_cache_schedule_registered() {
+		$this->assertArrayHasKey( 'activitypub_cleanup_avatar_cache', Scheduler::SCHEDULES );
+		$this->assertEquals( 'daily', Scheduler::SCHEDULES['activitypub_cleanup_avatar_cache'] );
 	}
 
 	/**
 	 * Test that the avatar cache cleanup action is registered on init.
 	 */
-	public function test_cleanup_actor_cache_action_registered() {
+	public function test_cleanup_avatar_cache_action_registered() {
 		Scheduler::init();
 
 		$this->assertNotFalse(
-			\has_action( 'activitypub_cleanup_actor_cache', array( Avatar::class, 'cleanup_actors' ) )
+			\has_action( 'activitypub_cleanup_avatar_cache', array( Avatar::class, 'cleanup' ) )
 		);
 	}
 }


### PR DESCRIPTION

Fixes #3583

## Proposed changes:

* Stop duplicate avatar copies from being created in the first place: when a remote actor changes their profile picture, the previous cached version is now removed at the moment the new one is downloaded. Remote actors rotate their icon URL often, and each change previously left an orphaned copy behind, which is how the actors folder kept filling up (the root cause of #3583).
* Add a daily cron job that scans the avatar cache directory and drains any backlog already on disk, removing orphaned actor directories that no longer match an actor post plus stale avatar files that no longer match an actor's current icon.
* Batch the cron cleanup with a resume cursor so a large backlog drains over several runs instead of blocking on one.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New unit tests added for the hash resolver, the file prune, write-time pruning when a new avatar replaces an old one, and the cron cleanup (orphan handling, batching, and the re-entrancy lock). A changelog entry file is included in the branch.

## Testing instructions:

* Enable the plugin and let a remote avatar render (a page with a federated comment or follower) so files land in `wp-content/uploads/activitypub/actors/`.
* Confirm the scheduled event exists: `wp cron event list | grep activitypub_cleanup_avatar_cache` (recurrence `daily`).
* Change the actor's avatar URL (or simulate a stale file) and load a page that renders the avatar; confirm only the current hash file remains for that actor after the refresh (no duplicate copies accumulate).
* Delete a remote actor post and rerun the cron event (`wp cron event run activitypub_cleanup_avatar_cache --due-now`); confirm its directory is removed.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

Changelog Entry Details

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [x] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Prevented unused copies of remote profile pictures from accumulating on your server and added automatic cleanup for leftover cached avatars.
