### PR TITLE
Process inbox activities once, after they are stored

### DIFF
--- a/.github/changelog/fix-duplicate-inbox-notifications
+++ b/.github/changelog/fix-duplicate-inbox-notifications
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fewer duplicate email notifications when another server delivers the same message more than once, and a reply that mentions you no longer also sends a separate mention email.

--- a/includes/class-mailer.php
+++ b/includes/class-mailer.php
@@ -23,8 +23,9 @@ class Mailer {
 
 		\add_action( 'activitypub_handled_follow', array( self::class, 'new_follower' ), 10, 3 );
 
-		\add_action( 'activitypub_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
-		\add_action( 'activitypub_inbox_create', array( self::class, 'mention' ), 20, 2 );  /** After @see \Activitypub\Handler\Create::handle_create() */
+		\add_action( 'activitypub_handled_inbox_create', array( self::class, 'direct_message' ), 10, 2 );
+		// Priority 20 keeps this after @see \Activitypub\Handler\Create::handle_create(), whose comment the reply check reads.
+		\add_action( 'activitypub_handled_inbox_create', array( self::class, 'mention' ), 20, 2 );
 
 		\add_filter( 'notify_post_author', array( self::class, 'maybe_prevent_comment_notification' ), 10, 2 );
 		\add_filter( 'notify_post_author', array( self::class, 'maybe_prevent_reaction_notification' ), 10, 2 );

--- a/includes/rest/class-actors-inbox-controller.php
+++ b/includes/rest/class-actors-inbox-controller.php
@@ -143,8 +143,6 @@ class Actors_Inbox_Controller extends Actors_Controller {
 				),
 			)
 		);
