### PR TITLE
List a few sites running the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ You can test out the plugin (settings) with [WordPress Playground](https://wordp
 > [!NOTE]
 > [WordPress Playground](https://wordpress.org/playground/) is the platform that lets you run WordPress instantly on any device without a host. It’s your place to build, experiment, test, and grow.
 
+## Sites using the plugin
+
+A few blogs that run the plugin, so you can see how it behaves before installing it. Follow any of them from your Fediverse account:
+
+- [Social Web Foundation](https://socialwebfoundation.org/), `swf@socialwebfoundation.org`
+- [ActivityPub Blog](https://activitypub.blog/), `activitypub.blog@activitypub.blog`
+- [Evan Prodromou](https://evanp.me/), `evanp.me@evanp.me`
+- [IFTAS](https://about.iftas.org/blog/), `about.iftas.org@about.iftas.org`
+- [Kaffeeringe](https://kaffeeringe.de/), `blog@kaffeeringe.de`
+
+If you run the plugin on your own site, add it to [Show and Tell](https://github.com/Automattic/wordpress-activitypub/discussions/categories/show-and-tell). We would like to see it.
+
 ## Documentation
 
 - [Developer Documentation](docs/developer-docs.md) - Guide for developers working with the plugin.


### PR DESCRIPTION
Fixes #3650

## Proposed changes:

* Add a short list of blogs running the plugin to the README, with the site URL and the Fediverse handle for each, so someone evaluating the plugin can follow a real site instead of guessing what it does.
* Point at [Show and Tell](https://github.com/Automattic/wordpress-activitypub/discussions/categories/show-and-tell) so the list does not have to grow in the repo.

@nemobis asked for exactly this, and suggested a handful of bullets in the README rather than a wiki page, on the grounds that a wiki only pays off once there are dozens. Five felt like the right number to start with.

Every handle was resolved from the site's own blog actor and then checked against its WebFinger endpoint, all five returning 200 with a matching `subject`. Worth mentioning because the obvious shortcut gives the wrong answer: the `fediverse:creator` meta tag on some of these sites points at an author actor with an auto-generated username, for instance `contact777526d3b5@socialwebfoundation.org`, which is not the handle anyone would want to publish.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Documentation only.

## Testing instructions:

* Read the new section in `README.md`.
* Follow any of the five handles from a Fediverse account and confirm it resolves to the site you would expect.

### Changelog entry

None needed, and `Skip Changelog` is set: this is a README change with no user-visible effect in the plugin.
