### PR TITLE
Add snippet to keep the featured image out of the Fediverse

### DIFF
--- a/snippets/README.md
+++ b/snippets/README.md
@@ -16,6 +16,7 @@ Think of snippets as a testing ground, similar to WordPress' [feature plugin](ht
 | [ATproto DID for Bridgy Fed](atproto-did-for-bridgy-fed/) | Allows you to serve an ATproto DID from your blog's `.well-known` directory to allow Bridgy Fed to use your blog's hostname as its Bluesky handle. |
 | [Quotes as Comments](quotes-as-comments/) | Displays ActivityPub quotes as regular comments instead of facepile reactions. |
 | [Auto-Approve Reactions](auto-approve-reactions/) | Automatically approves all incoming ActivityPub reactions (likes, reposts, and quotes) without manual moderation. |
+| [Keep the Featured Image out of the Fediverse](no-featured-image/) | Stops the featured image being federated, so it does not take a slot from the images in the post. |
 | [Inspect Internal Storage](inspect-internal-storage/) | Makes the plugin's internal Inbox, Outbox, and remote post (`ap_post`) storage visible in the WordPress admin for inspection and debugging. |
 
 ## How to Use

--- a/snippets/no-featured-image/README.md
+++ b/snippets/no-featured-image/README.md
@@ -1,6 +1,6 @@
 # Keep the Featured Image out of the Fediverse
 
-Stops the featured image being federated, so it does not take a slot from the images that are actually in the post.
+Stops the featured image from being federated, so it does not take a slot from the images that are actually in the post.
 
 The transformer lists the featured image first, ahead of anything found in the content. With a limit on how many attachments a post may carry, that means the featured image takes one of those slots and the last image in the post falls off the end. For a site that gives every post a featured image for search results, that image often carries no meaning in a Fediverse timeline.
 

