### PR TITLE
Federate enclosures that are not in the media library

### DIFF
--- a/.github/changelog/fix-off-site-enclosures
+++ b/.github/changelog/fix-off-site-enclosures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast episodes and other attached files hosted outside your media library are now included when a post is sent to the Fediverse.

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -320,7 +320,11 @@ function get_enclosures( $post_id ) {
 		$enclosures
 	);
 
-	return \array_filter( $enclosures );
+	/*
+	 * Re-indexed on the URL to drop duplicates: a file declared twice is still one file, and the
+	 * URL is the only identity an enclosure has unless it happens to be in the media library.
+	 */
+	return \array_values( \array_column( \array_filter( $enclosures ), null, 'url' ) );
 }
 
 /**

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -713,6 +713,11 @@ abstract class Base {
 	/**
 	 * Filter attachments to ensure uniqueness based on their ID.
 	 *
+	 * Media without an ID is passed through: there is nothing to compare it against, and whether
+	 * it belongs here at all was decided by whichever method added it. An enclosure names a file
+	 * the author declared belongs to the post and carries no ID when it is not in the media
+	 * library, which is the normal case for podcast audio.
+	 *
 	 * @param array $attachments Array of attachments with 'id' field.
 	 *
 	 * @return array Array with duplicate attachments removed.
@@ -723,11 +728,17 @@ abstract class Base {
 		return \array_filter(
 			$attachments,
 			static function ( $attachment ) use ( &$seen_ids ) {
-				if ( isset( $attachment['id'] ) && ! \in_array( $attachment['id'], $seen_ids, true ) ) {
-					$seen_ids[] = $attachment['id'];
+				if ( ! isset( $attachment['id'] ) ) {
 					return true;
 				}
-				return false;
+
+				if ( \in_array( $attachment['id'], $seen_ids, true ) ) {
+					return false;
+				}
+
+				$seen_ids[] = $attachment['id'];
+
+				return true;
 			}
 		);
 	}

--- a/includes/transformer/class-base.php
+++ b/includes/transformer/class-base.php
@@ -718,7 +718,7 @@ abstract class Base {
 	 * the author declared belongs to the post and carries no ID when it is not in the media
 	 * library, which is the normal case for podcast audio.
 	 *
-	 * @param array $attachments Array of attachments with 'id' field.
+	 * @param array $attachments Array of attachments, each optionally carrying an 'id'.
 	 *
 	 * @return array Array with duplicate attachments removed.
 	 */

