### PR TITLE
fix: only count previously approved normal comments for auto-approval

### DIFF
--- a/.github/changelog/fix-3579-auto-approved-comments
+++ b/.github/changelog/fix-3579-auto-approved-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed normal replies from distant accounts sometimes being auto-approved just because that account had previously liked or reposted a post.

--- a/includes/class-comment.php
+++ b/includes/class-comment.php
@@ -908,8 +908,9 @@ class Comment {
 
 		$author     = $comment_data['comment_author'];
 		$author_url = $comment_data['comment_author_url'];
+		// Only previously approved normal comments count, not approved likes or reposts.
 		// phpcs:ignore
-		$ok_to_comment = $wpdb->get_var( $wpdb->prepare( "SELECT comment_approved FROM $wpdb->comments WHERE comment_author = %s AND comment_author_url = %s and comment_approved = '1' LIMIT 1", $author, $author_url ) );
+		$ok_to_comment = $wpdb->get_var( $wpdb->prepare( "SELECT comment_approved FROM $wpdb->comments WHERE comment_author = %s AND comment_author_url = %s AND comment_approved = '1' AND comment_type = 'comment' LIMIT 1", $author, $author_url ) );
 
 		if ( 1 === (int) $ok_to_comment ) {
 			return 1;

--- a/tests/phpunit/tests/includes/class-test-comment.php
+++ b/tests/phpunit/tests/includes/class-test-comment.php
@@ -281,6 +281,69 @@ class Test_Comment extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that an approved like does not count as a previously approved comment.
+	 *
+	 * A previously approved reaction (like, repost, quote) should not cause a
+	 * later normal reply from the same actor to be auto-approved.
+	 *
+	 * @covers ::pre_comment_approved
+	 */
+	public function test_pre_comment_approved_ignores_reactions() {
+		// Disable flood control.
+		\remove_action( 'check_comment_flood', 'check_comment_flood_db' );
+
+		$previous = \get_option( 'comment_previously_approved' );
+		\update_option( 'comment_previously_approved', '1' );
+
+		$post_id = \wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'This is a test post.',
+				'post_status'  => 'publish',
+				'post_author'  => 1,
+			)
+		);
+
+		// Approved like from a remote actor. This must not count as a previously approved comment.
+		\wp_insert_comment(
+			array(
+				'comment_type'         => 'like',
+				'comment_approved'     => '1',
+				'comment_content'      => 'Liked this!',
+				'comment_author'       => 'Approved',
+				'comment_author_url'   => 'https://example.com/@approved',
+				'comment_post_ID'      => $post_id,
+				'comment_author_email' => '',
+				'comment_meta'         => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+
+		// A normal reply from the same actor must still be held for moderation.
+		$reply_id = \wp_new_comment(
+			array(
+				'comment_type'         => 'comment',
+				'comment_content'      => 'This reply should not be auto-approved.',
+				'comment_author'       => 'Approved',
+				'comment_author_url'   => 'https://example.com/@approved',
+				'comment_post_ID'      => $post_id,
+				'comment_author_email' => '',
+				'comment_meta'         => array(
+					'protocol' => 'activitypub',
+				),
+			)
+		);
+
+		$reply = \get_comment( $reply_id );
+		$this->assertEquals( '0', $reply->comment_approved );
+
+		// Restore the option and flood control.
+		\update_option( 'comment_previously_approved', $previous );
+		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
+	}
+
+	/**
 	 * Test pre_wp_update_comment_count_now.
 	 *
 	 * @covers ::pre_wp_update_comment_count_now


### PR DESCRIPTION
Fixes #3579

## Proposed changes:
When a remote account likes or reposts a post, the plugin stores that as an approved comment (with a non-default comment type such as `like` or `repost`). The `pre_comment_approved` filter then looked up whether the same author already had an approved comment, but did not filter by comment type. So that approved reaction counted as a "previously approved comment", and it auto-approved the same account's later normal replies even when "Comment author must have a previously approved comment" was enabled.

The fix mirrors what WordPress core's `wp_allow_comment()` does: it only counts prior approved comments of type `comment`, so reactions no longer leak approval to real replies. An account that previously replied normally is still auto-approved.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Added `test_pre_comment_approved_ignores_reactions()` in `tests/phpunit/tests/includes/class-test-comment.php`, which inserts an approved `like` from a remote actor and verifies that a normal reply from the same actor stays held for moderation.

## Testing instructions:
Because `$comment_previously_approved` needs to affect published replies, the trickiest part is setting up the scenario:

* Enable "Comment author must have a previously approved comment" (Settings -> Discussion).
* From a remote Mastodon account that has never commented on your site, like one of your posts (auto-approve Likes must be enabled).
* From that same account, reply with a normal comment on another post.
* The reply should land in Comments as pending (held for moderation), not approved.

Before this fix, that reply was auto-approved, because the account's previous Like was treated as a previously approved comment. A remote account that previously submitted a normal comment should still be auto-approved.

### Changelog entry
- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [x] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities

#### Message

Fixed normal replies from distant accounts sometimes being auto-approved just because that account had previously liked or reposted a post.

</details>