### PR TITLE
Handle unexpected WebFinger responses from remote servers

### DIFF
--- a/.github/changelog/fix-webfinger-remote-member-guards
+++ b/.github/changelog/fix-webfinger-remote-member-guards
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Looking up a profile on another Fediverse server no longer fails when that server sends back an unexpected response.
+Fixed an error that could occur when looking up a profile on another Fediverse server that sends back an unexpected response.

--- a/.github/changelog/fix-webfinger-remote-member-guards
+++ b/.github/changelog/fix-webfinger-remote-member-guards
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Looking up a profile on another Fediverse server no longer fails when that server sends back an unexpected response.

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -73,7 +73,7 @@ class Webfinger {
 			return $data;
 		}
 
-		if ( ! \is_array( $data ) || empty( $data['links'] ) ) {
+		if ( ! \is_array( $data ) || empty( $data['links'] ) || ! \is_array( $data['links'] ) ) {
 			return new \WP_Error(
 				'webfinger_missing_links',
 				\__( 'No valid Link elements found.', 'activitypub' ),
@@ -86,8 +86,9 @@ class Webfinger {
 
 		foreach ( $data['links'] as $link ) {
 			if (
+				isset( $link['rel'], $link['href'], $link['type'] ) &&
 				'self' === $link['rel'] &&
-				isset( $link['type'] ) &&
+				\is_string( $link['href'] ) &&
 				(
 					'application/activity+json' === $link['type'] ||
 					'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' === $link['type']
@@ -126,15 +127,16 @@ class Webfinger {
 		// Check if subject is an acct URI.
 		if (
 			isset( $data['subject'] ) &&
+			\is_string( $data['subject'] ) &&
 			\str_starts_with( $data['subject'], 'acct:' )
 		) {
 			return $data['subject'];
 		}
 
 		// Search for an acct URI in the aliases.
-		if ( isset( $data['aliases'] ) ) {
+		if ( isset( $data['aliases'] ) && \is_array( $data['aliases'] ) ) {
 			foreach ( $data['aliases'] as $alias ) {
-				if ( \str_starts_with( $alias, 'acct:' ) ) {
+				if ( \is_string( $alias ) && \str_starts_with( $alias, 'acct:' ) ) {
 					return $alias;
 				}
 			}
@@ -373,7 +375,7 @@ class Webfinger {
 			return $data;
 		}
 
-		if ( empty( $data['links'] ) ) {
+		if ( empty( $data['links'] ) || ! \is_array( $data['links'] ) ) {
 			return new \WP_Error(
 				'webfinger_missing_links',
 				\__( 'No valid Link elements found.', 'activitypub' ),

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -269,7 +269,7 @@ class Webfinger {
 	 *
 	 * @param string $uri The Identifier: <identifier>@<host> or URI.
 	 *
-	 * @return \WP_Error|array Error reaction or array with identifier and host as values.
+	 * @return \WP_Error|array|null Error reaction, the decoded document, or null if the body is not JSON.
 	 */
 	public static function get_data( $uri ) {
 		$identifier_and_host = self::get_identifier_and_host( $uri );
@@ -390,7 +390,7 @@ class Webfinger {
 		$links = array();
 
 		foreach ( $data['links'] as $link ) {
-			if ( isset( $link['rel'] ) && isset( $link['template'] ) ) {
+			if ( isset( $link['rel'], $link['template'] ) && \is_string( $link['rel'] ) && \is_string( $link['template'] ) ) {
 				$links[ \strtolower( $link['rel'] ) ] = $link['template'];
 			}
 		}

--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -269,7 +269,8 @@ class Webfinger {
 	 *
 	 * @param string $uri The Identifier: <identifier>@<host> or URI.
 	 *
-	 * @return \WP_Error|array|null Error reaction, the decoded document, or null if the body is not JSON.
+	 * @return \WP_Error|mixed Error reaction, or the decoded document. The remote server picks the
+	 *                         body, so callers check the shape before indexing it.
 	 */
 	public static function get_data( $uri ) {
 		$identifier_and_host = self::get_identifier_and_host( $uri );

--- a/tests/phpunit/tests/includes/class-test-webfinger.php
+++ b/tests/phpunit/tests/includes/class-test-webfinger.php
@@ -862,42 +862,6 @@ class Test_Webfinger extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a `self` link without an `href` does not resolve to `null`.
-	 *
-	 * `resolve()` declares `string|WP_Error`, and callers branch on `is_wp_error()`. A remote
-	 * server controls this document, so a matching link with no `href` must not slip past that
-	 * branch as a non-error `null`.
-	 *
-	 * @covers ::resolve
-	 */
-	public function test_resolve_requires_href_on_matching_link() {
-		$filter = function () {
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => \wp_json_encode(
-					array(
-						'subject' => 'acct:user@example.com',
-						'links'   => array(
-							array(
-								'rel'  => 'self',
-								'type' => 'application/activity+json',
-							),
-						),
-					)
-				),
-			);
-		};
-
-		\add_filter( 'pre_http_request', $filter );
-
-		$result = Webfinger::resolve( 'user@example.com' );
-
-		\remove_filter( 'pre_http_request', $filter );
-
-		$this->assertWPError( $result );
-	}
-
-	/**
 	 * Test that non-string members of a remote document do not fatal.
 	 *
 	 * `str_starts_with()` on an array is a TypeError on PHP 8.
@@ -962,17 +926,61 @@ class Test_Webfinger extends \WP_UnitTestCase {
 	/**
 	 * Data provider for unexpected `links` shapes.
 	 *
-	 * A list of non-array entries is the interesting one: `isset()` on a string offset returns
-	 * false rather than raising, so each entry is skipped and the loop falls through to the error.
-	 *
 	 * @return array[] Test parameters.
 	 */
 	public function unexpected_links_provider() {
 		return array(
-			'string'               => array( 'not-an-array', 'webfinger_missing_links' ),
-			'number'               => array( 42, 'webfinger_missing_links' ),
-			'list of non-arrays'   => array( array( 'x', 5, null ), 'webfinger_url_no_activitypub' ),
-			'list of empty arrays' => array( array( array(), array() ), 'webfinger_url_no_activitypub' ),
+			'not an array'       => array( 'not-an-array', 'webfinger_missing_links' ),
+			// `isset()` on a string offset is false rather than fatal, so each entry is skipped.
+			'list of non-arrays' => array( array( 'x', 5, null ), 'webfinger_url_no_activitypub' ),
+			'self link no href'  => array(
+				array(
+					array(
+						'rel'  => 'self',
+						'type' => 'application/activity+json',
+					),
+				),
+				'webfinger_url_no_activitypub',
+			),
 		);
+	}
+
+	/**
+	 * Test that non-string link members do not fatal.
+	 *
+	 * `strtolower()` on an array is a TypeError on PHP 8, and a non-string template would reach
+	 * `str_replace()` in the REST controllers.
+	 *
+	 * @covers ::get_intent_endpoint
+	 */
+	public function test_get_intent_endpoint_ignores_non_string_members() {
+		$filter = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode(
+					array(
+						'subject' => 'acct:user@example.com',
+						'links'   => array(
+							array(
+								'rel'      => array( 'http://ostatus.org/schema/1.0/subscribe' ),
+								'template' => 'https://example.com/a?uri={uri}',
+							),
+							array(
+								'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+								'template' => array( 'https://example.com/b?uri={uri}' ),
+							),
+						),
+					)
+				),
+			);
+		};
+
+		\add_filter( 'pre_http_request', $filter );
+
+		$result = Webfinger::get_intent_endpoint( 'user@example.com', 'like' );
+
+		\remove_filter( 'pre_http_request', $filter );
+
+		$this->assertWPError( $result );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-webfinger.php
+++ b/tests/phpunit/tests/includes/class-test-webfinger.php
@@ -860,4 +860,97 @@ class Test_Webfinger extends \WP_UnitTestCase {
 			'nothing left' => array( 'user@#x', '' ),
 		);
 	}
+
+	/**
+	 * Test that a `self` link without an `href` does not resolve to `null`.
+	 *
+	 * `resolve()` declares `string|WP_Error`, and callers branch on `is_wp_error()`. A remote
+	 * server controls this document, so a matching link with no `href` must not slip past that
+	 * branch as a non-error `null`.
+	 *
+	 * @covers ::resolve
+	 */
+	public function test_resolve_requires_href_on_matching_link() {
+		$filter = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode(
+					array(
+						'subject' => 'acct:user@example.com',
+						'links'   => array(
+							array(
+								'rel'  => 'self',
+								'type' => 'application/activity+json',
+							),
+						),
+					)
+				),
+			);
+		};
+
+		\add_filter( 'pre_http_request', $filter );
+
+		$result = Webfinger::resolve( 'user@example.com' );
+
+		\remove_filter( 'pre_http_request', $filter );
+
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * Test that non-string members of a remote document do not fatal.
+	 *
+	 * `str_starts_with()` on an array is a TypeError on PHP 8.
+	 *
+	 * @covers ::uri_to_acct
+	 */
+	public function test_uri_to_acct_ignores_non_string_members() {
+		$filter = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode(
+					array(
+						'subject' => array( 'acct:user@example.com' ),
+						'aliases' => array( array( 'acct:user@example.com' ), 'acct:real@example.com' ),
+					)
+				),
+			);
+		};
+
+		\add_filter( 'pre_http_request', $filter );
+
+		$result = Webfinger::uri_to_acct( 'https://example.com/user' );
+
+		\remove_filter( 'pre_http_request', $filter );
+
+		$this->assertSame( 'acct:real@example.com', $result );
+	}
+
+	/**
+	 * Test that a non-array `links` member does not warn.
+	 *
+	 * @covers ::resolve
+	 */
+	public function test_resolve_ignores_non_array_links() {
+		$filter = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => \wp_json_encode(
+					array(
+						'subject' => 'acct:user@example.com',
+						'links'   => 'not-an-array',
+					)
+				),
+			);
+		};
+
+		\add_filter( 'pre_http_request', $filter );
+
+		$result = Webfinger::resolve( 'user@example.com' );
+
+		\remove_filter( 'pre_http_request', $filter );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'webfinger_missing_links', $result->get_error_code() );
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-webfinger.php
+++ b/tests/phpunit/tests/includes/class-test-webfinger.php
@@ -927,18 +927,23 @@ class Test_Webfinger extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a non-array `links` member does not warn.
+	 * Test that unexpected `links` shapes do not warn or fatal.
 	 *
 	 * @covers ::resolve
+	 *
+	 * @dataProvider unexpected_links_provider
+	 *
+	 * @param mixed  $links The `links` member the remote server returns.
+	 * @param string $code  The expected error code.
 	 */
-	public function test_resolve_ignores_non_array_links() {
-		$filter = function () {
+	public function test_resolve_ignores_unexpected_links( $links, $code ) {
+		$filter = function () use ( $links ) {
 			return array(
 				'response' => array( 'code' => 200 ),
 				'body'     => \wp_json_encode(
 					array(
 						'subject' => 'acct:user@example.com',
-						'links'   => 'not-an-array',
+						'links'   => $links,
 					)
 				),
 			);
@@ -951,6 +956,23 @@ class Test_Webfinger extends \WP_UnitTestCase {
 		\remove_filter( 'pre_http_request', $filter );
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'webfinger_missing_links', $result->get_error_code() );
+		$this->assertSame( $code, $result->get_error_code() );
+	}
+
+	/**
+	 * Data provider for unexpected `links` shapes.
+	 *
+	 * A list of non-array entries is the interesting one: `isset()` on a string offset returns
+	 * false rather than raising, so each entry is skipped and the loop falls through to the error.
+	 *
+	 * @return array[] Test parameters.
+	 */
+	public function unexpected_links_provider() {
+		return array(
+			'string'               => array( 'not-an-array', 'webfinger_missing_links' ),
+			'number'               => array( 42, 'webfinger_missing_links' ),
+			'list of non-arrays'   => array( array( 'x', 5, null ), 'webfinger_url_no_activitypub' ),
+			'list of empty arrays' => array( array( array(), array() ), 'webfinger_url_no_activitypub' ),
+		);
 	}
 }


### PR DESCRIPTION
## Proposed changes:

`Webfinger` reads a document that the remote server controls, and in a few places it assumed the shape instead of checking it.

* `Webfinger::resolve()` promises `string|WP_Error`, but a remote server can make it return `null`. If a `self` link matches the rel and the type but carries no `href`, the loop returns the missing key. Every caller branches on `is_wp_error()`, so the null walks straight through that branch. There are 14 of them, including the admin search on the Followers, Following and Blocked Actors tables.
* `Webfinger::uri_to_acct()` calls `str_starts_with()` on `subject` and on each alias without checking that they are strings. A server answering with `{"subject": {"a": 1}}` is a TypeError on PHP 8, so a fatal. It is reachable from comment federation and from the migration path.
* `Webfinger::get_intent_endpoint()` had the same hole one loop further down: it checked `isset()` but not the type, so a non-string `rel` reaches `strtolower()` and fatals, and a non-string `template` would reach `str_replace()` in the three REST controllers that build the intent URL. This one came out of a later review pass, it is not in the first commit.
* `links` was never checked to be an array before the `foreach`, so `{"links": "x"}` warns.

The guards are the boring kind: `isset()`, `is_string()`, `is_array()`. Nothing changes for a well formed document.

I also corrected `get_data()`'s docblock. It claimed `WP_Error|array`, but it ends in a bare `json_decode()`, so a remote server can make it return an int, a string, a bool or null just as easily. That is why the callers guard shapes rather than trusting it, and the docblock now says so instead of implying the opposite.

While I was in there I noticed you cannot block an actor whose WebFinger does not resolve, because `Blocked_Actors::add()` needs a successfully fetched actor and `prepare_custom_post_type()` requires an inbox. That one is a data model question, not a guard, so I left it alone.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

Every new test fails without the fix, so the quickest check is to take the fix away again:

* `git checkout trunk -- includes/class-webfinger.php`
* `wp-env run tests-cli --env-cwd="wp-content/plugins/activitypub" vendor/bin/phpunit --filter 'test_resolve_ignores_unexpected_links|test_uri_to_acct_ignores_non_string_members|test_get_intent_endpoint_ignores_non_string_members'`
* You should see `TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, array given`, `TypeError: strtolower(): Argument #1 ($string) must be of type string, array given` and `foreach() argument must be of type array|object, string given`.
* `git checkout HEAD -- includes/class-webfinger.php` and run them again, they pass.

Full suite is green locally, 2973 tests.

### Changelog entry

Already in the branch as `.github/changelog/fix-webfinger-remote-member-guards`, patch / fixed.
