### PR TITLE
Pass the remote status through the proxy

### DIFF
--- a/.github/changelog/fix-proxy-remote-error-status
+++ b/.github/changelog/fix-proxy-remote-error-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Apps now see the real error when a post they open through your site is missing, instead of a generic failure.

--- a/includes/rest/class-proxy-controller.php
+++ b/includes/rest/class-proxy-controller.php
@@ -186,10 +186,19 @@ class Proxy_Controller extends \WP_REST_Controller {
 		$object = Http::get_remote_object( $url );
 
 		if ( \is_wp_error( $object ) ) {
+			/*
+			 * Pass on a status the remote actually returned, so a caller can tell a missing object
+			 * from an unreachable host. `Http::get()` uses the response code as the error code;
+			 * this method's own rejections use a string code and stay a 502, because a document we
+			 * refused is not the caller's request being wrong.
+			 */
+			$code   = $object->get_error_code();
+			$status = \is_numeric( $code ) ? (int) $code : 0;
+
 			return new \WP_Error(
 				'activitypub_fetch_failed',
 				\__( 'Failed to fetch the remote object.', 'activitypub' ),
-				array( 'status' => 502 )
+				array( 'status' => $status ?: 502 )
 			);
 		}
 

--- a/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-proxy-controller.php
@@ -504,6 +504,57 @@ class Test_Proxy_Controller extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the remote status reaches the client.
+	 *
+	 * A missing object and an unreachable host used to be indistinguishable, so a client could
+	 * not tell whether to drop the request or replay it later.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_remote_status_is_passed_on() {
+		$this->mock_oauth_auth();
+
+		$respond = function () {
+			return array(
+				'response' => array( 'code' => 404 ),
+				'body'     => '',
+				'headers'  => array(),
+			);
+		};
+		\add_filter( 'pre_http_request', $respond );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
+		$request->set_body_params( array( 'id' => 'https://example.com/gone-forever' ) );
+
+		$this->assertEquals( 404, $this->server->dispatch( $request )->get_status() );
+
+		\remove_filter( 'pre_http_request', $respond );
+		$this->unmock_oauth_auth();
+	}
+
+	/**
+	 * Test that a failure with no response at all is still a gateway error.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_unreachable_host_is_a_gateway_error() {
+		$this->mock_oauth_auth();
+
+		$respond = function () {
+			return new \WP_Error( 'http_request_failed', 'Connection timed out' );
+		};
+		\add_filter( 'pre_http_request', $respond );
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/proxy' );
+		$request->set_body_params( array( 'id' => 'https://example.com/unreachable' ) );
+
+		$this->assertEquals( 502, $this->server->dispatch( $request )->get_status() );
+
+		\remove_filter( 'pre_http_request', $respond );
+		$this->unmock_oauth_auth();
+	}
+
+	/**
 	 * Remove OAuth mock.
 	 */
 	private function unmock_oauth_auth() {


### PR DESCRIPTION
Fixes #3657

## Proposed changes:

* The proxy reported every remote failure as `502 activitypub_fetch_failed`, so a client could not tell an object that is gone from a host that is briefly unreachable, and had no way to decide between dropping the request and replaying it later. A remote `404` now reaches the client as a `404`.
* `Http::get()` already puts the remote response code in the error, the proxy was just throwing it away.
* Only a status the remote actually returned is passed on. `Http::get_remote_object()` also returns its own verdicts, and those carry a 4xx too: an object served under an id it does not own is refused with a `400`. Forwarding that would tell the caller its request was malformed when what really happened is that we rejected a spoofed document. Those stay a `502`, and `test_proxy_does_not_cache_cross_host_actor_id` covers it.
* A timeout or a refused connection has no status at all, so it stays a `502` as well.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* As a C2S client, fetch a URL you know is deleted through the `proxyUrl` endpoint. You should get a `404` now, matching what you get fetching it directly. Before this it was a `502`.
* Fetch something on a host that does not answer. That should still be a `502`.

**Automated:**
```bash
npm run env-test -- --filter=Test_Proxy_Controller
composer lint
```

### Changelog entry

Entry is in `.github/changelog/`.
