### PR TITLE
Strip emoji from the blog profile ID

### DIFF
--- a/.github/changelog/fix-emoji-in-blog-identifier
+++ b/.github/changelog/fix-emoji-in-blog-identifier
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Emoji in the blog profile ID are now dropped instead of being turned into a string of codes that other servers could not resolve.

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -175,9 +175,11 @@ class Sanitize {
 		$value = \sanitize_user( (string) $value, true );
 
 		// Hack to allow dots in the username.
-		$parts     = \explode( '.', $value );
-		$sanitized = \array_map( 'sanitize_title', $parts );
-		$sanitized = \implode( '.', $sanitized );
+		$parts = \explode( '.', $value );
+		$parts = \array_map( 'sanitize_title', $parts );
+
+		// A segment can sanitize away to nothing, and a leading, trailing or doubled dot is not a usable handle.
+		$sanitized = \implode( '.', \array_filter( $parts, 'strlen' ) );
 
 		if ( empty( $sanitized ) ) {
 			return Blog::get_default_username();

--- a/includes/class-sanitize.php
+++ b/includes/class-sanitize.php
@@ -167,8 +167,15 @@ class Sanitize {
 	 * @return string The sanitized blog identifier.
 	 */
 	public static function blog_identifier( $value ) {
+		/*
+		 * `sanitize_title()` hands multibyte characters to `utf8_uri_encode()`, which percent-encodes
+		 * them rather than dropping them, so an emoji survives into the handle as `%e2%9d%a4%ef%b8%8f`.
+		 * Strict `sanitize_user()` reduces to ASCII and kills any octets that are already there.
+		 */
+		$value = \sanitize_user( (string) $value, true );
+
 		// Hack to allow dots in the username.
-		$parts     = \explode( '.', (string) $value );
+		$parts     = \explode( '.', $value );
 		$sanitized = \array_map( 'sanitize_title', $parts );
 		$sanitized = \implode( '.', $sanitized );
 

--- a/tests/phpunit/tests/includes/class-test-sanitize.php
+++ b/tests/phpunit/tests/includes/class-test-sanitize.php
@@ -144,6 +144,12 @@ class Test_Sanitize extends \WP_UnitTestCase {
 			'non_latin_script' => array( 'блог', Blog::get_default_username() ),
 			'accents_kept'     => array( 'Café', 'cafe' ),
 			'percent_encoded'  => array( 'test-blog-%e2%9d%a4%ef%b8%8f', 'test-blog' ),
+			'emoji_then_dot'   => array( '❤️.blog', 'blog' ),
+			'dot_then_emoji'   => array( 'blog.❤️', 'blog' ),
+			'emoji_and_dot'    => array( '❤️.', Blog::get_default_username() ),
+			'bare_dot'         => array( '.', Blog::get_default_username() ),
+			'empty_segment'    => array( 'test..blog', 'test.blog' ),
+			'zero_segment'     => array( '0.blog', '0.blog' ),
 		);
 	}
 

--- a/tests/phpunit/tests/includes/class-test-sanitize.php
+++ b/tests/phpunit/tests/includes/class-test-sanitize.php
@@ -132,12 +132,18 @@ class Test_Sanitize extends \WP_UnitTestCase {
 	 */
 	public function blog_identifier_provider() {
 		return array(
-			'simple_string' => array( 'test-Blog', 'test-blog' ),
-			'with_spaces'   => array( 'test blog', 'test-blog' ),
-			'with_dots'     => array( 'test.blog', 'test.blog' ),
-			'special_chars' => array( 'test@#$%^&*blog', 'testblog' ),
-			'multiple_dots' => array( 'test.blog.name', 'test.blog.name' ),
-			'empty_string'  => array( '', Blog::get_default_username() ),
+			'simple_string'    => array( 'test-Blog', 'test-blog' ),
+			'with_spaces'      => array( 'test blog', 'test-blog' ),
+			'with_dots'        => array( 'test.blog', 'test.blog' ),
+			'special_chars'    => array( 'test@#$%^&*blog', 'testblog' ),
+			'multiple_dots'    => array( 'test.blog.name', 'test.blog.name' ),
+			'empty_string'     => array( '', Blog::get_default_username() ),
+			'emoji'            => array( 'test blog ❤️', 'test-blog' ),
+			'emoji_and_dots'   => array( 'test.blog❤️', 'test.blog' ),
+			'only_emoji'       => array( '❤️', Blog::get_default_username() ),
+			'non_latin_script' => array( 'блог', Blog::get_default_username() ),
+			'accents_kept'     => array( 'Café', 'cafe' ),
+			'percent_encoded'  => array( 'test-blog-%e2%9d%a4%ef%b8%8f', 'test-blog' ),
 		);
 	}
 


### PR DESCRIPTION
Fixes #3456

## Proposed changes:

`Sanitize::blog_identifier()` runs the value through `sanitize_title()`, and core's `sanitize_title()` hands multibyte input to `utf8_uri_encode()`, which percent-encodes it rather than dropping it. So a heart typed into the Profile ID field survives as the literal text `%e2%9d%a4%ef%b8%8f`, and the handle becomes `@myblog%e2%9d%a4%ef%b8%8f@example.com`. Mastodon only accepts `[A-Za-z0-9_.-]` in a username, so it cannot resolve that. That is the "Masto hasn't a clue what I'm talking about" in the report.

The fix is one line: run strict `sanitize_user()` first. It reduces to ASCII and kills any `%xx` octets already in the value, and then the existing dot-split `sanitize_title()` does the rest. I used core here rather than a regex of my own, since `sanitize_user()` already does exactly this job for `user_login`.

Through the real settings save path:

```
typed into Change Profile ID: My Blog ❤️
stored option:                my-blog
webfinger:                    my-blog@localhost   (was my-blog-%e2%9d%a4%ef%b8%8f@localhost)

emoji-only input falls back to: localhost
```

@lordmatt asked for one of three things, leave the emoji alone, show an error, or quietly trim it. This does the third.

One small thing about the report: it says "actor name", but the display name is a separate field that takes the WordPress site title, and it keeps its emoji correctly. Only "Change Profile ID" feeds the handle, so that is the only thing this touches.

I also checked whether user actors can hit the same thing, since `Model\User::get_preferred_username()` falls back to `user_nicename` for email logins. They cannot: core strict-sanitizes both `user_login` and `user_nicename` in `wp_insert_user()`, so an emoji never gets that far. Tried it both ways to be sure, and both come out clean.

### Two things I left out on purpose

**Non-Latin scripts now fall back to the host too.** `блог` and `ブログ` sanitize to nothing, so those sites end up with the domain as their handle. Today they get percent-encoded text nobody can resolve, so I think this is better either way, but it does mean there is no way to have a Cyrillic or Japanese handle. Transliterating is a much bigger change and I would rather look at it separately, if we want it at all.

**Identifiers that are already broken stay broken.** A site can hold one in two ways: somebody typed an emoji before this fix, or the site was installed between `2feca1388` and `626616a74` in 2023, when the identifier was seeded from `sanitize_title( get_bloginfo( 'name' ) )` and stored. Nothing has ever normalized those. A migration would clean them up, but it changes `preferredUsername`, which fires an actor Update and moves the handle, so I did not want to do that quietly in a patch. Happy to add one if we think it is worth it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Six new cases in `blog_identifier_provider()`, five of them failing before the change: an emoji in a name, an emoji next to a dot, an emoji on its own, a Cyrillic name, and a value that is already percent-encoded. The sixth, `accents_kept` (`Café` to `cafe`), passed before and is there so the fix cannot quietly break accent folding.

## Testing instructions:

* `npm run env-test -- --filter test_blog_identifier`.
* Go to Settings, ActivityPub, Blog Profile, put an emoji in "Change Profile ID" and save. The readable part should stay, the emoji should be gone, and there should be no `%` in the field.
* Look the resulting handle up from a Mastodon account. It should resolve.
* Set the field to nothing but an emoji and save. It should fall back to the domain.
* Check that the blog display name still shows its emoji. It comes from the WordPress site title and is not affected.

### Changelog entry

Added manually in `.github/changelog/fix-emoji-in-blog-identifier`.
