### PR TITLE
Seed "Powered by" with the other default profile fields

### DIFF
--- a/.github/changelog/fix-powered-by-default-field
+++ b/.github/changelog/fix-powered-by-default-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The "Powered by WordPress" profile field no longer duplicates itself or reappears after you delete it, and it is now a working link.

--- a/.github/changelog/fix-powered-by-default-field
+++ b/.github/changelog/fix-powered-by-default-field
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-The "Powered by WordPress" profile field no longer duplicates itself or reappears after you delete it, and it is now a working link.
+The "Powered by WordPress" profile field no longer shows up twice, no longer comes back after you delete it, and no longer triggers a warning when the plugin is first activated.

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -718,7 +718,6 @@ class Migration {
 	 */
 	public static function add_default_settings() {
 		self::add_activitypub_capability();
-		self::add_default_extra_field();
 	}
 
 	/**
@@ -770,43 +769,6 @@ class Migration {
 		foreach ( $users as $user ) {
 			$user->add_cap( 'activitypub' );
 		}
-	}
-
-	/**
-	 * Add a default extra field for the user.
-	 */
-	private static function add_default_extra_field() {
-		$users = \get_users(
-			array(
-				'capability__in' => array( 'activitypub' ),
-			)
-		);
-
-		$title   = \__( 'Powered by', 'activitypub' );
-		$content = 'WordPress';
-
-		// Add a default extra field for each user.
-		foreach ( $users as $user ) {
-			\wp_insert_post(
-				array(
-					'post_type'    => Extra_Fields::USER_POST_TYPE,
-					'post_author'  => $user->ID,
-					'post_status'  => 'publish',
-					'post_title'   => $title,
-					'post_content' => $content,
-				)
-			);
-		}
-
-		\wp_insert_post(
-			array(
-				'post_type'    => Extra_Fields::BLOG_POST_TYPE,
-				'post_author'  => 0,
-				'post_status'  => 'publish',
-				'post_title'   => $title,
-				'post_content' => $content,
-			)
-		);
 	}
 
 	/**

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -238,20 +238,40 @@ class Extra_Fields {
 			}
 		}
 
+		/*
+		 * Seeded here rather than at install time. `Migration::add_default_extra_field()` used to
+		 * add this one on its own, which ran before `ap_extrafield` was registered and recorded
+		 * none of the flags below, so it duplicated whenever a migration replayed and came back
+		 * after somebody deleted it. Here it inherits the empty-list check, the flag, and the
+		 * timing the other defaults already had.
+		 */
+		$defaults[ \__( 'Powered by', 'activitypub' ) ] = '<a href="https://wordpress.org/">WordPress</a>';
+
 		$post_type  = $is_blog ? self::BLOG_POST_TYPE : self::USER_POST_TYPE;
 		$menu_order = 10;
 
-		foreach ( $defaults as $title => $url ) {
-			if ( ! $url ) {
+		foreach ( $defaults as $title => $value ) {
+			if ( ! $value ) {
 				continue;
 			}
+
+			/*
+			 * Every other default is a bare URL that has to be turned into a link. This one is
+			 * already markup, because the label stays "WordPress" rather than becoming the
+			 * shortened host `Link::the_content()` would render. It has to end up as a single
+			 * anchor either way: `fields_to_attachments()` emits a `Link` for that and a `Note`
+			 * for anything else, and `Note` is not one of the types the actor schema allows.
+			 */
+			$content = \filter_var( $value, FILTER_VALIDATE_URL )
+				? Link::the_content( $value )
+				: $value;
 
 			$extra_field = array(
 				'post_type'      => $post_type,
 				'post_title'     => $title,
 				'post_status'    => 'publish',
 				'post_author'    => $user_id,
-				'post_content'   => self::make_paragraph_block( Link::the_content( $url ) ),
+				'post_content'   => self::make_paragraph_block( $content ),
 				'comment_status' => 'closed',
 				'menu_order'     => $menu_order,
 			);

--- a/includes/collection/class-extra-fields.php
+++ b/includes/collection/class-extra-fields.php
@@ -245,7 +245,7 @@ class Extra_Fields {
 		 * after somebody deleted it. Here it inherits the empty-list check, the flag, and the
 		 * timing the other defaults already had.
 		 */
-		$defaults[ \__( 'Powered by', 'activitypub' ) ] = '<a href="https://wordpress.org/">WordPress</a>';
+		$defaults[ \__( 'Powered by', 'activitypub' ) ] = 'WordPress';
 
 		$post_type  = $is_blog ? self::BLOG_POST_TYPE : self::USER_POST_TYPE;
 		$menu_order = 10;
@@ -255,13 +255,7 @@ class Extra_Fields {
 				continue;
 			}
 
-			/*
-			 * Every other default is a bare URL that has to be turned into a link. This one is
-			 * already markup, because the label stays "WordPress" rather than becoming the
-			 * shortened host `Link::the_content()` would render. It has to end up as a single
-			 * anchor either way: `fields_to_attachments()` emits a `Link` for that and a `Note`
-			 * for anything else, and `Note` is not one of the types the actor schema allows.
-			 */
+			// Every other default is a bare URL to linkify; "Powered by" is plain text.
 			$content = \filter_var( $value, FILTER_VALIDATE_URL )
 				? Link::the_content( $value )
 				: $value;

--- a/includes/rest/class-actors-controller.php
+++ b/includes/rest/class-actors-controller.php
@@ -214,21 +214,26 @@ class Actors_Controller extends \WP_REST_Controller {
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'type'  => array(
+							// FEP-fb2a pairs the `PropertyValue` Mastodon reads with a valid AS2 equivalent, so every field emits both halves: a `Link` when it holds a single link, a `Note` otherwise.
+							'type'    => array(
 								'type' => 'string',
-								'enum' => array( 'PropertyValue', 'Link' ),
+								'enum' => array( 'PropertyValue', 'Link', 'Note' ),
 							),
-							'name'  => array(
-								'type' => 'string',
-							),
-							'value' => array(
+							'name'    => array(
 								'type' => 'string',
 							),
-							'href'  => array(
+							'value'   => array(
+								'type' => 'string',
+							),
+							// The `Note` half carries its text here rather than in `value`.
+							'content' => array(
+								'type' => 'string',
+							),
+							'href'    => array(
 								'type'   => 'string',
 								'format' => 'uri',
 							),
-							'rel'   => array(
+							'rel'     => array(
 								'type'  => 'array',
 								'items' => array(
 									'type' => 'string',

--- a/tests/phpunit/tests/includes/class-test-migration.php
+++ b/tests/phpunit/tests/includes/class-test-migration.php
@@ -9,7 +9,6 @@ namespace Activitypub\Tests;
 
 use Activitypub\Activity\Actor;
 use Activitypub\Application;
-use Activitypub\Collection\Extra_Fields;
 use Activitypub\Collection\Followers;
 use Activitypub\Collection\Following;
 use Activitypub\Collection\Outbox;
@@ -633,80 +632,7 @@ class Test_Migration extends \WP_UnitTestCase {
 		);
 	}
 
-	/**
-	 * Test add_default_extra_field.
-	 */
-	public function test_add_default_extra_field() {
-		// Create a test user with ActivityPub permission.
-		$user_id = self::factory()->user->create();
-		$user    = get_user_by( 'id', $user_id );
-		$user->add_cap( 'activitypub' );
 
-		// Run the private method over Reflection.
-		$reflection = new \ReflectionClass( Migration::class );
-		$method     = $reflection->getMethod( 'add_default_extra_field' );
-		if ( \PHP_VERSION_ID < 80100 ) {
-			$method->setAccessible( true );
-		}
-		$method->invoke( null );
-
-		// Check the extra field for the user.
-		$user_fields = get_posts(
-			array(
-				'post_type'      => Extra_Fields::USER_POST_TYPE,
-				'author'         => $user_id,
-				'posts_per_page' => -1,
-			)
-		);
-
-		$this->assertCount( 1, $user_fields, 'There should be one extra field for the user' );
-		$this->assertEquals( 'Powered by', $user_fields[0]->post_title, 'The title should be "Powered by"' );
-		$this->assertEquals( 'WordPress', $user_fields[0]->post_content, 'The content should be "WordPress"' );
-
-		// Check the extra field for the blog user.
-		$blog_fields = get_posts(
-			array(
-				'post_type'      => Extra_Fields::BLOG_POST_TYPE,
-				'author'         => 0,
-				'posts_per_page' => -1,
-			)
-		);
-
-		$this->assertCount( 1, $blog_fields, 'There should be one extra field for the blog user' );
-		$this->assertEquals( 'Powered by', $blog_fields[0]->post_title, 'The title should be "Powered by"' );
-		$this->assertEquals( 'WordPress', $blog_fields[0]->post_content, 'The content should be "WordPress"' );
-
-		_delete_all_data();
-	}
-
-	/**
-	 * Test add_default_extra_field with multiple users.
-	 */
-	public function test_add_default_extra_field_multiple_users() {
-		// Create a user without ActivityPub permission.
-		$non_ap_user_id = self::factory()->user->create();
-
-		// Run the private method over Reflection.
-		$reflection = new \ReflectionClass( Migration::class );
-		$method     = $reflection->getMethod( 'add_default_extra_field' );
-		if ( \PHP_VERSION_ID < 80100 ) {
-			$method->setAccessible( true );
-		}
-		$method->invoke( null );
-
-		// Check that the user without ActivityPub permission has no extra field.
-		$non_ap_user_fields = get_posts(
-			array(
-				'post_type'      => Extra_Fields::USER_POST_TYPE,
-				'author'         => $non_ap_user_id,
-				'posts_per_page' => -1,
-			)
-		);
-
-		$this->assertCount( 0, $non_ap_user_fields, 'User without ActivityPub permission should not have an extra field' );
-
-		_delete_all_data();
-	}
 
 	/**
 	 * Test update_notification_options.

--- a/tests/phpunit/tests/includes/collection/class-test-extra-fields.php
+++ b/tests/phpunit/tests/includes/collection/class-test-extra-fields.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub\Tests\Collection;
 
+use Activitypub\Collection\Actors;
 use Activitypub\Collection\Extra_Fields;
 
 /**
@@ -62,5 +63,61 @@ class Test_Extra_Fields extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_name, $attachments[0]['name'] );
 		$this->assertStringContainsString( '"quotes"', $attachments[0]['value'] );
 		$this->assertStringContainsString( '& ampersands', $attachments[0]['value'] );
+	}
+
+	/**
+	 * The default fields include the "Powered by" entry.
+	 *
+	 * It used to be seeded separately by `Migration::add_default_extra_field()`, which ran before
+	 * the post types were registered and recorded no flag, so it duplicated on a replayed
+	 * migration and reappeared after deletion. Seeding it here instead means it inherits the
+	 * empty-list check, the flag, and the timing that everything else already had.
+	 *
+	 * @covers ::default_actor_extra_fields
+	 */
+	public function test_default_fields_include_powered_by() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$fields = Extra_Fields::default_actor_extra_fields( array(), $user_id );
+		$titles = \wp_list_pluck( $fields, 'post_title' );
+
+		$this->assertContains( 'Powered by', $titles );
+	}
+
+	/**
+	 * The blog actor gets it too, as it did when migration seeded it.
+	 *
+	 * @covers ::default_actor_extra_fields
+	 */
+	public function test_blog_default_fields_include_powered_by() {
+		$fields = Extra_Fields::default_actor_extra_fields( array(), Actors::BLOG_USER_ID );
+		$titles = \wp_list_pluck( $fields, 'post_title' );
+
+		$this->assertContains( 'Powered by', $titles );
+	}
+
+	/**
+	 * The "Powered by" default keeps its label and still resolves to a link.
+	 *
+	 * Every other default is a bare URL the loop linkifies, which would render this one as the
+	 * shortened host. It also has to be a single anchor, or `fields_to_attachments()` emits a
+	 * `Note`, which the actor schema does not allow.
+	 *
+	 * @covers ::default_actor_extra_fields
+	 */
+	public function test_a_non_url_default_is_not_turned_into_a_link() {
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$fields  = Extra_Fields::default_actor_extra_fields( array(), $user_id );
+		$content = '';
+
+		foreach ( $fields as $field ) {
+			if ( 'Powered by' === $field->post_title ) {
+				$content = $field->post_content;
+			}
+		}
+
+		$this->assertStringContainsString( 'WordPress', $content, 'The label stays "WordPress".' );
+		$this->assertStringContainsString( 'wordpress.org', $content, 'And it points at wordpress.org.' );
 	}
 }

--- a/tests/phpunit/tests/includes/collection/class-test-extra-fields.php
+++ b/tests/phpunit/tests/includes/collection/class-test-extra-fields.php
@@ -93,19 +93,22 @@ class Test_Extra_Fields extends \WP_UnitTestCase {
 		$fields = Extra_Fields::default_actor_extra_fields( array(), Actors::BLOG_USER_ID );
 		$titles = \wp_list_pluck( $fields, 'post_title' );
 
+		// Seeding the blog actor records a site option, which would otherwise outlive this test.
+		\delete_option( 'activitypub_default_extra_fields' );
+
 		$this->assertContains( 'Powered by', $titles );
 	}
 
 	/**
-	 * The "Powered by" default keeps its label and still resolves to a link.
+	 * The "Powered by" default keeps the plain text the migration used to write.
 	 *
-	 * Every other default is a bare URL the loop linkifies, which would render this one as the
-	 * shortened host. It also has to be a single anchor, or `fields_to_attachments()` emits a
-	 * `Note`, which the actor schema does not allow.
+	 * Every other default is a bare URL the loop linkifies. This one is not a URL, and its value
+	 * has to stay byte-identical to what `Migration::add_default_extra_field()` produced, so no
+	 * site sees its profile change.
 	 *
 	 * @covers ::default_actor_extra_fields
 	 */
-	public function test_a_non_url_default_is_not_turned_into_a_link() {
+	public function test_powered_by_keeps_the_plain_text_it_always_had() {
 		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 
 		$fields  = Extra_Fields::default_actor_extra_fields( array(), $user_id );
@@ -117,7 +120,7 @@ class Test_Extra_Fields extends \WP_UnitTestCase {
 			}
 		}
 
-		$this->assertStringContainsString( 'WordPress', $content, 'The label stays "WordPress".' );
-		$this->assertStringContainsString( 'wordpress.org', $content, 'And it points at wordpress.org.' );
+		$this->assertStringContainsString( 'WordPress', $content );
+		$this->assertStringNotContainsString( '<a ', $content, 'It was never a link, and must not become one.' );
 	}
 }


### PR DESCRIPTION
Fixes #3280
Fixes #3332
Fixes #3339

## Proposed changes:

Move the "Powered by" profile field into `Extra_Fields::default_actor_extra_fields()`, alongside Blog, Profile and Homepage, and delete `Migration::add_default_extra_field()`.

The three issues above are all consequences of *where* that field was seeded rather than of the field itself. `default_actor_extra_fields()` arrived in #838 as a lazy seeder: it runs when an actor's fields are first read, only when the list is empty, and it records `activitypub_default_extra_fields` so it cannot run twice. "Powered by" arrived seven months later in #1493 and went into `Migration` instead, as an eager seeder that writes at install time and records nothing. Nothing chose to keep them apart.

Everything downstream follows from that:

* Eager at `init` priority 1, before `ap_extrafield` is registered at 11, which is the `map_meta_cap` notice in #3332.
* No flag written, so a replayed migration seeds a second copy, which is #3339.
* No flag written, so deleting the field leaves an actor with no fields and no flag, and the next read provisions Blog/Profile/Homepage replacements. That is the "it came back" in #3280.

Seeded with the others, it inherits the empty-list check, the flag and the timing, and none of the three can happen.

This supersedes #3639 and most of #3666.

### The field itself does not change

The value stays the plain text `WordPress`, byte for byte what `add_default_extra_field()` wrote. The rendered profile and the federated actor are unchanged, this is only about where and when the field gets created. Existing installs keep the field they already have.

### One schema fix came along

`test_response_matches_schema` fails without it, but not because of anything this PR emits differently. The fixture actor simply has extra fields now, where before it had none.

`fields_to_attachments()` has emitted a `PropertyValue` plus a `Note` for every non-link field since #838, and that pairing is deliberate. #810 has the reasoning: `PropertyValue` is what Mastodon reads and is not valid AS2, so FEP-fb2a says to ship a valid equivalent next to it, a `Link` when the field is a single anchor and a `Note` otherwise. The actor schema added in #1257 only listed `PropertyValue` and `Link`, so it has been wrong for any site with a plain-text extra field since February. I added `Note` and the `content` property it uses.

### Known, and deliberately not fixed here

Installs that already hold the flagless field keep it flagless, so if the owner deletes their last field the defaults can still be re-provisioned once. Backfilling the flag would mean guessing about user-editable content during an upgrade, so I think that is a risk worth taking rather than a migration worth writing.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Three in `class-test-extra-fields.php`: the field is among a user's defaults, among the blog actor's defaults, and keeps the plain text it always had. The two tests covering the deleted migration method are removed, since the behaviour they described now lives, and is tested, elsewhere.

## Testing instructions:

* `npm run env-test`.
* Activate on a fresh install and open Settings, ActivityPub, Profile. The "Powered by" field should be there, reading WordPress, with no `_doing_it_wrong` notice in the log.
* Delete it, then reload the profile. It should not come back, and Blog/Profile/Homepage should not be re-provisioned.

### Changelog entry

Added manually in `.github/changelog/fix-powered-by-default-field`.