--- a/snippets/no-featured-image/README.md
+++ b/snippets/no-featured-image/README.md
@@ -1,0 +1,30 @@
+# Keep the Featured Image out of the Fediverse
+
+Stops the featured image being federated, so it does not take a slot from the images that are actually in the post.
+
+The transformer lists the featured image first, ahead of anything found in the content. With a limit on how many attachments a post may carry, that means the featured image takes one of those slots and the last image in the post falls off the end. For a site that gives every post a featured image for search results, that image often carries no meaning in a Fediverse timeline.
+
+Two things are removed:
+
+- the featured image is dropped from the attachments, which frees the slot
+- the `image` property is dropped from `Note` and `Article` objects, which is the preview some servers show for a link
+
+The actor icon is untouched. It is filled from the featured image too, falling back to the site icon, and it is a small avatar rather than a media attachment.
+
+## Installation
+
+Copy this folder to `wp-content/plugins/` and activate **Keep the Featured Image out of the Fediverse** from the WordPress admin, or copy `no-featured-image.php` to `wp-content/mu-plugins/` for automatic activation.
+
+## Requirements
+
+- WordPress 5.9+
+- PHP 7.4+
+- [ActivityPub](https://wordpress.org/plugins/activitypub/) plugin
+
+## Keeping the preview image
+
+To free the attachment slot but keep the link preview, delete the `remove_featured_image_property()` function and its `add_filter()` call. The featured image then stays in the `image` property and is only left out of the media.
+
+## Origin
+
+Requested in [#3655](https://github.com/Automattic/wordpress-activitypub/issues/3655), for a site using post formats where every post has a featured image for search results and a quote post federates a quote symbol.

--- a/snippets/no-featured-image/no-featured-image.php
+++ b/snippets/no-featured-image/no-featured-image.php
@@ -27,8 +27,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Drop the featured image from the attachments of a post.
  *
  * The transformer lists the thumbnail first, before the images found in the content, so with a
- * limit on attachments it is the featured image that takes a slot and the last image in the post
- * that falls off the end.
+ * limit on attachments the featured image takes a slot and the last image in the post falls off
+ * the end.
  *
  * @param array    $media The attachments, each one an array with an `id`.
  * @param \WP_Post $item  The post being transformed.

--- a/snippets/no-featured-image/no-featured-image.php
+++ b/snippets/no-featured-image/no-featured-image.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Plugin Name:       Keep the Featured Image out of the Fediverse
+ * Plugin URI:        https://github.com/Automattic/wordpress-activitypub
+ * Description:       Stops the featured image being federated as media, so it does not take a slot from the images in the post.
+ * Version:           1.0.0
+ * Requires at least: 5.9
+ * Requires PHP:      7.4
+ * Author:            Matthias Pfefferle
+ * Author URI:        https://notiz.blog/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       activitypub-no-featured-image
+ * Requires Plugins:  activitypub
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Snippets;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Drop the featured image from the attachments of a post.
+ *
+ * The transformer lists the thumbnail first, before the images found in the content, so with a
+ * limit on attachments it is the featured image that takes a slot and the last image in the post
+ * that falls off the end.
+ *
+ * @param array    $media The attachments, each one an array with an `id`.
+ * @param \WP_Post $item  The post being transformed.
+ *
+ * @return array The attachments without the featured image.
+ */
+function remove_featured_image_attachment( $media, $item ) {
+	if ( ! \has_post_thumbnail( $item ) ) {
+		return $media;
+	}
+
+	$thumbnail_id = (int) \get_post_thumbnail_id( $item );
+
+	return \array_values(
+		\array_filter(
+			$media,
+			static function ( $attachment ) use ( $thumbnail_id ) {
+				// Anything without an id came from somewhere else and is left alone.
+				return ! isset( $attachment['id'] ) || (int) $attachment['id'] !== $thumbnail_id;
+			}
+		)
+	);
+}
+\add_filter( 'activitypub_attachment_ids', __NAMESPACE__ . '\remove_featured_image_attachment', 10, 2 );
+
+/**
+ * Drop the `image` property from a federated post.
+ *
+ * Separate from the attachments above: `image` is the preview some servers show for a link, and
+ * it is filled from the featured image as well.
+ *
+ * Filtered here rather than on `activitypub_get_image`, which also runs for the actor icon and
+ * would take the site icon down with it.
+ *
+ * @param array  $object_array The object as it will be sent.
+ * @param string $object_class The object class, lowercased.
+ *
+ * @return array The object without its image.
+ */
+function remove_featured_image_property( $object_array, $object_class ) {
+	if ( \in_array( $object_class, array( 'note', 'article' ), true ) ) {
+		unset( $object_array['image'] );
+	}
+
+	return $object_array;
+}
+\add_filter( 'activitypub_activity_object_array', __NAMESPACE__ . '\remove_featured_image_property', 10, 2 );


### PR DESCRIPTION
See #3655

## Proposed changes:

A snippet for people who give every post a featured image and do not want it in the Fediverse.

* Drops the featured image from the attachments. The transformer lists the thumbnail first, ahead of anything in the content, so with a limit on attachments the featured image takes a slot and the last image in the post falls off the end. That is the part the issue is really about.
* Drops the `image` property from `Note` and `Article`, which is the preview some servers show for a link, and is filled from the featured image as well.

The actor icon is left alone. `activitypub_get_image` looks like the obvious hook for this, but it runs twice, once for the featured image at `large` and once from `get_icon()` at `thumbnail`, where the featured image is the first choice and the site icon is the fallback. Filtering it would take the icon down too, so the object array is filtered instead. The README says so, and it also says how to keep the preview and only free the slot, since those are separable.

Not a substitute for the setting the issue asks for. It is something to hand people in the meantime, and it shows which hooks a setting would need to drive.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Snippets carry no tests, in line with the others in that folder.

## Testing instructions:

* Set a featured image on a post, and put four or more images in the content.
* Federate it without the snippet and confirm the featured image is among the attachments, and that the last content image is missing once the limit is reached.
* Activate the snippet, federate again, and confirm the featured image is gone from the attachments and the content images all fit.
* Confirm the actor still has an icon, both for a post with a featured image and for one without.

### Changelog entry

Skip Changelog. Snippets are `export-ignore`d, so they never reach the plugin zip, and the other snippet PRs carry no entry either.