-
-		\add_action( 'activitypub_inbox_create_item', array( self::class, 'process_create_item' ) );
 	}
 
 	/**
@@ -410,53 +408,5 @@ class Actors_Inbox_Controller extends Actors_Controller {
 		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
-	}
-
-	/**
-	 * Process cached inbox activity.
-	 *
-	 * Retrieves all collected user IDs for an activity and processes them together.
-	 *
-	 * @param string $activity_id The activity ID.
-	 */
-	public static function process_create_item( $activity_id ) {
-		// Deduplicate if multiple inbox items were created due to race condition.
-		$inbox_item = Inbox::deduplicate( $activity_id );
-		if ( ! $inbox_item ) {
-			return;
-		}
-
-		$data = \json_decode( $inbox_item->post_content, true );
-		// Reconstruct activity from inbox post.
-		$activity = Activity::init_from_array( $data );
-		// Sanitize again here: the type comes from stored activity JSON, which bypassed REST arg sanitization.
-		$type     = camel_to_snake_case( \sanitize_html_class( (string) $activity->get_type() ) );
-		$context  = Inbox::CONTEXT_INBOX;
-		$user_ids = Inbox::get_recipients( $inbox_item->ID );
-
-		/**
-		 * Fires after any ActivityPub Inbox activity has been handled, regardless of activity type.
-		 *
-		 * This hook is triggered for all activity types processed by the inbox handler.
-		 *
-		 * @param array    $data     The data array.
-		 * @param array    $user_ids The user IDs.
-		 * @param string   $type     The type of the activity.
-		 * @param Activity $activity The Activity object.
-		 * @param int      $result   The ID of the inbox item that was created, or WP_Error if failed.
-		 * @param string   $context  The context of the request ('inbox' or 'shared_inbox').
-		 */
-		\do_action( 'activitypub_handled_inbox', $data, $user_ids, $type, $activity, $inbox_item->ID, $context );
-
-		/**
-		 * Fires after an ActivityPub Inbox activity has been handled.
-		 *
-		 * @param array    $data     The data array.
-		 * @param array    $user_ids The user IDs.
-		 * @param Activity $activity The Activity object.
-		 * @param int      $result   The ID of the inbox item that was created, or WP_Error if failed.
-		 * @param string   $context  The context of the request ('inbox' or 'shared_inbox').
-		 */
-		\do_action( 'activitypub_handled_inbox_' . $type, $data, $user_ids, $activity, $inbox_item->ID, $context );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -8,7 +8,10 @@
 namespace Activitypub\Tests;
 
 use Activitypub\Collection\Actors;
+use Activitypub\Handler\Create;
 use Activitypub\Mailer;
+use Activitypub\Rest\Server;
+use Activitypub\Scheduler;
 use WP_UnitTestCase;
 
 /**
@@ -384,8 +387,21 @@ class Test_Mailer extends WP_UnitTestCase {
 		$this->assertEquals( 10, \has_filter( 'comment_notification_subject', array( Mailer::class, 'comment_notification_subject' ) ) );
 		$this->assertEquals( 10, \has_filter( 'comment_notification_text', array( Mailer::class, 'comment_notification_text' ) ) );
 		$this->assertEquals( 10, \has_action( 'activitypub_handled_follow', array( Mailer::class, 'new_follower' ) ) );
-		$this->assertEquals( 10, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'direct_message' ) ) );
-		$this->assertEquals( 20, \has_action( 'activitypub_inbox_create', array( Mailer::class, 'mention' ) ) );
+		$this->assertEquals( 10, \has_action( 'activitypub_handled_inbox_create', array( Mailer::class, 'direct_message' ) ) );
+		$this->assertEquals( 20, \has_action( 'activitypub_handled_inbox_create', array( Mailer::class, 'mention' ) ) );
+
+		// Notifications must not run on the pre-storage hook, which fires again for every redelivery.
+		$this->assertFalse( \has_action( 'activitypub_inbox_create', array( Mailer::class, 'direct_message' ) ) );
+		$this->assertFalse( \has_action( 'activitypub_inbox_create', array( Mailer::class, 'mention' ) ) );
+
+		/*
+		 * The mention reply check reads the comment that Create::handle_create() writes, so it has
+		 * to run after it on the same hook.
+		 */
+		$this->assertGreaterThan(
+			\has_action( 'activitypub_handled_inbox_create', array( Create::class, 'handle_create' ) ),
+			\has_action( 'activitypub_handled_inbox_create', array( Mailer::class, 'mention' ) )
+		);
 	}
 
 	/**
@@ -1367,5 +1383,192 @@ class Test_Mailer extends WP_UnitTestCase {
 		\remove_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter );
 		\remove_filter( 'wp_mail', array( $mock, 'filter' ), 1 );
 		\remove_filter( 'wp_mail', $mail_filter );
+	}
+
+	/**
+	 * Deliver an activity to a user's inbox the way a remote server would.
+	 *
+	 * @param array $data    The activity.
+	 * @param int   $user_id The recipient.
+	 */
+	private function deliver_to_inbox( $data, $user_id ) {
+		\add_option( 'permalink_structure', '/%postname%/' );
+		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		Server::init();
+
+		$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/users/' . $user_id . '/inbox' );
+		$request->set_header( 'Content-Type', 'application/activity+json' );
+		$request->set_body( \wp_json_encode( $data ) );
+		\rest_get_server()->dispatch( $request );
+
+		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+		\delete_option( 'permalink_structure' );
+	}
+
+	/**
+	 * Run the event the inbox queued, the way WP-Cron would.
+	 *
+	 * Deliveries only store and queue, so nothing is handed to the handlers until this runs.
+	 *
+	 * @param string $activity_id The activity ID.
+	 */
+	private function run_inbox_queue( $activity_id ) {
+		$args      = array( $activity_id );
+		$timestamp = \wp_next_scheduled( 'activitypub_inbox_create_item', $args );
+
+		if ( ! $timestamp ) {
+			return;
+		}
+
+		\wp_unschedule_event( $timestamp, 'activitypub_inbox_create_item', $args );
+		Scheduler::process_inbox_activity( $activity_id );
+	}
+
+	/**
+	 * A redelivered Direct Message only notifies once, all the way through the inbox.
+	 *
+	 * @covers ::direct_message
+	 */
+	public function test_a_redelivered_direct_message_only_notifies_once() {
+		$user_id = self::$user_id;
+		$data    = array(
+			'id'     => 'https://example.com/activity/inbox-dm-1',
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'to'     => array( Actors::get_by_id( $user_id )->get_id() ),
+			'object' => array(
+				'id'      => 'https://example.com/note/inbox-dm-1',
+				'type'    => 'Note',
+				'content' => '<p>Hello there.</p>',
+			),
+		);
+
+		$count = $this->count_mails(
+			function () use ( $data, $user_id ) {
+				$this->deliver_to_inbox( $data, $user_id );
+				$this->deliver_to_inbox( $data, $user_id );
+				$this->run_inbox_queue( $data['id'] );
+			}
+		);
+
+		$this->assertEquals( 1, $count, 'A Direct Message delivered twice should only notify once.' );
+	}
+
+	/**
+	 * A Direct Message delivered to the shared inbox still notifies.
+	 *
+	 * Most servers deliver here rather than to a per-actor inbox, and this path hands the
+	 * notification hook every recipient at once instead of one per call.
+	 *
+	 * @covers ::direct_message
+	 */
+	public function test_a_direct_message_to_the_shared_inbox_still_notifies() {
+		$user_id = self::$user_id;
+		$data    = array(
+			'id'     => 'https://example.com/activity/shared-dm-1',
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'to'     => array( Actors::get_by_id( $user_id )->get_id() ),
+			'object' => array(
+				'id'      => 'https://example.com/note/shared-dm-1',
+				'type'    => 'Note',
+				'content' => '<p>Hello there.</p>',
+			),
+		);
+
+		$count = $this->count_mails(
+			function () use ( $data ) {
+				\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
+				Server::init();
+
+				$request = new \WP_REST_Request( 'POST', '/' . ACTIVITYPUB_REST_NAMESPACE . '/inbox' );
+				$request->set_header( 'Content-Type', 'application/activity+json' );
+				$request->set_body( \wp_json_encode( $data ) );
+				\rest_get_server()->dispatch( $request );
+
+				\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
+			}
+		);
+
+		$this->assertEquals( 1, $count, 'A Direct Message to the shared inbox should notify.' );
+	}
+
+	/**
+	 * A mention inside a reply does not notify, because the reply becomes a comment instead.
+	 *
+	 * This is what the priority of the `mention` hook is for: it has to run after
+	 * Create::handle_create() has stored the comment, or the reply check never sees it.
+	 *
+	 * @covers ::mention
+	 */
+	public function test_a_mention_in_a_reply_does_not_notify() {
+		$user_id  = self::$user_id;
+		$actor_id = Actors::get_by_id( $user_id )->get_id();
+		$data     = array(
+			'id'     => 'https://example.com/activity/inbox-reply-1',
+			'type'   => 'Create',
+			'actor'  => 'https://example.com/author',
+			'to'     => array( 'https://www.w3.org/ns/activitystreams#Public' ),
+			'cc'     => array( $actor_id ),
+			'object' => array(
+				'id'        => 'https://example.com/note/inbox-reply-1',
+				'type'      => 'Note',
+				'url'       => 'https://example.com/note/inbox-reply-1',
+				'inReplyTo' => \get_permalink( self::$post_id ),
+				'content'   => '<p>Hello @testuser.</p>',
+				'tag'       => array(
+					array(
+						'type' => 'Mention',
+						'href' => $actor_id,
+						'name' => '@testuser',
+					),
+				),
+			),
+		);
+
+		$count = $this->count_mails(
+			function () use ( $data, $user_id ) {
+				$this->deliver_to_inbox( $data, $user_id );
+				$this->run_inbox_queue( $data['id'] );
+			},
+			'Mention'
+		);
+
+		$this->assertEquals( 0, $count, 'A reply stored as a comment should not also send a mention email.' );
+	}
+
+
+	/**
+	 * Count the emails sent while running a callback.
+	 *
+	 * @param callable $callback The code to run.
+	 * @param string   $subject  Optional. Only count emails whose subject contains this. Default ''.
+	 * @return int The number of emails sent.
+	 */
+	private function count_mails( $callback, $subject = '' ) {
+		$metadata_filter = function () {
+			return array(
+				'name' => 'Test Author',
+				'url'  => 'https://example.com/author',
+			);
+		};
+		\add_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter );
+
+		$count      = 0;
+		$count_mail = function ( $args ) use ( &$count, $subject ) {
+			if ( '' === $subject || false !== \strpos( $args['subject'], $subject ) ) {
+				++$count;
+			}
+
+			return $args;
+		};
+		\add_filter( 'wp_mail', $count_mail, 1 );
+
+		$callback();
+
+		\remove_filter( 'wp_mail', $count_mail, 1 );
+		\remove_filter( 'pre_get_remote_metadata_by_actor', $metadata_filter );
+
+		return $count;
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-mailer.php
+++ b/tests/phpunit/tests/includes/class-test-mailer.php
@@ -1392,7 +1392,6 @@ class Test_Mailer extends WP_UnitTestCase {
 	 * @param int   $user_id The recipient.
 	 */
 	private function deliver_to_inbox( $data, $user_id ) {
-		\add_option( 'permalink_structure', '/%postname%/' );
 		\add_filter( 'activitypub_defer_signature_verification', '__return_true' );
 		Server::init();
 
@@ -1402,7 +1401,6 @@ class Test_Mailer extends WP_UnitTestCase {
 		\rest_get_server()->dispatch( $request );
 
 		\remove_filter( 'activitypub_defer_signature_verification', '__return_true' );
-		\delete_option( 'permalink_structure' );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-actors-inbox-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-actors-inbox-controller.php
@@ -753,6 +753,40 @@ class Test_Actors_Inbox_Controller extends \Activitypub\Tests\Test_REST_Controll
 	}
 
 	/**
+	 * One queued event hands the activity to the handlers exactly once.
+	 *
+	 * The controller used to register a second, near-identical dispatcher on the same event, so
+	 * every handler ran twice in any request where the REST routes had been registered.
+	 *
+	 * @covers \Activitypub\Scheduler::process_inbox_activity
+	 */
+	public function test_a_queued_event_dispatches_once() {
+		$activity_id = 'https://remote.example/@activity-dispatched-once';
+
+		$activity = \Activitypub\Activity\Activity::init_from_array(
+			array(
+				'id'     => $activity_id,
+				'type'   => 'Like',
+				'actor'  => 'https://remote.example/@test',
+				'object' => 'https://example.org/@user/post/1',
+			)
+		);
+		Inbox_Collection::add( $activity, array( self::$user_id ) );
+
+		$dispatches = 0;
+		$counter    = function () use ( &$dispatches ) {
+			++$dispatches;
+		};
+		\add_action( 'activitypub_handled_inbox_like', $counter );
+
+		\do_action( 'activitypub_inbox_create_item', $activity_id );
+
+		\remove_action( 'activitypub_handled_inbox_like', $counter );
+
+		$this->assertEquals( 1, $dispatches, 'The queued event must reach the handlers exactly once.' );
+	}
+
+	/**
 	 * Test inbox request schedules delayed processing.
 	 *
 	 * @covers \Activitypub\Rest\Actors_Inbox_Controller::create_item


### PR DESCRIPTION
Fixes #3254

## Proposed changes:

`Mailer::direct_message` and `Mailer::mention` were registered on `activitypub_inbox_create`, which `Actors_Inbox_Controller::create_item()` fires *before* `Inbox::add()` stores the activity. A remote server that retries a delivery, because it never saw our 200, re-fires them and the recipient gets the email again. They move to `activitypub_handled_inbox_create`, which runs after storage from the queued event, where the existing debounce in `create_item()` already collapses a redelivery into a single run. That is Option 1 from the issue.

While tracing that I found the queued event has **two handlers registered on it**, doing the same work:

* `Scheduler::process_inbox_activity()`, added in #2376
* `Actors_Inbox_Controller::process_create_item()`, added in #2381 the next morning

The two bodies are identical apart from one line. #2381 was the refactor that deleted `Handler\Inbox` and moved its work into the controllers, and it re-created the dispatcher that #2376 had added seventeen hours earlier. It never touched `class-scheduler.php`.

The controller's registration also sits in `register_routes()`, which only runs on `rest_api_init`. That is the wrong home for a scheduled event callback: it is absent on cron runs, WP-CLI and admin requests, and present twice on REST requests. Every other `activitypub_*` event callback lives in the `// Event callbacks.` block of `Scheduler::init()`, which is hooked on `init` and always runs.

So the controller's copy is deleted and the Scheduler keeps the event.

This matters for the Mailer move rather than being a tidy-up alongside it: `Create::handle_create` is on `activitypub_handled_inbox_create` too, so with two dispatchers registered that hook fires twice. Moving the Mailer onto it without removing the duplicate would have traded one duplicate email path for another.

### It also revives a check that stopped working in #2381

`Mailer::mention()` skips a reply that already exists as a local comment:

```php
if ( is_activity_reply( $activity ) && object_id_to_comment( $activity['object']['id'] ) ) {
```

`Create::handle_create()` writes that comment, and #2381 moved it to `activitypub_handled_inbox_create` while the Mailer stayed on the pre-storage hook. Since then the check has run about fifteen seconds before the comment exists, so it never matched and replies sent a mention email as well as creating the comment. Priority 20 now puts the Mailer after `Create::handle_create()` on the same hook, which is what the comment on that line always claimed.

### Known, and not fixed here

The shared inbox fires the handled hooks inline rather than queueing, so a retry there can still notify twice. Routing it through the same event would make the two endpoints consistent, but it would delay every shared inbox reply and mention by the fifteen second debounce, and shared inbox is how most servers deliver. That is a bigger user visible change than the bug, so it wants its own decision.

A redelivery arriving after the queued run has already happened also dispatches again. Closing that needs per recipient state, and I would rather accept a duplicate email than risk dropping a notification.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Four, and each was checked against the unfixed code first:

* the same Direct Message delivered twice notifies once, which counted two before
* a reply that mentions the author sends no mention email, which sent one before. It counts by subject, since the reply legitimately produces the WordPress new comment notification
* a Direct Message to the shared inbox still notifies, which is the path most servers use and nothing covered before
* one queued event reaches the handlers exactly once, which counted two with the second registration present

`test_init` now also asserts neither Mailer method is left on the pre-storage hook, and that `mention` sits after `Create::handle_create` on the shared one.

## Testing instructions:

* `npm run env-test`.
* From another server, send a direct message and a mention, and confirm one email each.
* Reply to a post that mentions its author. The comment should appear and no mention email should be sent.
* Check that incoming replies still turn into comments, since this touches the event they are processed from.

### Changelog entry

Added manually in `.github/changelog/fix-duplicate-inbox-notifications`.