--- a/tests/phpunit/tests/includes/transformer/class-test-post.php
+++ b/tests/phpunit/tests/includes/transformer/class-test-post.php
@@ -665,6 +665,56 @@ class Test_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An enclosure hosted off-site is federated.
+	 *
+	 * Podcast plugins declare episode audio as a standard WordPress enclosure, and the file
+	 * almost always lives on the podcast host rather than in the media library. It therefore has
+	 * no attachment ID, which is exactly the case the deduplication used to discard.
+	 *
+	 * The URL is on the test site's own host only so that `wp_http_validate_url()` inside
+	 * `get_enclosures()` does not need DNS. What this exercises is the missing attachment ID.
+	 *
+	 * @covers ::get_attachment
+	 */
+	public function test_federates_an_enclosure_hosted_off_site() {
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Episode 566' ) );
+
+		// Verbatim from a PowerPress episode: url, length, mime, then its own serialised extras.
+		\add_post_meta(
+			$post_id,
+			'enclosure',
+			"https://example.org/uploads/E566.mp3\n11657768\naudio/mpeg\na:1:{s:8:\"duration\";s:7:\"0:22:46\";}"
+		);
+
+		$attachments = ( new Post( \get_post( $post_id ) ) )->to_object()->get_attachment();
+
+		$this->assertCount( 1, $attachments, 'The episode audio has to survive deduplication.' );
+		$this->assertSame( 'https://example.org/uploads/E566.mp3', $attachments[0]['url'] );
+		$this->assertSame( 'audio/mpeg', $attachments[0]['mediaType'] );
+		$this->assertSame( 'Audio', $attachments[0]['type'] );
+	}
+
+	/**
+	 * The same off-site enclosure declared twice is federated once.
+	 *
+	 * Deduplication is the whole point of the filter these attachments now pass through, so it
+	 * has to keep working for media that has no ID to be keyed on.
+	 *
+	 * @covers ::get_attachment
+	 */
+	public function test_deduplicates_an_off_site_enclosure_by_url() {
+		$post_id   = self::factory()->post->create( array( 'post_title' => 'Episode 566' ) );
+		$enclosure = "https://example.org/uploads/E566.mp3\n11657768\naudio/mpeg";
+
+		\add_post_meta( $post_id, 'enclosure', $enclosure );
+		\add_post_meta( $post_id, 'enclosure', $enclosure );
+
+		$attachments = ( new Post( \get_post( $post_id ) ) )->to_object()->get_attachment();
+
+		$this->assertCount( 1, $attachments );
+	}
+
+	/**
 	 * Test get_attachments with zero max_media_attachments.
 	 *
 	 * @covers ::get_attachment

--- a/tests/phpunit/tests/integration/class-test-jetpack.php
+++ b/tests/phpunit/tests/integration/class-test-jetpack.php
@@ -633,7 +633,14 @@ class Test_Jetpack extends \WP_UnitTestCase {
 		$this->load_mock_podcast_show( false );
 		$this->add_enclosure( self::$post_id, \home_url( '/podcast/episode.mp3' ) );
 
-		$this->assertSame( array(), $this->transform_attachments( self::$post_id ), 'A stray enclosure must not federate as an episode.' );
+		$attachments = $this->transform_attachments( self::$post_id );
+
+		/*
+		 * The enclosure federates, because an enclosure is the author saying this file belongs to
+		 * the post. What it must not gain is the treatment an episode gets, so no show artwork.
+		 */
+		$this->assertCount( 1, $attachments, 'A declared enclosure still federates as ordinary media.' );
+		$this->assertArrayNotHasKey( 'icon', $attachments[0], 'A stray enclosure must not federate as an episode.' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3727

## Proposed changes:

A WordPress enclosure names a file the author declared belongs to a post, and podcast plugins use it for episode audio. That audio almost always lives on the podcast host rather than in the media library, so it has no attachment ID, and `filter_unique_attachments()` dropped everything without one. The transformer was already reading the enclosure and then throwing it away a step later, so podcast episodes federated with the hero image and no audio at all.

Two small changes, no new class, method or hook:

* **`filter_unique_attachments()` only deduplicates now.** Media with no ID is passed through, because there is nothing to compare it against and whether it belongs there was decided by whichever method added it. Discarding was cleanup that had ended up in the wrong place.
* **`get_enclosures()` deduplicates on the URL.** That is the only identity an enclosure has when the file is not in the library, and doing it at the source means every caller benefits, the Jetpack integration included.

### Why this and not a PowerPress integration

@andypiper asked for Blubrry PowerPress support alongside Podlove and Seriously Simple Podcasting. PowerPress writes a plain WordPress enclosure for its default feed, in exactly the format `get_enclosures()` already parses, so there is nothing plugin-specific to add. He confirmed it on a live site, and I ran his actual meta value through the parser:

```
url:       https://gamesatwork.biz/.../E566.mp3
length:    11657768
mediaType: audio/mpeg
ignored:   1 extra line(s)
```

The fourth line is PowerPress's own serialised extras, which the parser ignores harmlessly. So this fixes PowerPress and every other podcast plugin writing standard enclosures, rather than adding a fourth integration class.

### One behaviour change to be aware of

`Test_Jetpack::test_enclosure_outside_the_podcast_category_is_not_an_episode` asserted an empty attachment list, which conflated "not an episode" with "not federated at all". A stray enclosure now federates as ordinary audio, without the show artwork and without the leading position an episode gets. I updated that test to assert exactly that, which is what its own failure message says it is protecting. It is the only externally visible change beyond the fix itself.

Worth noting for review: the Jetpack integration gets simpler as a consequence, because `add_podcast_attachments()` now usually finds the audio already present and takes its own "the audio is already attached, so only the artwork is missing" branch rather than reconstructing it. I have not touched that code here.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Two, both failing before the change: an enclosure with no attachment ID federates, and the same file declared twice federates once. The fixture is a real PowerPress enclosure, fourth line and all.

## Testing instructions:

* `npm run env-test -- --filter Test_Post` and `--filter Test_Jetpack`.
* On a site with PowerPress, publish an episode to the default `podcast` feed and check the post's ActivityPub JSON: the MP3 should appear in `attachment` with `audio/mpeg`.
* On a site with Jetpack podcasts, confirm episodes still get the show cover art, and that a post outside the podcast category no longer silently loses its enclosure.

### Changelog entry

Added manually in `.github/changelog/fix-off-site-enclosures`.
