### PR TITLE
cut derivable stuff from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,57 +12,6 @@ Prefer reading project files and `docs/` over relying on training data for WordP
 - Use `remove_all_filters('pre_http_request')` in tests
 - Hardcode new version numbers (use `'unreleased'`)
 
-## Directory Structure
-
-```
-activitypub.php                 # Main plugin file.
-includes/
-├── class-*.php                 # Core classes (Activitypub, Dispatcher, Scheduler, Signature…).
-├── model/                      # Actor models (User, Blog, Application — extend Actor).
-├── activity/                   # Activity type classes (Activity, Follow, Undo…).
-├── collection/                 # Collection classes (Followers, Following).
-├── handler/                    # Incoming activity handlers (Follow, Create, Delete, Like…).
-├── rest/                       # REST API controllers (Actors, Inbox, Outbox, Followers…).
-├── transformer/                # Content transformers (Post, Comment, Event → AP objects).
-└── wp-admin/                   # Admin UI functionality.
-integration/                    # Third-party plugin integrations (root level).
-tests/
-├── phpunit/                    # PHPUnit tests.
-└── e2e/                        # Playwright E2E tests.
-```
-
-## Commands
-
-```bash
-# Environment
-npm run env-start               # Start WordPress at http://localhost:8888.
-npm run env-stop                # Stop WordPress environment.
-
-# PHP tests (require wp-env running)
-npm run env-test                            # All PHP tests.
-npm run env-test -- --filter=pattern        # Tests matching pattern.
-npm run env-test -- path/to/test.php        # Specific test file.
-npm run env-test -- --group=name            # Tests with @group annotation.
-
-# E2E tests (require wp-env running) — tests live in tests/e2e/specs/
-npm run test:e2e                            # All E2E tests.
-npm run test:e2e:debug                      # Debug with Playwright inspector.
-npx playwright test tests/e2e/specs/path/to/test.js --config tests/e2e/playwright.config.js  # Specific file.
-
-# JavaScript tests
-npm run test:unit                           # Unit tests.
-
-# Code quality
-composer lint                   # Check PHP coding standards (PHPCS).
-composer lint:fix               # Auto-fix PHP issues.
-npm run lint:js                 # Check JavaScript.
-npm run lint:css                # Check CSS.
-
-# Build
-npm run build                   # Production build (formatted + minified).
-npm run dev                     # Development watch mode.
-```
-
 ## Common Pitfalls
 
 - **PHP 7.4 compatibility.** CI tests against PHP 7.4. No named arguments, no union types, no `match` (PHP 8.0+).
@@ -73,19 +22,7 @@ npm run dev                     # Development watch mode.
 - **`post_date_gmt` may be empty.** Check for `0000-00-00` or empty values.
 - **Scheduled cron handlers must be idempotent if they have user-visible side effects** (emails, external API calls, push notifications). WP-Cron can re-enter the same callback via concurrent workers, plugin deactivate→reactivate (which re-runs `register_schedules()`), `wp cron event run`, and traffic spikes that fire overlapping loopback requests. Claim the unit of work atomically — `add_option( $key, $value, '', false )` only succeeds when the row doesn't yet exist, which makes it a race-safe sentinel — *before* the side effect runs, not after. See `Activitypub\Scheduler\Statistics::send_monthly_email()` for the canonical pattern.
 
-## Pre-commit Hooks
-
-Automated hooks (`.githooks/pre-commit`) run on `git commit`: sort PHP imports, check unused imports, validate test patterns, run PHPCS auto-fix, format JavaScript.
-
-**CRITICAL:** Hooks modify staged files automatically. If hooks make changes, you MUST stage and commit again. Setup: `npm run prepare` (automatic after `npm install`).
-
 ## PHP Conventions
-
-Files: `class-{name}.php` | `trait-{name}.php` | `interface-{name}.php`
-
-Namespaces: `Activitypub`, `Activitypub\{Transformer,Collection,Handler,Activity,Rest,Model}`
-
-Text domain: always `'activitypub'`.
 
 **MUST** backslash-prefix all WordPress functions in namespaced code: `\get_option()`, `\add_action()`, `\apply_filters()`, `\__()`, `\_e()`, etc. PHP falls back to global scope, but backslashes are a project standard for consistency and to avoid accidentally shadowing globals.
 
@@ -95,27 +32,7 @@ Text domain: always `'activitypub'`.
 
 ## Testing Conventions
 
