### PR TITLE
Gate the reader's REST routes on the ActivityPub capability

### DIFF
--- a/.github/changelog/fix-rest-post-type-authorization
+++ b/.github/changelog/fix-rest-post-type-authorization
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: security
 
 Followers, cached remote profiles, and reader posts are no longer readable by logged-out visitors through the WordPress REST API, and the setting that hides your follower list is now honoured everywhere.

--- a/.github/changelog/fix-rest-post-type-authorization
+++ b/.github/changelog/fix-rest-post-type-authorization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Followers, cached remote profiles, and reader posts are no longer readable by logged-out visitors through the WordPress REST API, and the setting that hides your follower list is now honoured everywhere.

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -45,7 +45,9 @@ class Post_Types {
 
 		\add_filter( 'rest_ap_post_query', array( self::class, 'filter_ap_post_by_user' ), 10, 2 );
 		\add_filter( 'rest_ap_object_type_query', array( self::class, 'filter_object_type_by_user' ), 10, 2 );
+		\add_filter( 'rest_ap_tag_query', array( self::class, 'filter_tag_by_user' ), 10, 2 );
 		\add_filter( 'rest_ap_object_type_collection_params', array( self::class, 'register_object_type_user_param' ) );
+		\add_filter( 'rest_ap_tag_collection_params', array( self::class, 'register_object_type_user_param' ) );
 
 		\add_filter( 'activitypub_get_actor_extra_fields', array( Extra_Fields::class, 'default_actor_extra_fields' ), 10, 2 );
 
@@ -1006,6 +1008,31 @@ class Post_Types {
 	 * @return array Modified query arguments.
 	 */
 	public static function filter_object_type_by_user( $args, $request ) {
+		return self::filter_terms_by_user( $args, $request, 'ap_object_type' );
+	}
+
+	/**
+	 * Filter the ap_tag REST query to terms that have posts for the given user.
+	 *
+	 * @param array            $args    Query arguments.
+	 * @param \WP_REST_Request $request The REST API request.
+	 *
+	 * @return array Modified query arguments.
+	 */
+	public static function filter_tag_by_user( $args, $request ) {
+		return self::filter_terms_by_user( $args, $request, 'ap_tag' );
+	}
+
+	/**
+	 * Filter a reader taxonomy REST query to terms that have posts for the given user.
+	 *
+	 * @param array            $args     Query arguments.
+	 * @param \WP_REST_Request $request  The REST API request.
+	 * @param string           $taxonomy The taxonomy to scope.
+	 *
+	 * @return array Modified query arguments.
+	 */
+	private static function filter_terms_by_user( $args, $request, $taxonomy ) {
 		$user_id = $request->get_param( 'user_id' );
 
 		// Users who cannot list users may only ever see terms from their own feed.
@@ -1027,10 +1054,12 @@ class Post_Types {
 				INNER JOIN {$wpdb->term_relationships} tr ON tt.term_taxonomy_id = tr.term_taxonomy_id
 				INNER JOIN {$wpdb->posts} p ON tr.object_id = p.ID
 				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-				WHERE tt.taxonomy = 'ap_object_type'
-				AND p.post_type = 'ap_post'
+				WHERE tt.taxonomy = %s
+				AND p.post_type = %s
 				AND pm.meta_key = '_activitypub_user_id'
 				AND pm.meta_value = %s",
+				$taxonomy,
+				Remote_Posts::POST_TYPE,
 				$user_id
 			)
 		);

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -1064,9 +1064,13 @@ class Post_Types {
 			)
 		);
 
+		/*
+		 * `include => array( 0 )` does not restrict anything: `WP_Term_Query` adds the `IN` clause
+		 * only when the imploded id list is truthy, and the string "0" is not, so the clause is
+		 * dropped and every term comes back. An id that cannot exist forces the empty result.
+		 */
 		if ( empty( $term_ids ) ) {
-			// Force empty result.
-			$term_ids = array( 0 );
+			$term_ids = array( PHP_INT_MAX );
 		}
 
 		$args['include'] = \array_map( 'intval', $term_ids );

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -72,6 +72,9 @@ class Post_Types {
 					'singular_name' => \_x( 'Follower', 'post_type single name', 'activitypub' ),
 				),
 				'public'                => false,
+				'capabilities'          => array(
+					'create_posts' => false,
+				),
 				'show_in_rest'          => true,
 				'rest_controller_class' => Remote_Actors_Controller::class,
 				'hierarchical'          => false,
@@ -363,6 +366,9 @@ class Post_Types {
 				),
 				'map_meta_cap'          => true,
 				'public'                => false,
+				'capabilities'          => array(
+					'create_posts' => false,
+				),
 				'show_in_rest'          => true,
 				'rest_controller_class' => Remote_Posts_Controller::class,
 				'rewrite'               => false,

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -108,7 +108,6 @@ class Post_Types {
 			array(
 				'type'              => 'string',
 				'single'            => false,
-				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
 			)
 		);

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -907,10 +907,10 @@ class Post_Types {
 	 */
 	public static function filter_ap_post_by_user( $args, $request ) {
 		/*
-		 * Filter by user_id (defaults to current user, use 0 for site/blog actor).
-		 *
-		 * This has to run for every request, whatever else is being filtered on, or a
-		 * tag or object type filter would return the whole cache instead of one feed.
+		 * Scope to one actor's feed. `scope_user_id()` pins the value to the current user unless
+		 * the caller can `list_users`, so only a privileged caller can ask for another actor or
+		 * for 0, the site/blog actor. This runs for every request, whatever else is being
+		 * filtered on, or a tag or object type filter would match the whole cache.
 		 */
 		if ( ! isset( $args['meta_query'] ) ) {
 			$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/includes/class-post-types.php
+++ b/includes/class-post-types.php
@@ -18,6 +18,9 @@ use Activitypub\Collection\Remote_Posts;
 use Activitypub\OAuth\Client;
 use Activitypub\OAuth\Scope;
 use Activitypub\OAuth\Token;
+use Activitypub\Rest\Reader_Terms_Controller;
+use Activitypub\Rest\Remote_Actors_Controller;
+use Activitypub\Rest\Remote_Posts_Controller;
 
 /**
  * Post Types class.
@@ -62,18 +65,19 @@ class Post_Types {
 		\register_post_type(
 			Remote_Actors::POST_TYPE,
 			array(
-				'labels'           => array(
+				'labels'                => array(
 					'name'          => \_x( 'Followers', 'post_type plural name', 'activitypub' ),
 					'singular_name' => \_x( 'Follower', 'post_type single name', 'activitypub' ),
 				),
-				'public'           => false,
-				'show_in_rest'     => true,
-				'hierarchical'     => false,
-				'rewrite'          => false,
-				'query_var'        => false,
-				'delete_with_user' => false,
-				'can_export'       => true,
-				'supports'         => array( 'custom-fields' ),
+				'public'                => false,
+				'show_in_rest'          => true,
+				'rest_controller_class' => Remote_Actors_Controller::class,
+				'hierarchical'          => false,
+				'rewrite'               => false,
+				'query_var'             => false,
+				'delete_with_user'      => false,
+				'can_export'            => true,
+				'supports'              => array( 'custom-fields' ),
 			)
 		);
 
@@ -352,23 +356,21 @@ class Post_Types {
 		\register_post_type(
 			Remote_Posts::POST_TYPE,
 			array(
-				'labels'              => array(
+				'labels'                => array(
 					'name'          => \_x( 'Posts', 'post_type plural name', 'activitypub' ),
 					'singular_name' => \_x( 'Post', 'post_type single name', 'activitypub' ),
 				),
-				'capabilities'        => array(
-					'activitypub' => true,
-				),
-				'map_meta_cap'        => true,
-				'public'              => false,
-				'show_in_rest'        => true,
-				'rewrite'             => false,
-				'query_var'           => false,
-				'supports'            => array( 'title', 'editor', 'author', 'custom-fields', 'excerpt', 'comments' ),
-				'delete_with_user'    => true,
-				'can_export'          => true,
-				'exclude_from_search' => true,
-				'taxonomies'          => array( 'ap_tag', 'ap_object_type' ),
+				'map_meta_cap'          => true,
+				'public'                => false,
+				'show_in_rest'          => true,
+				'rest_controller_class' => Remote_Posts_Controller::class,
+				'rewrite'               => false,
+				'query_var'             => false,
+				'supports'              => array( 'title', 'editor', 'author', 'custom-fields', 'excerpt', 'comments' ),
+				'delete_with_user'      => true,
+				'can_export'            => true,
+				'exclude_from_search'   => true,
+				'taxonomies'            => array( 'ap_tag', 'ap_object_type' ),
 			)
 		);
 
@@ -376,9 +378,10 @@ class Post_Types {
 			'ap_tag',
 			array( Remote_Posts::POST_TYPE ),
 			array(
-				'public'       => false,
-				'query_var'    => true,
-				'show_in_rest' => true,
+				'public'                => false,
+				'query_var'             => true,
+				'show_in_rest'          => true,
+				'rest_controller_class' => Reader_Terms_Controller::class,
 			)
 		);
 
@@ -386,9 +389,10 @@ class Post_Types {
 			'ap_object_type',
 			array( Remote_Posts::POST_TYPE ),
 			array(
-				'public'       => false,
-				'query_var'    => true,
-				'show_in_rest' => true,
+				'public'                => false,
+				'query_var'             => true,
+				'show_in_rest'          => true,
+				'rest_controller_class' => Reader_Terms_Controller::class,
 			)
 		);
 
@@ -793,17 +797,26 @@ class Post_Types {
 	 * @return array Modified query arguments.
 	 */
 	public static function filter_ap_actor_query_by_follower( $args, $request ) {
-		if ( ! empty( $request['follower_of'] ) ) {
-			// Add meta_query to filter by _activitypub_following.
-			if ( ! isset( $args['meta_query'] ) ) {
-				$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			}
+		$follower_of = isset( $request['follower_of'] ) ? (int) $request['follower_of'] : null;
 
-			$args['meta_query'][] = array(
-				'key'   => Followers::FOLLOWER_META_KEY,
-				'value' => $request['follower_of'],
-			);
+		// Users who cannot list users may only ever see their own followers.
+		if ( ! \current_user_can( 'list_users' ) ) {
+			$follower_of = \get_current_user_id();
 		}
+
+		if ( null === $follower_of ) {
+			return $args;
+		}
+
+		// Add meta_query to filter by _activitypub_following.
+		if ( ! isset( $args['meta_query'] ) ) {
+			$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		}
+
+		$args['meta_query'][] = array(
+			'key'   => Followers::FOLLOWER_META_KEY,
+			'value' => $follower_of,
+		);
 
 		return $args;
 	}
@@ -893,6 +906,23 @@ class Post_Types {
 	 * @return array Modified query arguments.
 	 */
 	public static function filter_ap_post_by_user( $args, $request ) {
+		/*
+		 * Filter by user_id (defaults to current user, use 0 for site/blog actor).
+		 *
+		 * This has to run for every request, whatever else is being filtered on, or a
+		 * tag or object type filter would return the whole cache instead of one feed.
+		 */
+		if ( ! isset( $args['meta_query'] ) ) {
+			$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		}
+
+		$args['meta_query'][] = array(
+			'key'     => '_activitypub_user_id',
+			'value'   => self::scope_user_id( isset( $request['user_id'] ) ? $request['user_id'] : null ),
+			'compare' => '=',
+		);
+
+		// Filter by tag if provided.
 		$ap_tag = $request->get_param( 'ap_tag' );
 		if ( ! empty( $ap_tag ) ) {
 			if ( ! isset( $args['tax_query'] ) ) {
@@ -904,22 +934,7 @@ class Post_Types {
 				'field'    => 'term_id',
 				'terms'    => $ap_tag,
 			);
-
-			return $args;
 		}
-
-		// Filter by user_id (defaults to current user, use 0 for site/blog actor).
-		$user_id = isset( $request['user_id'] ) ? (int) $request['user_id'] : \get_current_user_id();
-
-		if ( ! isset( $args['meta_query'] ) ) {
-			$args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-		}
-
-		$args['meta_query'][] = array(
-			'key'     => '_activitypub_user_id',
-			'value'   => $user_id,
-			'compare' => '=',
-		);
 
 		// Filter by object type if provided.
 		if ( ! empty( $request['ap_object_type'] ) ) {
@@ -935,6 +950,33 @@ class Post_Types {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Clamp a requested user ID to a feed the current user is allowed to read.
+	 *
+	 * Users who can list users may read any actor's reader data, everybody else is
+	 * limited to their own.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int|null $requested_user_id The requested user ID, or null when none was given.
+	 * @return int The user ID to scope the query to.
+	 */
+	private static function scope_user_id( $requested_user_id ) {
+		$current_user_id = \get_current_user_id();
+
+		if ( null === $requested_user_id ) {
+			return $current_user_id;
+		}
+
+		$requested_user_id = (int) $requested_user_id;
+
+		if ( $requested_user_id !== $current_user_id && ! \current_user_can( 'list_users' ) ) {
+			return $current_user_id;
+		}
+
+		return $requested_user_id;
 	}
 
 	/**
@@ -966,6 +1008,12 @@ class Post_Types {
 	 */
 	public static function filter_object_type_by_user( $args, $request ) {
 		$user_id = $request->get_param( 'user_id' );
+
+		// Users who cannot list users may only ever see terms from their own feed.
+		if ( ! \current_user_can( 'list_users' ) ) {
+			$user_id = \get_current_user_id();
+		}
+
 		if ( null === $user_id ) {
 			return $args;
 		}

--- a/includes/rest/class-reader-terms-controller.php
+++ b/includes/rest/class-reader-terms-controller.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Reader_Terms_Controller file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Rest;
+
+/**
+ * Reader_Terms_Controller class.
+ *
+ * Restricts the WordPress REST routes that core generates for the `ap_tag` and
+ * `ap_object_type` taxonomies. Their terms are derived from the cached remote
+ * posts, so they are limited to users who can use ActivityPub.
+ *
+ * @since unreleased
+ */
+class Reader_Terms_Controller extends \WP_REST_Terms_Controller {
+	use Reader_Permission;
+
+	/**
+	 * Check whether a request has read access to the terms.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$permission = $this->check_reader_permission();
+
+		if ( \is_wp_error( $permission ) ) {
+			return $permission;
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Check whether a request has read access to a single term.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		$permission = $this->check_reader_permission();
+
+		if ( \is_wp_error( $permission ) ) {
+			return $permission;
+		}
+
+		return parent::get_item_permissions_check( $request );
+	}
+}

--- a/includes/rest/class-reader-terms-controller.php
+++ b/includes/rest/class-reader-terms-controller.php
@@ -20,24 +20,6 @@ class Reader_Terms_Controller extends \WP_REST_Terms_Controller {
 	use Reader_Permission;
 
 	/**
-	 * Check whether a request has read access to the terms.
-	 *
-	 * @since unreleased
-	 *
-	 * @param \WP_REST_Request $request Full details about the request.
-	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
-	 */
-	public function get_items_permissions_check( $request ) {
-		$permission = $this->check_reader_permission();
-
-		if ( \is_wp_error( $permission ) ) {
-			return $permission;
-		}
-
-		return parent::get_items_permissions_check( $request );
-	}
-
-	/**
 	 * Check whether a request has read access to a single term.
 	 *
 	 * @since unreleased

--- a/includes/rest/class-reader-terms-controller.php
+++ b/includes/rest/class-reader-terms-controller.php
@@ -28,7 +28,7 @@ class Reader_Terms_Controller extends \WP_REST_Terms_Controller {
 	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
-		$permission = $this->check_reader_permission();
+		$permission = $this->check_reader_capability();
 
 		if ( \is_wp_error( $permission ) ) {
 			return $permission;

--- a/includes/rest/class-remote-actors-controller.php
+++ b/includes/rest/class-remote-actors-controller.php
@@ -24,24 +24,6 @@ class Remote_Actors_Controller extends \WP_REST_Posts_Controller {
 	use Reader_Permission;
 
 	/**
-	 * Check whether a request has read access to the collection.
-	 *
-	 * @since unreleased
-	 *
-	 * @param \WP_REST_Request $request Full details about the request.
-	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
-	 */
-	public function get_items_permissions_check( $request ) {
-		$permission = $this->check_reader_permission();
-
-		if ( \is_wp_error( $permission ) ) {
-			return $permission;
-		}
-
-		return parent::get_items_permissions_check( $request );
-	}
-
-	/**
 	 * Check whether a request has read access to a single cached actor.
 	 *
 	 * The collection is scoped by a query filter, which single item requests never

--- a/includes/rest/class-remote-actors-controller.php
+++ b/includes/rest/class-remote-actors-controller.php
@@ -36,7 +36,7 @@ class Remote_Actors_Controller extends \WP_REST_Posts_Controller {
 	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
-		$permission = $this->check_reader_permission();
+		$permission = $this->check_reader_capability();
 
 		if ( \is_wp_error( $permission ) ) {
 			return $permission;

--- a/includes/rest/class-remote-actors-controller.php
+++ b/includes/rest/class-remote-actors-controller.php
@@ -9,6 +9,7 @@ namespace Activitypub\Rest;
 
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
+use Activitypub\Collection\Remote_Posts;
 
 /**
  * Remote_Actors_Controller class.
@@ -60,14 +61,62 @@ class Remote_Actors_Controller extends \WP_REST_Posts_Controller {
 			\get_post_meta( $post->ID, Following::PENDING_META_KEY, false )
 		);
 
-		if ( ! $this->can_read_feed_of( $related_user_ids ) ) {
-			return new \WP_Error(
-				'activitypub_rest_forbidden',
-				\__( 'Sorry, you are not allowed to read this actor.', 'activitypub' ),
-				array( 'status' => \rest_authorization_required_code() )
-			);
+		if ( $this->can_read_feed_of( $related_user_ids ) ) {
+			return true;
 		}
 
-		return true;
+		/*
+		 * Following is not the only way an actor gets cached: authoring a post that was boosted
+		 * or replied to into someone's feed does it too, and those records carry no relationship
+		 * meta. The reader already renders that actor's name and avatar next to the post, so the
+		 * record is readable by whoever the feed belongs to.
+		 */
+		if ( self::authored_a_post_in_feed_of( $post->ID, \get_current_user_id() ) ) {
+			return true;
+		}
+
+		return new \WP_Error(
+			'activitypub_rest_forbidden',
+			\__( 'Sorry, you are not allowed to read this actor.', 'activitypub' ),
+			array( 'status' => \rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Check whether an actor authored a cached post in a given user's feed.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int $actor_post_id The `ap_actor` post ID.
+	 * @param int $user_id       The local user whose feed to look in.
+	 * @return bool True if the actor authored at least one post in that feed.
+	 */
+	private static function authored_a_post_in_feed_of( $actor_post_id, $user_id ) {
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$posts = \get_posts(
+			array(
+				'post_type'      => Remote_Posts::POST_TYPE,
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'     => array(
+					array(
+						'key'   => '_activitypub_remote_actor_id',
+						'value' => $actor_post_id,
+					),
+					array(
+						'key'   => '_activitypub_user_id',
+						'value' => $user_id,
+					),
+				),
+			)
+		);
+
+		return ! empty( $posts );
 	}
 }

--- a/includes/rest/class-remote-actors-controller.php
+++ b/includes/rest/class-remote-actors-controller.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Remote_Actors_Controller file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Rest;
+
+use Activitypub\Collection\Followers;
+use Activitypub\Collection\Following;
+
+/**
+ * Remote_Actors_Controller class.
+ *
+ * Restricts the WordPress REST route that core generates for the `ap_actor` post
+ * type. The route holds the cached remote actor documents and the follower graph,
+ * which the plugin's own collection endpoints only expose when the site owner has
+ * chosen to publish the social graph.
+ *
+ * @since unreleased
+ */
+class Remote_Actors_Controller extends \WP_REST_Posts_Controller {
+	use Reader_Permission;
+
+	/**
+	 * Check whether a request has read access to the collection.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$permission = $this->check_reader_permission();
+
+		if ( \is_wp_error( $permission ) ) {
+			return $permission;
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Check whether a request has read access to a single cached actor.
+	 *
+	 * The collection is scoped by a query filter, which single item requests never
+	 * run, so the relationship is checked here to keep another actor's followers
+	 * from being read by ID.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		$permission = $this->check_reader_permission();
+
+		if ( \is_wp_error( $permission ) ) {
+			return $permission;
+		}
+
+		$permission = parent::get_item_permissions_check( $request );
+
+		if ( \is_wp_error( $permission ) || ! $permission ) {
+			return $permission;
+		}
+
+		$post = $this->get_post( $request['id'] );
+
+		if ( \is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		$related_user_ids = \array_merge(
+			\get_post_meta( $post->ID, Followers::FOLLOWER_META_KEY, false ),
+			\get_post_meta( $post->ID, Following::FOLLOWING_META_KEY, false ),
+			\get_post_meta( $post->ID, Following::PENDING_META_KEY, false )
+		);
+
+		if ( ! $this->can_read_feed_of( $related_user_ids ) ) {
+			return new \WP_Error(
+				'activitypub_rest_forbidden',
+				\__( 'Sorry, you are not allowed to read this actor.', 'activitypub' ),
+				array( 'status' => \rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+}

--- a/includes/rest/class-remote-posts-controller.php
+++ b/includes/rest/class-remote-posts-controller.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Remote_Posts_Controller file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Rest;
+
+/**
+ * Remote_Posts_Controller class.
+ *
+ * Restricts the WordPress REST route that core generates for the `ap_post` post
+ * type. The route holds remote posts cached for a specific local user, so it is
+ * limited to users who can use ActivityPub, and to their own feed.
+ *
+ * @since unreleased
+ */
+class Remote_Posts_Controller extends \WP_REST_Posts_Controller {
+	use Reader_Permission;
+
+	/**
+	 * Check whether a request has read access to the collection.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$permission = $this->check_reader_permission();
+
+		if ( \is_wp_error( $permission ) ) {
+			return $permission;
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Check whether a request has read access to a single cached post.
+	 *
+	 * The collection is scoped by a query filter, which single item requests never
+	 * run, so ownership is checked here to keep the feed from being read by ID.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		$permission = $this->check_reader_permission();
+
+		if ( \is_wp_error( $permission ) ) {
+			return $permission;
+		}
+
+		$permission = parent::get_item_permissions_check( $request );
+
+		if ( \is_wp_error( $permission ) || ! $permission ) {
+			return $permission;
+		}
+
+		$post = $this->get_post( $request['id'] );
+
+		if ( \is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		if ( ! $this->can_read_feed_of( \get_post_meta( $post->ID, '_activitypub_user_id', false ) ) ) {
+			return new \WP_Error(
+				'activitypub_rest_forbidden',
+				\__( 'Sorry, you are not allowed to read this post.', 'activitypub' ),
+				array( 'status' => \rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+}

--- a/includes/rest/class-remote-posts-controller.php
+++ b/includes/rest/class-remote-posts-controller.php
@@ -28,7 +28,7 @@ class Remote_Posts_Controller extends \WP_REST_Posts_Controller {
 	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
-		$permission = $this->check_reader_permission();
+		$permission = $this->check_reader_capability();
 
 		if ( \is_wp_error( $permission ) ) {
 			return $permission;

--- a/includes/rest/class-remote-posts-controller.php
+++ b/includes/rest/class-remote-posts-controller.php
@@ -22,9 +22,6 @@ class Remote_Posts_Controller extends \WP_REST_Posts_Controller {
 	/**
 	 * Check whether a request has read access to a single cached post.
 	 *
-	 * The collection is scoped by a query filter, which single item requests never
-	 * run, so ownership is checked here to keep the feed from being read by ID.
-	 *
 	 * @since unreleased
 	 *
 	 * @param \WP_REST_Request $request Full details about the request.
@@ -37,26 +34,27 @@ class Remote_Posts_Controller extends \WP_REST_Posts_Controller {
 			return $permission;
 		}
 
-		$permission = parent::get_item_permissions_check( $request );
+		return parent::get_item_permissions_check( $request );
+	}
 
-		if ( \is_wp_error( $permission ) || ! $permission ) {
-			return $permission;
+	/**
+	 * Check whether a post can be read.
+	 *
+	 * This is the shared predicate: core's own `get_item_permissions_check()` calls it, and so
+	 * does `WP_REST_Comments_Controller`, which serves the remote replies cached on these posts.
+	 * Scoping here covers both routes; scoping only the route callbacks leaves the comment route
+	 * reading the same records.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return bool True if the post can be read, false otherwise.
+	 */
+	public function check_read_permission( $post ) {
+		if ( ! parent::check_read_permission( $post ) ) {
+			return false;
 		}
 
-		$post = $this->get_post( $request['id'] );
-
-		if ( \is_wp_error( $post ) ) {
-			return $post;
-		}
-
-		if ( ! $this->can_read_feed_of( \get_post_meta( $post->ID, '_activitypub_user_id', false ) ) ) {
-			return new \WP_Error(
-				'activitypub_rest_forbidden',
-				\__( 'Sorry, you are not allowed to read this post.', 'activitypub' ),
-				array( 'status' => \rest_authorization_required_code() )
-			);
-		}
-
-		return true;
+		return $this->can_read_feed_of( \get_post_meta( $post->ID, '_activitypub_user_id', false ) );
 	}
 }

--- a/includes/rest/class-remote-posts-controller.php
+++ b/includes/rest/class-remote-posts-controller.php
@@ -20,24 +20,6 @@ class Remote_Posts_Controller extends \WP_REST_Posts_Controller {
 	use Reader_Permission;
 
 	/**
-	 * Check whether a request has read access to the collection.
-	 *
-	 * @since unreleased
-	 *
-	 * @param \WP_REST_Request $request Full details about the request.
-	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
-	 */
-	public function get_items_permissions_check( $request ) {
-		$permission = $this->check_reader_permission();
-
-		if ( \is_wp_error( $permission ) ) {
-			return $permission;
-		}
-
-		return parent::get_items_permissions_check( $request );
-	}
-
-	/**
 	 * Check whether a request has read access to a single cached post.
 	 *
 	 * The collection is scoped by a query filter, which single item requests never

--- a/includes/rest/trait-reader-permission.php
+++ b/includes/rest/trait-reader-permission.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Reader_Permission trait file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Rest;
+
+/**
+ * Reader_Permission trait.
+ *
+ * Shared authorization checks for the WordPress REST routes that WordPress core
+ * generates for the reader's own post types and taxonomies. Those routes hold
+ * cached remote content and the social graph, so they are restricted to users
+ * who can use ActivityPub rather than being world readable.
+ *
+ * @since unreleased
+ */
+trait Reader_Permission {
+	/**
+	 * Check whether the current user may read the reader's cached data at all.
+	 *
+	 * @since unreleased
+	 *
+	 * @return true|\WP_Error True if the current user may read, WP_Error otherwise.
+	 */
+	protected function check_reader_permission() {
+		if ( \current_user_can( 'activitypub' ) || \current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		return new \WP_Error(
+			'activitypub_rest_forbidden',
+			\__( 'Sorry, you are not allowed to read ActivityPub data.', 'activitypub' ),
+			array( 'status' => \rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Check whether the current user may read the feed of the given actor(s).
+	 *
+	 * Users who can list users may read any actor's feed, everybody else is
+	 * limited to their own.
+	 *
+	 * @since unreleased
+	 *
+	 * @param int|int[] $user_ids One or more local user IDs a record belongs to.
+	 * @return bool True if the current user may read it, false otherwise.
+	 */
+	protected function can_read_feed_of( $user_ids ) {
+		if ( \current_user_can( 'list_users' ) ) {
+			return true;
+		}
+
+		return \in_array( \get_current_user_id(), \array_map( 'intval', (array) $user_ids ), true );
+	}
+}

--- a/includes/rest/trait-reader-permission.php
+++ b/includes/rest/trait-reader-permission.php
@@ -19,13 +19,16 @@ namespace Activitypub\Rest;
  */
 trait Reader_Permission {
 	/**
-	 * Check whether the current user may read the reader's cached data at all.
+	 * Check whether the current user holds the capability to read the reader's cached data.
+	 *
+	 * Named for the capability rather than the read, so it is not mistaken for core's
+	 * `check_read_permission()`, which answers whether one given post may be read.
 	 *
 	 * @since unreleased
 	 *
 	 * @return true|\WP_Error True if the current user may read, WP_Error otherwise.
 	 */
-	protected function check_reader_permission() {
+	protected function check_reader_capability() {
 		if ( \current_user_can( 'activitypub' ) || \current_user_can( 'manage_options' ) ) {
 			return true;
 		}
@@ -49,7 +52,7 @@ trait Reader_Permission {
 	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
-		$permission = $this->check_reader_permission();
+		$permission = $this->check_reader_capability();
 
 		if ( \is_wp_error( $permission ) ) {
 			return $permission;

--- a/includes/rest/trait-reader-permission.php
+++ b/includes/rest/trait-reader-permission.php
@@ -38,6 +38,27 @@ trait Reader_Permission {
 	}
 
 	/**
+	 * Check whether a request has read access to the collection.
+	 *
+	 * A trait method wins over an inherited one, so this overrides the core controller's check
+	 * and defers to it once the reader gate has passed.
+	 *
+	 * @since unreleased
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$permission = $this->check_reader_permission();
+
+		if ( \is_wp_error( $permission ) ) {
+			return $permission;
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
 	 * Check whether the current user may read the feed of the given actor(s).
 	 *
 	 * Users who can list users may read any actor's feed, everybody else is

--- a/includes/rest/trait-reader-permission.php
+++ b/includes/rest/trait-reader-permission.php
@@ -82,6 +82,11 @@ trait Reader_Permission {
 	 * @return bool True if the current user may read it, false otherwise.
 	 */
 	protected function can_read_feed_of( $user_ids ) {
+		// Blanket access: an actor with no relationship at all has nothing to check per target.
+		if ( \current_user_can( 'list_users' ) ) {
+			return true;
+		}
+
 		$user_ids = \array_map( 'intval', (array) $user_ids );
 
 		if ( \in_array( \get_current_user_id(), $user_ids, true ) ) {

--- a/includes/rest/trait-reader-permission.php
+++ b/includes/rest/trait-reader-permission.php
@@ -7,6 +7,9 @@
 
 namespace Activitypub\Rest;
 
+use function Activitypub\user_can_act_as_blog;
+use function Activitypub\user_can_activitypub;
+
 /**
  * Reader_Permission trait.
  *
@@ -29,7 +32,13 @@ trait Reader_Permission {
 	 * @return true|\WP_Error True if the current user may read, WP_Error otherwise.
 	 */
 	protected function check_reader_capability() {
-		if ( \current_user_can( 'activitypub' ) || \current_user_can( 'manage_options' ) ) {
+		/*
+		 * `user_can_activitypub()` rather than the raw capability: it also honours
+		 * `is_user_type_disabled( 'user' )` and the `activitypub_user_can_activitypub` filter, the
+		 * way the plugin's own admin routes do. A logged-out request has user ID 0, which is also
+		 * `Actors::BLOG_USER_ID`, so the login check has to come first.
+		 */
+		if ( \is_user_logged_in() && ( user_can_activitypub( \get_current_user_id() ) || user_can_act_as_blog() ) ) {
 			return true;
 		}
 
@@ -73,10 +82,18 @@ trait Reader_Permission {
 	 * @return bool True if the current user may read it, false otherwise.
 	 */
 	protected function can_read_feed_of( $user_ids ) {
-		if ( \current_user_can( 'list_users' ) ) {
+		$user_ids = \array_map( 'intval', (array) $user_ids );
+
+		if ( \in_array( \get_current_user_id(), $user_ids, true ) ) {
 			return true;
 		}
 
-		return \in_array( \get_current_user_id(), \array_map( 'intval', (array) $user_ids ), true );
+		foreach ( $user_ids as $user_id ) {
+			if ( \current_user_can( 'edit_user', $user_id ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -141,6 +141,15 @@ a server-rendered table.
   `useEntityRecord` / `useEntityRecords` against the REST API. The plugin's custom
   post types `ap_post` (feed) and `ap_actor` (followers/following) and their
   taxonomies (`ap_object_type`, `ap_tag`) are the entities behind the lists.
+- **Those routes are gated and self-scoping.** They are served by the plugin's own
+  controllers (`includes/rest/`), not core's, so they require the `activitypub`
+  capability and return nothing to logged-out visitors. Collections are scoped to
+  the current user automatically: `user_id` on `ap_post` and `follower_of` on
+  `ap_actor` are clamped unless the caller can `list_users`, so a screen never has
+  to pass the viewer's own ID to stay within its own data. A screen that needs a
+  relationship these routes do not expose yet — the site's *following* list lives
+  in `_activitypub_followed_by`, which is not registered for REST — needs that
+  wired up first.
 - **The `activitypub/app` `@wordpress/data` store is for UI/app state only** —
   things with no REST representation, such as the active actor selection (which is
   persisted through `@wordpress/preferences`). Do not duplicate entity data in it.

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -48,7 +48,6 @@ export interface Actor {
 	title: { rendered: string };
 	content: { rendered: string; protected: boolean };
 	meta: {
-		_activitypub_following: string[];
 		[ key: string ]: any;
 	};
 	actor_info?: ActorInfo;

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -394,6 +394,51 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Hashtags and object types only list terms from the caller's own feed.
+	 *
+	 * @covers \Activitypub\Post_Types::filter_tag_by_user
+	 * @covers \Activitypub\Post_Types::filter_object_type_by_user
+	 * @dataProvider data_reader_taxonomies
+	 *
+	 * @param string $route    Taxonomy route to request.
+	 * @param string $taxonomy Taxonomy to attach the term to.
+	 */
+	public function test_reader_taxonomies_are_scoped_to_the_current_user( $route, $taxonomy ) {
+		$term = \wp_insert_term( 'term-' . $taxonomy, $taxonomy );
+		\wp_set_object_terms( self::$remote_post_id, array( $term['term_id'] ), $taxonomy );
+
+		\wp_set_current_user( self::$user_id );
+		$mine = $this->request( $route );
+
+		$this->assertSame( 200, $mine->get_status() );
+		$this->assertSame(
+			array( $term['term_id'] ),
+			\wp_list_pluck( $mine->get_data(), 'id' ),
+			'The feed owner has to see the term, or this test proves nothing.'
+		);
+
+		\wp_set_current_user( self::$other_user_id );
+		$theirs = $this->request( $route );
+
+		$this->assertSame( 200, $theirs->get_status() );
+		$this->assertSame( array(), $theirs->get_data(), 'Another user\'s terms must not be listed.' );
+
+		\wp_delete_term( $term['term_id'], $taxonomy );
+	}
+
+	/**
+	 * Data provider for the reader taxonomy routes.
+	 *
+	 * @return array[] Test parameters.
+	 */
+	public function data_reader_taxonomies() {
+		return array(
+			'hashtags'     => array( '/wp/v2/ap_tag', 'ap_tag' ),
+			'object types' => array( '/wp/v2/ap_object_type', 'ap_object_type' ),
+		);
+	}
+
+	/**
 	 * A user cannot read an unrelated actor by ID.
 	 *
 	 * @covers ::get_item_permissions_check

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -103,7 +103,7 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new \WP_REST_Server();
-		\do_action( 'rest_api_init', $wp_rest_server );
+		\do_action( 'rest_api_init' );
 	}
 
 	/**
@@ -239,6 +239,21 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( array(), $response->get_data(), 'Another user\'s followers must not be returned.' );
+	}
+
+	/**
+	 * A user cannot read another user's cached post by ID.
+	 *
+	 * The collection filter never runs for a single item, so this is the only gate on that route.
+	 *
+	 * @covers \Activitypub\Rest\Remote_Posts_Controller::get_item_permissions_check
+	 */
+	public function test_unrelated_post_cannot_be_read_by_id() {
+		\wp_set_current_user( self::$other_user_id );
+
+		$response = $this->request( '/wp/v2/ap_post/' . self::$remote_post_id );
+
+		$this->assertSame( 403, $response->get_status() );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -500,6 +500,37 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An administrator can read an actor that has no relationship at all.
+	 *
+	 * Per-target checks have nothing to iterate for such a record, so the blanket capability has
+	 * to answer it.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_administrators_can_read_an_unrelated_actor() {
+		$orphan = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Actors::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => \wp_slash(
+					\wp_json_encode(
+						array(
+							'id'   => 'https://example.org/users/orphan',
+							'type' => 'Person',
+						)
+					)
+				),
+			)
+		);
+
+		\wp_set_current_user( self::$admin_id );
+
+		$this->assertSame( 200, $this->request( '/wp/v2/ap_actor/' . $orphan )->get_status() );
+
+		\wp_delete_post( $orphan, true );
+	}
+
+	/**
 	 * A user cannot read an unrelated actor by ID.
 	 *
 	 * @covers ::get_item_permissions_check

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -142,7 +142,7 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	/**
 	 * Logged-out visitors get no reader data at all.
 	 *
-	 * @covers ::get_items_permissions_check
+	 * @covers \Activitypub\Rest\Reader_Permission::get_items_permissions_check
 	 * @dataProvider data_reader_routes
 	 *
 	 * @param string $route  Route to request.
@@ -186,7 +186,7 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	/**
 	 * Users without the ActivityPub capability get nothing.
 	 *
-	 * @covers ::get_items_permissions_check
+	 * @covers \Activitypub\Rest\Reader_Permission::get_items_permissions_check
 	 */
 	public function test_reader_routes_are_closed_to_users_without_the_capability() {
 		\wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
@@ -257,7 +257,7 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	/**
 	 * The admin screens still get their data.
 	 *
-	 * @covers ::get_items_permissions_check
+	 * @covers \Activitypub\Rest\Reader_Permission::get_items_permissions_check
 	 */
 	public function test_administrators_can_still_read_reader_data() {
 		\wp_set_current_user( self::$admin_id );
@@ -274,7 +274,7 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	/**
 	 * A user still gets their own feed and followers.
 	 *
-	 * @covers ::get_items_permissions_check
+	 * @covers \Activitypub\Rest\Reader_Permission::get_items_permissions_check
 	 */
 	public function test_users_can_still_read_their_own_data() {
 		\wp_set_current_user( self::$user_id );

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -326,7 +326,7 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	 * The collection filter decides which actors a user may list. The record it hands back must
 	 * not then name the other local users who follow that same actor.
 	 *
-	 * @covers \Activitypub\Post_Types::register_post_meta
+	 * @covers \Activitypub\Post_Types::register_remote_actors_post_type
 	 */
 	public function test_actor_response_does_not_disclose_other_followers() {
 		\add_post_meta( self::$actor_id, Followers::FOLLOWER_META_KEY, (string) self::$other_user_id );

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -475,6 +475,31 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A site that has switched off user actors does not serve reader data to those users.
+	 *
+	 * The gate goes through `user_can_activitypub()` rather than the raw capability, so it honours
+	 * the same opt-outs the plugin's own admin routes do.
+	 *
+	 * @covers \Activitypub\Rest\Reader_Permission::check_reader_capability
+	 */
+	public function test_disabled_user_actors_are_refused() {
+		\wp_set_current_user( self::$user_id );
+
+		$this->assertSame( 200, $this->request( '/wp/v2/ap_actor' )->get_status(), 'The user has to start with access, or this test proves nothing.' );
+
+		$filter = function ( $enabled, $user_id ) {
+			return self::$user_id === $user_id ? false : $enabled;
+		};
+		\add_filter( 'activitypub_user_can_activitypub', $filter, 10, 2 );
+
+		$response = $this->request( '/wp/v2/ap_actor' );
+
+		\remove_filter( 'activitypub_user_can_activitypub', $filter, 10 );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
 	 * A user cannot read an unrelated actor by ID.
 	 *
 	 * @covers ::get_item_permissions_check

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -439,6 +439,42 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * The reader routes are read-only.
+	 *
+	 * These records are written by the inbox through `wp_insert_post()`, which does not consult
+	 * capabilities, so refusing `create_posts` closes the REST write path without touching
+	 * federation.
+	 *
+	 * @covers \Activitypub\Post_Types::register_post_post_type
+	 * @covers \Activitypub\Post_Types::register_remote_actors_post_type
+	 * @dataProvider data_reader_post_types
+	 *
+	 * @param string $route Route to post to.
+	 */
+	public function test_reader_routes_refuse_writes( $route ) {
+		\wp_set_current_user( self::$user_id );
+
+		$request = new \WP_REST_Request( 'POST', $route );
+		$request->set_param( 'title', 'injected' );
+
+		$response = \rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Data provider for the reader post type routes.
+	 *
+	 * @return array[] Test parameters.
+	 */
+	public function data_reader_post_types() {
+		return array(
+			'posts'  => array( '/wp/v2/ap_post' ),
+			'actors' => array( '/wp/v2/ap_actor' ),
+		);
+	}
+
+	/**
 	 * A user cannot read an unrelated actor by ID.
 	 *
 	 * @covers ::get_item_permissions_check

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -321,6 +321,31 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * The follower list of an actor is not disclosed in its REST response.
+	 *
+	 * The collection filter decides which actors a user may list. The record it hands back must
+	 * not then name the other local users who follow that same actor.
+	 *
+	 * @covers \Activitypub\Post_Types::register_post_meta
+	 */
+	public function test_actor_response_does_not_disclose_other_followers() {
+		\add_post_meta( self::$actor_id, Followers::FOLLOWER_META_KEY, (string) self::$other_user_id );
+
+		\wp_set_current_user( self::$user_id );
+
+		$response = $this->request( '/wp/v2/ap_actor/' . self::$actor_id );
+
+		$this->assertSame( 200, $response->get_status(), 'The follower has to reach the actor, or this test proves nothing.' );
+		$this->assertStringNotContainsString(
+			Followers::FOLLOWER_META_KEY,
+			\wp_json_encode( $response->get_data() ),
+			'The follower list must not be serialized into the response.'
+		);
+
+		\delete_post_meta( self::$actor_id, Followers::FOLLOWER_META_KEY, (string) self::$other_user_id );
+	}
+
+	/**
 	 * A user cannot read an unrelated actor by ID.
 	 *
 	 * @covers ::get_item_permissions_check

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Reader REST route authorization test file.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Rest;
+
+use Activitypub\Collection\Followers;
+use Activitypub\Collection\Remote_Actors;
+use Activitypub\Collection\Remote_Posts;
+
+/**
+ * Tests that the REST routes WordPress core generates for the reader's post types
+ * and taxonomies are not readable by logged-out or unprivileged visitors.
+ *
+ * @group rest
+ * @coversDefaultClass \Activitypub\Rest\Remote_Actors_Controller
+ */
+class Test_Reader_Authorization extends \WP_UnitTestCase {
+
+	/**
+	 * An actor that follows $user_id.
+	 *
+	 * @var int
+	 */
+	protected static $actor_id;
+
+	/**
+	 * A cached remote post delivered to $user_id.
+	 *
+	 * @var int
+	 */
+	protected static $remote_post_id;
+
+	/**
+	 * A user who can use ActivityPub.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Another user who can use ActivityPub, unrelated to the fixtures above.
+	 *
+	 * @var int
+	 */
+	protected static $other_user_id;
+
+	/**
+	 * An administrator.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Create fixtures.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$user_id       = $factory->user->create( array( 'role' => 'author' ) );
+		self::$other_user_id = $factory->user->create( array( 'role' => 'author' ) );
+
+		\get_user_by( 'id', self::$user_id )->add_cap( 'activitypub' );
+		\get_user_by( 'id', self::$other_user_id )->add_cap( 'activitypub' );
+
+		self::$actor_id = $factory->post->create(
+			array(
+				'post_type'    => Remote_Actors::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => \wp_slash(
+					\wp_json_encode(
+						array(
+							'id'                => 'https://example.org/users/bob',
+							'type'              => 'Person',
+							'preferredUsername' => 'bob',
+						)
+					)
+				),
+				'meta_input'   => array( Followers::FOLLOWER_META_KEY => (string) self::$user_id ),
+			)
+		);
+
+		self::$remote_post_id = $factory->post->create(
+			array(
+				'post_type'    => Remote_Posts::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'Cached remote content.',
+				'meta_input'   => array( '_activitypub_user_id' => (string) self::$user_id ),
+			)
+		);
+	}
+
+	/**
+	 * Set up the REST server.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		\do_action( 'rest_api_init', $wp_rest_server );
+	}
+
+	/**
+	 * Perform a REST request.
+	 *
+	 * @param string $route  Route to request.
+	 * @param array  $params Optional. Query parameters. Default empty array.
+	 * @return \WP_REST_Response Response object.
+	 */
+	protected function request( $route, $params = array() ) {
+		$request = new \WP_REST_Request( 'GET', $route );
+
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return \rest_do_request( $request );
+	}
+
+	/**
+	 * Routes that must never answer a logged-out visitor.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_reader_routes() {
+		return array(
+			'actor collection'       => array( '/wp/v2/ap_actor', array() ),
+			'actor by follower'      => array( '/wp/v2/ap_actor', array( 'follower_of' => 1 ) ),
+			'post collection'        => array( '/wp/v2/ap_post', array() ),
+			'post by user'           => array( '/wp/v2/ap_post', array( 'user_id' => 1 ) ),
+			'tag collection'         => array( '/wp/v2/ap_tag', array() ),
+			'object type collection' => array( '/wp/v2/ap_object_type', array() ),
+		);
+	}
+
+	/**
+	 * Logged-out visitors get no reader data at all.
+	 *
+	 * @covers ::get_items_permissions_check
+	 * @dataProvider data_reader_routes
+	 *
+	 * @param string $route  Route to request.
+	 * @param array  $params Query parameters.
+	 */
+	public function test_reader_routes_are_closed_to_logged_out_visitors( $route, $params ) {
+		\wp_set_current_user( 0 );
+
+		$response = $this->request( $route, $params );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'activitypub_rest_forbidden', $response->get_data()['code'] );
+	}
+
+	/**
+	 * A logged-out visitor cannot read a cached post by ID either.
+	 *
+	 * @covers \Activitypub\Rest\Remote_Posts_Controller::get_item_permissions_check
+	 */
+	public function test_single_post_is_closed_to_logged_out_visitors() {
+		\wp_set_current_user( 0 );
+
+		$response = $this->request( '/wp/v2/ap_post/' . self::$remote_post_id );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * A logged-out visitor cannot read a cached actor by ID either.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_single_actor_is_closed_to_logged_out_visitors() {
+		\wp_set_current_user( 0 );
+
+		$response = $this->request( '/wp/v2/ap_actor/' . self::$actor_id );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Users without the ActivityPub capability get nothing.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_reader_routes_are_closed_to_users_without_the_capability() {
+		\wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$response = $this->request( '/wp/v2/ap_actor' );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * A user cannot read another user's feed by asking for it.
+	 *
+	 * @covers \Activitypub\Post_Types::filter_ap_post_by_user
+	 */
+	public function test_user_id_is_clamped_to_the_current_user() {
+		\wp_set_current_user( self::$other_user_id );
+
+		$response = $this->request( '/wp/v2/ap_post', array( 'user_id' => self::$user_id ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data(), 'Another user\'s feed must not be returned.' );
+	}
+
+	/**
+	 * A tag filter does not skip the per-user scoping.
+	 *
+	 * @covers \Activitypub\Post_Types::filter_ap_post_by_user
+	 */
+	public function test_tag_filter_does_not_bypass_user_scoping() {
+		$term = \wp_insert_term( 'regression', 'ap_tag' );
+		\wp_set_object_terms( self::$remote_post_id, array( (int) $term['term_id'] ), 'ap_tag' );
+
+		\wp_set_current_user( self::$other_user_id );
+
+		$response = $this->request( '/wp/v2/ap_post', array( 'ap_tag' => array( (int) $term['term_id'] ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data(), 'A tag filter must not return another user\'s feed.' );
+	}
+
+	/**
+	 * A user cannot read another user's followers by asking for them.
+	 *
+	 * @covers \Activitypub\Post_Types::filter_ap_actor_query_by_follower
+	 */
+	public function test_follower_of_is_clamped_to_the_current_user() {
+		\wp_set_current_user( self::$other_user_id );
+
+		$response = $this->request( '/wp/v2/ap_actor', array( 'follower_of' => self::$user_id ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data(), 'Another user\'s followers must not be returned.' );
+	}
+
+	/**
+	 * A user cannot read an unrelated actor by ID.
+	 *
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_unrelated_actor_cannot_be_read_by_id() {
+		\wp_set_current_user( self::$other_user_id );
+
+		$response = $this->request( '/wp/v2/ap_actor/' . self::$actor_id );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * The admin screens still get their data.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_administrators_can_still_read_reader_data() {
+		\wp_set_current_user( self::$admin_id );
+
+		$actors = $this->request( '/wp/v2/ap_actor', array( 'follower_of' => self::$user_id ) );
+		$this->assertSame( 200, $actors->get_status() );
+		$this->assertCount( 1, $actors->get_data() );
+
+		$posts = $this->request( '/wp/v2/ap_post', array( 'user_id' => self::$user_id ) );
+		$this->assertSame( 200, $posts->get_status() );
+		$this->assertCount( 1, $posts->get_data() );
+	}
+
+	/**
+	 * A user still gets their own feed and followers.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_users_can_still_read_their_own_data() {
+		\wp_set_current_user( self::$user_id );
+
+		$actors = $this->request( '/wp/v2/ap_actor' );
+		$this->assertSame( 200, $actors->get_status() );
+		$this->assertCount( 1, $actors->get_data() );
+
+		$posts = $this->request( '/wp/v2/ap_post' );
+		$this->assertSame( 200, $posts->get_status() );
+		$this->assertCount( 1, $posts->get_data() );
+
+		$actor = $this->request( '/wp/v2/ap_actor/' . self::$actor_id );
+		$this->assertSame( 200, $actor->get_status() );
+	}
+}

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -242,6 +242,70 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Cached replies are not readable through the comments route.
+	 *
+	 * `ap_post` supports comments and remote replies are stored on it, so
+	 * `WP_REST_Comments_Controller` reaches these records through `check_read_permission()`
+	 * rather than through this controller's own permission callbacks.
+	 *
+	 * @covers \Activitypub\Rest\Remote_Posts_Controller::check_read_permission
+	 * @dataProvider data_users_without_access_to_the_feed
+	 *
+	 * @param string $user Property holding the user ID to test with.
+	 */
+	public function test_cached_replies_are_not_readable_through_the_comments_route( $user ) {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$remote_post_id,
+				'comment_content'  => 'Cached remote reply.',
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+			)
+		);
+
+		\wp_set_current_user( 'none' === $user ? 0 : self::${$user} );
+
+		$response = $this->request( '/wp/v2/comments/' . $comment_id );
+
+		$this->assertNotSame( 200, $response->get_status() );
+		$this->assertStringNotContainsString( 'Cached remote reply.', \wp_json_encode( $response->get_data() ) );
+	}
+
+	/**
+	 * Data provider for users that must not reach another user's cached replies.
+	 *
+	 * @return array[] Test parameters.
+	 */
+	public function data_users_without_access_to_the_feed() {
+		return array(
+			'logged out' => array( 'none' ),
+			'other user' => array( 'other_user_id' ),
+		);
+	}
+
+	/**
+	 * The owner still reads the replies cached in their own feed.
+	 *
+	 * @covers \Activitypub\Rest\Remote_Posts_Controller::check_read_permission
+	 */
+	public function test_owner_can_read_cached_replies_through_the_comments_route() {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$remote_post_id,
+				'comment_content'  => 'Cached remote reply.',
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+			)
+		);
+
+		\wp_set_current_user( self::$user_id );
+
+		$response = $this->request( '/wp/v2/comments/' . $comment_id );
+
+		$this->assertSame( 200, $response->get_status(), 'The owner has to keep access, or this test proves nothing.' );
+	}
+
+	/**
 	 * A user cannot read another user's cached post by ID.
 	 *
 	 * The collection filter never runs for a single item, so this is the only gate on that route.

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -346,6 +346,54 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An actor whose post is in your feed is readable, even without a follow relationship.
+	 *
+	 * Boosts and replies cache the author too, and those records carry no follower, following or
+	 * pending meta. The reader already shows that actor beside the post.
+	 *
+	 * @covers \Activitypub\Rest\Remote_Actors_Controller::get_item_permissions_check
+	 */
+	public function test_actor_of_a_post_in_the_feed_can_be_read() {
+		$stranger_id = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Actors::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => \wp_slash(
+					\wp_json_encode(
+						array(
+							'id'   => 'https://example.org/users/eve',
+							'type' => 'Person',
+						)
+					)
+				),
+			)
+		);
+		$post_id     = self::factory()->post->create(
+			array(
+				'post_type'   => Remote_Posts::POST_TYPE,
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					'_activitypub_user_id'         => (string) self::$user_id,
+					'_activitypub_remote_actor_id' => (string) $stranger_id,
+				),
+			)
+		);
+
+		\wp_set_current_user( self::$user_id );
+		$mine = $this->request( '/wp/v2/ap_actor/' . $stranger_id );
+
+		$this->assertSame( 200, $mine->get_status(), 'The feed owner has to reach the author of a post in their feed.' );
+
+		\wp_set_current_user( self::$other_user_id );
+		$theirs = $this->request( '/wp/v2/ap_actor/' . $stranger_id );
+
+		$this->assertSame( 403, $theirs->get_status(), 'A user with no such post must still be refused.' );
+
+		\wp_delete_post( $post_id, true );
+		\wp_delete_post( $stranger_id, true );
+	}
+
+	/**
 	 * A user cannot read an unrelated actor by ID.
 	 *
 	 * @covers ::get_item_permissions_check


### PR DESCRIPTION
Fixes CM-887

## Proposed changes:

`ap_actor` and `ap_post` are registered with `show_in_rest => true` and no controller of their own, so WordPress core generates `/wp/v2/ap_actor` and `/wp/v2/ap_post` for us. Core's `WP_REST_Posts_Controller` only gates `context=edit`, so those two routes, plus the `ap_tag` and `ap_object_type` term routes, answered logged-out visitors.

With `/wp/v2/ap_actor`, it's problematic. It returns every cached remote actor document along with the `_activitypub_following` meta, which is enough to rebuild the follower graph. It's possible even on sites that have enabled "hide social graph". Our own followers endpoint honours that setting; the generated route never saw it.

For `ap_post`, its `user_id` parameter is read straight off the request with no ownership comparison, the `ap_tag` branch returns before applying it at all, and single-item requests never run the query filter, so a feed could be read by ID anyway.

So this binds a controller to each of the four routes:

* `Remote_Actors_Controller`, `Remote_Posts_Controller` and `Reader_Terms_Controller` require the `activitypub` capability on collection and single-item reads, and check ownership per item.
* `user_id` and `follower_of` now clamp to the current user unless the caller can `list_users`.
* The `ap_tag` early return is gone, so per-user scoping always applies.
* Drops `'capabilities' => array( 'activitypub' => true )` from `ap_post`. It's not a recognised capability key so it never did anything, but it's the line that made the registration look guarded, which is how we all read past it :)


### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

Seed a follower, then turn on the privacy setting this is meant to honour:

```bash
wp option update activitypub_hide_social_graph 1
```

Logged out, with no cookie and no signature:

```bash
curl -s "http://localhost:8888/?rest_route=/wp/v2/ap_actor&per_page=100"
curl -s "http://localhost:8888/?rest_route=/wp/v2/ap_actor&follower_of=1"
curl -s "http://localhost:8888/?rest_route=/wp/v2/ap_post&user_id=2"
curl -s "http://localhost:8888/?rest_route=/wp/v2/ap_tag"
```

On trunk the first two hand back the actor document and `_activitypub_following`. Here all four return `401`. Single items (`/wp/v2/ap_actor/<id>`, `/wp/v2/ap_post/<id>`) return `401` too, where trunk returns `200`.

Then check nothing regressed in the UI:

1. Enable the Reader under Settings > ActivityPub > Advanced.
2. Dashboard > Social Web: the feed loads.
3. Users > Followers: the list loads, and search / sort / pagination still work.
4. As a non-admin author with the ActivityPub capability, the feed and followers show only their own data.
5. As a subscriber, all four routes return `403`.

