### PR TITLE
Update Tested up to: 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaformat, nuriapena, cavalierlife, andremenrath
 Tags: fediverse, activitypub, indieweb, activitystream, social web
 Requires at least: 6.5
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 9.2.2
 Requires PHP: 7.4
 License: MIT


### PR DESCRIPTION
Follows the precedent of #3388. WordPress 7.1 is out and the plugin runs fine on it, wp-env is already on 7.1.

## Testing instructions:

* Check that `Tested up to` in readme.txt says 7.1.