-Tests use namespace `Activitypub\Tests` and extend `WP_UnitTestCase`. E2E tests import from `@wordpress/e2e-test-utils-playwright` with fixtures: `request`, `admin`, `page`, `requestUtils`.
-
-Use `@group` annotations to categorize tests (`@group activitypub`, `@group federation`).
-
 See `tests/README.md` for test utilities, data factories, and detailed patterns.
-
-## Architectural Patterns
-
-**Actor types** — The plugin supports 3 actor types: `User` (WordPress users), `Blog` (site-wide blog actor), and `Application` (system-level). All extend `Actor` base class. See `includes/model/`.
-
-**Transformers** — Convert WordPress content into ActivityPub objects. Extend `Activitypub\Transformer\Base`. See `includes/transformer/`.
-
-**Handlers** — Process incoming activities from remote servers. One handler per activity type. See `includes/handler/`.
-
-**Collections** — Implement AP collections (Followers, Following). See `includes/collection/`.
-
-**REST Controllers** — Expose AP endpoints under `ACTIVITYPUB_REST_NAMESPACE`. See `includes/rest/`.
-
-**Key helpers** (see `includes/functions-*.php` and `includes/class-webfinger.php`): `get_remote_metadata_by_actor()`, `object_to_uri()`, `Webfinger::resolve()`.
-
-**Custom hooks:** see `includes/class-activitypub.php` and `includes/class-dispatcher.php` for the plugin's main actions and filters.
 
 ## Documentation Index
 
@@ -136,24 +53,3 @@ FEDERATION.md                    — implemented FEPs, supported standards, comp
 Skills are complex procedures loaded on demand. Canonical files live in `.agents/skills/`, with stubs in `.claude/skills/` for Claude Code discovery.
 
 **CRITICAL:** After reading a skill, check for a local override at `~/.claude/skills/{skill-name}-local/SKILL.md`. Local overrides take precedence.
-
-| Skill | Use when… |
-|-------|-----------|
-| **code-style** | Writing PHP, creating classes, implementing hooks, or structuring plugin files. |
-| **dev** | Setting up wp-env, running tests, linting, or building assets. |
-| **test** | Writing or debugging PHPUnit and Playwright E2E tests. |
-| **federation** | Working with ActivityPub protocol, federation mechanics, or debugging. |
-| **integrations** | Adding or debugging third-party plugin integrations. |
-| **pr** | Creating or reviewing pull requests. MUST invoke before any PR creation. |
-| **release** | Creating releases, bumping versions, managing changelogs. |
-| **gitattributes** | Auditing `.gitattributes` export-ignore coverage before a release or after adding a top-level file or config. |
-
-| Agent | Trigger |
-|-------|---------|
-| **summary** | Auto-invoked when session ends (goodbye/done/thanks). |
-| **code-review** | Auto-invoked before PR creation to review changes. |
-| **spec-check** | Audit endpoints against W3C ActivityPub and SWICG specs. |
-| **bug-bounty** | Pick easiest open bug, fix with tests, create draft PR. Runs in background. |
-| **patch-release** | Create a patch release by cherry-picking fixes onto a release branch. |
-| **security-audit** | Audit for SSRF, auth bypass, content disclosure, XSS, and content negotiation issues. |
-| **support** | Diagnose federation issues on live sites (WebFinger, outbox, actors, common misconfigurations). |


### PR DESCRIPTION
Fixes #

## Proposed changes:

* AGENTS.md is loaded into every session, so everything in it costs context all the time. A lot of it was stuff a session can just look up itself, so I cut it. 159 lines down to 55, around 1.4k tokens saved per session.
* Removed: the directory structure block (ls shows it), the commands block (it is already in the dev skill, word for word), the pre-commit hooks section (the one real warning is in Common Pitfalls anyway), the architectural patterns tour, the skills and agents tables (Claude Code already injects both listings with their descriptions), and the first lines of PHP Conventions and Testing Conventions (file naming, namespaces, text domain, base class, all visible in any source file).
* Kept: the Do NOT list, all of Common Pitfalls, the three PHP conventions that differ from defaults (backslash prefixing, no inline namespaces, 'unreleased'), the documentation index, and the local skill override warning.
* No code changes, docs only. I think everything I cut is derivable, but if something in there was a real gotcha and I misread it as boilerplate, say so and I will put it back.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Read the new AGENTS.md and check nothing you rely on went missing.
* `git diff trunk -- AGENTS.md` shows every removed block.

### Changelog entry

Skip Changelog, this does not change anything for users.
