### PR TITLE
Stop Update and Create dispatching to each other on a disabled post

### DIFF
--- a/.github/changelog/fix-update-create-recursion
+++ b/.github/changelog/fix-update-create-recursion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a crash that could fill the error log when another server edited a reply to a post that is no longer shared to the Fediverse.

--- a/includes/collection/class-interactions.php
+++ b/includes/collection/class-interactions.php
@@ -164,7 +164,23 @@ class Interactions {
 		$content                         = Emoji::wrap_in_content( $activity['object']['content'], $activity['object'] );
 		$comment_data['comment_content'] = \addslashes( $content );
 
-		return self::persist( $comment_data, self::UPDATE );
+		$result = self::persist( $comment_data, self::UPDATE );
+
+		/*
+		 * `persist()` returns false when it refuses to write, typically because the post is no
+		 * longer federated. That is not "no comment to update": the comment exists, it was found
+		 * above. The Update handler treats false as not-found and falls back to Create, which
+		 * finds the same comment and dispatches back to Update, without end. A WP_Error is
+		 * handled but unsuccessful, so it stops here.
+		 */
+		if ( false === $result ) {
+			return new \WP_Error(
+				'activitypub_update_refused',
+				\__( 'The comment can no longer be updated.', 'activitypub' )
+			);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/handler/class-test-update.php
+++ b/tests/phpunit/tests/includes/handler/class-test-update.php
@@ -368,6 +368,84 @@ class Test_Update extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An Update for a reply whose post is no longer federated must not recurse.
+	 *
+	 * `persist()` refuses to write to a disabled post and returns false. The Update handler
+	 * read that as "no comment to update" and fell back to Create, which found the comment and
+	 * dispatched back to Update, until the stack ran out. Note the handled-update action only
+	 * fires once a handler returns, so on a regression this test times out rather than tripping
+	 * the depth guard; the guard still bounds any re-dispatch shape that does return.
+	 *
+	 * @covers ::update_object
+	 */
+	public function test_update_object_does_not_recurse_when_post_is_disabled() {
+		$post_id = self::factory()->post->create();
+		$id      = 'https://remote.example/notes/1';
+		$actor   = 'https://remote.example/users/bob';
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'original',
+			)
+		);
+		\add_comment_meta( $comment_id, 'source_id', $id );
+		\add_comment_meta( $comment_id, 'protocol', 'activitypub' );
+
+		// The post stops federating after the reply was cached.
+		\update_post_meta( $post_id, 'activitypub_content_visibility', ACTIVITYPUB_CONTENT_VISIBILITY_LOCAL );
+
+		$metadata = function () use ( $actor ) {
+			return array(
+				'id'                => $actor,
+				'type'              => 'Person',
+				'name'              => 'bob',
+				'preferredUsername' => 'bob',
+				'inbox'             => $actor . '/inbox',
+				'url'               => $actor,
+			);
+		};
+		\add_filter( 'pre_get_remote_metadata_by_actor', $metadata );
+
+		$depth = 0;
+		$guard = function () use ( &$depth ) {
+			if ( ++$depth > 3 ) {
+				throw new \RuntimeException( 'Update and Create are dispatching to each other.' );
+			}
+		};
+		\add_action( 'activitypub_handled_update', $guard );
+
+		$activity = array(
+			'type'   => 'Update',
+			'actor'  => $actor,
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'object' => array(
+				'id'           => $id,
+				'type'         => 'Note',
+				'content'      => 'edited',
+				'inReplyTo'    => \get_permalink( $post_id ),
+				'attributedTo' => $actor,
+				'to'           => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			),
+		);
+
+		$caught = null;
+		try {
+			Update::handle_update( $activity, array( 1 ), null );
+		} catch ( \RuntimeException $e ) {
+			$caught = $e->getMessage();
+		}
+
+		\remove_action( 'activitypub_handled_update', $guard );
+		\remove_filter( 'pre_get_remote_metadata_by_actor', $metadata );
+
+		$this->assertNull( $caught );
+		$this->assertSame( 1, $depth, 'The Update has to be handled exactly once.' );
+		$this->assertSame( 'original', \get_comment( $comment_id )->comment_content, 'A disabled post must not be written to.' );
+	}
+
+	/**
 	 * A foreign actor's comment Update is handled but reported as unsuccessful, so relay mode
 	 * does not re-announce it, and it does not fall back to Create.
 	 *


### PR DESCRIPTION
Fixes #3653

## Proposed changes:

The stack trace in #3653 is Update and Create dispatching to each other until PHP runs out of stack. I reproduced it: the test run is OOM killed (exit 137) on trunk. The handlers are identical between 9.2.2 and trunk, so this is live.

The cause is one value carrying two meanings. `Interactions::persist()` returns `false` when it refuses to write, which it does when the comment's post is no longer federated (`is_post_disabled()`, not an `ap_post`). But `Update::update_object()` treats `false` from `update_comment()` as "there is no comment, fall back to Create". So a remote edit of a reply on such a post goes: Update finds the comment, `persist()` refuses, `false`, fall back to Create, Create finds the same comment, dispatches back to Update, and so on with nothing to stop it. That is the trace in the issue frame for frame.

The trigger is a reply cached while the post still federated, after which the post went local-only, private, password protected, or its post type lost `activitypub` support, without being marked as federated (that lifecycle state reopens the gate). The remote server then edits the reply, and keeps redelivering the Update, which is why the log fills up. Both sites in the report hit the same actor over and over.

The code already knew about this shape: the owner check in `update_comment()` returns a `WP_Error` precisely because, as its comment says, `false` "would make the Update handler fall back to Create (which re-dispatches to Update for an existing comment and recurses)". That covered one `false` path and left this one.

The fix is at the only `UPDATE` caller of `persist()`, so the Create path, where `false` is the right answer, is untouched: `update_comment()` turns a refusal into a `WP_Error`, which `update_object()` already treats as handled but not successful, with no fallback.

Things I ruled out by measuring, so nobody chases them again: escaping differences between the two `object_id_to_comment()` lookups (every mismatch runs in the safe direction, Create just adds a comment), failed actor metadata, comment status, and `wp_update_comment()` errors. None of them loop.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

`test_update_object_does_not_recurse_when_post_is_disabled` reproduces it. With the fix it passes. With trunk's `includes/collection/class-interactions.php` the test does not fail, it hangs until the runner kills it, because the handled-update action only fires once a handler returns and none ever does. So if you want to see the bug, run it with a timeout:

* `git show origin/trunk:includes/collection/class-interactions.php > includes/collection/class-interactions.php`
* `timeout 60 wp-env run tests-cli --env-cwd="wp-content/plugins/activitypub" vendor/bin/phpunit --filter test_update_object_does_not_recurse` and watch it get terminated.
* `git checkout -- includes/collection/class-interactions.php` and it passes in well under a second.

By hand: publish a post, let a remote account reply to it, then set the post to local-only. Edit the reply on the remote side. Before, the error log fills with the trace from the issue. After, the edit is refused and nothing is logged.

### Changelog entry

In the branch as `.github/changelog/fix-update-create-recursion`, patch / fixed.
