### PR TITLE
Add Polylang integration

### DIFF
--- a/.github/changelog/add-polylang-integration
+++ b/.github/changelog/add-polylang-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Posts and comments on sites using Polylang are now federated with the language Polylang assigned to them.

--- a/integration/README.md
+++ b/integration/README.md
@@ -58,6 +58,7 @@ A few integrations are always initialized (`Nodeinfo`, `Webfinger`, `Surge`, `Li
 | Integration | What it does |
 |---|---|
 | **WPML** | Supplies the correct per-object locale for federated content under WPML. |
+| **Polylang** | Supplies the correct per-object locale for federated posts and their comments under Polylang. |
 | **Multisite Language Switcher** | Keeps ActivityPub data consistent across MSLS post translations. |
 
 ### Other

--- a/integration/class-polylang.php
+++ b/integration/class-polylang.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Polylang integration.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Integration;
+
+/**
+ * Compatibility with the Polylang plugin.
+ *
+ * @see https://polylang.pro/
+ */
+class Polylang {
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_filter( 'activitypub_locale', array( self::class, 'get_post_locale' ), 10, 2 );
+	}
+
+	/**
+	 * Use the language Polylang assigned to the post as the locale of the ActivityPub object.
+	 *
+	 * A comment takes the language of the post it belongs to.
+	 *
+	 * @param string $lang The language code.
+	 * @param mixed  $item The transformed object.
+	 *
+	 * @return string The language code.
+	 */
+	public static function get_post_locale( $lang, $item ) {
+		if ( $item instanceof \WP_Comment ) {
+			$item = \get_post( $item->comment_post_ID );
+		}
+
+		if ( ! $item instanceof \WP_Post || ! \function_exists( 'pll_get_post_language' ) ) {
+			return $lang;
+		}
+
+		$post_lang = \pll_get_post_language( $item->ID, 'slug' );
+
+		return $post_lang ? $post_lang : $lang;
+	}
+}

--- a/integration/load.php
+++ b/integration/load.php
@@ -132,6 +132,17 @@ function plugin_init() {
 	}
 
 	/**
+	 * Adds Polylang support.
+	 *
+	 * This class handles the compatibility with the Polylang plugin.
+	 *
+	 * @see https://wordpress.org/plugins/polylang/
+	 */
+	if ( \defined( 'POLYLANG_VERSION' ) ) {
+		Polylang::init();
+	}
+
+	/**
 	 * Adds Seriously Simple Podcasting support.
 	 *
 	 * This class handles the compatibility with Seriously Simple Podcasting.

--- a/tests/phpunit/data/mocks/polylang-api.php
+++ b/tests/phpunit/data/mocks/polylang-api.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Mock of Polylang's API for tests.
+ *
+ * @package Activitypub
+ */
+
+if ( ! function_exists( 'pll_get_post_language' ) ) {
+	/**
+	 * Minimal stand-in for Polylang's `pll_get_post_language()`.
+	 *
+	 * The real function reads the language term of the post; the mock reads the
+	 * `_test_pll_language` post meta a test sets.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $field   The language field. Only `slug` is supported.
+	 *
+	 * @return string|false The language slug, or false when the post has none.
+	 */
+	function pll_get_post_language( $post_id, $field = 'slug' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$lang = \get_post_meta( $post_id, '_test_pll_language', true );
+
+		return $lang ? $lang : false;
+	}
+}

--- a/tests/phpunit/tests/integration/class-test-polylang.php
+++ b/tests/phpunit/tests/integration/class-test-polylang.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Test Polylang integration.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Tests\Integration;
+
+use Activitypub\Integration\Polylang;
+use Activitypub\Transformer\Comment;
+use Activitypub\Transformer\Post;
+
+/**
+ * Test the Polylang integration.
+ *
+ * @group integration
+ * @coversDefaultClass \Activitypub\Integration\Polylang
+ */
+class Test_Polylang extends \WP_UnitTestCase {
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		require_once AP_TESTS_DIR . '/data/mocks/polylang-api.php';
+
+		Polylang::init();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		\remove_filter( 'activitypub_locale', array( Polylang::class, 'get_post_locale' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * A post's content map is keyed by the language Polylang assigned to it.
+	 *
+	 * @covers ::get_post_locale
+	 */
+	public function test_post_uses_its_polylang_language() {
+		$post_id = self::factory()->post->create( array( 'post_content' => 'Hallo Welt' ) );
+		\update_post_meta( $post_id, '_test_pll_language', 'de' );
+
+		$object = Post::transform( \get_post( $post_id ) )->to_object();
+
+		$this->assertSame( array( 'de' ), \array_keys( $object->get_content_map() ) );
+	}
+
+	/**
+	 * A comment takes the language of the post it belongs to.
+	 *
+	 * @covers ::get_post_locale
+	 */
+	public function test_comment_uses_the_language_of_its_post() {
+		$post_id    = self::factory()->post->create();
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $post_id ) );
+		\update_post_meta( $post_id, '_test_pll_language', 'fr' );
+
+		$object = Comment::transform( \get_comment( $comment_id ) )->to_object();
+
+		$this->assertSame( array( 'fr' ), \array_keys( $object->get_content_map() ) );
+	}
+
+	/**
+	 * A post without a Polylang language keeps the site locale.
+	 *
+	 * @covers ::get_post_locale
+	 */
+	public function test_post_without_language_keeps_the_site_locale() {
+		$post_id = self::factory()->post->create();
+
+		$object = Post::transform( \get_post( $post_id ) )->to_object();
+
+		$this->assertSame( array( 'en' ), \array_keys( $object->get_content_map() ) );
+	}
+}


### PR DESCRIPTION
## Proposed changes:

Adds a Polylang integration, the same thing the WPML integration does: the `activitypub_locale` filter returns the language Polylang assigned to the post, so `contentMap`, `nameMap` and `summaryMap` are keyed by the post's language instead of the site locale. A comment takes the language of the post it belongs to, which the WPML integration does not do yet. A post without a Polylang language keeps the site locale.

That is all there is to it. I checked whether Polylang needs more handling and did not find anything: its `home_url` filter only applies to calls from theme files and a short whitelist, so our actor and object IDs are not touched; its post type settings only list public post types, so our internal ones stay out of it; and the `term_id` it puts on every request is handled generically since #3744.

What this does not do: build a multi-language `contentMap` from the linked translations (`pll_get_post_translations()`). Each translation is its own post and federates as its own object, so merging them would either post twice or need one canonical object per translation group. That is a product decision, not an integration detail.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Three tests with a small mock of `pll_get_post_language()`: a post gets its Polylang language, a comment gets the language of its post, a post without a language keeps the site locale.

## Testing instructions:

* Install Polylang, add two languages, and publish a post in the non-default one.
* Fetch the post with `Accept: application/activity+json`. `contentMap` is keyed by the post's language, e.g. `de`, not the site locale.
* Reply to it from the Fediverse and fetch the comment the same way. Same key.
* A post Polylang has no language for still uses the site locale.

### Changelog entry

Added manually in `.github/changelog/add-polylang-integration`.
