### PR TITLE
Fix embed crash when a post's author or avatar is sent in an unexpected format

### DIFF
--- a/.github/changelog/fix-embed-ltrim-type-error
+++ b/.github/changelog/fix-embed-ltrim-type-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an error that could break embeds of Fediverse posts whose author was sent in an unexpected format.

--- a/includes/class-embed.php
+++ b/includes/class-embed.php
@@ -49,9 +49,10 @@ class Embed {
 	 * @return string The embed HTML.
 	 */
 	public static function get_html_for_object( $activity_object, $inline_css = true ) {
-		$author_name = $activity_object['attributedTo'] ?? '';
-		$avatar_url  = $activity_object['icon']['url'] ?? '';
-		$author_url  = $author_name;
+		// `attributedTo` may be a string, an embedded actor object, or a list of references. Normalize it to a URI string before use.
+		$author_url  = object_to_uri( $activity_object['attributedTo'] ?? '' ) ?? '';
+		$avatar_url  = object_to_uri( $activity_object['icon']['url'] ?? '' ) ?? '';
+		$author_name = $author_url;
 
 		// If we don't have an avatar URL, but we have an author URL, try to fetch it.
 		if ( ! $avatar_url && $author_url ) {
@@ -59,7 +60,7 @@ class Embed {
 			if ( \is_wp_error( $author ) ) {
 				$author = array();
 			} else {
-				$avatar_url  = $author['icon']['url'] ?? '';
+				$avatar_url  = object_to_uri( $author['icon']['url'] ?? '' ) ?? '';
 				$author_name = empty( $author['name'] ) ? $author_name : $author['name'];
 			}
 		}

--- a/tests/phpunit/tests/includes/class-test-embed.php
+++ b/tests/phpunit/tests/includes/class-test-embed.php
@@ -315,7 +315,7 @@ class Test_Embed extends \WP_UnitTestCase {
 		$filter = static function () {
 			return new \WP_Error( 'http_request_failed', 'Connection failed' );
 		};
-		\add_filter( 'activitypub_pre_http_get_remote_object', $filter, 10, 2 );
+		\add_filter( 'activitypub_pre_http_get_remote_object', $filter );
 
 		$object = array(
 			'id'           => 'https://example.com/post/5',

--- a/tests/phpunit/tests/includes/class-test-embed.php
+++ b/tests/phpunit/tests/includes/class-test-embed.php
@@ -296,6 +296,112 @@ class Test_Embed extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_html_for_object when attributedTo is a non-string value.
+	 *
+	 * Per the ActivityStreams spec, `attributedTo` may be a string, an embedded
+	 * actor object, or a list of references. When it arrives as an array it must
+	 * be normalized to a URI before reaching the template, otherwise esc_url()
+	 * fatals with "Argument #1 ($string) must be of type string, array given".
+	 *
+	 * @covers ::get_html_for_object
+	 *
+	 * @dataProvider data_attributed_to_non_string
+	 *
+	 * @param mixed  $attributed_to The attributedTo value to test.
+	 * @param string $expected_url  The URI the author link should resolve to.
+	 */
+	public function test_get_html_for_object_with_non_string_attributed_to( $attributed_to, $expected_url ) {
+		// Avoid any remote fetch for the author object.
+		$filter = static function () {
+			return new \WP_Error( 'http_request_failed', 'Connection failed' );
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $filter, 10, 2 );
+
+		$object = array(
+			'id'           => 'https://example.com/post/5',
+			'url'          => 'https://example.com/post/5',
+			'content'      => 'Test content with non-string attributedTo.',
+			'attributedTo' => $attributed_to,
+		);
+
+		// This should not throw a fatal error in esc_url().
+		$result = Embed::get_html_for_object( $object );
+
+		$this->assertStringContainsString( 'Test content with non-string attributedTo.', $result );
+		$this->assertStringContainsString( $expected_url, $result );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+	}
+
+	/**
+	 * Data provider for test_get_html_for_object_with_non_string_attributed_to.
+	 *
+	 * @return array[]
+	 */
+	public function data_attributed_to_non_string() {
+		return array(
+			'list of URIs'          => array(
+				array( 'https://example.com/author/5' ),
+				'https://example.com/author/5',
+			),
+			'embedded actor object' => array(
+				array(
+					'type' => 'Person',
+					'id'   => 'https://example.com/author/6',
+					'name' => 'Embedded Author',
+				),
+				'https://example.com/author/6',
+			),
+		);
+	}
+
+	/**
+	 * Test get_html_for_object when a fetched author's icon URL is a non-string value.
+	 *
+	 * The remote author object is untrusted input too: its `icon.url` may be a Link
+	 * object or a list. It must be normalized before reaching esc_url() in the template.
+	 *
+	 * @covers ::get_html_for_object
+	 */
+	public function test_get_html_for_object_with_non_string_author_icon_url() {
+		// Mock the author fetch to return an icon whose URL is a Link object rather than a string.
+		$filter = static function ( $pre, $url_or_object ) {
+			$url = \Activitypub\object_to_uri( $url_or_object );
+			if ( 'https://example.com/author/7' === $url ) {
+				return array(
+					'id'   => 'https://example.com/author/7',
+					'type' => 'Person',
+					'name' => 'Author With Link Icon',
+					'icon' => array(
+						'type' => 'Image',
+						'url'  => array(
+							'type' => 'Link',
+							'href' => 'https://example.com/avatar7.png',
+						),
+					),
+				);
+			}
+			return $pre;
+		};
+		\add_filter( 'activitypub_pre_http_get_remote_object', $filter, 10, 2 );
+
+		$object = array(
+			'id'           => 'https://example.com/post/7',
+			'url'          => 'https://example.com/post/7',
+			'content'      => 'Test content with non-string author icon URL.',
+			'attributedTo' => 'https://example.com/author/7',
+		);
+
+		// This should not throw a fatal error in esc_url().
+		$result = Embed::get_html_for_object( $object );
+
+		$this->assertStringContainsString( 'Test content with non-string author icon URL.', $result );
+		$this->assertStringContainsString( 'https://example.com/avatar7.png', $result );
+
+		\remove_filter( 'activitypub_pre_http_get_remote_object', $filter );
+	}
+
+	/**
 	 * Test get_html_for_object webfinger fallback when author has no preferredUsername.
 	 *
 	 * @covers ::get_html_for_object


### PR DESCRIPTION
## Proposed changes:

When you embed a Fediverse post, the plugin builds the preview from the remote object's fields. A couple of those fields can come back in more than one shape: `attributedTo` (the author) and `icon.url` (the avatar) may be a plain string, an embedded object, or a list of references, depending on the platform that sent them.

The embed template passed those values straight to `esc_url()`. When one arrived as an array, `esc_url()` hit `ltrim()` and threw a fatal `TypeError: ltrim(): Argument #1 ($string) must be of type string, array given`, which took down the whole embed.

This routes the author and avatar URLs through the existing `object_to_uri()` helper before they reach the template, so the template always gets a string. Two paths are covered: the values read directly off the object, and the avatar pulled from a separately fetched author actor (which is untrusted remote data too, and could crash the same way).

### Rationale

`object_to_uri()` already exists for exactly this normalization and is used elsewhere in the same class, so this reuses it rather than adding new type checks. It handles all three shapes and returns `null` for an object with nothing usable, which the `?? ''` guard turns into the template's empty-string default.

This deliberately stays scoped to the author and avatar fields, which is where the reported crash came from. Attachment media URLs (`image` / `video` / `audio`) read from the object can technically arrive in the same shapes and aren't normalized here; that's the same class of bug through a different field and is worth a separate follow-up rather than widening this fix.

### Other information:

Internal reference: p1787821893629969-slack-C4N88L95W

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

Regression tests cover the three shapes of `attributedTo` and a non-string `icon.url` from a fetched author:

```
npm run env-test -- --filter Test_Embed
```

To reproduce the original crash manually, embed a Fediverse post whose server sends `attributedTo` as an object or a list (rather than a plain URL string) into a post, and view it. Before this change the embed fatals; after it, the author link renders normally.

### Changelog entry

Changelog file included in the branch (`.github/changelog/fix-embed-ltrim-type-error`).
