### PR TITLE
Improve permission checks for reader feeds

### DIFF
--- a/.github/changelog/fix-blog-feed-comment-visibility
+++ b/.github/changelog/fix-blog-feed-comment-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Replies cached on posts in the blog profile's reader feed are no longer readable by logged-out visitors through the WordPress REST API.

--- a/includes/rest/trait-reader-permission.php
+++ b/includes/rest/trait-reader-permission.php
@@ -82,6 +82,16 @@ trait Reader_Permission {
 	 * @return bool True if the current user may read it, false otherwise.
 	 */
 	protected function can_read_feed_of( $user_ids ) {
+		/*
+		 * Same reason the login check leads in `check_reader_capability()`: a logged-out request
+		 * has user ID 0, and so does the blog actor, so the identity match below would hand the
+		 * blog actor's feed to anybody. This predicate is also reached from callers that never
+		 * pass through that gate, such as core's comments controller.
+		 */
+		if ( ! \is_user_logged_in() ) {
+			return false;
+		}
+
 		// Blanket access: an actor with no relationship at all has nothing to check per target.
 		if ( \current_user_can( 'list_users' ) ) {
 			return true;

--- a/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
+++ b/tests/phpunit/tests/includes/rest/class-test-reader-authorization.php
@@ -284,6 +284,66 @@ class Test_Reader_Authorization extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * The blog actor's cached replies are not readable by a logged-out visitor.
+	 *
+	 * The blog actor is user ID 0, and `get_current_user_id()` also returns 0 when nobody is
+	 * logged in, so matching the request against the feed owner alone lets anyone read the
+	 * blog actor's feed. The fixtures above all belong to a real user, which is why the
+	 * existing coverage passes without catching this.
+	 *
+	 * @covers \Activitypub\Rest\Remote_Posts_Controller::check_read_permission
+	 */
+	public function test_blog_actor_cached_replies_are_not_readable_when_logged_out() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Posts::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'Blog actor content.',
+				'meta_input'   => array( '_activitypub_user_id' => '0' ),
+			)
+		);
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'Blog actor reply.',
+				'comment_approved' => '1',
+				'comment_type'     => 'comment',
+			)
+		);
+
+		\wp_set_current_user( 0 );
+
+		$response = $this->request( '/wp/v2/comments/' . $comment_id );
+
+		$this->assertNotSame( 200, $response->get_status() );
+		$this->assertStringNotContainsString( 'Blog actor reply.', \wp_json_encode( $response->get_data() ) );
+	}
+
+	/**
+	 * The blog actor's cached posts are not readable by a logged-out visitor.
+	 *
+	 * @covers \Activitypub\Rest\Remote_Posts_Controller::check_read_permission
+	 */
+	public function test_blog_actor_post_is_not_readable_when_logged_out() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => Remote_Posts::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'Blog actor content.',
+				'meta_input'   => array( '_activitypub_user_id' => '0' ),
+			)
+		);
+
+		\wp_set_current_user( 0 );
+
+		$response = $this->request( '/wp/v2/ap_post/' . $post_id );
+
+		$this->assertNotSame( 200, $response->get_status() );
+		$this->assertStringNotContainsString( 'Blog actor content.', \wp_json_encode( $response->get_data() ) );
+	}
+
+	/**
 	 * The owner still reads the replies cached in their own feed.
 	 *
 	 * @covers \Activitypub\Rest\Remote_Posts_Controller::check_read_permission


### PR DESCRIPTION
## Proposed changes:

* `can_read_feed_of()` now requires a logged-in user before it compares the request against the owners of a feed. Without that, user ID 0 matches the blog actor, which is also 0, so anything belonging to the blog actor's feed was treated as the caller's own.
* The guard goes in the shared predicate rather than in one controller, because this is reached from callers that never pass the reader's own permission callbacks. `check_reader_capability()` right above it already leads with the same login check for the same reason, so the two now read alike.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

The existing coverage in `class-test-reader-authorization.php` all uses fixtures belonging to a real user, so the zero case was never exercised. The two new tests use a record owned by the blog actor.

## Testing instructions:

* `npm run env-test -- --filter Test_Reader_Authorization`, 29 tests. The two new ones fail without the change.
* With the Reader enabled, check that your own feed still reads normally in wp-admin, and that an administrator can still see another user's, since the change sits on the path both of those take.

### Changelog entry

Added manually in `.github/changelog/fix-blog-feed-comment-visibility`.
